### PR TITLE
Prevent double key input issue on Windows

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use crate::blocker::{BulkAddResult, EditSiteResult, InvalidSiteInput, SiteBlocker};
 use crate::config::{
@@ -1249,6 +1249,10 @@ impl Default for App {
     }
 }
 
+pub(crate) fn should_handle_key(key: &KeyEvent) -> bool {
+    key.kind == KeyEventKind::Press
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2309,6 +2313,24 @@ mod tests {
         assert_eq!(
             app.wakatime.runtime_state(),
             crate::wakatime::WakatimeRuntimeState::Error("HTTP 503".to_string())
+        );
+    }
+
+    #[test]
+    fn prevent_double_input_on_windows() {
+        let mut press_event = KeyEvent::from(KeyCode::Char('a'));
+        press_event.kind = KeyEventKind::Press;
+
+        let mut release_event = KeyEvent::from(KeyCode::Char('a'));
+        release_event.kind = KeyEventKind::Release;
+
+        assert!(
+            should_handle_key(&press_event),
+            "Press event should be handled"
+        );
+        assert!(
+            !should_handle_key(&release_event),
+            "Release event should NOT be handled"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::{
 use crossterm::{
     event::{
         self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event,
+        Event, KeyEventKind,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -96,7 +96,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
 
         if event::poll(timeout)? {
             match event::read()? {
-                Event::Key(key) => app.handle_key(key),
+                Event::Key(key) if key.kind == KeyEventKind::Press => app.handle_key(key),
+                Event::Key(key) if key.kind == KeyEventKind::Release => {}
                 Event::Paste(text) => app.handle_paste(text),
                 _ => {}
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::{
 use crossterm::{
     event::{
         self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event, KeyEventKind,
+        Event,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -23,6 +23,7 @@ use crossterm::{
 use ratatui::{Terminal, backend::CrosstermBackend};
 
 use app::App;
+use app::should_handle_key;
 
 /// RAII guard that restores the terminal on drop, ensuring cleanup on any exit path.
 struct TerminalGuard {
@@ -96,8 +97,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<
 
         if event::poll(timeout)? {
             match event::read()? {
-                Event::Key(key) if key.kind == KeyEventKind::Press => app.handle_key(key),
-                Event::Key(key) if key.kind == KeyEventKind::Release => {}
+                Event::Key(key) if should_handle_key(&key) => app.handle_key(key),
                 Event::Paste(text) => app.handle_paste(text),
                 _ => {}
             }


### PR DESCRIPTION
## What

Fixed a bug where key inputs were being registered twice in Windows environments by ignoring 'Release' events.

## Why

In Windows consoles, 'crossterm' captures both 'Press' and 'Release' events. By explicitly filtering for 'KeyEventKind::Press' in the event loop, this prevents the duplicate execution of 'app.handle_key(key).

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [ ] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard input now only processes actual key presses and ignores key releases, preventing duplicate or spurious input on affected platforms.

* **Tests**
  * Added coverage to ensure key-release events are ignored and presses are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->