### PR TITLE
v0.1.0 — Initial release of focustime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- No unreleased changes yet.
+
+## [0.1.0] - 2026-04-06
+
+### Added
+- Initial release of `focustime` as a Rust TUI application.
+- Pomodoro timer with focus, short break, and long break session flow.
+- Distraction website blocking through hosts file updates during focus sessions.
+- Optional WakaTime heartbeat integration for focus activity tracking.
+- Release automation for tagged builds across Linux, macOS, and Windows.
+
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/utilForever/focustime/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ The project uses Conventional Commit-style release commits:
 
 - Release commit format: `feat: vX.Y.Z — short summary`
 - Hotfix format: `fix: description` (no version in the message)
+- Update [CHANGELOG.md](CHANGELOG.md) with release notes before creating a release commit/tag.
 
 Before preparing a release commit, make sure all CI jobs pass for the release changes.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "focustime"
 version = "0.1.0"
 edition = "2024"
+description = "TUI Pomodoro timer with site blocking and WakaTime tracking"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/utilForever/focustime"
+homepage = "https://github.com/utilForever/focustime"
+keywords = ["pomodoro", "tui", "productivity", "focus", "wakatime"]
+categories = ["command-line-utilities"]
 
 [dependencies]
 ratatui = "0.30"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
+For a human-readable summary of notable changes, see [CHANGELOG.md](CHANGELOG.md).
+
 ## License
 
 <img align="right" src="https://149753425.v2.pressablecdn.com/wp-content/uploads/2009/06/OSIApproved_100X125.png">


### PR DESCRIPTION
## What

- Add a new root `CHANGELOG.md` with baseline notes for `0.1.0` (without an `Unreleased` section).
- Add missing project metadata to `Cargo.toml` (`description`, `license`, `readme`, `repository`, `homepage`, `keywords`, `categories`).
- Improve changelog discoverability by linking it from `README.md` and `CONTRIBUTING.md`.

## Why

Issue #41 asked for `CHANGELOG.md`, and this branch also prepares a cleaner first-release baseline for `v0.1.0` by adding package metadata that was missing from the manifest.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`) — Closes #41

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable) — N/A (docs/metadata-only changes)
- [x] Site blocking behavior was verified for this change (if applicable) — N/A (docs/metadata-only changes)
- [x] WakaTime integration behavior was verified for this change (if applicable) — N/A (docs/metadata-only changes)
- [x] I added or updated tests for changed behavior (if applicable) — N/A (no behavior changes)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) — N/A (none added)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) — no security-impacting code path changes
- [x] Breaking behavior changes are clearly described in this PR — N/A (no breaking behavior changes)