### PR TITLE
Improve WakaTime visibility and heartbeat reliability

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,16 +73,20 @@ sequenceDiagram
 ```
 
 1. `main` creates `App`, initializes terminal state, and enters a loop.
-2. Each loop iteration draws UI from current state (`ui::render(frame, &app)`).
+2. Each loop iteration first polls async WakaTime heartbeat outcomes, then draws
+   UI from current state (`ui::render(frame, &app)`).
 3. Key events are routed to `App::handle_key`, which updates timer state, mode,
    site list, and quit intent.
 4. A 100ms tick cadence accumulates elapsed time; every elapsed second while the
    timer is running triggers `App::on_tick()`, which advances timer state and
    reapplies block/unblock policy when phase transitions occur.
 5. WakaTime tracking is synchronized by `App`: focus-running state starts/stops
-   tracking, and accumulated elapsed focus seconds (when at least 1s has passed)
-   are fed to `WakatimeTracker::tick_elapsed(elapsed_secs)` to avoid heartbeat
-   bursts after suspend/resume.
+   tracking, accumulated elapsed focus seconds (when at least 1s has passed) are
+   fed to `WakatimeTracker::tick_elapsed(elapsed_secs)`, and async heartbeat
+   outcomes are polled once per frame to surface `sending`/`retrying`/`error`
+   status in UI without blocking timer flow. `WakatimeTracker` retries transient
+   failures with bounded backoff to improve reliability while preserving
+   best-effort semantics.
 6. Phase notifications are dispatched asynchronously on natural phase completions
    (not manual skips), with optional sound and platform-specific desktop delivery.
 7. Blocking policy is phase-aware: blocking is active only during focus sessions

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,6 +57,8 @@ sequenceDiagram
     participant UI as ui::render
 
     loop every frame
+        Main->>App: poll_wakatime_status()
+        App->>Waka: poll_events()
         Main->>UI: render(frame, &app)
         Main->>App: handle_key(key) (if input)
         Main->>App: on_tick() (when 1s elapsed)
@@ -69,6 +71,7 @@ sequenceDiagram
         alt Focus + Running
             App->>Waka: tick_elapsed(elapsed_secs)
         end
+        App-->>UI: expose sending/retrying/error state
     end
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,19 @@ Runtime flow (high-level):
 3. Timer ticks advance every elapsed second while running.
 4. Phase-completion notifications are dispatched asynchronously.
 5. Blocking is applied during focus phases and removed outside focus.
-6. WakaTime tracking stays in sync with focus-running state.
+6. WakaTime tracking stays in sync with focus-running state and applies async
+   heartbeat outcomes without blocking timer flow.
+
+### WakaTime reliability behavior
+
+When WakaTime is configured, heartbeats are still best-effort and non-blocking.
+The timer never waits on network calls.
+
+- transient heartbeat failures (`429`, `5xx`, and connectivity/timeout errors)
+  retry with bounded backoff (`1s`, then `2s`)
+- non-retryable failures are surfaced in the timer view status line
+- status line now reflects runtime states (`tracking`, `sending`, `retrying`,
+  `error`, `idle`, `not configured`)
 
 For full module map and design details, see [ARCHITECTURE.md](ARCHITECTURE.md).
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -217,6 +217,12 @@ impl App {
         }
     }
 
+    /// Applies any completed async WakaTime heartbeat results to tracker state.
+    /// Intended to be called once per UI frame.
+    pub fn poll_wakatime_status(&mut self) {
+        self.wakatime.poll_events();
+    }
+
     pub fn selected_profile_name(&self) -> &'static str {
         self.selected_profile.label()
     }
@@ -1204,5 +1210,19 @@ mod tests {
         app.handle_key(key(KeyCode::Char('e')));
         app.handle_key(ctrl_key(KeyCode::Char('c')));
         assert!(app.should_quit);
+    }
+
+    #[test]
+    fn poll_wakatime_status_applies_async_failure_event() {
+        let mut app = App::default();
+        app.wakatime = WakatimeTracker::new_configured_for_tests();
+        app.wakatime.push_failed_event_for_tests("HTTP 503");
+
+        app.poll_wakatime_status();
+
+        assert_eq!(
+            app.wakatime.runtime_state(),
+            crate::wakatime::WakatimeRuntimeState::Error("HTTP 503".to_string())
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
     let mut tick_accumulator: u64 = 0; // milliseconds accumulated towards next second
 
     loop {
+        app.poll_wakatime_status();
         terminal.draw(|frame| ui::render(frame, &app))?;
 
         let timeout = tick_rate

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,6 +8,7 @@ use ratatui::{
 
 use crate::app::{App, AppMode, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS};
 use crate::timer::{TimerPhase, TimerStatus};
+use crate::wakatime::WakatimeRuntimeState;
 
 pub fn render(frame: &mut Frame, app: &App) {
     match app.mode {
@@ -153,12 +154,27 @@ fn render_timer(frame: &mut Frame, app: &App) {
     frame.render_widget(stats_widget, inner[6]);
 
     // WakaTime status
-    let (waka_text, waka_color) = if app.wakatime.is_tracking() {
-        ("⏱ WakaTime: tracking", Color::Green)
-    } else if app.wakatime.is_configured() {
-        ("⏱ WakaTime: idle", Color::DarkGray)
-    } else {
-        ("⏱ WakaTime: not configured", Color::DarkGray)
+    let (waka_text, waka_color) = match app.wakatime.runtime_state() {
+        WakatimeRuntimeState::NotConfigured => {
+            ("⏱ WakaTime: not configured".to_string(), Color::DarkGray)
+        }
+        WakatimeRuntimeState::Idle => ("⏱ WakaTime: idle".to_string(), Color::DarkGray),
+        WakatimeRuntimeState::Tracking => ("⏱ WakaTime: tracking".to_string(), Color::Green),
+        WakatimeRuntimeState::Sending => {
+            ("⏱ WakaTime: sending heartbeat...".to_string(), Color::Cyan)
+        }
+        WakatimeRuntimeState::Retrying {
+            attempt,
+            max_attempts,
+            next_backoff_secs,
+            error,
+        } => (
+            format!(
+                "⏱ WakaTime: retrying ({attempt}/{max_attempts}) in {next_backoff_secs}s ({error})"
+            ),
+            Color::Yellow,
+        ),
+        WakatimeRuntimeState::Error(error) => (format!("⏱ WakaTime: error ({error})"), Color::Red),
     };
     let waka_widget = Paragraph::new(waka_text)
         .alignment(Alignment::Center)

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -1,11 +1,14 @@
 use std::fs;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Serialize;
 
 const HEARTBEAT_INTERVAL_SECS: u64 = 120;
+const HEARTBEAT_RETRY_BACKOFF_SECS: [u64; 2] = [1, 2];
+const HEARTBEAT_MAX_ATTEMPTS: u8 = 3;
 const DEFAULT_API_URL: &str = "https://wakatime.com";
 
 #[derive(Debug, Serialize)]
@@ -17,6 +20,43 @@ struct Heartbeat {
     project: String,
     language: String,
     is_write: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WakatimeRuntimeState {
+    NotConfigured,
+    Idle,
+    Tracking,
+    Sending,
+    Retrying {
+        attempt: u8,
+        max_attempts: u8,
+        next_backoff_secs: u64,
+        error: String,
+    },
+    Error(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RetryState {
+    attempt: u8,
+    max_attempts: u8,
+    next_backoff_secs: u64,
+    error: String,
+}
+
+#[derive(Debug, Clone)]
+enum HeartbeatEvent {
+    Sent,
+    Retrying {
+        attempt: u8,
+        max_attempts: u8,
+        next_backoff_secs: u64,
+        error: String,
+    },
+    Failed {
+        error: String,
+    },
 }
 
 /// Returns the machine hostname for the `X-Machine-Name` header.
@@ -114,27 +154,94 @@ pub struct WakatimeTracker {
     secs_since_last_heartbeat: u64,
     /// Whether a focus session is currently being tracked.
     tracking: bool,
+    /// Sender/receiver pair for heartbeat outcomes from background worker threads.
+    result_tx: Sender<HeartbeatEvent>,
+    result_rx: Receiver<HeartbeatEvent>,
+    /// Whether a heartbeat request is currently in flight.
+    heartbeat_in_flight: bool,
+    /// Retry details for the current in-flight heartbeat, if any.
+    retry_state: Option<RetryState>,
+    /// Last terminal heartbeat failure message.
+    last_error: Option<String>,
 }
 
 impl WakatimeTracker {
     pub fn new() -> Self {
         let config = WakatimeConfig::load();
+        let (result_tx, result_rx) = mpsc::channel();
         Self {
             api_key: config.api_key,
             api_url: config.api_url,
             secs_since_last_heartbeat: 0,
             tracking: false,
+            result_tx,
+            result_rx,
+            heartbeat_in_flight: false,
+            retry_state: None,
+            last_error: None,
         }
-    }
-
-    /// Returns `true` if an API key is configured.
-    pub fn is_configured(&self) -> bool {
-        self.api_key.is_some()
     }
 
     /// Returns `true` if actively sending heartbeats for a focus session.
     pub fn is_tracking(&self) -> bool {
         self.tracking
+    }
+
+    pub fn runtime_state(&self) -> WakatimeRuntimeState {
+        if self.api_key.is_none() {
+            return WakatimeRuntimeState::NotConfigured;
+        }
+        if let Some(retry) = self.retry_state.as_ref() {
+            return WakatimeRuntimeState::Retrying {
+                attempt: retry.attempt,
+                max_attempts: retry.max_attempts,
+                next_backoff_secs: retry.next_backoff_secs,
+                error: retry.error.clone(),
+            };
+        }
+        if self.heartbeat_in_flight {
+            return WakatimeRuntimeState::Sending;
+        }
+        if let Some(error) = self.last_error.as_ref() {
+            return WakatimeRuntimeState::Error(error.clone());
+        }
+        if self.tracking {
+            WakatimeRuntimeState::Tracking
+        } else {
+            WakatimeRuntimeState::Idle
+        }
+    }
+
+    /// Drains heartbeat events from worker threads and updates tracker status.
+    pub fn poll_events(&mut self) {
+        while let Ok(event) = self.result_rx.try_recv() {
+            match event {
+                HeartbeatEvent::Sent => {
+                    self.heartbeat_in_flight = false;
+                    self.retry_state = None;
+                    self.last_error = None;
+                }
+                HeartbeatEvent::Retrying {
+                    attempt,
+                    max_attempts,
+                    next_backoff_secs,
+                    error,
+                } => {
+                    self.heartbeat_in_flight = true;
+                    self.retry_state = Some(RetryState {
+                        attempt,
+                        max_attempts,
+                        next_backoff_secs,
+                        error,
+                    });
+                }
+                HeartbeatEvent::Failed { error } => {
+                    self.heartbeat_in_flight = false;
+                    self.retry_state = None;
+                    self.last_error = Some(error);
+                }
+            }
+        }
     }
 
     /// Called when a focus session starts (timer transitions to Running in Focus phase).
@@ -144,8 +251,9 @@ impl WakatimeTracker {
         if self.api_key.is_none() {
             return;
         }
+        self.poll_events();
         self.set_tracking_state(true);
-        self.send_heartbeat_async();
+        self.queue_heartbeat_async();
     }
 
     /// Advances the heartbeat counter by `secs` simulated seconds.
@@ -154,6 +262,7 @@ impl WakatimeTracker {
     /// so that a burst of catch-up ticks after a suspend/resume does not
     /// trigger multiple rapid HTTP requests.
     pub fn tick_elapsed(&mut self, secs: u64) {
+        self.poll_events();
         if !self.tracking || secs == 0 {
             return;
         }
@@ -162,7 +271,7 @@ impl WakatimeTracker {
             (self.secs_since_last_heartbeat + secs).min(HEARTBEAT_INTERVAL_SECS);
         if self.secs_since_last_heartbeat >= HEARTBEAT_INTERVAL_SECS {
             self.secs_since_last_heartbeat = 0;
-            self.send_heartbeat_async();
+            self.queue_heartbeat_async();
         }
     }
 
@@ -177,11 +286,17 @@ impl WakatimeTracker {
     }
 
     /// Spawns a background thread to send a heartbeat to the WakaTime API.
-    /// Failures are silently ignored so the TUI remains unaffected.
-    fn send_heartbeat_async(&self) {
+    /// Retries transient failures with bounded exponential backoff.
+    fn queue_heartbeat_async(&mut self) {
         let Some(ref api_key) = self.api_key else {
             return;
         };
+        if self.heartbeat_in_flight {
+            return;
+        }
+        self.heartbeat_in_flight = true;
+        self.retry_state = None;
+        self.last_error = None;
 
         let auth = format!("Basic {}", BASE64.encode(api_key.as_bytes()));
         let api_url = self.api_url.trim_end_matches('/');
@@ -207,20 +322,106 @@ impl WakatimeTracker {
             language: "Pomodoro".to_string(),
             is_write: false,
         };
+        let result_tx = self.result_tx.clone();
 
         std::thread::spawn(move || {
-            let agent: ureq::Agent = ureq::Agent::config_builder()
-                .timeout_global(Some(std::time::Duration::from_secs(10)))
-                .build()
-                .into();
-            let _ = agent
-                .post(&url)
-                .header("Authorization", &auth)
-                .header("Content-Type", "application/json")
-                .header("User-Agent", &user_agent)
-                .header("X-Machine-Name", &hostname)
-                .send_json(heartbeat);
+            send_heartbeat_with_retries(result_tx, url, auth, user_agent, hostname, heartbeat);
         });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_configured_for_tests() -> Self {
+        let (result_tx, result_rx) = mpsc::channel();
+        Self {
+            api_key: Some("test-key".to_string()),
+            api_url: DEFAULT_API_URL.to_string(),
+            secs_since_last_heartbeat: 0,
+            tracking: false,
+            result_tx,
+            result_rx,
+            heartbeat_in_flight: false,
+            retry_state: None,
+            last_error: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn push_failed_event_for_tests(&self, error: impl Into<String>) {
+        let _ = self.result_tx.send(HeartbeatEvent::Failed {
+            error: error.into(),
+        });
+    }
+}
+
+fn send_heartbeat_with_retries(
+    result_tx: Sender<HeartbeatEvent>,
+    url: String,
+    auth: String,
+    user_agent: String,
+    hostname: String,
+    heartbeat: Heartbeat,
+) {
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(10)))
+        .build()
+        .into();
+    let mut attempt: u8 = 1;
+
+    loop {
+        let result = agent
+            .post(&url)
+            .header("Authorization", &auth)
+            .header("Content-Type", "application/json")
+            .header("User-Agent", &user_agent)
+            .header("X-Machine-Name", &hostname)
+            .send_json(&heartbeat);
+
+        match result {
+            Ok(_) => {
+                let _ = result_tx.send(HeartbeatEvent::Sent);
+                return;
+            }
+            Err(error) => {
+                let error_message = format_heartbeat_error(&error);
+                let backoff_index = attempt.saturating_sub(1) as usize;
+                if is_retryable_error(&error)
+                    && let Some(backoff_secs) = HEARTBEAT_RETRY_BACKOFF_SECS.get(backoff_index)
+                {
+                    let _ = result_tx.send(HeartbeatEvent::Retrying {
+                        attempt,
+                        max_attempts: HEARTBEAT_MAX_ATTEMPTS,
+                        next_backoff_secs: *backoff_secs,
+                        error: error_message.clone(),
+                    });
+                    std::thread::sleep(Duration::from_secs(*backoff_secs));
+                    attempt = attempt.saturating_add(1);
+                    continue;
+                }
+
+                let _ = result_tx.send(HeartbeatEvent::Failed {
+                    error: error_message,
+                });
+                return;
+            }
+        }
+    }
+}
+
+fn is_retryable_error(error: &ureq::Error) -> bool {
+    match error {
+        ureq::Error::StatusCode(code) => *code == 429 || (500..=599).contains(code),
+        ureq::Error::Io(_)
+        | ureq::Error::Timeout(_)
+        | ureq::Error::HostNotFound
+        | ureq::Error::ConnectionFailed => true,
+        _ => false,
+    }
+}
+
+fn format_heartbeat_error(error: &ureq::Error) -> String {
+    match error {
+        ureq::Error::StatusCode(code) => format!("HTTP {code}"),
+        _ => error.to_string(),
     }
 }
 
@@ -242,6 +443,25 @@ fn parse_setting_line(line: &str) -> Option<(&str, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn tracker_with(
+        api_key: Option<&str>,
+        tracking: bool,
+        secs_since_last_heartbeat: u64,
+    ) -> WakatimeTracker {
+        let (result_tx, result_rx) = mpsc::channel();
+        WakatimeTracker {
+            api_key: api_key.map(str::to_string),
+            api_url: DEFAULT_API_URL.to_string(),
+            secs_since_last_heartbeat,
+            tracking,
+            result_tx,
+            result_rx,
+            heartbeat_in_flight: false,
+            retry_state: None,
+            last_error: None,
+        }
+    }
 
     #[test]
     fn parse_config_extracts_api_key() {
@@ -270,35 +490,20 @@ mod tests {
 
     #[test]
     fn tracker_not_configured_when_no_api_key() {
-        let tracker = WakatimeTracker {
-            api_key: None,
-            api_url: DEFAULT_API_URL.to_string(),
-            secs_since_last_heartbeat: 0,
-            tracking: false,
-        };
-        assert!(!tracker.is_configured());
+        let tracker = tracker_with(None, false, 0);
         assert!(!tracker.is_tracking());
+        assert_eq!(tracker.runtime_state(), WakatimeRuntimeState::NotConfigured);
     }
 
     #[test]
     fn tracker_configured_when_api_key_present() {
-        let tracker = WakatimeTracker {
-            api_key: Some("test-key".to_string()),
-            api_url: DEFAULT_API_URL.to_string(),
-            secs_since_last_heartbeat: 0,
-            tracking: false,
-        };
-        assert!(tracker.is_configured());
+        let tracker = tracker_with(Some("test-key"), false, 0);
+        assert_eq!(tracker.runtime_state(), WakatimeRuntimeState::Idle);
     }
 
     #[test]
     fn on_focus_start_does_not_track_without_api_key() {
-        let mut tracker = WakatimeTracker {
-            api_key: None,
-            api_url: DEFAULT_API_URL.to_string(),
-            secs_since_last_heartbeat: 50,
-            tracking: false,
-        };
+        let mut tracker = tracker_with(None, false, 50);
         tracker.on_focus_start();
         assert!(!tracker.is_tracking());
         assert_eq!(tracker.secs_since_last_heartbeat, 50);
@@ -306,12 +511,7 @@ mod tests {
 
     #[test]
     fn on_focus_start_sets_tracking_when_configured() {
-        let mut tracker = WakatimeTracker {
-            api_key: Some("test-key".to_string()),
-            api_url: DEFAULT_API_URL.to_string(),
-            secs_since_last_heartbeat: 50,
-            tracking: false,
-        };
+        let mut tracker = tracker_with(Some("test-key"), false, 50);
         tracker.on_focus_start();
         assert!(tracker.is_tracking());
         assert_eq!(tracker.secs_since_last_heartbeat, 0);
@@ -319,12 +519,7 @@ mod tests {
 
     #[test]
     fn on_focus_stop_clears_tracking() {
-        let mut tracker = WakatimeTracker {
-            api_key: None,
-            api_url: DEFAULT_API_URL.to_string(),
-            secs_since_last_heartbeat: 60,
-            tracking: true,
-        };
+        let mut tracker = tracker_with(None, true, 60);
         tracker.on_focus_stop();
         assert!(!tracker.is_tracking());
         assert_eq!(tracker.secs_since_last_heartbeat, 0);
@@ -332,12 +527,7 @@ mod tests {
 
     #[test]
     fn tick_increments_counter_and_resets_at_interval() {
-        let mut tracker = WakatimeTracker {
-            api_key: None, // no HTTP call made
-            api_url: DEFAULT_API_URL.to_string(),
-            secs_since_last_heartbeat: HEARTBEAT_INTERVAL_SECS - 1,
-            tracking: true,
-        };
+        let mut tracker = tracker_with(None, true, HEARTBEAT_INTERVAL_SECS - 1);
         tracker.tick_elapsed(1);
         // Counter should have reset after reaching the interval threshold
         assert_eq!(tracker.secs_since_last_heartbeat, 0);
@@ -345,26 +535,102 @@ mod tests {
 
     #[test]
     fn tick_does_nothing_when_not_tracking() {
-        let mut tracker = WakatimeTracker {
-            api_key: None,
-            api_url: DEFAULT_API_URL.to_string(),
-            secs_since_last_heartbeat: 0,
-            tracking: false,
-        };
+        let mut tracker = tracker_with(None, false, 0);
         tracker.tick_elapsed(1);
         assert_eq!(tracker.secs_since_last_heartbeat, 0);
     }
 
     #[test]
     fn tick_elapsed_clamps_to_single_heartbeat_on_burst() {
-        let mut tracker = WakatimeTracker {
-            api_key: None, // no HTTP call made
-            api_url: DEFAULT_API_URL.to_string(),
-            secs_since_last_heartbeat: 0,
-            tracking: true,
-        };
+        let mut tracker = tracker_with(None, true, 0);
         // Simulate 10 minutes of catch-up at once; should only fire one heartbeat
         tracker.tick_elapsed(600);
         assert_eq!(tracker.secs_since_last_heartbeat, 0);
+    }
+
+    #[test]
+    fn runtime_state_tracking_when_configured_and_running() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        tracker.poll_events();
+        assert_eq!(tracker.runtime_state(), WakatimeRuntimeState::Tracking);
+    }
+
+    #[test]
+    fn runtime_state_updates_to_retrying_from_worker_event() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Retrying {
+                attempt: 1,
+                max_attempts: HEARTBEAT_MAX_ATTEMPTS,
+                next_backoff_secs: 1,
+                error: "HTTP 503".to_string(),
+            })
+            .expect("test event send must succeed");
+
+        tracker.poll_events();
+
+        assert_eq!(
+            tracker.runtime_state(),
+            WakatimeRuntimeState::Retrying {
+                attempt: 1,
+                max_attempts: HEARTBEAT_MAX_ATTEMPTS,
+                next_backoff_secs: 1,
+                error: "HTTP 503".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_state_updates_to_error_after_failure_event() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Failed {
+                error: "HTTP 500".to_string(),
+            })
+            .expect("test event send must succeed");
+
+        tracker.poll_events();
+
+        assert_eq!(
+            tracker.runtime_state(),
+            WakatimeRuntimeState::Error("HTTP 500".to_string())
+        );
+    }
+
+    #[test]
+    fn success_event_clears_previous_error_state() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Failed {
+                error: "io: network unreachable".to_string(),
+            })
+            .expect("test event send must succeed");
+        tracker.poll_events();
+        assert!(matches!(
+            tracker.runtime_state(),
+            WakatimeRuntimeState::Error(_)
+        ));
+
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Sent)
+            .expect("test event send must succeed");
+        tracker.poll_events();
+
+        assert_eq!(tracker.runtime_state(), WakatimeRuntimeState::Tracking);
+    }
+
+    #[test]
+    fn retryable_error_classification_matches_policy() {
+        assert!(is_retryable_error(&ureq::Error::StatusCode(429)));
+        assert!(is_retryable_error(&ureq::Error::StatusCode(503)));
+        assert!(!is_retryable_error(&ureq::Error::StatusCode(400)));
+        assert!(is_retryable_error(&ureq::Error::ConnectionFailed));
+        assert!(!is_retryable_error(&ureq::Error::BadUri(
+            "missing-host".to_string()
+        )));
     }
 }

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -163,6 +163,10 @@ pub struct WakatimeTracker {
     retry_state: Option<RetryState>,
     /// Last terminal heartbeat failure message.
     last_error: Option<String>,
+    /// Latches an immediate heartbeat request while another worker is in flight.
+    pending_immediate_heartbeat: bool,
+    #[cfg(test)]
+    disable_network_io: bool,
 }
 
 impl WakatimeTracker {
@@ -179,6 +183,9 @@ impl WakatimeTracker {
             heartbeat_in_flight: false,
             retry_state: None,
             last_error: None,
+            pending_immediate_heartbeat: false,
+            #[cfg(test)]
+            disable_network_io: false,
         }
     }
 
@@ -220,6 +227,7 @@ impl WakatimeTracker {
                     self.heartbeat_in_flight = false;
                     self.retry_state = None;
                     self.last_error = None;
+                    self.dispatch_pending_immediate_heartbeat();
                 }
                 HeartbeatEvent::Retrying {
                     attempt,
@@ -239,6 +247,7 @@ impl WakatimeTracker {
                     self.heartbeat_in_flight = false;
                     self.retry_state = None;
                     self.last_error = Some(error);
+                    self.dispatch_pending_immediate_heartbeat();
                 }
             }
         }
@@ -253,7 +262,7 @@ impl WakatimeTracker {
         }
         self.poll_events();
         self.set_tracking_state(true);
-        self.queue_heartbeat_async();
+        self.queue_heartbeat_async(true);
     }
 
     /// Advances the heartbeat counter by `secs` simulated seconds.
@@ -271,7 +280,7 @@ impl WakatimeTracker {
             (self.secs_since_last_heartbeat + secs).min(HEARTBEAT_INTERVAL_SECS);
         if self.secs_since_last_heartbeat >= HEARTBEAT_INTERVAL_SECS {
             self.secs_since_last_heartbeat = 0;
-            self.queue_heartbeat_async();
+            self.queue_heartbeat_async(false);
         }
     }
 
@@ -287,16 +296,24 @@ impl WakatimeTracker {
 
     /// Spawns a background thread to send a heartbeat to the WakaTime API.
     /// Retries transient failures with bounded exponential backoff.
-    fn queue_heartbeat_async(&mut self) {
+    fn queue_heartbeat_async(&mut self, immediate: bool) {
         let Some(ref api_key) = self.api_key else {
             return;
         };
         if self.heartbeat_in_flight {
+            if immediate {
+                self.pending_immediate_heartbeat = true;
+            }
             return;
         }
         self.heartbeat_in_flight = true;
         self.retry_state = None;
         self.last_error = None;
+
+        #[cfg(test)]
+        if self.disable_network_io {
+            return;
+        }
 
         let auth = format!("Basic {}", BASE64.encode(api_key.as_bytes()));
         let api_url = self.api_url.trim_end_matches('/');
@@ -329,6 +346,13 @@ impl WakatimeTracker {
         });
     }
 
+    fn dispatch_pending_immediate_heartbeat(&mut self) {
+        if self.pending_immediate_heartbeat && self.tracking {
+            self.pending_immediate_heartbeat = false;
+            self.queue_heartbeat_async(true);
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn new_configured_for_tests() -> Self {
         let (result_tx, result_rx) = mpsc::channel();
@@ -342,6 +366,8 @@ impl WakatimeTracker {
             heartbeat_in_flight: false,
             retry_state: None,
             last_error: None,
+            pending_immediate_heartbeat: false,
+            disable_network_io: true,
         }
     }
 
@@ -460,6 +486,8 @@ mod tests {
             heartbeat_in_flight: false,
             retry_state: None,
             last_error: None,
+            pending_immediate_heartbeat: false,
+            disable_network_io: true,
         }
     }
 
@@ -546,6 +574,60 @@ mod tests {
         // Simulate 10 minutes of catch-up at once; should only fire one heartbeat
         tracker.tick_elapsed(600);
         assert_eq!(tracker.secs_since_last_heartbeat, 0);
+    }
+
+    #[test]
+    fn on_focus_start_latches_immediate_heartbeat_when_inflight() {
+        let mut tracker = tracker_with(Some("test-key"), false, 0);
+        tracker.heartbeat_in_flight = true;
+        tracker.retry_state = Some(RetryState {
+            attempt: 1,
+            max_attempts: HEARTBEAT_MAX_ATTEMPTS,
+            next_backoff_secs: 1,
+            error: "HTTP 503".to_string(),
+        });
+
+        tracker.on_focus_start();
+
+        assert!(tracker.tracking);
+        assert!(tracker.heartbeat_in_flight);
+        assert!(tracker.pending_immediate_heartbeat);
+    }
+
+    #[test]
+    fn pending_immediate_heartbeat_dispatches_after_inflight_send_completes() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        tracker.heartbeat_in_flight = true;
+        tracker.pending_immediate_heartbeat = true;
+
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Sent)
+            .expect("test event send must succeed");
+
+        tracker.poll_events();
+
+        assert!(tracker.heartbeat_in_flight);
+        assert!(!tracker.pending_immediate_heartbeat);
+    }
+
+    #[test]
+    fn pending_immediate_heartbeat_dispatches_after_inflight_failure() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        tracker.heartbeat_in_flight = true;
+        tracker.pending_immediate_heartbeat = true;
+
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Failed {
+                error: "HTTP 503".to_string(),
+            })
+            .expect("test event send must succeed");
+
+        tracker.poll_events();
+
+        assert!(tracker.heartbeat_in_flight);
+        assert!(!tracker.pending_immediate_heartbeat);
     }
 
     #[test]


### PR DESCRIPTION
## What

Improve WakaTime integration so users can see heartbeat state and failures in the timer UI, while making heartbeat delivery more resilient to transient network issues.

This adds explicit runtime states (`not configured`, `idle`, `tracking`, `sending`, `retrying`, `error`), bounded retry/backoff for retryable failures (3 attempts total with 1s then 2s backoff), and per-frame polling so async heartbeat outcomes are reflected quickly without blocking timer flow.

## Why

The previous behavior silently ignored heartbeat failures and used single-attempt sends, which made reliability and troubleshooting hard. This change improves visibility and robustness while preserving optional, non-blocking WakaTime semantics.

Closes #55

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WakaTime status now shows detailed runtime states (tracking, sending, retrying with attempt/backoff, error, idle, not configured) with color-coded status line.
  * UI updates heartbeat outcomes each frame so status reflects send/retry/error quickly.

* **Improvements**
  * Heartbeats are best-effort and non-blocking; timer flow never waits on network.
  * Transient failures automatically retry with bounded backoff and surface errors when terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->