### PR TITLE
Site manager quality-of-life improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ enabled = true
 sound = false
 ```
 
+## Site manager workflow
+
+Open the site manager from timer view with **`b`**.
+
+- `a`: add/import hostnames
+- `e`: edit the selected hostname
+- `d` or `Delete`: remove the selected hostname
+- `↑/↓`: move selection
+- `b` or `Esc`: return to timer view
+
+Add/import input supports:
+
+- single hostnames (`youtube.com`)
+- comma-separated lists (`youtube.com, reddit.com`)
+- newline-separated lists (paste multi-line blocklists, then press `Enter`)
+
+Invalid and duplicate entries are reported inline so you can fix them without leaving the view.
+
 ## Phase notifications
 
 `focustime` emits a phase notification when a phase naturally completes at `00:00`:

--- a/README.md
+++ b/README.md
@@ -107,13 +107,15 @@ Open the site manager from timer view with **`b`**.
 - `e`: edit the selected hostname
 - `d` or `Delete`: remove the selected hostname
 - `↑/↓`: move selection
-- `b` or `Esc`: return to timer view
+- `b`: return to timer view
+- `Esc`: return to timer view only when add/edit mode is not active
 
 Add/import input supports:
 
 - single hostnames (`youtube.com`)
 - comma-separated lists (`youtube.com, reddit.com`)
 - newline-separated lists (paste multi-line blocklists, then press `Enter`)
+- while add/import or edit mode is active, `Enter` commits and `Esc` cancels the current draft
 
 Invalid and duplicate entries are reported inline so you can fix them without leaving the view.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -648,21 +648,24 @@ impl App {
     }
 
     fn commit_site_input(&mut self) {
-        let input = std::mem::take(&mut self.site_input);
-        self.site_input_active = false;
-        let edit_index = self.site_edit_index.take();
+        let input = self.site_input.clone();
 
-        if let Some(index) = edit_index {
+        let committed = if let Some(index) = self.site_edit_index {
             let edit_result = self.blocker.edit_site_from_input(index, &input);
-            self.apply_edit_site_result(edit_result);
+            self.apply_edit_site_result(edit_result)
         } else {
             let add_result = self.blocker.add_sites_from_input(&input);
-            self.apply_bulk_add_result(add_result);
+            self.apply_bulk_add_result(add_result)
+        };
+
+        if committed {
+            self.cancel_site_input();
         }
     }
 
-    fn apply_bulk_add_result(&mut self, result: BulkAddResult) {
-        if !result.added.is_empty() {
+    fn apply_bulk_add_result(&mut self, result: BulkAddResult) -> bool {
+        let committed = !result.added.is_empty();
+        if committed {
             self.selected_site = self.blocker.sites.len().saturating_sub(1);
             self.finalize_site_mutation();
         }
@@ -703,9 +706,10 @@ impl App {
             parts.join(" • ")
         };
         self.set_site_feedback(level, message);
+        committed
     }
 
-    fn apply_edit_site_result(&mut self, result: EditSiteResult) {
+    fn apply_edit_site_result(&mut self, result: EditSiteResult) -> bool {
         match result {
             EditSiteResult::Updated { old, new } => {
                 self.finalize_site_mutation();
@@ -713,18 +717,21 @@ impl App {
                     SiteFeedbackLevel::Success,
                     format!("Updated `{old}` -> `{new}`"),
                 );
+                true
             }
             EditSiteResult::Unchanged { hostname } => {
                 self.set_site_feedback(
                     SiteFeedbackLevel::Warning,
                     format!("No change for `{hostname}`"),
                 );
+                false
             }
             EditSiteResult::Duplicate { hostname } => {
                 self.set_site_feedback(
                     SiteFeedbackLevel::Warning,
                     format!("`{hostname}` is already in the blocklist"),
                 );
+                false
             }
             EditSiteResult::Invalid(invalid) => {
                 self.set_site_feedback(
@@ -735,9 +742,11 @@ impl App {
                         invalid.reason.message()
                     ),
                 );
+                false
             }
             EditSiteResult::MissingSelection => {
                 self.set_site_feedback(SiteFeedbackLevel::Warning, "No site selected to edit");
+                false
             }
         }
     }
@@ -1390,6 +1399,23 @@ mod tests {
     }
 
     #[test]
+    fn site_manager_invalid_add_keeps_draft_open() {
+        let mut app = App::default();
+        app.handle_key(key(KeyCode::Char('b')));
+        app.handle_key(key(KeyCode::Char('a')));
+        for c in "exam_ple.com".chars() {
+            app.handle_key(key(KeyCode::Char(c)));
+        }
+
+        app.handle_key(key(KeyCode::Enter));
+
+        assert!(app.site_input_active);
+        assert!(app.site_edit_index.is_none());
+        assert_eq!(app.site_input, "exam_ple.com");
+        assert!(app.blocker.sites.is_empty());
+    }
+
+    #[test]
     fn site_manager_edit_selected_site() {
         let config = AppConfig {
             blocked_sites: vec!["a.com".to_string(), "b.com".to_string()],
@@ -1417,6 +1443,33 @@ mod tests {
                 level: SiteFeedbackLevel::Success,
                 message: "Updated `a.com` -> `news.ycombinator.com`".to_string(),
             })
+        );
+    }
+
+    #[test]
+    fn site_manager_invalid_edit_keeps_draft_open() {
+        let config = AppConfig {
+            blocked_sites: vec!["a.com".to_string(), "b.com".to_string()],
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.handle_key(key(KeyCode::Char('b')));
+        app.handle_key(key(KeyCode::Char('e')));
+        for _ in 0.."a.com".len() {
+            app.handle_key(key(KeyCode::Backspace));
+        }
+        for c in "b.com".chars() {
+            app.handle_key(key(KeyCode::Char(c)));
+        }
+
+        app.handle_key(key(KeyCode::Enter));
+
+        assert!(app.site_input_active);
+        assert_eq!(app.site_edit_index, Some(0));
+        assert_eq!(app.site_input, "b.com");
+        assert_eq!(
+            app.blocker.sites,
+            vec!["a.com".to_string(), "b.com".to_string()]
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::blocker::SiteBlocker;
+use crate::blocker::{BulkAddResult, EditSiteResult, InvalidSiteInput, SiteBlocker};
 use crate::config::{AppConfig, CustomProfileConfig, NotificationConfig, ProfileId};
 use crate::notifications::PhaseNotifier;
 use crate::stats::{DailyStats, FocusStats, SessionStats, current_day_key};
@@ -92,15 +92,35 @@ struct ProfileEditSnapshot {
     notification_settings: NotificationConfig,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiteInputMode {
+    Add,
+    Edit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiteFeedbackLevel {
+    Success,
+    Warning,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SiteFeedback {
+    pub level: SiteFeedbackLevel,
+    pub message: String,
+}
+
 pub struct App {
     pub timer: TimerState,
     pub should_quit: bool,
     pub mode: AppMode,
     pub blocker: SiteBlocker,
-    /// Text being typed when adding a new site.
+    /// Text being typed for add/import or edit site input.
     pub site_input: String,
     /// Whether the user is currently typing a new site.
     pub site_input_active: bool,
+    site_edit_index: Option<usize>,
+    pub site_feedback: Option<SiteFeedback>,
     /// Index of the highlighted site in the SiteManager list.
     pub selected_site: usize,
     /// Last error from a block/unblock operation (e.g. permission denied).
@@ -162,6 +182,8 @@ impl App {
             blocker,
             site_input: String::new(),
             site_input_active: false,
+            site_edit_index: None,
+            site_feedback: None,
             selected_site: 0,
             block_error: None,
             config_error: None,
@@ -275,6 +297,14 @@ impl App {
         }
     }
 
+    pub fn site_input_mode(&self) -> SiteInputMode {
+        if self.site_edit_index.is_some() {
+            SiteInputMode::Edit
+        } else {
+            SiteInputMode::Add
+        }
+    }
+
     /// Persist the current blocked-sites list and timer preferences to disk.
     /// Failures are best-effort; the error is surfaced through `config_error`.
     fn persisted_config(&self) -> AppConfig {
@@ -344,6 +374,17 @@ impl App {
             AppMode::ProfileManager => self.handle_key_profile_manager(key),
             AppMode::StatsHistory => self.handle_key_stats_history(key),
         }
+    }
+
+    pub fn handle_paste(&mut self, text: String) {
+        if self.mode != AppMode::SiteManager {
+            return;
+        }
+
+        if !self.site_input_active {
+            self.start_site_input(SiteInputMode::Add);
+        }
+        self.site_input.push_str(&text);
     }
 
     fn handle_key_timer(&mut self, key: KeyEvent) {
@@ -528,14 +569,10 @@ impl App {
         if self.site_input_active {
             match key.code {
                 KeyCode::Enter => {
-                    let site = std::mem::take(&mut self.site_input);
-                    self.blocker.add_site(site);
-                    self.site_input_active = false;
-                    self.finalize_site_mutation();
+                    self.commit_site_input();
                 }
                 KeyCode::Esc => {
-                    self.site_input.clear();
-                    self.site_input_active = false;
+                    self.cancel_site_input();
                 }
                 KeyCode::Backspace => {
                     self.site_input.pop();
@@ -569,16 +606,156 @@ impl App {
             }
             // Start adding a site
             KeyCode::Char('a') => {
-                self.site_input_active = true;
+                self.start_site_input(SiteInputMode::Add);
+            }
+            // Edit selected site
+            KeyCode::Char('e') => {
+                self.start_site_input(SiteInputMode::Edit);
             }
             // Delete selected site
             KeyCode::Char('d') | KeyCode::Delete => {
-                if !self.blocker.sites.is_empty() {
-                    self.blocker.remove_site(self.selected_site);
-                    self.finalize_site_mutation();
-                }
+                self.remove_selected_site();
             }
             _ => {}
+        }
+    }
+
+    fn start_site_input(&mut self, mode: SiteInputMode) {
+        self.site_input_active = true;
+        self.site_feedback = None;
+        match mode {
+            SiteInputMode::Add => {
+                self.site_edit_index = None;
+                self.site_input.clear();
+            }
+            SiteInputMode::Edit => {
+                if self.blocker.sites.is_empty() {
+                    self.site_input_active = false;
+                    self.set_site_feedback(SiteFeedbackLevel::Warning, "No site selected to edit");
+                    return;
+                }
+                self.clamp_selection();
+                self.site_edit_index = Some(self.selected_site);
+                self.site_input = self.blocker.sites[self.selected_site].clone();
+            }
+        }
+    }
+
+    fn cancel_site_input(&mut self) {
+        self.site_input.clear();
+        self.site_input_active = false;
+        self.site_edit_index = None;
+    }
+
+    fn commit_site_input(&mut self) {
+        let input = std::mem::take(&mut self.site_input);
+        self.site_input_active = false;
+        let edit_index = self.site_edit_index.take();
+
+        if let Some(index) = edit_index {
+            let edit_result = self.blocker.edit_site_from_input(index, &input);
+            self.apply_edit_site_result(edit_result);
+        } else {
+            let add_result = self.blocker.add_sites_from_input(&input);
+            self.apply_bulk_add_result(add_result);
+        }
+    }
+
+    fn apply_bulk_add_result(&mut self, result: BulkAddResult) {
+        if !result.added.is_empty() {
+            self.selected_site = self.blocker.sites.len().saturating_sub(1);
+            self.finalize_site_mutation();
+        }
+
+        let mut parts = Vec::new();
+        if !result.added.is_empty() {
+            parts.push(format!(
+                "Added {}",
+                format_count(result.added.len(), "site", "sites")
+            ));
+        }
+        if !result.duplicates.is_empty() {
+            parts.push(format!(
+                "Skipped {}",
+                format_count(result.duplicates.len(), "duplicate", "duplicates")
+            ));
+        }
+        if !result.invalid.is_empty() {
+            parts.push(format!(
+                "Rejected {} ({})",
+                format_count(
+                    result.invalid.len(),
+                    "invalid hostname",
+                    "invalid hostnames"
+                ),
+                summarize_invalid_inputs(&result.invalid)
+            ));
+        }
+
+        let level = if result.invalid.is_empty() && result.duplicates.is_empty() {
+            SiteFeedbackLevel::Success
+        } else {
+            SiteFeedbackLevel::Warning
+        };
+        let message = if parts.is_empty() {
+            "No hostnames submitted".to_string()
+        } else {
+            parts.join(" • ")
+        };
+        self.set_site_feedback(level, message);
+    }
+
+    fn apply_edit_site_result(&mut self, result: EditSiteResult) {
+        match result {
+            EditSiteResult::Updated { old, new } => {
+                self.finalize_site_mutation();
+                self.set_site_feedback(
+                    SiteFeedbackLevel::Success,
+                    format!("Updated `{old}` -> `{new}`"),
+                );
+            }
+            EditSiteResult::Unchanged { hostname } => {
+                self.set_site_feedback(
+                    SiteFeedbackLevel::Warning,
+                    format!("No change for `{hostname}`"),
+                );
+            }
+            EditSiteResult::Duplicate { hostname } => {
+                self.set_site_feedback(
+                    SiteFeedbackLevel::Warning,
+                    format!("`{hostname}` is already in the blocklist"),
+                );
+            }
+            EditSiteResult::Invalid(invalid) => {
+                self.set_site_feedback(
+                    SiteFeedbackLevel::Warning,
+                    format!(
+                        "Invalid hostname `{}` ({})",
+                        display_input_value(&invalid.input),
+                        invalid.reason.message()
+                    ),
+                );
+            }
+            EditSiteResult::MissingSelection => {
+                self.set_site_feedback(SiteFeedbackLevel::Warning, "No site selected to edit");
+            }
+        }
+    }
+
+    fn remove_selected_site(&mut self) {
+        if self.blocker.sites.is_empty() {
+            self.set_site_feedback(SiteFeedbackLevel::Warning, "No site selected to delete");
+            return;
+        }
+
+        if let Some(removed) = self.blocker.remove_site(self.selected_site) {
+            self.finalize_site_mutation();
+            self.set_site_feedback(
+                SiteFeedbackLevel::Success,
+                format!("Removed `{removed}` from blocklist"),
+            );
+        } else {
+            self.set_site_feedback(SiteFeedbackLevel::Warning, "No site selected to delete");
         }
     }
 
@@ -645,6 +822,7 @@ impl App {
 
     fn open_site_manager(&mut self) {
         self.mode = AppMode::SiteManager;
+        self.cancel_site_input();
         self.clamp_selection();
     }
 
@@ -673,15 +851,25 @@ impl App {
     }
 
     fn sync_blocking_after_site_mutation(&mut self) {
-        if !self.blocker.is_blocking {
+        if !self.should_resync_blocking_after_site_mutation() {
             return;
         }
-        let block_result = if self.blocker.sites.is_empty() {
-            self.blocker.unblock()
+
+        let should_block = self.should_block_for_current_state();
+        let block_result = if should_block {
+            if self.blocker.sites.is_empty() {
+                self.blocker.unblock()
+            } else {
+                self.blocker.block()
+            }
         } else {
-            self.blocker.block()
+            self.blocker.unblock()
         };
         self.set_block_error_from_result(block_result);
+    }
+
+    fn should_resync_blocking_after_site_mutation(&self) -> bool {
+        self.should_block_for_current_state() || self.blocker.is_blocking
     }
 
     fn should_block_for_current_state(&self) -> bool {
@@ -735,6 +923,13 @@ impl App {
         }
     }
 
+    fn set_site_feedback(&mut self, level: SiteFeedbackLevel, message: impl Into<String>) {
+        self.site_feedback = Some(SiteFeedback {
+            level,
+            message: message.into(),
+        });
+    }
+
     fn rebuild_notifier(&mut self) {
         self.notifier = PhaseNotifier::new(self.notification_settings);
     }
@@ -762,6 +957,44 @@ fn format_duration_label(seconds: u64) -> String {
 
 fn bool_label(value: bool) -> &'static str {
     if value { "On" } else { "Off" }
+}
+
+fn format_count(count: usize, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {plural}")
+    }
+}
+
+fn summarize_invalid_inputs(invalid: &[InvalidSiteInput]) -> String {
+    const PREVIEW_LIMIT: usize = 3;
+    let preview_count = invalid.len().min(PREVIEW_LIMIT);
+    let mut details = invalid
+        .iter()
+        .take(preview_count)
+        .map(|entry| {
+            format!(
+                "`{}`: {}",
+                display_input_value(&entry.input),
+                entry.reason.message()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    if invalid.len() > PREVIEW_LIMIT {
+        details.push_str(&format!(", +{} more", invalid.len() - PREVIEW_LIMIT));
+    }
+    details
+}
+
+fn display_input_value(input: &str) -> String {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        "<empty>".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 impl Drop for App {
@@ -1094,6 +1327,13 @@ mod tests {
         assert!(!app.site_input_active);
         assert_eq!(app.blocker.sites, vec!["example.com"]);
         assert_eq!(app.selected_site, 0);
+        assert_eq!(
+            app.site_feedback,
+            Some(SiteFeedback {
+                level: SiteFeedbackLevel::Success,
+                message: "Added 1 site".to_string(),
+            })
+        );
         assert!(app.config_error.is_none());
     }
 
@@ -1118,7 +1358,76 @@ mod tests {
             vec!["a.com".to_string(), "b.com".to_string()]
         );
         assert_eq!(app.selected_site, 1);
+        assert_eq!(
+            app.site_feedback,
+            Some(SiteFeedback {
+                level: SiteFeedbackLevel::Success,
+                message: "Removed `c.com` from blocklist".to_string(),
+            })
+        );
         assert!(app.config_error.is_none());
+    }
+
+    #[test]
+    fn site_manager_bulk_add_via_paste_supports_comma_and_newline() {
+        let mut app = App::default();
+        app.handle_key(key(KeyCode::Char('b')));
+
+        app.handle_paste("Example.com,\ngithub.com\nexam_ple.com".to_string());
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(
+            app.blocker.sites,
+            vec!["example.com".to_string(), "github.com".to_string()]
+        );
+        let feedback = app
+            .site_feedback
+            .as_ref()
+            .expect("bulk add should provide feedback");
+        assert_eq!(feedback.level, SiteFeedbackLevel::Warning);
+        assert!(feedback.message.contains("Added 2 sites"));
+        assert!(feedback.message.contains("invalid hostname"));
+    }
+
+    #[test]
+    fn site_manager_edit_selected_site() {
+        let config = AppConfig {
+            blocked_sites: vec!["a.com".to_string(), "b.com".to_string()],
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('b')));
+        app.handle_key(key(KeyCode::Char('e')));
+        for _ in 0.."a.com".len() {
+            app.handle_key(key(KeyCode::Backspace));
+        }
+        for c in "news.ycombinator.com".chars() {
+            app.handle_key(key(KeyCode::Char(c)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(
+            app.blocker.sites,
+            vec!["news.ycombinator.com".to_string(), "b.com".to_string()]
+        );
+        assert_eq!(
+            app.site_feedback,
+            Some(SiteFeedback {
+                level: SiteFeedbackLevel::Success,
+                message: "Updated `a.com` -> `news.ycombinator.com`".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn site_manager_reapply_decision_uses_focus_state() {
+        let mut app = App::default();
+        assert!(!app.should_resync_blocking_after_site_mutation());
+
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        assert!(app.should_resync_blocking_after_site_mutation());
     }
 
     #[test]

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -15,6 +15,51 @@ pub struct SiteBlocker {
     pub is_blocking: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiteValidationError {
+    EmptyHostname,
+    MissingHostname,
+    ContainsWhitespace,
+    InvalidCharacter,
+    InvalidLabel,
+    MultipleHostnames,
+}
+
+impl SiteValidationError {
+    pub fn message(self) -> &'static str {
+        match self {
+            SiteValidationError::EmptyHostname => "empty hostname",
+            SiteValidationError::MissingHostname => "missing hostname",
+            SiteValidationError::ContainsWhitespace => "contains whitespace",
+            SiteValidationError::InvalidCharacter => "contains invalid characters",
+            SiteValidationError::InvalidLabel => "invalid hostname format",
+            SiteValidationError::MultipleHostnames => "multiple hostnames not allowed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidSiteInput {
+    pub input: String,
+    pub reason: SiteValidationError,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BulkAddResult {
+    pub added: Vec<String>,
+    pub duplicates: Vec<String>,
+    pub invalid: Vec<InvalidSiteInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditSiteResult {
+    Updated { old: String, new: String },
+    Unchanged { hostname: String },
+    Duplicate { hostname: String },
+    Invalid(InvalidSiteInput),
+    MissingSelection,
+}
+
 impl SiteBlocker {
     pub fn new() -> Self {
         Self {
@@ -24,20 +69,102 @@ impl SiteBlocker {
     }
 
     pub fn add_site(&mut self, site: String) {
-        if let Some(hostname) = Self::sanitize_hostname(&site)
-            && !self.sites.contains(&hostname)
+        let _ = self.add_sites_from_input(&site);
+    }
+
+    pub fn add_sites_from_input(&mut self, input: &str) -> BulkAddResult {
+        let candidates = split_hostname_candidates(input);
+        let mut result = BulkAddResult::default();
+
+        if candidates.is_empty() {
+            result.invalid.push(InvalidSiteInput {
+                input: input.trim().to_string(),
+                reason: SiteValidationError::EmptyHostname,
+            });
+            return result;
+        }
+
+        for candidate in candidates {
+            match Self::sanitize_hostname_with_reason(&candidate) {
+                Ok(hostname) => {
+                    if self.sites.contains(&hostname) {
+                        result.duplicates.push(hostname);
+                    } else {
+                        self.sites.push(hostname.clone());
+                        result.added.push(hostname);
+                    }
+                }
+                Err(reason) => result.invalid.push(InvalidSiteInput {
+                    input: candidate,
+                    reason,
+                }),
+            }
+        }
+
+        result
+    }
+
+    pub fn edit_site_from_input(&mut self, index: usize, input: &str) -> EditSiteResult {
+        if index >= self.sites.len() {
+            return EditSiteResult::MissingSelection;
+        }
+
+        let candidates = split_hostname_candidates(input);
+        if candidates.is_empty() {
+            return EditSiteResult::Invalid(InvalidSiteInput {
+                input: input.trim().to_string(),
+                reason: SiteValidationError::EmptyHostname,
+            });
+        }
+        if candidates.len() > 1 {
+            return EditSiteResult::Invalid(InvalidSiteInput {
+                input: input.trim().to_string(),
+                reason: SiteValidationError::MultipleHostnames,
+            });
+        }
+
+        let candidate = candidates[0].clone();
+        let normalized = match Self::sanitize_hostname_with_reason(&candidate) {
+            Ok(hostname) => hostname,
+            Err(reason) => {
+                return EditSiteResult::Invalid(InvalidSiteInput {
+                    input: candidate,
+                    reason,
+                });
+            }
+        };
+
+        let current = self.sites[index].clone();
+        if normalized == current {
+            return EditSiteResult::Unchanged {
+                hostname: normalized,
+            };
+        }
+
+        if self
+            .sites
+            .iter()
+            .enumerate()
+            .any(|(i, site)| i != index && site == &normalized)
         {
-            self.sites.push(hostname);
+            return EditSiteResult::Duplicate {
+                hostname: normalized,
+            };
+        }
+
+        self.sites[index] = normalized.clone();
+        EditSiteResult::Updated {
+            old: current,
+            new: normalized,
         }
     }
 
     /// Validate and normalise a user-supplied hostname.
-    /// Returns `None` if the input cannot be reduced to a valid single hostname.
-    fn sanitize_hostname(input: &str) -> Option<String> {
+    fn sanitize_hostname_with_reason(input: &str) -> Result<String, SiteValidationError> {
         let mut hostname = input.trim().to_lowercase();
 
         if hostname.is_empty() {
-            return None;
+            return Err(SiteValidationError::EmptyHostname);
         }
 
         // Strip URI scheme (e.g. "https://example.com" → "example.com").
@@ -50,13 +177,26 @@ impl SiteBlocker {
             hostname.truncate(pos);
         }
 
+        if let Some(at_pos) = hostname.rfind('@') {
+            hostname = hostname[at_pos + 1..].to_string();
+        }
+
+        // Strip a port suffix from host:port forms when the suffix is numeric.
+        if let Some(colon_pos) = hostname.rfind(':') {
+            let port = &hostname[colon_pos + 1..];
+            if hostname[..colon_pos].contains(':') || !port.chars().all(|c| c.is_ascii_digit()) {
+                return Err(SiteValidationError::InvalidLabel);
+            }
+            hostname.truncate(colon_pos);
+        }
+
         if hostname.is_empty() {
-            return None;
+            return Err(SiteValidationError::MissingHostname);
         }
 
         // Reject anything with internal whitespace (would produce multi-hostname lines).
         if hostname.chars().any(char::is_whitespace) {
-            return None;
+            return Err(SiteValidationError::ContainsWhitespace);
         }
 
         // Allow only ASCII letters, digits, dots, and hyphens.
@@ -64,16 +204,35 @@ impl SiteBlocker {
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-')
         {
-            return None;
+            return Err(SiteValidationError::InvalidCharacter);
         }
 
-        Some(hostname)
+        if hostname.starts_with('.')
+            || hostname.ends_with('.')
+            || hostname.contains("..")
+            || hostname.len() > 253
+        {
+            return Err(SiteValidationError::InvalidLabel);
+        }
+
+        for label in hostname.split('.') {
+            if label.is_empty()
+                || label.len() > 63
+                || label.starts_with('-')
+                || label.ends_with('-')
+            {
+                return Err(SiteValidationError::InvalidLabel);
+            }
+        }
+
+        Ok(hostname)
     }
 
-    pub fn remove_site(&mut self, index: usize) {
+    pub fn remove_site(&mut self, index: usize) -> Option<String> {
         if index < self.sites.len() {
-            self.sites.remove(index);
+            return Some(self.sites.remove(index));
         }
+        None
     }
 
     /// Activate blocking by writing entries into the hosts file.
@@ -216,6 +375,15 @@ fn append_hosts_mapping(content: &mut String, host: &str, site: &str, nl: &str) 
     content.push_str(nl);
 }
 
+fn split_hostname_candidates(input: &str) -> Vec<String> {
+    input
+        .split([',', '\n', '\r'])
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
 /// Write `content` to the hosts file atomically via a temp file + rename so
 /// an interrupted write cannot corrupt the file or leave it truncated.
 /// On non-Windows the original file's permissions are copied to the replacement.
@@ -335,6 +503,13 @@ mod tests {
     }
 
     #[test]
+    fn add_site_strips_numeric_port() {
+        let mut b = SiteBlocker::new();
+        b.add_site("https://example.com:443/some/path".to_string());
+        assert_eq!(b.sites, vec!["example.com"]);
+    }
+
+    #[test]
     fn add_site_rejects_multiple_hostnames() {
         let mut b = SiteBlocker::new();
         b.add_site("example.com other.com".to_string());
@@ -346,6 +521,84 @@ mod tests {
         let mut b = SiteBlocker::new();
         b.add_site("exam_ple.com".to_string());
         assert!(b.sites.is_empty());
+    }
+
+    #[test]
+    fn bulk_add_accepts_comma_and_newline_separators() {
+        let mut b = SiteBlocker::new();
+        let result = b.add_sites_from_input("example.com, github.com\nhttps://rust-lang.org/docs");
+        assert_eq!(
+            result.added,
+            vec!["example.com", "github.com", "rust-lang.org"]
+        );
+        assert!(result.duplicates.is_empty());
+        assert!(result.invalid.is_empty());
+        assert_eq!(b.sites, vec!["example.com", "github.com", "rust-lang.org"]);
+    }
+
+    #[test]
+    fn bulk_add_reports_duplicates_and_invalid_entries() {
+        let mut b = SiteBlocker::new();
+        let result = b.add_sites_from_input("github.com, bad host, exam_ple.com, github.com");
+        assert_eq!(result.added, vec!["github.com"]);
+        assert_eq!(result.duplicates, vec!["github.com"]);
+        assert_eq!(
+            result.invalid,
+            vec![
+                InvalidSiteInput {
+                    input: "bad host".to_string(),
+                    reason: SiteValidationError::ContainsWhitespace,
+                },
+                InvalidSiteInput {
+                    input: "exam_ple.com".to_string(),
+                    reason: SiteValidationError::InvalidCharacter,
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn edit_site_updates_selected_entry() {
+        let mut b = SiteBlocker::new();
+        b.add_site("a.com".to_string());
+        let result = b.edit_site_from_input(0, "https://news.ycombinator.com:443/newest");
+        assert_eq!(
+            result,
+            EditSiteResult::Updated {
+                old: "a.com".to_string(),
+                new: "news.ycombinator.com".to_string()
+            }
+        );
+        assert_eq!(b.sites, vec!["news.ycombinator.com"]);
+    }
+
+    #[test]
+    fn edit_site_rejects_duplicate_hostname() {
+        let mut b = SiteBlocker::new();
+        b.add_site("a.com".to_string());
+        b.add_site("b.com".to_string());
+        let result = b.edit_site_from_input(0, "b.com");
+        assert_eq!(
+            result,
+            EditSiteResult::Duplicate {
+                hostname: "b.com".to_string()
+            }
+        );
+        assert_eq!(b.sites, vec!["a.com", "b.com"]);
+    }
+
+    #[test]
+    fn edit_site_rejects_multiple_hostnames() {
+        let mut b = SiteBlocker::new();
+        b.add_site("a.com".to_string());
+        let result = b.edit_site_from_input(0, "a.com, b.com");
+        assert_eq!(
+            result,
+            EditSiteResult::Invalid(InvalidSiteInput {
+                input: "a.com, b.com".to_string(),
+                reason: SiteValidationError::MultipleHostnames,
+            })
+        );
     }
 
     #[test]
@@ -375,7 +628,8 @@ mod tests {
         let mut b = SiteBlocker::new();
         b.add_site("a.com".to_string());
         b.add_site("b.com".to_string());
-        b.remove_site(0);
+        let removed = b.remove_site(0);
+        assert_eq!(removed.as_deref(), Some("a.com"));
         assert_eq!(b.sites, vec!["b.com"]);
     }
 
@@ -383,7 +637,7 @@ mod tests {
     fn remove_site_out_of_bounds_is_safe() {
         let mut b = SiteBlocker::new();
         b.add_site("a.com".to_string());
-        b.remove_site(5); // should not panic
+        assert!(b.remove_site(5).is_none()); // should not panic
         assert_eq!(b.sites.len(), 1);
     }
 }

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -75,6 +76,7 @@ impl SiteBlocker {
     pub fn add_sites_from_input(&mut self, input: &str) -> BulkAddResult {
         let candidates = split_hostname_candidates(input);
         let mut result = BulkAddResult::default();
+        let mut known_sites: HashSet<String> = self.sites.iter().cloned().collect();
 
         if candidates.is_empty() {
             result.invalid.push(InvalidSiteInput {
@@ -87,7 +89,7 @@ impl SiteBlocker {
         for candidate in candidates {
             match Self::sanitize_hostname_with_reason(&candidate) {
                 Ok(hostname) => {
-                    if self.sites.contains(&hostname) {
+                    if !known_sites.insert(hostname.clone()) {
                         result.duplicates.push(hostname);
                     } else {
                         self.sites.push(hostname.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,10 @@ use std::{
 };
 
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event},
+    event::{
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event,
+    },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -30,7 +33,12 @@ impl TerminalGuard {
     fn new() -> io::Result<Self> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        if let Err(e) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture) {
+        if let Err(e) = execute!(
+            stdout,
+            EnterAlternateScreen,
+            EnableMouseCapture,
+            EnableBracketedPaste
+        ) {
             let _ = disable_raw_mode();
             return Err(e);
         }
@@ -41,7 +49,12 @@ impl TerminalGuard {
                 // Alternate screen and mouse capture are already active; undo them
                 // before returning since Drop won't run on an unconstructed value.
                 let mut stdout = io::stdout();
-                let _ = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture);
+                let _ = execute!(
+                    stdout,
+                    LeaveAlternateScreen,
+                    DisableMouseCapture,
+                    DisableBracketedPaste
+                );
                 let _ = disable_raw_mode();
                 Err(e)
             }
@@ -55,7 +68,8 @@ impl Drop for TerminalGuard {
         let _ = execute!(
             self.terminal.backend_mut(),
             LeaveAlternateScreen,
-            DisableMouseCapture
+            DisableMouseCapture,
+            DisableBracketedPaste
         );
         let _ = self.terminal.show_cursor();
     }
@@ -80,10 +94,12 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
             .checked_sub(last_tick.elapsed())
             .unwrap_or(Duration::ZERO);
 
-        if event::poll(timeout)?
-            && let Event::Key(key) = event::read()?
-        {
-            app.handle_key(key);
+        if event::poll(timeout)? {
+            match event::read()? {
+                Event::Key(key) => app.handle_key(key),
+                Event::Paste(text) => app.handle_paste(text),
+                _ => {}
+            }
         }
 
         if last_tick.elapsed() >= tick_rate {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,7 +6,9 @@ use ratatui::{
     widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph},
 };
 
-use crate::app::{App, AppMode, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS};
+use crate::app::{
+    App, AppMode, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, SiteFeedbackLevel, SiteInputMode,
+};
 use crate::timer::{TimerPhase, TimerStatus};
 use crate::wakatime::WakatimeRuntimeState;
 
@@ -264,6 +266,8 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
             .style(Style::default().fg(Color::Yellow));
     frame.render_widget(doh_warning, inner[1]);
 
+    let input_mode = app.site_input_mode();
+
     // Site list
     let list_title = format!(" Blocked Sites ({}) ", app.blocker.sites.len());
     let list_block = Block::default()
@@ -300,9 +304,13 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
     }
 
     // Input area
+    let input_title = match input_mode {
+        SiteInputMode::Add => " Add / Import Sites ",
+        SiteInputMode::Edit => " Edit Site ",
+    };
     let input_block = Block::default()
         .borders(Borders::ALL)
-        .title(" Add Site ")
+        .title(input_title)
         .style(if app.site_input_active {
             Style::default().fg(Color::Yellow)
         } else {
@@ -312,7 +320,7 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
     let input_text = if app.site_input_active {
         format!("{}_", app.site_input)
     } else {
-        "Press [a] to add a site (e.g. youtube.com)".to_string()
+        "Press [a] to add/import (comma/newline) or [e] to edit selected".to_string()
     };
     let input_widget =
         Paragraph::new(input_text)
@@ -334,13 +342,25 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         render_centered_error(frame, inner[6], format!("⚠  {err}{privilege_hint}"));
     } else if let Some(err) = app.config_error.as_ref() {
         render_centered_error(frame, inner[6], format!("⚠  {err}"));
+    } else if let Some(feedback) = app.site_feedback.as_ref() {
+        let (prefix, color) = match feedback.level {
+            SiteFeedbackLevel::Success => ("✓", Color::Green),
+            SiteFeedbackLevel::Warning => ("⚠", Color::Yellow),
+        };
+        let feedback_widget = Paragraph::new(format!("{prefix}  {}", feedback.message))
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(color));
+        frame.render_widget(feedback_widget, inner[6]);
     }
 
     // Key hints
     let hints = if app.site_input_active {
-        "[Enter] Confirm  [Esc] Cancel"
+        match input_mode {
+            SiteInputMode::Add => "[Enter] Add/Import  [Esc] Cancel",
+            SiteInputMode::Edit => "[Enter] Save  [Esc] Cancel",
+        }
     } else {
-        "[a] Add  [d] Delete  [↑/↓] Navigate  [b/Esc] Back  [q] Quit"
+        "[a] Add/Import  [e] Edit  [d] Delete  [↑/↓] Navigate  [b/Esc] Back  [q] Quit"
     };
     let hints_widget = Paragraph::new(hints)
         .alignment(Alignment::Center)


### PR DESCRIPTION
## What

Improve the site manager workflow for larger blocklists and faster iteration. This change adds bulk import support, an edit flow for existing entries, clearer inline feedback for invalid and duplicate hostnames, and deterministic block reapplication behavior after list mutations.

## Why

Issue #56 requested quality-of-life improvements for site management: bulk add/import, better validation feedback, smoother edit/delete interactions, and predictable reapplication behavior. Closes #56.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site manager workflow: add/import/edit/remove hostnames with keyboard shortcuts, paste support (bracketed paste) and unified add/edit input mode; Enter commits, Esc cancels.
  * Inline success/warning feedback for add/edit/delete operations.

* **Bug Fixes**
  * Stronger hostname validation and improved duplicate detection on bulk imports and edits.

* **Documentation**
  * Added detailed Site Manager usage and key bindings to README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->