### PR TITLE
Replace winrt-notification with winrt-toast-reborn

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,17 @@ jobs:
       - name: Run cargo test
         run: cargo test --all
 
+  windows_build:
+    name: 🪟 Windows Build
+    runs-on: windows-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo build
+        run: cargo build --all-targets
+
   security_audit:
     name: 👮 Audit
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Configurable Pomodoro profiles (#51):** includes built-in **Classic** and **Deep Work** presets plus an editable **Custom** profile with configurable focus/short-break/long-break durations and long-break cadence.
 - **Session stats and daily history (#52):** tracks focused time and completed Pomodoros for the active session and per-day aggregates, then surfaces them in the timer summary and history view.
 - **Project review and refactoring improvements (#61):** consolidated app orchestration and state transitions to improve reliability around timer flow, persistence, and error reporting.
-- **Phase notifications and optional sound (#53):** sends completion notices only on natural `00:00` phase transitions (not manual skip), dispatches desktop notifications asynchronously (WinRT toast with `msg` fallback on Windows, `osascript` on macOS, `notify-send` on Linux), and supports `notifications.enabled`/`notifications.sound` toggles from config and the TUI settings editor.
+- **Phase notifications and optional sound (#53):** sends completion notices only on natural `00:00` phase transitions (not manual skip), dispatches desktop notifications asynchronously (`winrt-toast-reborn` toast with `msg` fallback on Windows, `osascript` on macOS, `notify-send` on Linux), and supports `notifications.enabled`/`notifications.sound` toggles from config and the TUI settings editor.
 
 ## [0.1.0] - 2026-04-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -476,7 +476,7 @@ dependencies = [
  "serde",
  "toml",
  "ureq",
- "winrt-notification",
+ "winrt-toast-reborn",
 ]
 
 [[package]]
@@ -568,15 +568,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -615,7 +606,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1038,7 +1029,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1245,7 +1236,7 @@ dependencies = [
  "itertools",
  "kasuari",
  "lru",
- "strum 0.27.2",
+ "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -1297,7 +1288,7 @@ dependencies = [
  "itertools",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -1574,32 +1565,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
-dependencies = [
- "strum_macros 0.22.0",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1608,7 +1578,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2188,14 +2158,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.24.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f39345ae0c8ab072c0ac7fe8a8b411636aa34f89be19ddd0d9226544f13944"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows_i686_gnu 0.24.0",
- "windows_i686_msvc 0.24.0",
- "windows_x86_64_gnu 0.24.0",
- "windows_x86_64_msvc 0.24.0",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -2206,9 +2199,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2235,9 +2239,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -2245,7 +2274,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2254,7 +2292,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2268,11 +2306,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2283,12 +2330,21 @@ checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
- "windows_i686_gnu 0.52.6",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.52.6",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2305,12 +2361,6 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0866510a3eca9aed73a077490bbbf03e5eaac4e1fd70849d89539e5830501fd"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
@@ -2323,21 +2373,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0ffed56b7e9369a29078d2ab3aaeceea48eb58999d2cff3aa2494a275b95c6"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384a173630588044205a2993b6864a2f56e5a8c1e7668c07b93ec18cf4888dc4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2353,12 +2391,6 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd8f062d8ca5446358159d79a90be12c543b3a965c847c8f3eedf14b321d399"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -2370,14 +2402,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
-name = "winrt-notification"
-version = "0.5.1"
+name = "winreg"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007a0353840b23e0c6dc73e5b962ff58ed7f6bc9ceff3ce7fe6fbad8d496edf4"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
- "strum 0.22.0",
+ "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winrt-toast-reborn"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4536ba8861defe9571414f4629a64e613cc5be2ebf7739858b2ca64a2bdadf1"
+dependencies = [
+ "scopeguard",
+ "thiserror 2.0.18",
+ "url",
  "windows",
- "xml-rs",
+ "winreg",
 ]
 
 [[package]]
@@ -2396,7 +2440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -2407,7 +2451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
@@ -2473,12 +2517,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winrt-notification = "0.5.1"
+winrt-toast-reborn = "0.3.8"

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Manual skip (`n`) changes phase immediately but does not emit a completion notif
 Notifications are delivered best-effort:
 
 - terminal notice in the timer view
-- desktop notification via platform-specific delivery (WinRT toast on Windows with a `msg` fallback, `osascript` on macOS, `notify-send` on Linux)
+- desktop notification via platform-specific delivery (`winrt-toast-reborn` toast on Windows with a `msg` fallback, `osascript` on macOS, `notify-send` on Linux)
 - optional sound alert using platform audio capabilities when `notifications.sound = true`
 
 You can also configure `notifications.enabled` and `notifications.sound` directly from the TUI:

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -50,6 +50,18 @@ fn transition_message(completed_phase: TimerPhase, next_phase: TimerPhase) -> St
     )
 }
 
+#[cfg(any(target_os = "windows", test))]
+fn notify_windows_with_fallback(
+    title: &str,
+    body: &str,
+    mut show_toast: impl FnMut(&str, &str) -> bool,
+    mut send_fallback: impl FnMut(&str, &str),
+) {
+    if !show_toast(title, body) {
+        send_fallback(title, body);
+    }
+}
+
 #[cfg(not(test))]
 fn send_desktop_notification(title: &str, body: &str) {
     #[cfg(target_os = "windows")]
@@ -57,19 +69,25 @@ fn send_desktop_notification(title: &str, body: &str) {
         use winrt_toast_reborn::content::audio::{Audio, Sound};
         use winrt_toast_reborn::{Toast, ToastDuration, ToastManager};
 
-        let manager = ToastManager::new(ToastManager::POWERSHELL_AUM_ID);
-        let mut toast = Toast::new();
-        toast
-            .text1(title)
-            .text2(body)
-            .duration(ToastDuration::Short)
-            .audio(Audio::new(Sound::None));
-        let toast_result = manager.show(&toast);
-        if toast_result.is_err() {
-            let _ = Command::new("msg")
-                .args(["*", &format!("{title}: {body}")])
-                .status();
-        }
+        notify_windows_with_fallback(
+            title,
+            body,
+            |toast_title, toast_body| {
+                let manager = ToastManager::new(ToastManager::POWERSHELL_AUM_ID);
+                let mut toast = Toast::new();
+                toast
+                    .text1(toast_title)
+                    .text2(toast_body)
+                    .duration(ToastDuration::Short)
+                    .audio(Audio::new(Sound::None));
+                manager.show(&toast).is_ok()
+            },
+            |fallback_title, fallback_body| {
+                let _ = Command::new("msg")
+                    .args(["*", &format!("{fallback_title}: {fallback_body}")])
+                    .status();
+            },
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -161,6 +179,67 @@ fn command_succeeded(result: std::io::Result<ExitStatus>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn windows_notification_fallback_runs_when_toast_fails() {
+        let mut toast_inputs = Vec::new();
+        let mut fallback_inputs = Vec::new();
+
+        notify_windows_with_fallback(
+            "focustime",
+            "Focus complete. Next up: Short Break.",
+            |title, body| {
+                toast_inputs.push((title.to_string(), body.to_string()));
+                false
+            },
+            |title, body| {
+                fallback_inputs.push((title.to_string(), body.to_string()));
+            },
+        );
+
+        assert_eq!(
+            toast_inputs,
+            vec![(
+                "focustime".to_string(),
+                "Focus complete. Next up: Short Break.".to_string(),
+            )]
+        );
+        assert_eq!(
+            fallback_inputs,
+            vec![(
+                "focustime".to_string(),
+                "Focus complete. Next up: Short Break.".to_string(),
+            )]
+        );
+    }
+
+    #[test]
+    fn windows_notification_does_not_fallback_when_toast_succeeds() {
+        let cases = [
+            ("focustime", "Focus complete. Next up: Short Break."),
+            ("alert", "Long Break complete. Next up: Focus."),
+        ];
+
+        for (title, body) in cases {
+            let mut toast_inputs = Vec::new();
+            let mut fallback_calls = 0;
+
+            notify_windows_with_fallback(
+                title,
+                body,
+                |toast_title, toast_body| {
+                    toast_inputs.push((toast_title.to_string(), toast_body.to_string()));
+                    true
+                },
+                |_fallback_title, _fallback_body| {
+                    fallback_calls += 1;
+                },
+            );
+
+            assert_eq!(toast_inputs, vec![(title.to_string(), body.to_string())]);
+            assert_eq!(fallback_calls, 0);
+        }
+    }
 
     #[test]
     fn notifier_returns_none_when_disabled() {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -54,14 +54,17 @@ fn transition_message(completed_phase: TimerPhase, next_phase: TimerPhase) -> St
 fn send_desktop_notification(title: &str, body: &str) {
     #[cfg(target_os = "windows")]
     {
-        use winrt_notification::{Duration, Toast};
+        use winrt_toast_reborn::content::audio::{Audio, Sound};
+        use winrt_toast_reborn::{Toast, ToastDuration, ToastManager};
 
-        let toast_result = Toast::new(Toast::POWERSHELL_APP_ID)
-            .title(title)
-            .text1(body)
-            .duration(Duration::Short)
-            .sound(None)
-            .show();
+        let manager = ToastManager::new(ToastManager::POWERSHELL_AUM_ID);
+        let mut toast = Toast::new();
+        toast
+            .text1(title)
+            .text2(body)
+            .duration(ToastDuration::Short)
+            .audio(Audio::new(Sound::None));
+        let toast_result = manager.show(&toast);
         if toast_result.is_err() {
             let _ = Command::new("msg")
                 .args(["*", &format!("{title}: {body}")])
@@ -89,7 +92,7 @@ fn send_desktop_notification(title: &str, body: &str) {
 #[cfg(test)]
 fn send_desktop_notification(_title: &str, _body: &str) {}
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(test)))]
 fn escape_applescript_literal(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }


### PR DESCRIPTION
## What

Replace the unmaintained Windows notification crate with `winrt-toast-reborn` while preserving current phase-notification behavior and fallback delivery.

## Why

`winrt-notification` is no longer maintained and may be unreliable on newer Windows versions. This change migrates Windows toast delivery to a maintained crate without changing user-facing notification flow.

Closes #68

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows desktop notification reliability with improved fallback handling to ensure notifications display correctly when the primary notification method is unavailable

* **Chores**
  * Added Windows platform build verification to continuous integration pipeline
  * Updated documentation and changelog reflecting Windows notification system improvements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->