### PR TITLE
Add auto-start options for phase transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Notifications are delivered best-effort:
 - desktop notification via platform-specific delivery (`winrt-toast-reborn` toast on Windows with a `msg` fallback, `osascript` on macOS, `notify-send` on Linux)
 - optional sound alert using platform audio capabilities when `notifications.sound = true`
 
-Natural phase transitions can also auto-start the next timer with safe defaults (`Off`):
+Natural, non-catchup phase transitions can also auto-start the next timer with safe defaults (`Off`):
 
-- `auto_start.focus_to_break` starts break timers automatically after focus completion
-- `auto_start.break_to_focus` starts focus timers automatically after break completion
+- `auto_start.focus_to_break` starts break timers automatically after focus completion on non-catchup ticks
+- `auto_start.break_to_focus` starts focus timers automatically after break completion on non-catchup ticks
 
 You can configure notification and auto-start settings directly from the TUI:
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ long_break_interval = 3
 enabled = true
 sound = false
 
+[auto_start]
+focus_to_break = false
+break_to_focus = false
+
 [daily_goal]
 minutes = 120
 pomodoros = 4
@@ -150,8 +154,8 @@ Invalid and duplicate entries are reported inline so you can fix them without le
 
 `focustime` emits a phase notification when a phase naturally completes at `00:00`:
 
-- **Focus complete** → next break starts
-- **Break complete** → focus starts
+- **Focus complete** → next break phase
+- **Break complete** → focus phase
 
 Manual skip (`n`) changes phase immediately but does not emit a completion notification.
 
@@ -161,11 +165,16 @@ Notifications are delivered best-effort:
 - desktop notification via platform-specific delivery (`winrt-toast-reborn` toast on Windows with a `msg` fallback, `osascript` on macOS, `notify-send` on Linux)
 - optional sound alert using platform audio capabilities when `notifications.sound = true`
 
-You can also configure `notifications.enabled` and `notifications.sound` directly from the TUI:
+Natural phase transitions can also auto-start the next timer with safe defaults (`Off`):
+
+- `auto_start.focus_to_break` starts break timers automatically after focus completion
+- `auto_start.break_to_focus` starts focus timers automatically after break completion
+
+You can configure notification and auto-start settings directly from the TUI:
 
 - open profile manager with `p`
 - press `e` to open the editor
-- use `↑/↓` to select **Phase notifications**, **Sound alert**, **Strict focus mode**, **Daily goal (minutes)**, or **Daily goal (pomodoros)**
+- use `↑/↓` to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily goal (minutes)**, or **Daily goal (pomodoros)**
 - use `←/→` to adjust values (or toggle `Off`/`On` for boolean fields), then `Enter` to save
 
 ## Strict focus mode

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::blocker::{BulkAddResult, EditSiteResult, InvalidSiteInput, SiteBlocker};
 use crate::config::{
-    AppConfig, CustomProfileConfig, DailyGoalConfig, NotificationConfig, ProfileId,
+    AppConfig, AutoStartConfig, CustomProfileConfig, DailyGoalConfig, NotificationConfig, ProfileId,
 };
 use crate::notifications::PhaseNotifier;
 use crate::stats::{DailyStats, FocusStats, SessionStats, current_day_key};
@@ -14,13 +14,15 @@ use crate::wakatime::WakatimeTracker;
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
-pub const PROFILE_EDIT_FIELD_LABELS: [&str; 9] = [
+pub const PROFILE_EDIT_FIELD_LABELS: [&str; 11] = [
     "Focus",
     "Short Break",
     "Long Break",
     "Long-break cadence",
     "Phase notifications",
     "Sound alert",
+    "Auto-start break",
+    "Auto-start focus",
     "Strict focus mode",
     "Goal minutes",
     "Goal pomodoros",
@@ -96,6 +98,7 @@ fn profile_for_index(index: usize) -> ProfileId {
 struct ProfileEditSnapshot {
     custom_profile: CustomProfileConfig,
     notification_settings: NotificationConfig,
+    auto_start: AutoStartConfig,
     strict_mode: bool,
     daily_goal: DailyGoalConfig,
 }
@@ -176,6 +179,7 @@ pub struct App {
     pub profile_edit_field: usize,
     profile_edit_snapshot: Option<ProfileEditSnapshot>,
     notification_settings: NotificationConfig,
+    auto_start: AutoStartConfig,
     pub strict_mode: bool,
     daily_goal: DailyGoalConfig,
     pending_timer_action: Option<PendingTimerAction>,
@@ -201,6 +205,7 @@ impl App {
         let selected_profile = config.selected_profile;
         let custom_profile = config.effective_custom_profile();
         let notification_settings = config.notifications;
+        let auto_start = config.auto_start;
         let strict_mode = config.strict_mode;
         let daily_goal = config.daily_goal;
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
@@ -240,6 +245,7 @@ impl App {
             profile_edit_field: 0,
             profile_edit_snapshot: None,
             notification_settings,
+            auto_start,
             strict_mode,
             daily_goal,
             pending_timer_action: None,
@@ -265,6 +271,9 @@ impl App {
         }
         if phase_changed {
             self.pending_timer_action = None;
+            if !is_catchup && self.should_auto_start_transition(completed_phase, self.timer.phase) {
+                self.timer.status = TimerStatus::Running;
+            }
             if !is_catchup {
                 self.phase_notification = self
                     .notifier
@@ -354,9 +363,11 @@ impl App {
             ),
             4 => bool_label(self.notification_settings.enabled).to_string(),
             5 => bool_label(self.notification_settings.sound).to_string(),
-            6 => bool_label(self.strict_mode).to_string(),
-            7 => format_daily_goal_minutes_label(self.daily_goal.minutes),
-            8 => format_daily_goal_pomodoros_label(self.daily_goal.pomodoros),
+            6 => bool_label(self.auto_start.focus_to_break).to_string(),
+            7 => bool_label(self.auto_start.break_to_focus).to_string(),
+            8 => bool_label(self.strict_mode).to_string(),
+            9 => format_daily_goal_minutes_label(self.daily_goal.minutes),
+            10 => format_daily_goal_pomodoros_label(self.daily_goal.pomodoros),
             _ => String::new(),
         }
     }
@@ -392,6 +403,7 @@ impl App {
             selected_profile: self.selected_profile,
             custom_profile: Some(custom_profile),
             notifications: self.notification_settings,
+            auto_start: self.auto_start,
             strict_mode: self.strict_mode,
             daily_goal: self.daily_goal,
         }
@@ -590,6 +602,7 @@ impl App {
         self.profile_edit_snapshot = Some(ProfileEditSnapshot {
             custom_profile: self.custom_profile.clone(),
             notification_settings: self.notification_settings,
+            auto_start: self.auto_start,
             strict_mode: self.strict_mode,
             daily_goal: self.daily_goal,
         });
@@ -601,6 +614,7 @@ impl App {
         if let Some(snapshot) = self.profile_edit_snapshot.take() {
             self.custom_profile = snapshot.custom_profile;
             self.notification_settings = snapshot.notification_settings;
+            self.auto_start = snapshot.auto_start;
             self.strict_mode = snapshot.strict_mode;
             self.daily_goal = snapshot.daily_goal;
             self.rebuild_notifier();
@@ -655,15 +669,21 @@ impl App {
                 self.notification_settings.sound = increase;
             }
             6 => {
+                self.auto_start.focus_to_break = increase;
+            }
+            7 => {
+                self.auto_start.break_to_focus = increase;
+            }
+            8 => {
                 if !increase && self.strict_mode_enforced_for_focus() {
                     return;
                 }
                 self.strict_mode = increase;
             }
-            7 => {
+            9 => {
                 adjust_daily_goal_minutes(&mut self.daily_goal.minutes, increase);
             }
-            8 => {
+            10 => {
                 adjust_daily_goal_pomodoros(&mut self.daily_goal.pomodoros, increase);
             }
             _ => {}
@@ -1030,6 +1050,22 @@ impl App {
         self.timer.phase == TimerPhase::Focus && self.timer.status == TimerStatus::Running
     }
 
+    fn should_auto_start_transition(
+        &self,
+        completed_phase: TimerPhase,
+        next_phase: TimerPhase,
+    ) -> bool {
+        match (completed_phase, next_phase) {
+            (TimerPhase::Focus, TimerPhase::ShortBreak | TimerPhase::LongBreak) => {
+                self.auto_start.focus_to_break
+            }
+            (TimerPhase::ShortBreak | TimerPhase::LongBreak, TimerPhase::Focus) => {
+                self.auto_start.break_to_focus
+            }
+            _ => false,
+        }
+    }
+
     fn record_focus_elapsed(&mut self, elapsed_secs: u64) {
         if elapsed_secs == 0 {
             return;
@@ -1234,6 +1270,7 @@ mod tests {
         assert_eq!(app.timer.short_break_secs, DEFAULT_SHORT_BREAK_SECS);
         assert_eq!(app.timer.long_break_secs, DEFAULT_LONG_BREAK_SECS);
         assert_eq!(app.timer.long_break_interval, DEFAULT_LONG_BREAK_INTERVAL);
+        assert_eq!(app.auto_start, AutoStartConfig::default());
         assert!(!app.strict_mode);
         assert_eq!(app.daily_goal, DailyGoalConfig::default());
     }
@@ -1254,6 +1291,7 @@ mod tests {
                 long_break_interval: 2,
             }),
             notifications: NotificationConfig::default(),
+            auto_start: AutoStartConfig::default(),
             strict_mode: false,
             daily_goal: DailyGoalConfig::default(),
         };
@@ -1399,6 +1437,7 @@ mod tests {
         assert_eq!(persisted.long_break_interval, custom.long_break_interval);
         assert_eq!(persisted.custom_profile, Some(custom));
         assert_eq!(persisted.notifications, NotificationConfig::default());
+        assert_eq!(persisted.auto_start, AutoStartConfig::default());
         assert!(persisted.strict_mode);
         assert_eq!(persisted.daily_goal, DailyGoalConfig::default());
     }
@@ -1443,6 +1482,8 @@ mod tests {
         assert_eq!(app.profile_edit_field_value(6), "Off");
         assert_eq!(app.profile_edit_field_value(7), "Off");
         assert_eq!(app.profile_edit_field_value(8), "Off");
+        assert_eq!(app.profile_edit_field_value(9), "Off");
+        assert_eq!(app.profile_edit_field_value(10), "Off");
     }
 
     #[test]
@@ -1451,7 +1492,7 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char('p')));
         app.handle_key(key(KeyCode::Char('e')));
-        for _ in 0..6 {
+        for _ in 0..8 {
             app.handle_key(key(KeyCode::Down));
         }
         app.handle_key(key(KeyCode::Right));
@@ -1508,12 +1549,34 @@ mod tests {
     }
 
     #[test]
+    fn editing_auto_start_fields_updates_and_persists_settings() {
+        let mut app = App::default();
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        for _ in 0..6 {
+            app.handle_key(key(KeyCode::Down));
+        }
+        app.handle_key(key(KeyCode::Right)); // auto-start break -> On
+        app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Right)); // auto-start focus -> On
+        app.handle_key(key(KeyCode::Enter));
+
+        assert!(app.auto_start.focus_to_break);
+        assert!(app.auto_start.break_to_focus);
+
+        let persisted = app.persisted_config();
+        assert!(persisted.auto_start.focus_to_break);
+        assert!(persisted.auto_start.break_to_focus);
+    }
+
+    #[test]
     fn editing_daily_goal_fields_updates_and_persists_settings() {
         let mut app = App::default();
 
         app.handle_key(key(KeyCode::Char('p')));
         app.handle_key(key(KeyCode::Char('e')));
-        for _ in 0..7 {
+        for _ in 0..9 {
             app.handle_key(key(KeyCode::Down));
         }
         app.handle_key(key(KeyCode::Right)); // minutes goal -> 5m
@@ -1543,7 +1606,7 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char('p')));
         app.handle_key(key(KeyCode::Char('e')));
-        for _ in 0..7 {
+        for _ in 0..9 {
             app.handle_key(key(KeyCode::Down));
         }
         app.handle_key(key(KeyCode::Right)); // minutes goal -> 30m
@@ -1553,6 +1616,32 @@ mod tests {
 
         assert_eq!(app.daily_goal.minutes, 25);
         assert_eq!(app.daily_goal.pomodoros, 3);
+    }
+
+    #[test]
+    fn cancelling_profile_edit_restores_auto_start_settings() {
+        let config = AppConfig {
+            auto_start: AutoStartConfig {
+                focus_to_break: true,
+                break_to_focus: true,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        for _ in 0..6 {
+            app.handle_key(key(KeyCode::Down));
+        }
+        app.handle_key(key(KeyCode::Left)); // auto-start break -> Off
+        app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Left)); // auto-start focus -> Off
+        app.handle_key(key(KeyCode::Esc)); // cancel
+
+        assert!(!app.profile_edit_active);
+        assert!(app.auto_start.focus_to_break);
+        assert!(app.auto_start.break_to_focus);
     }
 
     #[test]
@@ -1788,6 +1877,7 @@ mod tests {
             app.phase_notification.as_deref(),
             Some("Focus complete. Next up: Short Break.")
         );
+        assert_eq!(app.timer.status, TimerStatus::Idle);
     }
 
     #[test]
@@ -1798,6 +1888,64 @@ mod tests {
         app.handle_key(key(KeyCode::Char('n')));
 
         assert_eq!(app.session_stats().pomodoros_completed, 0);
+        assert!(app.phase_notification.is_none());
+    }
+
+    #[test]
+    fn natural_focus_completion_auto_starts_break_when_enabled() {
+        let config = AppConfig {
+            auto_start: AutoStartConfig {
+                focus_to_break: true,
+                break_to_focus: false,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.timer.remaining_secs = 1;
+
+        app.on_tick(false);
+
+        assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+    }
+
+    #[test]
+    fn natural_break_completion_auto_starts_focus_when_enabled() {
+        let config = AppConfig {
+            auto_start: AutoStartConfig {
+                focus_to_break: false,
+                break_to_focus: true,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.timer.phase = TimerPhase::ShortBreak;
+        app.timer.status = TimerStatus::Running;
+        app.timer.remaining_secs = 1;
+
+        app.on_tick(false);
+
+        assert_eq!(app.timer.phase, TimerPhase::Focus);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+    }
+
+    #[test]
+    fn manual_skip_keeps_next_phase_idle_when_auto_start_is_enabled() {
+        let config = AppConfig {
+            auto_start: AutoStartConfig {
+                focus_to_break: true,
+                break_to_focus: true,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('n')));
+
+        assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
+        assert_eq!(app.timer.status, TimerStatus::Idle);
         assert!(app.phase_notification.is_none());
     }
 
@@ -1954,7 +2102,7 @@ mod tests {
         app.timer.status = TimerStatus::Running;
         app.mode = AppMode::ProfileManager;
         app.profile_edit_active = true;
-        app.profile_edit_field = 6;
+        app.profile_edit_field = 8;
 
         app.handle_key(key(KeyCode::Left));
 
@@ -1978,6 +2126,7 @@ mod tests {
         app.profile_edit_snapshot = Some(ProfileEditSnapshot {
             custom_profile: app.custom_profile.clone(),
             notification_settings: app.notification_settings,
+            auto_start: app.auto_start,
             strict_mode: app.strict_mode,
             daily_goal: app.daily_goal,
         });
@@ -2013,10 +2162,11 @@ mod tests {
         app.timer.remaining_secs = app.timer.focus_secs.saturating_sub(30);
         app.mode = AppMode::ProfileManager;
         app.profile_edit_active = true;
-        app.profile_edit_field = 6;
+        app.profile_edit_field = 8;
         app.profile_edit_snapshot = Some(ProfileEditSnapshot {
             custom_profile: app.custom_profile.clone(),
             notification_settings: app.notification_settings,
+            auto_start: app.auto_start,
             strict_mode: app.strict_mode,
             daily_goal: app.daily_goal,
         });
@@ -2105,7 +2255,14 @@ mod tests {
 
     #[test]
     fn catchup_tick_does_not_increment_focus_stats() {
-        let mut app = App::default();
+        let config = AppConfig {
+            auto_start: AutoStartConfig {
+                focus_to_break: true,
+                break_to_focus: true,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
         app.timer.phase = TimerPhase::Focus;
         app.timer.status = TimerStatus::Running;
         app.timer.remaining_secs = 1;
@@ -2113,6 +2270,7 @@ mod tests {
         app.on_tick(true);
 
         assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
+        assert_eq!(app.timer.status, TimerStatus::Idle);
         assert_eq!(app.session_stats().pomodoros_completed, 0);
         assert_eq!(app.session_stats().focused_seconds, 0);
         assert!(app.phase_notification.is_none());

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,9 @@ pub struct AppConfig {
     /// Notification preferences for phase transitions.
     #[serde(default)]
     pub notifications: NotificationConfig,
+    /// Auto-start preferences for natural phase transitions.
+    #[serde(default)]
+    pub auto_start: AutoStartConfig,
     /// Whether strict focus mode is enabled.
     ///
     /// When enabled, active focus sessions disallow skip and require
@@ -58,6 +61,14 @@ pub struct NotificationConfig {
     pub enabled: bool,
     #[serde(default)]
     pub sound: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AutoStartConfig {
+    #[serde(default)]
+    pub focus_to_break: bool,
+    #[serde(default)]
+    pub break_to_focus: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -188,6 +199,7 @@ impl Default for AppConfig {
             selected_profile: ProfileId::default(),
             custom_profile: None,
             notifications: NotificationConfig::default(),
+            auto_start: AutoStartConfig::default(),
             strict_mode: false,
             daily_goal: DailyGoalConfig::default(),
         }
@@ -367,6 +379,7 @@ mod tests {
         assert!(cfg.custom_profile.is_none());
         assert!(cfg.blocked_sites.is_empty());
         assert_eq!(cfg.notifications, NotificationConfig::default());
+        assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
     }
@@ -390,6 +403,10 @@ mod tests {
                 enabled: true,
                 sound: true,
             },
+            auto_start: AutoStartConfig {
+                focus_to_break: true,
+                break_to_focus: false,
+            },
             strict_mode: true,
             daily_goal: DailyGoalConfig {
                 minutes: 180,
@@ -406,6 +423,7 @@ mod tests {
         assert_eq!(parsed.selected_profile, original.selected_profile);
         assert_eq!(parsed.custom_profile, original.custom_profile);
         assert_eq!(parsed.notifications, original.notifications);
+        assert_eq!(parsed.auto_start, original.auto_start);
         assert_eq!(parsed.strict_mode, original.strict_mode);
         assert_eq!(parsed.daily_goal, original.daily_goal);
     }
@@ -422,6 +440,7 @@ mod tests {
         assert!(cfg.custom_profile.is_none());
         assert!(cfg.blocked_sites.is_empty());
         assert_eq!(cfg.notifications, NotificationConfig::default());
+        assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
     }
@@ -443,6 +462,7 @@ blocked_sites = ["reddit.com", "youtube.com"]
         assert_eq!(parsed.long_break_secs, 900);
         assert_eq!(parsed.long_break_interval, 3);
         assert_eq!(parsed.blocked_sites, vec!["reddit.com", "youtube.com"]);
+        assert_eq!(parsed.auto_start, AutoStartConfig::default());
         assert_eq!(parsed.daily_goal, DailyGoalConfig::default());
     }
 
@@ -478,6 +498,7 @@ long_break_interval = 3
                 long_break_interval: 2,
             }),
             notifications: NotificationConfig::default(),
+            auto_start: AutoStartConfig::default(),
             strict_mode: false,
             daily_goal: DailyGoalConfig::default(),
         };
@@ -521,6 +542,7 @@ long_break_interval = 3
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
         assert!(cfg.blocked_sites.is_empty());
+        assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -446,6 +446,18 @@ mod tests {
     }
 
     #[test]
+    fn partial_auto_start_block_uses_defaults_for_missing_fields() {
+        let partial = r#"
+[auto_start]
+focus_to_break = true
+"#;
+        let cfg: AppConfig = toml::from_str(partial).unwrap();
+
+        assert!(cfg.auto_start.focus_to_break);
+        assert!(!cfg.auto_start.break_to_focus);
+    }
+
+    #[test]
     fn unknown_selected_profile_falls_back_to_custom_without_dropping_config() {
         let config = r#"
 focus_secs = 1500

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -463,6 +463,7 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
 fn render_profile_manager(frame: &mut Frame, app: &App) {
     let area = frame.area();
     let outer = centered_rect(70, 80, area);
+    let profile_editor_height = PROFILE_EDIT_FIELD_LABELS.len() as u16 + 2;
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -475,14 +476,14 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(1),  // current profile
-            Constraint::Length(1),  // spacer
-            Constraint::Length(7),  // profile list
-            Constraint::Length(1),  // spacer
-            Constraint::Length(13), // custom + notification + auto-start + daily goal editor
-            Constraint::Min(0),     // spacer
-            Constraint::Length(1),  // error line
-            Constraint::Length(2),  // key hints
+            Constraint::Length(1), // current profile
+            Constraint::Length(1), // spacer
+            Constraint::Length(7), // profile list
+            Constraint::Length(1), // spacer
+            Constraint::Length(profile_editor_height),
+            Constraint::Min(0),    // spacer
+            Constraint::Length(1), // error line
+            Constraint::Length(2), // key hints
         ])
         .split(outer);
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -479,7 +479,7 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
             Constraint::Length(1),  // spacer
             Constraint::Length(7),  // profile list
             Constraint::Length(1),  // spacer
-            Constraint::Length(11), // custom + notification + daily goal editor
+            Constraint::Length(13), // custom + notification + auto-start + daily goal editor
             Constraint::Min(0),     // spacer
             Constraint::Length(1),  // error line
             Constraint::Length(2),  // key hints
@@ -521,9 +521,9 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
     frame.render_stateful_widget(list, inner[2], &mut list_state);
 
     let editor_title = if app.profile_edit_active {
-        " Custom + notification settings editor "
+        " Custom + notification + auto-start settings editor "
     } else {
-        " Custom + notification settings ([e] to edit) "
+        " Custom + notification + auto-start settings ([e] to edit) "
     };
     let editor_block = Block::default()
         .borders(Borders::ALL)


### PR DESCRIPTION
## What

- Added `auto_start` config with `focus_to_break` and `break_to_focus` booleans (default `false`).
- Wired auto-start settings through app state, persisted config, and the profile editor with two new fields.
- Updated transition logic so only natural, non-catchup phase completions can auto-start the next phase.
- Kept manual skip behavior unchanged, and expanded app/config tests for new behavior.
- Updated README example config and settings documentation for the new options.

## Why

Issue #82 requested optional auto-start transitions with safe defaults. This lets users opt into continuous flow while preserving existing default behavior.

Closes #82.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Auto-start toggles: "Auto-start break" and "Auto-start focus" in the TUI (defaults Off).
  * Timers can auto-start the next phase on natural (non-catchup) transitions between focus and break.
  * Manual skip keeps the next phase idle even when auto-start is enabled.

* **Documentation**
  * README updated with [auto_start] config and clarified phase-completion messages labeling the upcoming phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->