### PR TITLE
Add phase-completion notifications with optional sound

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Architecture
 
-`focustime` is a single-binary Rust TUI application with six modules in `src/`:
-timer logic, app state/orchestration, site blocking, WakaTime tracking, UI rendering,
-and the main event loop.
+`focustime` is a single-binary Rust TUI application with seven modules in `src/`:
+timer logic, app state/orchestration, site blocking, WakaTime tracking, phase
+notifications, UI rendering, and the main event loop.
 
 ## Visual overview
 
@@ -13,6 +13,7 @@ flowchart LR
     T["timer.rs<br/>Pomodoro state machine"]
     B["blocker.rs<br/>hosts file blocking"]
     W["wakatime.rs<br/>heartbeat tracking"]
+    N["notifications.rs<br/>phase notifications"]
     U["ui.rs<br/>Ratatui rendering"]
     OS["OS / hosts file / DNS cache"]
     API["WakaTime API"]
@@ -22,9 +23,11 @@ flowchart LR
     A --> T
     A --> B
     A --> W
+    A --> N
     A -->|"state read by ui"| U
     B --> OS
     W --> API
+    N --> OS
 ```
 
 ## Module map
@@ -32,10 +35,11 @@ flowchart LR
 | Module | Responsibility | Main collaborators |
 | --- | --- | --- |
 | `main.rs` | Entry point, terminal setup/teardown, event loop cadence, key event polling | `app`, `ui`, `crossterm`, `ratatui` |
-| `app.rs` | Application state, mode switching, key handling, coordination between timer/blocker/WakaTime | `timer`, `blocker`, `wakatime` |
+| `app.rs` | Application state, mode switching, key handling, coordination between timer/blocker/WakaTime/notifications | `timer`, `blocker`, `wakatime`, `notifications` |
 | `timer.rs` | Pomodoro domain model and transitions (`Focus`, `ShortBreak`, `LongBreak`) | `app` |
 | `blocker.rs` | Hosts-file based site blocking/unblocking and DNS cache flush integration | `app`, OS commands/filesystem |
 | `wakatime.rs` | WakaTime config parsing and heartbeat scheduling/sending | `app`, HTTP (`ureq`) |
+| `notifications.rs` | Phase completion notifications and optional sound alerts | `app`, OS notification commands |
 | `ui.rs` | Ratatui rendering for Timer and Site Manager screens | `app`, `timer` |
 
 ## Related explanation
@@ -49,6 +53,7 @@ sequenceDiagram
     participant Timer as TimerState
     participant Blocker as SiteBlocker
     participant Waka as WakatimeTracker
+    participant Notify as PhaseNotifier
     participant UI as ui::render
 
     loop every frame
@@ -58,6 +63,7 @@ sequenceDiagram
         App->>Timer: tick()
         alt phase changed
             App->>Blocker: block()/unblock()
+            App->>Notify: notify_phase_completion()
         end
         Main->>App: on_wakatime_elapsed(elapsed_secs) (when >=1s)
         alt Focus + Running
@@ -77,7 +83,9 @@ sequenceDiagram
    tracking, and accumulated elapsed focus seconds (when at least 1s has passed)
    are fed to `WakatimeTracker::tick_elapsed(elapsed_secs)` to avoid heartbeat
    bursts after suspend/resume.
-6. Blocking policy is phase-aware: blocking is active only during focus sessions
+6. Phase notifications are dispatched asynchronously on natural phase completions
+   (not manual skips), with optional sound and platform-specific desktop delivery.
+7. Blocking policy is phase-aware: blocking is active only during focus sessions
    (running or paused), and removed for break/idle phases.
 
 ## Visibility rules
@@ -95,7 +103,8 @@ sequenceDiagram
 ## File conventions
 
 - One top-level module per file in `src/` (`app.rs`, `timer.rs`, `blocker.rs`,
-  `ui.rs`, `wakatime.rs`), with `main.rs` as the composition root.
+  `ui.rs`, `wakatime.rs`, `notifications.rs`), with `main.rs` as the composition
+  root.
 - Keep domain logic (`timer`, `blocker`, `wakatime`) separate from presentation
   (`ui`) and orchestration (`app`).
 - Place module tests in the same file using `#[cfg(test)] mod tests`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- No unreleased changes yet.
+- Phase completion notifications for natural `00:00` transitions between Focus and Break phases.
+- Optional sound alerts controlled by `[notifications] sound` in `config.toml`.
+- Cross-platform best-effort desktop notification dispatch (`msg` on Windows, `osascript` on macOS, `notify-send` on Linux) without blocking the TUI loop.
 
 ## [0.1.0] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Configurable Pomodoro profiles (#51):** includes built-in **Classic** and **Deep Work** presets plus an editable **Custom** profile with configurable focus/short-break/long-break durations and long-break cadence.
 - **Session stats and daily history (#52):** tracks focused time and completed Pomodoros for the active session and per-day aggregates, then surfaces them in the timer summary and history view.
 - **Project review and refactoring improvements (#61):** consolidated app orchestration and state transitions to improve reliability around timer flow, persistence, and error reporting.
-- **Phase notifications and optional sound (#53):** sends completion notices only on natural `00:00` phase transitions (not manual skip), dispatches desktop notifications asynchronously (`msg` on Windows, `osascript` on macOS, `notify-send` on Linux), and supports `notifications.enabled`/`notifications.sound` toggles from config and the TUI settings editor.
+- **Phase notifications and optional sound (#53):** sends completion notices only on natural `00:00` phase transitions (not manual skip), dispatches desktop notifications asynchronously (WinRT toast with `msg` fallback on Windows, `osascript` on macOS, `notify-send` on Linux), and supports `notifications.enabled`/`notifications.sound` toggles from config and the TUI settings editor.
 
 ## [0.1.0] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Phase completion notifications for natural `00:00` transitions between Focus and Break phases.
-- Optional sound alerts controlled by `[notifications] sound` in `config.toml`.
-- Cross-platform best-effort desktop notification dispatch (`msg` on Windows, `osascript` on macOS, `notify-send` on Linux) without blocking the TUI loop.
+- **Persistent settings and blocked sites (#50):** timer preferences, selected profile, notification settings, and blocked-site lists are now saved to `config.toml` and restored at startup with safe fallback defaults for missing/corrupt config.
+- **Configurable Pomodoro profiles (#51):** includes built-in **Classic** and **Deep Work** presets plus an editable **Custom** profile with configurable focus/short-break/long-break durations and long-break cadence.
+- **Session stats and daily history (#52):** tracks focused time and completed Pomodoros for the active session and per-day aggregates, then surfaces them in the timer summary and history view.
+- **Project review and refactoring improvements (#61):** consolidated app orchestration and state transitions to improve reliability around timer flow, persistence, and error reporting.
+- **Phase notifications and optional sound (#53):** sends completion notices only on natural `00:00` phase transitions (not manual skip), dispatches desktop notifications asynchronously (`msg` on Windows, `osascript` on macOS, `notify-send` on Linux), and supports `notifications.enabled`/`notifications.sound` toggles from config and the TUI settings editor.
 
 ## [0.1.0] - 2026-04-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "serde",
  "toml",
  "ureq",
+ "winrt-notification",
 ]
 
 [[package]]
@@ -563,6 +564,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1235,7 +1245,7 @@ dependencies = [
  "itertools",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -1287,7 +1297,7 @@ dependencies = [
  "itertools",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -1564,11 +1574,32 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
+dependencies = [
+ "strum_macros 0.22.0",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1577,7 +1608,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2156,6 +2187,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f39345ae0c8ab072c0ac7fe8a8b411636aa34f89be19ddd0d9226544f13944"
+dependencies = [
+ "windows_i686_gnu 0.24.0",
+ "windows_i686_msvc 0.24.0",
+ "windows_x86_64_gnu 0.24.0",
+ "windows_x86_64_msvc 0.24.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,12 +2283,12 @@ checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2262,6 +2305,12 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0866510a3eca9aed73a077490bbbf03e5eaac4e1fd70849d89539e5830501fd"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
@@ -2274,9 +2323,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0ffed56b7e9369a29078d2ab3aaeceea48eb58999d2cff3aa2494a275b95c6"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384a173630588044205a2993b6864a2f56e5a8c1e7668c07b93ec18cf4888dc4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2292,6 +2353,12 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd8f062d8ca5446358159d79a90be12c543b3a965c847c8f3eedf14b321d399"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -2301,6 +2368,17 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
+name = "winrt-notification"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007a0353840b23e0c6dc73e5b962ff58ed7f6bc9ceff3ce7fe6fbad8d496edf4"
+dependencies = [
+ "strum 0.22.0",
+ "windows",
+ "xml-rs",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2318,7 +2396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -2329,7 +2407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
@@ -2395,6 +2473,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "1", features = ["derive"] }
 toml = "1.1"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winrt-notification = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Open profile manager from timer view with **`p`**.
 
 - `↑/↓`: move between profiles
 - `Enter`: apply selected profile
-- `e`: edit the Custom profile (when Custom is highlighted)
-- In custom editor: `↑/↓` selects field, `←/→` adjusts value, `Enter` saves
+- `e`: open profile/settings editor
+- In editor: `↑/↓` selects field, `←/→` adjusts value, `Enter` saves
 
 Profile selection and custom values are persisted in `config.toml`.
 
@@ -103,6 +103,13 @@ Notifications are delivered best-effort:
 - terminal notice in the timer view
 - desktop notification via platform-specific command (`msg` on Windows, `osascript` on macOS, `notify-send` on Linux)
 - optional sound alert when `notifications.sound = true`
+
+You can also configure `notifications.enabled` and `notifications.sound` directly from the TUI:
+
+- open profile manager with `p`
+- press `e` to open the editor
+- use `↑/↓` to select **Phase notifications** or **Sound alert**
+- use `←/→` to set `Off`/`On`, then `Enter` to save
 
 ## Session stats and daily history
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Manual skip (`n`) changes phase immediately but does not emit a completion notif
 Notifications are delivered best-effort:
 
 - terminal notice in the timer view
-- desktop notification via platform-specific delivery (WinRT toast on Windows with `msg` fallback, `osascript` on macOS, `notify-send` on Linux)
-- optional sound alert when `notifications.sound = true` (`[console]::Beep()` on Windows, `afplay` on macOS, `paplay`/`aplay` on Linux, BEL fallback when unavailable)
+- desktop notification via platform-specific delivery (WinRT toast on Windows with a `msg` fallback, `osascript` on macOS, `notify-send` on Linux)
+- optional sound alert using platform audio capabilities when `notifications.sound = true`
 
 You can also configure `notifications.enabled` and `notifications.sound` directly from the TUI:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,26 @@ focus_secs = 1800
 short_break_secs = 360
 long_break_secs = 900
 long_break_interval = 3
+
+[notifications]
+enabled = true
+sound = false
 ```
+
+## Phase notifications
+
+`focustime` emits a phase notification when a phase naturally completes at `00:00`:
+
+- **Focus complete** → next break starts
+- **Break complete** → focus starts
+
+Manual skip (`n`) changes phase immediately but does not emit a completion notification.
+
+Notifications are delivered best-effort:
+
+- terminal notice in the timer view
+- desktop notification via platform-specific command (`msg` on Windows, `osascript` on macOS, `notify-send` on Linux)
+- optional sound alert when `notifications.sound = true`
 
 ## Session stats and daily history
 
@@ -100,13 +119,14 @@ From timer view:
 
 ## The way the system works
 
-`focustime` is a single-binary Rust TUI app composed of six modules in `src/`:
+`focustime` is a single-binary Rust TUI app composed of seven modules in `src/`:
 
 - `src/main.rs`: terminal lifecycle and event loop.
 - `src/app.rs`: application state and orchestration.
 - `src/timer.rs`: Pomodoro timer state machine.
 - `src/blocker.rs`: hosts-file site blocking and unblocking.
 - `src/wakatime.rs`: heartbeat tracking integration.
+- `src/notifications.rs`: phase transition notifications and optional sound.
 - `src/ui.rs`: Ratatui rendering for timer and site manager views.
 
 WakaTime tracking is optional and activates only when an API key is configured
@@ -117,8 +137,9 @@ Runtime flow (high-level):
 1. The main loop renders UI and reads keyboard input.
 2. `App` handles key events (`start/pause`, `stop`, `next`, site manager actions).
 3. Timer ticks advance every elapsed second while running.
-4. Blocking is applied during focus phases and removed outside focus.
-5. WakaTime tracking stays in sync with focus-running state.
+4. Phase-completion notifications are dispatched asynchronously.
+5. Blocking is applied during focus phases and removed outside focus.
+6. WakaTime tracking stays in sync with focus-running state.
 
 For full module map and design details, see [ARCHITECTURE.md](ARCHITECTURE.md).
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Manual skip (`n`) changes phase immediately but does not emit a completion notif
 Notifications are delivered best-effort:
 
 - terminal notice in the timer view
-- desktop notification via platform-specific command (`msg` on Windows, `osascript` on macOS, `notify-send` on Linux)
-- optional sound alert when `notifications.sound = true`
+- desktop notification via platform-specific delivery (WinRT toast on Windows with `msg` fallback, `osascript` on macOS, `notify-send` on Linux)
+- optional sound alert when `notifications.sound = true` (`[console]::Beep()` on Windows, `afplay` on macOS, `paplay`/`aplay` on Linux, BEL fallback when unavailable)
 
 You can also configure `notifications.enabled` and `notifications.sound` directly from the TUI:
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,8 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::blocker::SiteBlocker;
-use crate::config::{AppConfig, CustomProfileConfig, ProfileId};
+use crate::config::{AppConfig, CustomProfileConfig, NotificationConfig, ProfileId};
+use crate::notifications::PhaseNotifier;
 use crate::stats::{DailyStats, FocusStats, SessionStats, current_day_key};
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
@@ -96,6 +97,7 @@ pub struct App {
     pub config_error: Option<String>,
     /// Last error from persisting focus stats.
     pub stats_error: Option<String>,
+    pub phase_notification: Option<String>,
     pub wakatime: WakatimeTracker,
     pub selected_profile: ProfileId,
     pub custom_profile: CustomProfileConfig,
@@ -103,6 +105,8 @@ pub struct App {
     pub profile_edit_active: bool,
     pub profile_edit_field: usize,
     pub profile_edit_snapshot: Option<CustomProfileConfig>,
+    notification_settings: NotificationConfig,
+    notifier: PhaseNotifier,
     stats: FocusStats,
     stats_dirty: bool,
     stats_has_unsaved_elapsed: bool,
@@ -116,6 +120,7 @@ impl App {
     fn from_config(config: AppConfig) -> Self {
         let selected_profile = config.selected_profile;
         let custom_profile = config.effective_custom_profile();
+        let notification_settings = config.notifications;
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
         let (stats, stats_error) = match FocusStats::load() {
             Ok(stats) => (stats, None),
@@ -142,6 +147,7 @@ impl App {
             block_error: None,
             config_error: None,
             stats_error,
+            phase_notification: None,
             wakatime: WakatimeTracker::new(),
             selected_profile,
             custom_profile,
@@ -149,6 +155,8 @@ impl App {
             profile_edit_active: false,
             profile_edit_field: 0,
             profile_edit_snapshot: None,
+            notification_settings,
+            notifier: PhaseNotifier::new(notification_settings),
             stats,
             stats_dirty: false,
             stats_has_unsaved_elapsed: false,
@@ -158,6 +166,7 @@ impl App {
     pub fn on_tick(&mut self, is_catchup: bool) {
         let was_focus_running = self.focus_running_for_current_state();
         let was_focus_phase = self.timer.phase == TimerPhase::Focus;
+        let completed_phase = self.timer.phase;
         if was_focus_running && !is_catchup {
             self.record_focus_elapsed(1);
         }
@@ -168,6 +177,11 @@ impl App {
             self.record_completed_focus_session();
         }
         if phase_changed {
+            if !is_catchup {
+                self.phase_notification = self
+                    .notifier
+                    .notify_phase_completion(completed_phase, self.timer.phase);
+            }
             self.apply_blocking_for_phase();
         }
         self.flush_stats_if_dirty(false);
@@ -248,6 +262,7 @@ impl App {
             blocked_sites: self.blocker.sites.clone(),
             selected_profile: self.selected_profile,
             custom_profile: Some(custom_profile),
+            notifications: self.notification_settings,
         }
     }
 
@@ -746,6 +761,7 @@ mod tests {
                 long_break_secs: 16 * 60,
                 long_break_interval: 2,
             }),
+            notifications: NotificationConfig::default(),
         };
         let app = App::from_config(config);
         assert_eq!(app.selected_profile, ProfileId::Classic);
@@ -887,6 +903,7 @@ mod tests {
         assert_eq!(persisted.long_break_secs, custom.long_break_secs);
         assert_eq!(persisted.long_break_interval, custom.long_break_interval);
         assert_eq!(persisted.custom_profile, Some(custom));
+        assert_eq!(persisted.notifications, NotificationConfig::default());
     }
 
     #[test]
@@ -985,6 +1002,10 @@ mod tests {
 
         assert_eq!(app.session_stats().pomodoros_completed, 1);
         assert_eq!(app.today_stats().pomodoros_completed, 1);
+        assert_eq!(
+            app.phase_notification.as_deref(),
+            Some("Focus complete. Next up: Short Break.")
+        );
     }
 
     #[test]
@@ -995,6 +1016,7 @@ mod tests {
         app.handle_key(key(KeyCode::Char('n')));
 
         assert_eq!(app.session_stats().pomodoros_completed, 0);
+        assert!(app.phase_notification.is_none());
     }
 
     #[test]
@@ -1035,6 +1057,7 @@ mod tests {
         assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
         assert_eq!(app.session_stats().pomodoros_completed, 0);
         assert_eq!(app.session_stats().focused_seconds, 0);
+        assert!(app.phase_notification.is_none());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,8 +12,14 @@ use crate::wakatime::WakatimeTracker;
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
-pub const CUSTOM_PROFILE_FIELD_LABELS: [&str; 4] =
-    ["Focus", "Short Break", "Long Break", "Long-break cadence"];
+pub const PROFILE_EDIT_FIELD_LABELS: [&str; 6] = [
+    "Focus",
+    "Short Break",
+    "Long Break",
+    "Long-break cadence",
+    "Phase notifications",
+    "Sound alert",
+];
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,6 +86,12 @@ fn profile_for_index(index: usize) -> ProfileId {
         .unwrap_or(PROFILE_IDS[PROFILE_IDS.len() - 1])
 }
 
+#[derive(Debug, Clone)]
+struct ProfileEditSnapshot {
+    custom_profile: CustomProfileConfig,
+    notification_settings: NotificationConfig,
+}
+
 pub struct App {
     pub timer: TimerState,
     pub should_quit: bool,
@@ -104,7 +116,7 @@ pub struct App {
     pub profile_selection_index: usize,
     pub profile_edit_active: bool,
     pub profile_edit_field: usize,
-    pub profile_edit_snapshot: Option<CustomProfileConfig>,
+    profile_edit_snapshot: Option<ProfileEditSnapshot>,
     notification_settings: NotificationConfig,
     notifier: PhaseNotifier,
     stats: FocusStats,
@@ -235,7 +247,7 @@ impl App {
         self.stats.recent_daily(limit)
     }
 
-    pub fn custom_profile_field_value(&self, field_index: usize) -> String {
+    pub fn profile_edit_field_value(&self, field_index: usize) -> String {
         match field_index {
             0 => format_duration_label(self.custom_profile.focus_secs),
             1 => format_duration_label(self.custom_profile.short_break_secs),
@@ -244,6 +256,8 @@ impl App {
                 "every {} focus sessions",
                 self.custom_profile.long_break_interval
             ),
+            4 => bool_label(self.notification_settings.enabled).to_string(),
+            5 => bool_label(self.notification_settings.sound).to_string(),
             _ => String::new(),
         }
     }
@@ -381,13 +395,13 @@ impl App {
                 }
                 KeyCode::Down | KeyCode::Char('j') => {
                     self.profile_edit_field = (self.profile_edit_field + 1)
-                        .min(CUSTOM_PROFILE_FIELD_LABELS.len().saturating_sub(1));
+                        .min(PROFILE_EDIT_FIELD_LABELS.len().saturating_sub(1));
                 }
                 KeyCode::Left | KeyCode::Char('h') => {
-                    self.adjust_custom_profile_field(false);
+                    self.adjust_profile_edit_field(false);
                 }
                 KeyCode::Right | KeyCode::Char('l') => {
-                    self.adjust_custom_profile_field(true);
+                    self.adjust_profile_edit_field(true);
                 }
                 KeyCode::Enter => {
                     self.commit_profile_edit();
@@ -418,23 +432,26 @@ impl App {
                 self.exit_profile_manager();
             }
             KeyCode::Char('e') => {
-                if profile_for_index(self.profile_selection_index) == ProfileId::Custom {
-                    self.begin_profile_edit();
-                }
+                self.begin_profile_edit();
             }
             _ => {}
         }
     }
 
     fn begin_profile_edit(&mut self) {
-        self.profile_edit_snapshot = Some(self.custom_profile.clone());
+        self.profile_edit_snapshot = Some(ProfileEditSnapshot {
+            custom_profile: self.custom_profile.clone(),
+            notification_settings: self.notification_settings,
+        });
         self.profile_edit_active = true;
         self.profile_edit_field = 0;
     }
 
     fn cancel_profile_edit(&mut self) {
         if let Some(snapshot) = self.profile_edit_snapshot.take() {
-            self.custom_profile = snapshot;
+            self.custom_profile = snapshot.custom_profile;
+            self.notification_settings = snapshot.notification_settings;
+            self.rebuild_notifier();
         }
         self.profile_edit_active = false;
         self.profile_edit_field = 0;
@@ -445,6 +462,7 @@ impl App {
         self.profile_edit_field = 0;
         self.profile_edit_snapshot = None;
         self.custom_profile = self.custom_profile.normalized();
+        self.rebuild_notifier();
         if self.selected_profile == ProfileId::Custom {
             self.apply_profile(ProfileId::Custom);
         } else {
@@ -452,7 +470,7 @@ impl App {
         }
     }
 
-    fn adjust_custom_profile_field(&mut self, increase: bool) {
+    fn adjust_profile_edit_field(&mut self, increase: bool) {
         match self.profile_edit_field {
             0 => adjust_duration_minutes(&mut self.custom_profile.focus_secs, increase),
             1 => adjust_duration_minutes(&mut self.custom_profile.short_break_secs, increase),
@@ -468,6 +486,12 @@ impl App {
                         .saturating_sub(1)
                         .max(1);
                 }
+            }
+            4 => {
+                self.notification_settings.enabled = increase;
+            }
+            5 => {
+                self.notification_settings.sound = increase;
             }
             _ => {}
         }
@@ -697,6 +721,10 @@ impl App {
             Err(e) => self.block_error = Some(e.to_string()),
         }
     }
+
+    fn rebuild_notifier(&mut self) {
+        self.notifier = PhaseNotifier::new(self.notification_settings);
+    }
 }
 
 fn adjust_duration_minutes(value: &mut u64, increase: bool) {
@@ -717,6 +745,10 @@ fn format_duration_label(seconds: u64) -> String {
     } else {
         format!("{minutes}:{remaining_seconds:02}")
     }
+}
+
+fn bool_label(value: bool) -> &'static str {
+    if value { "On" } else { "Off" }
 }
 
 impl Drop for App {
@@ -926,7 +958,7 @@ mod tests {
     }
 
     #[test]
-    fn custom_profile_field_value_displays_second_precision() {
+    fn profile_edit_field_value_displays_second_precision() {
         let config = AppConfig {
             selected_profile: ProfileId::Custom,
             custom_profile: Some(CustomProfileConfig {
@@ -938,9 +970,83 @@ mod tests {
             ..AppConfig::default()
         };
         let app = App::from_config(config);
-        assert_eq!(app.custom_profile_field_value(0), "10:07");
-        assert_eq!(app.custom_profile_field_value(1), "2m");
-        assert_eq!(app.custom_profile_field_value(2), "8:09");
+        assert_eq!(app.profile_edit_field_value(0), "10:07");
+        assert_eq!(app.profile_edit_field_value(1), "2m");
+        assert_eq!(app.profile_edit_field_value(2), "8:09");
+        assert_eq!(app.profile_edit_field_value(4), "On");
+        assert_eq!(app.profile_edit_field_value(5), "Off");
+    }
+
+    #[test]
+    fn profile_manager_edit_mode_available_for_non_custom_profile() {
+        let config = AppConfig {
+            selected_profile: ProfileId::Classic,
+            notifications: NotificationConfig {
+                enabled: false,
+                sound: false,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+
+        assert!(app.profile_edit_active);
+    }
+
+    #[test]
+    fn editing_notification_fields_updates_and_persists_settings() {
+        let config = AppConfig {
+            selected_profile: ProfileId::DeepWork,
+            notifications: NotificationConfig {
+                enabled: false,
+                sound: false,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        for _ in 0..4 {
+            app.handle_key(key(KeyCode::Down));
+        }
+        app.handle_key(key(KeyCode::Right)); // notifications -> On
+        app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Right)); // sound -> On
+        app.handle_key(key(KeyCode::Enter));
+
+        let persisted = app.persisted_config();
+        assert!(persisted.notifications.enabled);
+        assert!(persisted.notifications.sound);
+    }
+
+    #[test]
+    fn cancelling_profile_edit_restores_notification_settings() {
+        let config = AppConfig {
+            selected_profile: ProfileId::Classic,
+            notifications: NotificationConfig {
+                enabled: true,
+                sound: true,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        for _ in 0..4 {
+            app.handle_key(key(KeyCode::Down));
+        }
+        app.handle_key(key(KeyCode::Left)); // notifications -> Off
+        app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Left)); // sound -> Off
+        app.handle_key(key(KeyCode::Esc)); // cancel
+
+        assert!(!app.profile_edit_active);
+        assert!(app.notification_settings.enabled);
+        assert!(app.notification_settings.sound);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,30 @@ pub struct AppConfig {
     /// When this is absent, the app derives it from the legacy duration fields.
     #[serde(default)]
     pub custom_profile: Option<CustomProfileConfig>,
+    /// Notification preferences for phase transitions.
+    #[serde(default)]
+    pub notifications: NotificationConfig,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotificationConfig {
+    #[serde(default = "default_notification_enabled")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub sound: bool,
+}
+
+impl Default for NotificationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_notification_enabled(),
+            sound: false,
+        }
+    }
+}
+
+fn default_notification_enabled() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
@@ -142,6 +166,7 @@ impl Default for AppConfig {
             blocked_sites: Vec::new(),
             selected_profile: ProfileId::default(),
             custom_profile: None,
+            notifications: NotificationConfig::default(),
         }
     }
 }
@@ -316,6 +341,7 @@ mod tests {
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
         assert!(cfg.blocked_sites.is_empty());
+        assert_eq!(cfg.notifications, NotificationConfig::default());
     }
 
     #[test]
@@ -333,6 +359,10 @@ mod tests {
                 long_break_secs: 12 * 60,
                 long_break_interval: 5,
             }),
+            notifications: NotificationConfig {
+                enabled: true,
+                sound: true,
+            },
         };
         let toml_str = toml::to_string_pretty(&original).unwrap();
         let parsed: AppConfig = toml::from_str(&toml_str).unwrap();
@@ -343,6 +373,7 @@ mod tests {
         assert_eq!(parsed.blocked_sites, original.blocked_sites);
         assert_eq!(parsed.selected_profile, original.selected_profile);
         assert_eq!(parsed.custom_profile, original.custom_profile);
+        assert_eq!(parsed.notifications, original.notifications);
     }
 
     #[test]
@@ -356,6 +387,7 @@ mod tests {
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
         assert!(cfg.blocked_sites.is_empty());
+        assert_eq!(cfg.notifications, NotificationConfig::default());
     }
 
     #[test]
@@ -408,6 +440,7 @@ long_break_interval = 3
                 long_break_secs: 16 * 60,
                 long_break_interval: 2,
             }),
+            notifications: NotificationConfig::default(),
         };
         let custom = cfg.effective_custom_profile();
         assert_eq!(custom.focus_secs, 40 * 60);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod blocker;
 mod config;
+mod notifications;
 mod stats;
 mod timer;
 mod ui;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -2,6 +2,8 @@
 use std::io::Write;
 #[cfg(not(test))]
 use std::process::Command;
+#[cfg(not(test))]
+use std::process::ExitStatus;
 use std::thread;
 
 use crate::config::NotificationConfig;
@@ -52,9 +54,19 @@ fn transition_message(completed_phase: TimerPhase, next_phase: TimerPhase) -> St
 fn send_desktop_notification(title: &str, body: &str) {
     #[cfg(target_os = "windows")]
     {
-        let _ = Command::new("msg")
-            .args(["*", &format!("{title}: {body}")])
-            .status();
+        use winrt_notification::{Duration, Toast};
+
+        let toast_result = Toast::new(Toast::POWERSHELL_APP_ID)
+            .title(title)
+            .text1(body)
+            .duration(Duration::Short)
+            .sound(None)
+            .show();
+        if toast_result.is_err() {
+            let _ = Command::new("msg")
+                .args(["*", &format!("{title}: {body}")])
+                .status();
+        }
     }
 
     #[cfg(target_os = "macos")]
@@ -84,6 +96,52 @@ fn escape_applescript_literal(value: &str) -> String {
 
 #[cfg(not(test))]
 fn play_sound_alert() {
+    #[cfg(target_os = "windows")]
+    {
+        if command_succeeded(
+            Command::new("powershell")
+                .args([
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    "[console]::Beep(880,180)",
+                ])
+                .status(),
+        ) {
+            return;
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if command_succeeded(
+            Command::new("afplay")
+                .arg("/System/Library/Sounds/Glass.aiff")
+                .status(),
+        ) {
+            return;
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if command_succeeded(
+            Command::new("paplay")
+                .arg("/usr/share/sounds/freedesktop/stereo/complete.oga")
+                .status(),
+        ) {
+            return;
+        }
+        if command_succeeded(
+            Command::new("aplay")
+                .args(["-q", "/usr/share/sounds/alsa/Front_Center.wav"])
+                .status(),
+        ) {
+            return;
+        }
+    }
+
+    // Last-resort fallback: many terminals ignore BEL, so this may be silent.
     let mut stderr = std::io::stderr();
     let _ = stderr.write_all(b"\x07");
     let _ = stderr.flush();
@@ -91,6 +149,11 @@ fn play_sound_alert() {
 
 #[cfg(test)]
 fn play_sound_alert() {}
+
+#[cfg(not(test))]
+fn command_succeeded(result: std::io::Result<ExitStatus>) -> bool {
+    matches!(result, Ok(status) if status.success())
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,0 +1,118 @@
+#[cfg(not(test))]
+use std::io::Write;
+#[cfg(not(test))]
+use std::process::Command;
+use std::thread;
+
+use crate::config::NotificationConfig;
+use crate::timer::TimerPhase;
+
+const NOTIFICATION_TITLE: &str = "focustime";
+
+pub struct PhaseNotifier {
+    settings: NotificationConfig,
+}
+
+impl PhaseNotifier {
+    pub fn new(settings: NotificationConfig) -> Self {
+        Self { settings }
+    }
+
+    pub fn notify_phase_completion(
+        &self,
+        completed_phase: TimerPhase,
+        next_phase: TimerPhase,
+    ) -> Option<String> {
+        if !self.settings.enabled {
+            return None;
+        }
+
+        let message = transition_message(completed_phase, next_phase);
+        let body = message.clone();
+        let settings = self.settings;
+        thread::spawn(move || {
+            send_desktop_notification(NOTIFICATION_TITLE, &body);
+            if settings.sound {
+                play_sound_alert();
+            }
+        });
+        Some(message)
+    }
+}
+
+fn transition_message(completed_phase: TimerPhase, next_phase: TimerPhase) -> String {
+    format!(
+        "{} complete. Next up: {}.",
+        completed_phase.label(),
+        next_phase.label()
+    )
+}
+
+#[cfg(not(test))]
+fn send_desktop_notification(title: &str, body: &str) {
+    #[cfg(target_os = "windows")]
+    {
+        let _ = Command::new("msg")
+            .args(["*", &format!("{title}: {body}")])
+            .status();
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let escaped_title = escape_applescript_literal(title);
+        let escaped_body = escape_applescript_literal(body);
+        let script = format!(
+            "display notification \"{}\" with title \"{}\"",
+            escaped_body, escaped_title
+        );
+        let _ = Command::new("osascript").args(["-e", &script]).status();
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let _ = Command::new("notify-send").args([title, body]).status();
+    }
+}
+
+#[cfg(test)]
+fn send_desktop_notification(_title: &str, _body: &str) {}
+
+#[cfg(target_os = "macos")]
+fn escape_applescript_literal(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(not(test))]
+fn play_sound_alert() {
+    let mut stderr = std::io::stderr();
+    let _ = stderr.write_all(b"\x07");
+    let _ = stderr.flush();
+}
+
+#[cfg(test)]
+fn play_sound_alert() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notifier_returns_none_when_disabled() {
+        let notifier = PhaseNotifier::new(NotificationConfig {
+            enabled: false,
+            sound: true,
+        });
+        let message = notifier.notify_phase_completion(TimerPhase::Focus, TimerPhase::ShortBreak);
+        assert!(message.is_none());
+    }
+
+    #[test]
+    fn notifier_builds_transition_message() {
+        let notifier = PhaseNotifier::new(NotificationConfig::default());
+        let message = notifier.notify_phase_completion(TimerPhase::LongBreak, TimerPhase::Focus);
+        assert_eq!(
+            message.as_deref(),
+            Some("Long Break complete. Next up: Focus.")
+        );
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -32,7 +32,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
         .style(Style::default().fg(phase_color(app.timer.phase)));
     frame.render_widget(block, outer);
 
-    // Inner layout: title | time | profile | progress | status | stats | wakatime | spacer | hints
+    // Inner layout: title | time | profile | progress | status | phase notice | stats | wakatime | spacer | hints
     let inner = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
@@ -42,6 +42,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
             Constraint::Length(1), // active profile
             Constraint::Length(3), // progress bar
             Constraint::Length(2), // status
+            Constraint::Length(1), // latest phase notification
             Constraint::Length(1), // stats summary
             Constraint::Length(1), // wakatime status
             Constraint::Min(0),    // spacer
@@ -112,6 +113,21 @@ fn render_timer(frame: &mut Frame, app: &App) {
         .style(Style::default().fg(Color::Gray));
     frame.render_widget(status_widget, inner[4]);
 
+    // Phase transition notification
+    let (phase_notification_text, phase_notification_style) =
+        if let Some(message) = app.phase_notification.as_ref() {
+            (format!("🔔 {message}"), Style::default().fg(Color::Yellow))
+        } else {
+            (
+                "🔔 Waiting for next completed phase".to_string(),
+                Style::default().fg(Color::DarkGray),
+            )
+        };
+    let phase_notification_widget = Paragraph::new(phase_notification_text)
+        .alignment(Alignment::Center)
+        .style(phase_notification_style);
+    frame.render_widget(phase_notification_widget, inner[5]);
+
     // Session + today stats summary
     let stats_line = if let Some(err) = app.stats_error.as_ref() {
         (
@@ -135,7 +151,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
     let stats_widget = Paragraph::new(stats_line.0)
         .alignment(Alignment::Center)
         .style(stats_line.1);
-    frame.render_widget(stats_widget, inner[5]);
+    frame.render_widget(stats_widget, inner[6]);
 
     // WakaTime status
     let (waka_text, waka_color) = if app.wakatime.is_tracking() {
@@ -148,7 +164,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
     let waka_widget = Paragraph::new(waka_text)
         .alignment(Alignment::Center)
         .style(Style::default().fg(waka_color));
-    frame.render_widget(waka_widget, inner[6]);
+    frame.render_widget(waka_widget, inner[7]);
 
     // Key hints
     let hints_widget = Paragraph::new(vec![
@@ -157,7 +173,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
     ])
     .alignment(Alignment::Center)
     .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(hints_widget, inner[8]);
+    frame.render_widget(hints_widget, inner[9]);
 }
 
 fn render_site_manager(frame: &mut Frame, app: &App) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,8 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph},
 };
 
-use crate::app::{App, AppMode, CUSTOM_PROFILE_FIELD_LABELS, PROFILE_IDS};
-use crate::config::ProfileId;
+use crate::app::{App, AppMode, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS};
 use crate::timer::{TimerPhase, TimerStatus};
 
 pub fn render(frame: &mut Frame, app: &App) {
@@ -352,7 +351,7 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
             Constraint::Length(1), // spacer
             Constraint::Length(7), // profile list
             Constraint::Length(1), // spacer
-            Constraint::Length(7), // custom editor
+            Constraint::Length(9), // custom + notification editor
             Constraint::Min(0),    // spacer
             Constraint::Length(1), // error line
             Constraint::Length(2), // key hints
@@ -394,9 +393,9 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
     frame.render_stateful_widget(list, inner[2], &mut list_state);
 
     let editor_title = if app.profile_edit_active {
-        " Custom profile editor "
+        " Custom + notification settings editor "
     } else {
-        " Custom profile (select Custom + [e] to edit) "
+        " Custom + notification settings ([e] to edit) "
     };
     let editor_block = Block::default()
         .borders(Borders::ALL)
@@ -407,9 +406,9 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
             Style::default().fg(Color::DarkGray)
         });
 
-    let mut lines = Vec::with_capacity(CUSTOM_PROFILE_FIELD_LABELS.len());
-    for (index, label) in CUSTOM_PROFILE_FIELD_LABELS.iter().enumerate() {
-        let value = app.custom_profile_field_value(index);
+    let mut lines = Vec::with_capacity(PROFILE_EDIT_FIELD_LABELS.len());
+    for (index, label) in PROFILE_EDIT_FIELD_LABELS.iter().enumerate() {
+        let value = app.profile_edit_field_value(index);
         let mut line = Line::from(format!("{label:<18} {value}"));
         if app.profile_edit_active && index == app.profile_edit_field {
             line = Line::from(vec![
@@ -435,14 +434,9 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
             Line::from("[↑/↓] Field  [←/→] Adjust"),
             Line::from("[Enter] Save  [Esc] Cancel  [q/Ctrl-C] Quit"),
         ]
-    } else if profile_for_index(app.profile_selection_index) == ProfileId::Custom {
-        vec![
-            Line::from("[↑/↓] Select  [Enter] Apply  [e] Edit Custom"),
-            Line::from("[p/Esc] Back  [q] Quit"),
-        ]
     } else {
         vec![
-            Line::from("[↑/↓] Select  [Enter] Apply"),
+            Line::from("[↑/↓] Select  [Enter] Apply  [e] Edit Settings"),
             Line::from("[p/Esc] Back  [q] Quit"),
         ]
     };
@@ -538,10 +532,6 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(hints, inner[5]);
-}
-
-fn profile_for_index(index: usize) -> ProfileId {
-    PROFILE_IDS.get(index).copied().unwrap_or(ProfileId::Custom)
 }
 
 fn phase_color(phase: TimerPhase) -> Color {


### PR DESCRIPTION
## What

Add non-blocking phase-completion notifications with optional sound alerts, plus config/UI/docs support for the new behavior.

## Why

Focus and break transitions previously happened silently, which made it easy to miss phase boundaries while coding. This change implements issue #53 by surfacing natural phase completions across terminal and desktop notification channels without blocking the TUI loop.

Closes #53.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase completion notifications on natural transitions with optional sound and cross-platform delivery
  * Notification toggles (enabled, sound) and profile-editable settings
  * Profile editor available for all profiles; Classic, Deep Work, and editable Custom presets
  * Session tracking with per-day focused time and completed Pomodoros; config persistence

* **Documentation**
  * Updated guides and help text covering notifications, profile manager, and config options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->