### PR TITLE
Integrate SonarCloud analysis workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,35 @@
+name: SonarCloud
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sonarcloud:
+    name: 🔎 SonarCloud
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Skip scan when SONAR_TOKEN is missing
+        if: ${{ env.SONAR_TOKEN == '' }}
+        run: echo "SONAR_TOKEN is not configured. Skipping SonarCloud scan."
+
+      - name: Run SonarCloud scan
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@v6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # focustime
 
 [![Rust CI](https://github.com/utilForever/focustime/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/utilForever/focustime/actions/workflows/rust.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=utilForever_focustime&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=utilForever_focustime)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 TUI-based application for **Pomodoro timing**, **distraction-site blocking**, and **WakaTime tracking**.
@@ -65,6 +66,19 @@ cargo fmt --all -- --check
 cargo clippy --all-targets -- -D warnings
 cargo test --all
 ```
+
+### SonarCloud setup
+
+Static analysis runs in `.github/workflows/sonarcloud.yml` for pushes and pull
+requests to `main`.
+
+1. Import `utilForever/focustime` into SonarCloud.
+2. Confirm `sonar.projectKey` and `sonar.organization` in
+   `sonar-project.properties` match your SonarCloud project.
+3. Add `SONAR_TOKEN` as a repository secret in GitHub.
+
+> For pull requests from forks, the SonarCloud job is skipped because
+> repository secrets are not available in untrusted fork contexts.
 
 ## Pomodoro profiles
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=utilForever_focustime
-sonar.organization=utilforever
+sonar.organization=utilforever-github
 sonar.host.url=https://sonarcloud.io
 
 sonar.sources=src

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=utilForever_focustime
+sonar.organization=utilforever
+sonar.host.url=https://sonarcloud.io
+
+sonar.sources=src
+sonar.exclusions=target/**


### PR DESCRIPTION
## What

Integrates SonarCloud into repository CI by adding a dedicated GitHub Actions workflow, repository scanner configuration, and README guidance plus badge.

## Why

Issue #71 requests SonarCloud integration so quality gates and static analysis run automatically for changes targeting `main`.

This is implemented as a separate workflow to keep existing Rust build/test pipelines decoupled. The workflow also avoids hard failures for untrusted fork PRs where repository secrets are unavailable.

Closes #71

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Integrated SonarCloud for automated code quality scanning
  * Added project quality status badge to documentation
  * Configured static analysis workflow and settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->