### PR TITLE
Add issue templates with auto labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Report a reproducible problem in focustime
+title: "[Bug] "
+labels: bug
+---
+
+## Bug description
+Clearly and concisely describe the bug.
+
+## Steps to reproduce
+1. Go to `...`
+2. Run `...`
+3. Observe `...`
+
+## Expected behavior
+Describe what you expected to happen.
+
+## Actual behavior
+Describe what actually happened.
+
+## Environment
+- OS:
+- Terminal:
+- focustime version/commit:
+
+## Logs or screenshots
+Paste relevant logs, error output, or screenshots.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement for focustime
+title: "[Feature] "
+labels: enhancement
+---
+
+## Summary
+Briefly describe the feature you want.
+
+## Problem to solve
+What problem does this feature solve?  
+Who is affected?
+
+## Proposed solution
+Describe your preferred solution in detail.
+
+## Alternatives considered
+List any alternative approaches you considered.
+
+## Additional context
+Add examples, screenshots, links, or related issues if applicable.


### PR DESCRIPTION
## Why
This PR implements issue #24 by adding structured issue templates so new issues are more complete and consistent. It also automatically applies the right label at issue creation time, reducing manual triage work.

## What changed
- Added `.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md` with fields for summary, problem, solution, alternatives, and context.
- Added `.github/ISSUE_TEMPLATE/BUG_REPORT.md` with fields for reproduction, expected/actual behavior, environment, and logs.
- Configured automatic labels in template front matter:
  - Feature requests: `enhancement`
  - Bug reports: `bug`

## Notes
- Chose Markdown templates (`.md`) to match the issue requirement exactly.
- Verified both labels already exist in the repository.
- This is a documentation/metadata-only change; no Rust code paths were modified.

Closes #24.