### PR TITLE
Session stats and daily history view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +145,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +206,12 @@ dependencies = [
  "time",
  "url",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -444,6 +470,7 @@ name = "focustime"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "chrono",
  "crossterm",
  "ratatui",
  "serde",
@@ -565,6 +592,30 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -2105,10 +2156,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"
 base64 = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ long_break_secs = 900
 long_break_interval = 3
 ```
 
+## Session stats and daily history
+
+`focustime` tracks:
+
+- completed pomodoros for the current app session
+- focused minutes for the current app session
+- daily aggregates persisted in `stats.toml` (in the same config directory as `config.toml`)
+
+From timer view:
+
+- press **`h`** to open the daily history panel
+- press **`h`** or **`Esc`** to return to timer view
+
 ## The way the system works
 
 `focustime` is a single-binary Rust TUI app composed of six modules in `src/`:

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::blocker::SiteBlocker;
 use crate::config::{AppConfig, CustomProfileConfig, ProfileId};
+use crate::stats::{DailyStats, FocusStats, SessionStats, current_day_key};
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
     DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerState, TimerStatus,
@@ -19,6 +20,7 @@ pub enum AppMode {
     Timer,
     SiteManager,
     ProfileManager,
+    StatsHistory,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -92,6 +94,8 @@ pub struct App {
     pub block_error: Option<String>,
     /// Last error from persisting timer/site configuration.
     pub config_error: Option<String>,
+    /// Last error from persisting focus stats.
+    pub stats_error: Option<String>,
     pub wakatime: WakatimeTracker,
     pub selected_profile: ProfileId,
     pub custom_profile: CustomProfileConfig,
@@ -99,6 +103,7 @@ pub struct App {
     pub profile_edit_active: bool,
     pub profile_edit_field: usize,
     pub profile_edit_snapshot: Option<CustomProfileConfig>,
+    stats: FocusStats,
 }
 
 impl App {
@@ -130,6 +135,7 @@ impl App {
             selected_site: 0,
             block_error: None,
             config_error: None,
+            stats_error: None,
             wakatime: WakatimeTracker::new(),
             selected_profile,
             custom_profile,
@@ -137,11 +143,21 @@ impl App {
             profile_edit_active: false,
             profile_edit_field: 0,
             profile_edit_snapshot: None,
+            stats: FocusStats::load(),
         }
     }
 
     pub fn on_tick(&mut self) {
+        let was_focus_running = self.focus_running_for_current_state();
+        let was_focus_phase = self.timer.phase == TimerPhase::Focus;
+        if was_focus_running {
+            self.record_focus_elapsed(1);
+        }
+
         let phase_changed = self.timer.tick();
+        if phase_changed && was_focus_phase && self.timer.phase != TimerPhase::Focus {
+            self.record_completed_focus_session();
+        }
         if phase_changed {
             self.apply_blocking_for_phase();
         }
@@ -181,6 +197,18 @@ impl App {
             format_duration_label(long_break),
             cadence
         )
+    }
+
+    pub fn session_stats(&self) -> SessionStats {
+        self.stats.session()
+    }
+
+    pub fn today_stats(&self) -> DailyStats {
+        self.stats.daily_for(&current_day_key())
+    }
+
+    pub fn recent_daily_stats(&self, limit: usize) -> Vec<(String, DailyStats)> {
+        self.stats.recent_daily(limit)
     }
 
     pub fn custom_profile_field_value(&self, field_index: usize) -> String {
@@ -231,11 +259,26 @@ impl App {
         self.config_error = None;
     }
 
+    #[cfg(not(test))]
+    fn save_stats(&mut self) {
+        if let Err(e) = self.stats.save() {
+            self.stats_error = Some(format!("stats save failed: {e}"));
+        } else {
+            self.stats_error = None;
+        }
+    }
+
+    #[cfg(test)]
+    fn save_stats(&mut self) {
+        self.stats_error = None;
+    }
+
     pub fn handle_key(&mut self, key: KeyEvent) {
         match self.mode {
             AppMode::Timer => self.handle_key_timer(key),
             AppMode::SiteManager => self.handle_key_site_manager(key),
             AppMode::ProfileManager => self.handle_key_profile_manager(key),
+            AppMode::StatsHistory => self.handle_key_stats_history(key),
         }
     }
 
@@ -264,6 +307,23 @@ impl App {
             // Open profile manager
             KeyCode::Char('p') => {
                 self.open_profile_manager();
+            }
+            // Open stats history
+            KeyCode::Char('h') => {
+                self.open_stats_history();
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_key_stats_history(&mut self, key: KeyEvent) {
+        if self.handle_quit_key(&key, false) {
+            return;
+        }
+
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('h') => {
+                self.mode = AppMode::Timer;
             }
             _ => {}
         }
@@ -523,6 +583,10 @@ impl App {
         self.clamp_profile_selection();
     }
 
+    fn open_stats_history(&mut self) {
+        self.mode = AppMode::StatsHistory;
+    }
+
     fn exit_profile_manager(&mut self) {
         self.mode = AppMode::Timer;
         self.profile_edit_snapshot = None;
@@ -554,12 +618,39 @@ impl App {
         self.timer.phase == TimerPhase::Focus && self.timer.status == TimerStatus::Running
     }
 
+    fn record_focus_elapsed(&mut self, elapsed_secs: u64) {
+        if elapsed_secs == 0 {
+            return;
+        }
+
+        let day_key = current_day_key();
+        let session_minutes_before = self.stats.session().focused_minutes();
+        let today_minutes_before = self.stats.daily_for(&day_key).focused_minutes();
+
+        self.stats.record_focus_elapsed(&day_key, elapsed_secs);
+
+        let session_minutes_after = self.stats.session().focused_minutes();
+        let today_minutes_after = self.stats.daily_for(&day_key).focused_minutes();
+        if session_minutes_before != session_minutes_after
+            || today_minutes_before != today_minutes_after
+        {
+            self.save_stats();
+        }
+    }
+
+    fn record_completed_focus_session(&mut self) {
+        let day_key = current_day_key();
+        self.stats.record_completed_pomodoro(&day_key);
+        self.save_stats();
+    }
+
     fn sync_wakatime_tracking_for_state(&mut self) {
         let focus_running = self.focus_running_for_current_state();
         if focus_running && !self.wakatime.is_tracking() {
             self.wakatime.on_focus_start();
         } else if !focus_running && self.wakatime.is_tracking() {
             self.wakatime.on_focus_stop();
+            self.save_stats();
         }
     }
 
@@ -593,6 +684,7 @@ fn format_duration_label(seconds: u64) -> String {
 
 impl Drop for App {
     fn drop(&mut self) {
+        self.save_stats();
         // Ensure hosts-file block entries are removed on every exit path,
         // including early returns caused by I/O errors in run_app.
         self.blocker.cleanup();
@@ -858,6 +950,55 @@ mod tests {
         );
         assert_eq!(app.selected_site, 1);
         assert!(app.config_error.is_none());
+    }
+
+    #[test]
+    fn completed_focus_tick_increments_session_pomodoros() {
+        let mut app = App::default();
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.timer.remaining_secs = 1;
+
+        app.on_tick();
+
+        assert_eq!(app.session_stats().pomodoros_completed, 1);
+        assert_eq!(app.today_stats().pomodoros_completed, 1);
+    }
+
+    #[test]
+    fn skipping_focus_does_not_increment_session_pomodoros() {
+        let mut app = App::default();
+        assert_eq!(app.session_stats().pomodoros_completed, 0);
+
+        app.handle_key(key(KeyCode::Char('n')));
+
+        assert_eq!(app.session_stats().pomodoros_completed, 0);
+    }
+
+    #[test]
+    fn focus_elapsed_accumulates_session_and_today_minutes() {
+        let mut app = App::default();
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.timer.remaining_secs = app.timer.focus_secs;
+
+        for _ in 0..120 {
+            app.on_tick();
+        }
+
+        assert_eq!(app.session_stats().focused_minutes(), 2);
+        assert_eq!(app.today_stats().focused_minutes(), 2);
+    }
+
+    #[test]
+    fn history_view_toggles_from_timer_mode() {
+        let mut app = App::default();
+
+        app.handle_key(key(KeyCode::Char('h')));
+        assert_eq!(app.mode, AppMode::StatsHistory);
+
+        app.handle_key(key(KeyCode::Esc));
+        assert_eq!(app.mode, AppMode::Timer);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -105,6 +105,7 @@ pub struct App {
     pub profile_edit_snapshot: Option<CustomProfileConfig>,
     stats: FocusStats,
     stats_dirty: bool,
+    stats_has_unsaved_elapsed: bool,
 }
 
 impl App {
@@ -150,6 +151,7 @@ impl App {
             profile_edit_snapshot: None,
             stats,
             stats_dirty: false,
+            stats_has_unsaved_elapsed: false,
         }
     }
 
@@ -168,7 +170,7 @@ impl App {
         if phase_changed {
             self.apply_blocking_for_phase();
         }
-        self.flush_stats_if_dirty();
+        self.flush_stats_if_dirty(false);
     }
 
     /// Advance WakaTime tracking by `elapsed_secs` simulated seconds.
@@ -281,14 +283,15 @@ impl App {
         self.stats_error = None;
     }
 
-    fn flush_stats_if_dirty(&mut self) {
-        if !self.stats_dirty {
+    fn flush_stats_if_dirty(&mut self, force_partial: bool) {
+        if !(self.stats_dirty || (force_partial && self.stats_has_unsaved_elapsed)) {
             return;
         }
 
         self.save_stats();
         if self.stats_error.is_none() {
             self.stats_dirty = false;
+            self.stats_has_unsaved_elapsed = false;
         }
     }
 
@@ -647,6 +650,7 @@ impl App {
         let today_minutes_before = self.stats.daily_for(&day_key).focused_minutes();
 
         self.stats.record_focus_elapsed(&day_key, elapsed_secs);
+        self.stats_has_unsaved_elapsed = true;
 
         let session_minutes_after = self.stats.session().focused_minutes();
         let today_minutes_after = self.stats.daily_for(&day_key).focused_minutes();
@@ -702,7 +706,7 @@ fn format_duration_label(seconds: u64) -> String {
 
 impl Drop for App {
     fn drop(&mut self) {
-        self.flush_stats_if_dirty();
+        self.flush_stats_if_dirty(true);
         // Ensure hosts-file block entries are removed on every exit path,
         // including early returns caused by I/O errors in run_app.
         self.blocker.cleanup();
@@ -1031,6 +1035,19 @@ mod tests {
         assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
         assert_eq!(app.session_stats().pomodoros_completed, 0);
         assert_eq!(app.session_stats().focused_seconds, 0);
+    }
+
+    #[test]
+    fn partial_focus_elapsed_marks_unsaved_flag_for_drop_flush() {
+        let mut app = App::default();
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.timer.remaining_secs = app.timer.focus_secs;
+
+        app.on_tick(false);
+
+        assert!(app.stats_has_unsaved_elapsed);
+        assert_eq!(app.session_stats().focused_seconds, 1);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,6 +115,10 @@ impl App {
         let selected_profile = config.selected_profile;
         let custom_profile = config.effective_custom_profile();
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
+        let (stats, stats_error) = match FocusStats::load() {
+            Ok(stats) => (stats, None),
+            Err(e) => (FocusStats::default(), Some(e)),
+        };
         let timer = TimerState::with_profile(
             profile_spec.focus_secs,
             profile_spec.short_break_secs,
@@ -135,7 +139,7 @@ impl App {
             selected_site: 0,
             block_error: None,
             config_error: None,
-            stats_error: None,
+            stats_error,
             wakatime: WakatimeTracker::new(),
             selected_profile,
             custom_profile,
@@ -143,19 +147,20 @@ impl App {
             profile_edit_active: false,
             profile_edit_field: 0,
             profile_edit_snapshot: None,
-            stats: FocusStats::load(),
+            stats,
         }
     }
 
-    pub fn on_tick(&mut self) {
+    pub fn on_tick(&mut self, is_catchup: bool) {
         let was_focus_running = self.focus_running_for_current_state();
         let was_focus_phase = self.timer.phase == TimerPhase::Focus;
-        if was_focus_running {
+        if was_focus_running && !is_catchup {
             self.record_focus_elapsed(1);
         }
 
         let phase_changed = self.timer.tick();
-        if phase_changed && was_focus_phase && self.timer.phase != TimerPhase::Focus {
+        if !is_catchup && phase_changed && was_focus_phase && self.timer.phase != TimerPhase::Focus
+        {
             self.record_completed_focus_session();
         }
         if phase_changed {
@@ -746,18 +751,18 @@ mod tests {
         for _ in 0..2 {
             app.timer.status = TimerStatus::Running;
             app.timer.remaining_secs = 1;
-            app.on_tick(); // focus -> short break
+            app.on_tick(false); // focus -> short break
             assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
 
             app.timer.status = TimerStatus::Running;
             app.timer.remaining_secs = 1;
-            app.on_tick(); // short break -> focus
+            app.on_tick(false); // short break -> focus
             assert_eq!(app.timer.phase, TimerPhase::Focus);
         }
 
         app.timer.status = TimerStatus::Running;
         app.timer.remaining_secs = 1;
-        app.on_tick(); // third focus completion -> long break
+        app.on_tick(false); // third focus completion -> long break
         assert_eq!(app.timer.phase, TimerPhase::LongBreak);
     }
 
@@ -959,7 +964,7 @@ mod tests {
         app.timer.status = TimerStatus::Running;
         app.timer.remaining_secs = 1;
 
-        app.on_tick();
+        app.on_tick(false);
 
         assert_eq!(app.session_stats().pomodoros_completed, 1);
         assert_eq!(app.today_stats().pomodoros_completed, 1);
@@ -983,7 +988,7 @@ mod tests {
         app.timer.remaining_secs = app.timer.focus_secs;
 
         for _ in 0..120 {
-            app.on_tick();
+            app.on_tick(false);
         }
 
         assert_eq!(app.session_stats().focused_minutes(), 2);
@@ -999,6 +1004,20 @@ mod tests {
 
         app.handle_key(key(KeyCode::Esc));
         assert_eq!(app.mode, AppMode::Timer);
+    }
+
+    #[test]
+    fn catchup_tick_does_not_increment_focus_stats() {
+        let mut app = App::default();
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.timer.remaining_secs = 1;
+
+        app.on_tick(true);
+
+        assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
+        assert_eq!(app.session_stats().pomodoros_completed, 0);
+        assert_eq!(app.session_stats().focused_seconds, 0);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -104,6 +104,7 @@ pub struct App {
     pub profile_edit_field: usize,
     pub profile_edit_snapshot: Option<CustomProfileConfig>,
     stats: FocusStats,
+    stats_dirty: bool,
 }
 
 impl App {
@@ -148,6 +149,7 @@ impl App {
             profile_edit_field: 0,
             profile_edit_snapshot: None,
             stats,
+            stats_dirty: false,
         }
     }
 
@@ -166,6 +168,7 @@ impl App {
         if phase_changed {
             self.apply_blocking_for_phase();
         }
+        self.flush_stats_if_dirty();
     }
 
     /// Advance WakaTime tracking by `elapsed_secs` simulated seconds.
@@ -276,6 +279,17 @@ impl App {
     #[cfg(test)]
     fn save_stats(&mut self) {
         self.stats_error = None;
+    }
+
+    fn flush_stats_if_dirty(&mut self) {
+        if !self.stats_dirty {
+            return;
+        }
+
+        self.save_stats();
+        if self.stats_error.is_none() {
+            self.stats_dirty = false;
+        }
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) {
@@ -639,14 +653,14 @@ impl App {
         if session_minutes_before != session_minutes_after
             || today_minutes_before != today_minutes_after
         {
-            self.save_stats();
+            self.stats_dirty = true;
         }
     }
 
     fn record_completed_focus_session(&mut self) {
         let day_key = current_day_key();
         self.stats.record_completed_pomodoro(&day_key);
-        self.save_stats();
+        self.stats_dirty = true;
     }
 
     fn sync_wakatime_tracking_for_state(&mut self) {
@@ -655,7 +669,6 @@ impl App {
             self.wakatime.on_focus_start();
         } else if !focus_running && self.wakatime.is_tracking() {
             self.wakatime.on_focus_stop();
-            self.save_stats();
         }
     }
 
@@ -689,7 +702,7 @@ fn format_duration_label(seconds: u64) -> String {
 
 impl Drop for App {
     fn drop(&mut self) {
-        self.save_stats();
+        self.flush_stats_if_dirty();
         // Ensure hosts-file block entries are removed on every exit path,
         // including early returns caused by I/O errors in run_app.
         self.blocker.cleanup();

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,20 +236,28 @@ impl AppConfig {
 
     #[cfg_attr(test, allow(dead_code))]
     fn config_path() -> Option<PathBuf> {
-        let config_dir = config_dir()?;
-        Some(config_dir.join("focustime").join("config.toml"))
+        app_data_path("config.toml")
     }
 
     fn config_path_with_env(get_var: impl FnMut(&str) -> Option<OsString>) -> Option<PathBuf> {
-        let config_dir = config_dir_from_env(get_var)?;
-        Some(config_dir.join("focustime").join("config.toml"))
+        let app_dir = app_dir_with_env(get_var)?;
+        Some(app_dir.join("config.toml"))
     }
 }
 
-/// Returns the platform-appropriate configuration base directory.
 #[cfg_attr(test, allow(dead_code))]
-fn config_dir() -> Option<PathBuf> {
-    config_dir_from_env(|key| std::env::var_os(key))
+pub(crate) fn app_data_path(file_name: &str) -> Option<PathBuf> {
+    let app_dir = app_dir()?;
+    Some(app_dir.join(file_name))
+}
+
+fn app_dir() -> Option<PathBuf> {
+    app_dir_with_env(|key| std::env::var_os(key))
+}
+
+fn app_dir_with_env(get_var: impl FnMut(&str) -> Option<OsString>) -> Option<PathBuf> {
+    let config_dir = config_dir_from_env(get_var)?;
+    Some(config_dir.join("focustime"))
 }
 
 fn config_dir_from_env(mut get_var: impl FnMut(&str) -> Option<OsString>) -> Option<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,10 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
                 while tick_accumulator >= 1000 {
                     tick_accumulator -= 1000;
                     elapsed_secs += 1;
-                    app.on_tick();
+                }
+                let is_catchup = elapsed_secs > 1;
+                for _ in 0..elapsed_secs {
+                    app.on_tick(is_catchup);
                 }
                 // Advance WakaTime once per UI frame to avoid burst heartbeats
                 // after a suspend/resume catch-up.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod blocker;
 mod config;
+mod stats;
 mod timer;
 mod ui;
 mod wakatime;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,223 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(test, allow(dead_code))]
+const STATS_FILE_NAME: &str = "stats.toml";
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SessionStats {
+    pub pomodoros_completed: u32,
+    pub focused_seconds: u64,
+}
+
+impl SessionStats {
+    pub fn focused_minutes(self) -> u64 {
+        self.focused_seconds / 60
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct DailyStats {
+    #[serde(default)]
+    pub pomodoros_completed: u32,
+    #[serde(default)]
+    pub focused_seconds: u64,
+}
+
+impl DailyStats {
+    pub fn focused_minutes(self) -> u64 {
+        self.focused_seconds / 60
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+struct PersistedStats {
+    #[serde(default)]
+    daily: BTreeMap<String, DailyStats>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FocusStats {
+    session: SessionStats,
+    daily: BTreeMap<String, DailyStats>,
+}
+
+impl FocusStats {
+    #[cfg(not(test))]
+    pub fn load() -> Self {
+        Self::try_load().unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub fn load() -> Self {
+        Self::default()
+    }
+
+    #[cfg(not(test))]
+    fn try_load() -> Option<Self> {
+        let path = crate::config::app_data_path(STATS_FILE_NAME)?;
+        let content = fs::read_to_string(path).ok()?;
+        Self::try_from_toml(&content)
+    }
+
+    fn try_from_toml(content: &str) -> Option<Self> {
+        let persisted: PersistedStats = toml::from_str(content).ok()?;
+        Some(Self::from_persisted(persisted))
+    }
+
+    fn from_persisted(persisted: PersistedStats) -> Self {
+        Self {
+            session: SessionStats::default(),
+            daily: persisted.daily,
+        }
+    }
+
+    fn to_persisted(&self) -> PersistedStats {
+        PersistedStats {
+            daily: self.daily.clone(),
+        }
+    }
+
+    #[cfg_attr(test, allow(dead_code))]
+    pub fn save(&self) -> io::Result<()> {
+        let path = crate::config::app_data_path(STATS_FILE_NAME).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotFound, "cannot determine stats directory")
+        })?;
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let content = toml::to_string_pretty(&self.to_persisted())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        // Best-effort atomic write: temp file + rename.
+        // On Windows, rename cannot replace an existing file; fall back to
+        // remove+rename when destination already exists.
+        let tmp = path.with_extension("toml.tmp");
+        fs::write(&tmp, &content)?;
+        #[cfg(target_os = "windows")]
+        {
+            match fs::rename(&tmp, &path) {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                    fs::remove_file(&path)?;
+                    fs::rename(&tmp, &path)
+                }
+                Err(e) => Err(e),
+            }
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            fs::rename(&tmp, &path)
+        }
+    }
+
+    pub fn record_focus_elapsed(&mut self, day_key: &str, elapsed_secs: u64) {
+        if elapsed_secs == 0 {
+            return;
+        }
+
+        self.session.focused_seconds = self.session.focused_seconds.saturating_add(elapsed_secs);
+        let daily = self.daily.entry(day_key.to_string()).or_default();
+        daily.focused_seconds = daily.focused_seconds.saturating_add(elapsed_secs);
+    }
+
+    pub fn record_completed_pomodoro(&mut self, day_key: &str) {
+        self.session.pomodoros_completed = self.session.pomodoros_completed.saturating_add(1);
+        let daily = self.daily.entry(day_key.to_string()).or_default();
+        daily.pomodoros_completed = daily.pomodoros_completed.saturating_add(1);
+    }
+
+    pub fn session(&self) -> SessionStats {
+        self.session
+    }
+
+    pub fn daily_for(&self, day_key: &str) -> DailyStats {
+        self.daily.get(day_key).copied().unwrap_or_default()
+    }
+
+    pub fn recent_daily(&self, limit: usize) -> Vec<(String, DailyStats)> {
+        self.daily
+            .iter()
+            .rev()
+            .take(limit)
+            .map(|(day, stats)| (day.clone(), *stats))
+            .collect()
+    }
+}
+
+pub fn current_day_key() -> String {
+    chrono::Local::now()
+        .date_naive()
+        .format("%Y-%m-%d")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recording_updates_session_and_daily_totals() {
+        let mut stats = FocusStats::default();
+
+        stats.record_focus_elapsed("2026-04-09", 125);
+        stats.record_completed_pomodoro("2026-04-09");
+
+        let session = stats.session();
+        assert_eq!(session.pomodoros_completed, 1);
+        assert_eq!(session.focused_seconds, 125);
+        assert_eq!(session.focused_minutes(), 2);
+
+        let day = stats.daily_for("2026-04-09");
+        assert_eq!(day.pomodoros_completed, 1);
+        assert_eq!(day.focused_seconds, 125);
+        assert_eq!(day.focused_minutes(), 2);
+    }
+
+    #[test]
+    fn recent_daily_is_sorted_newest_first() {
+        let mut stats = FocusStats::default();
+        stats.record_focus_elapsed("2026-04-08", 60);
+        stats.record_focus_elapsed("2026-04-09", 120);
+
+        let recent = stats.recent_daily(2);
+        assert_eq!(recent[0].0, "2026-04-09");
+        assert_eq!(recent[1].0, "2026-04-08");
+    }
+
+    #[test]
+    fn persisted_stats_round_trip_preserves_daily_history() {
+        let mut original = FocusStats::default();
+        original.record_focus_elapsed("2026-04-09", 300);
+        original.record_completed_pomodoro("2026-04-09");
+
+        let persisted = original.to_persisted();
+        let toml_str = toml::to_string_pretty(&persisted).unwrap();
+        let restored = FocusStats::try_from_toml(&toml_str).unwrap();
+
+        // Session stats are intentionally runtime-only and reset on startup.
+        assert_eq!(restored.session(), SessionStats::default());
+        let day = restored.daily_for("2026-04-09");
+        assert_eq!(day.pomodoros_completed, 1);
+        assert_eq!(day.focused_seconds, 300);
+    }
+
+    #[test]
+    fn invalid_toml_falls_back_to_none_for_loader() {
+        assert!(FocusStats::try_from_toml("this is not valid toml").is_none());
+    }
+
+    #[test]
+    fn current_day_key_uses_iso_date_format() {
+        let key = current_day_key();
+        assert_eq!(key.len(), 10);
+        assert_eq!(&key[4..5], "-");
+        assert_eq!(&key[7..8], "-");
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -46,26 +46,31 @@ pub struct FocusStats {
 }
 
 impl FocusStats {
-    #[cfg(not(test))]
-    pub fn load() -> Self {
-        Self::try_load().unwrap_or_default()
-    }
-
     #[cfg(test)]
-    pub fn load() -> Self {
-        Self::default()
+    pub fn load() -> Result<Self, String> {
+        Ok(Self::default())
     }
 
     #[cfg(not(test))]
-    fn try_load() -> Option<Self> {
-        let path = crate::config::app_data_path(STATS_FILE_NAME)?;
-        let content = fs::read_to_string(path).ok()?;
-        Self::try_from_toml(&content)
+    pub fn load() -> Result<Self, String> {
+        Self::try_load()
     }
 
-    fn try_from_toml(content: &str) -> Option<Self> {
-        let persisted: PersistedStats = toml::from_str(content).ok()?;
-        Some(Self::from_persisted(persisted))
+    #[cfg(not(test))]
+    fn try_load() -> Result<Self, String> {
+        let path = crate::config::app_data_path(STATS_FILE_NAME)
+            .ok_or_else(|| "cannot determine stats directory".to_string())?;
+        match fs::read_to_string(path) {
+            Ok(content) => Self::try_from_toml(&content),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(format!("stats read failed: {e}")),
+        }
+    }
+
+    fn try_from_toml(content: &str) -> Result<Self, String> {
+        let persisted: PersistedStats =
+            toml::from_str(content).map_err(|e| format!("stats parse failed: {e}"))?;
+        Ok(Self::from_persisted(persisted))
     }
 
     fn from_persisted(persisted: PersistedStats) -> Self {
@@ -209,8 +214,8 @@ mod tests {
     }
 
     #[test]
-    fn invalid_toml_falls_back_to_none_for_loader() {
-        assert!(FocusStats::try_from_toml("this is not valid toml").is_none());
+    fn invalid_toml_returns_parse_error() {
+        assert!(FocusStats::try_from_toml("this is not valid toml").is_err());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,6 +15,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         AppMode::Timer => render_timer(frame, app),
         AppMode::SiteManager => render_site_manager(frame, app),
         AppMode::ProfileManager => render_profile_manager(frame, app),
+        AppMode::StatsHistory => render_stats_history(frame, app),
     }
 }
 
@@ -31,7 +32,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
         .style(Style::default().fg(phase_color(app.timer.phase)));
     frame.render_widget(block, outer);
 
-    // Inner layout: title | time | profile | progress | status | wakatime | spacer | hints
+    // Inner layout: title | time | profile | progress | status | stats | wakatime | spacer | hints
     let inner = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
@@ -41,6 +42,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
             Constraint::Length(1), // active profile
             Constraint::Length(3), // progress bar
             Constraint::Length(2), // status
+            Constraint::Length(1), // stats summary
             Constraint::Length(1), // wakatime status
             Constraint::Min(0),    // spacer
             Constraint::Length(2), // key hints
@@ -110,6 +112,31 @@ fn render_timer(frame: &mut Frame, app: &App) {
         .style(Style::default().fg(Color::Gray));
     frame.render_widget(status_widget, inner[4]);
 
+    // Session + today stats summary
+    let stats_line = if let Some(err) = app.stats_error.as_ref() {
+        (
+            format!("⚠ Stats persistence warning: {err}"),
+            Style::default().fg(Color::Yellow),
+        )
+    } else {
+        let session_stats = app.session_stats();
+        let today_stats = app.today_stats();
+        (
+            format!(
+                "Session: 🍅{} · {}m   Today: 🍅{} · {}m",
+                session_stats.pomodoros_completed,
+                session_stats.focused_minutes(),
+                today_stats.pomodoros_completed,
+                today_stats.focused_minutes()
+            ),
+            Style::default().fg(Color::DarkGray),
+        )
+    };
+    let stats_widget = Paragraph::new(stats_line.0)
+        .alignment(Alignment::Center)
+        .style(stats_line.1);
+    frame.render_widget(stats_widget, inner[5]);
+
     // WakaTime status
     let (waka_text, waka_color) = if app.wakatime.is_tracking() {
         ("⏱ WakaTime: tracking", Color::Green)
@@ -121,16 +148,16 @@ fn render_timer(frame: &mut Frame, app: &App) {
     let waka_widget = Paragraph::new(waka_text)
         .alignment(Alignment::Center)
         .style(Style::default().fg(waka_color));
-    frame.render_widget(waka_widget, inner[5]);
+    frame.render_widget(waka_widget, inner[6]);
 
     // Key hints
     let hints_widget = Paragraph::new(vec![
         Line::from("[Space] Start/Pause  [s] Stop  [n] Next"),
-        Line::from("[p] Profiles  [b] Block Sites  [q/Esc] Quit"),
+        Line::from("[h] History  [p] Profiles  [b] Block Sites  [q/Esc] Quit"),
     ])
     .alignment(Alignment::Center)
     .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(hints_widget, inner[7]);
+    frame.render_widget(hints_widget, inner[8]);
 }
 
 fn render_site_manager(frame: &mut Frame, app: &App) {
@@ -407,6 +434,94 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
         .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(hints_widget, inner[7]);
+}
+
+fn render_stats_history(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+    let outer = centered_rect(65, 80, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Daily Focus History ")
+        .title_alignment(Alignment::Center)
+        .style(Style::default().fg(Color::Cyan));
+    frame.render_widget(block, outer);
+
+    let inner = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints([
+            Constraint::Length(1), // session summary
+            Constraint::Length(1), // today summary
+            Constraint::Length(1), // spacer
+            Constraint::Min(3),    // history list
+            Constraint::Length(1), // error line
+            Constraint::Length(1), // hints
+        ])
+        .split(outer);
+
+    let session_stats = app.session_stats();
+    let today_stats = app.today_stats();
+    let session_summary = Paragraph::new(format!(
+        "This session: 🍅{} · {}m",
+        session_stats.pomodoros_completed,
+        session_stats.focused_minutes()
+    ))
+    .style(
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
+    );
+    frame.render_widget(session_summary, inner[0]);
+
+    let today_summary = Paragraph::new(format!(
+        "Today: 🍅{} · {}m",
+        today_stats.pomodoros_completed,
+        today_stats.focused_minutes()
+    ))
+    .style(Style::default().fg(Color::Gray));
+    frame.render_widget(today_summary, inner[1]);
+
+    let history_items: Vec<ListItem> = app
+        .recent_daily_stats(14)
+        .into_iter()
+        .map(|(day, stats)| {
+            ListItem::new(format!(
+                "  {day}   🍅{}   {}m",
+                stats.pomodoros_completed,
+                stats.focused_minutes()
+            ))
+        })
+        .collect();
+
+    if history_items.is_empty() {
+        let empty = Paragraph::new("  No completed focus history yet.")
+            .style(Style::default().fg(Color::DarkGray))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Recent Days "),
+            );
+        frame.render_widget(empty, inner[3]);
+    } else {
+        let list = List::new(history_items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Recent Days "),
+            )
+            .style(Style::default().fg(Color::Gray));
+        frame.render_widget(list, inner[3]);
+    }
+
+    if let Some(err) = app.stats_error.as_ref() {
+        render_centered_error(frame, inner[4], format!("⚠  {err}"));
+    }
+
+    let hints = Paragraph::new("[h/Esc] Back  [q/Ctrl-C] Quit")
+        .alignment(Alignment::Center)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(hints, inner[5]);
 }
 
 fn profile_for_index(index: usize) -> ProfileId {


### PR DESCRIPTION
## What

Add persistent focus statistics and an in-app history surface for Pomodoro usage.

- Introduces `src/stats.rs` to track session totals and persist per-day aggregates in `stats.toml`
- Integrates stats updates into timer lifecycle logic in `App` (count completed focus sessions and accumulate focused time)
- Adds a new `StatsHistory` mode (`h` key) plus timer-screen session/today summary
- Shares app data path logic for config/stats persistence and updates README/docs
- Adds targeted tests for stats persistence, counting rules, elapsed accumulation, and history-mode navigation

## Why

Issue #52 requests session stats and daily history so users can review completed pomodoros and focused minutes across runs with low runtime overhead. This change adds that capability while keeping updates lightweight and preserving existing timer/blocker/WakaTime behavior.

Closes #52.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable) — N/A (unchanged)
- [x] WakaTime integration behavior was verified for this change (if applicable) — N/A (unchanged)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (no new sensitive surfaces; no additional action needed)
- [x] Breaking behavior changes are clearly described in this PR — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session and daily stats for completed pomodoros and focused minutes.
  * Persistent stats saved between runs (periodic flush and on exit).
  * Daily history panel (up to 14 days) accessible from the timer with "h"; close with "h" or Esc.
  * Session/today stats summary shown on the timer, with a warning line if persistence fails.

* **Documentation**
  * Added docs for session stats, daily history, persistence, and keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->