### PR TITLE
Show last successful WakaTime heartbeat in timer status

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,9 @@ The timer never waits on network calls.
 - transient heartbeat failures (`429`, `5xx`, and connectivity/timeout errors)
   retry with bounded backoff (`1s`, then `2s`)
 - non-retryable failures are surfaced in the timer view status line
-- status line now reflects runtime states (`tracking`, `sending`, `retrying`,
-  `error`, `idle`, `not configured`)
+- status line reflects runtime states (`tracking`, `sending`, `retrying`,
+  `error`, `idle`, `not configured`) and, when configured, also shows the last
+  successful heartbeat time (`HH:MM:SS`) or `not yet sent` before first success
 
 For full module map and design details, see [ARCHITECTURE.md](ARCHITECTURE.md).
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,4 @@
+use chrono::{Local, TimeZone};
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -219,7 +220,8 @@ fn render_timer_wakatime_status(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn wakatime_status_line(app: &App) -> (String, Color) {
-    match app.wakatime.runtime_state() {
+    let runtime_state = app.wakatime.runtime_state();
+    let (status_text, status_color) = match &runtime_state {
         WakatimeRuntimeState::NotConfigured => {
             ("⏱ WakaTime: not configured".to_string(), Color::DarkGray)
         }
@@ -240,7 +242,34 @@ fn wakatime_status_line(app: &App) -> (String, Color) {
             Color::Yellow,
         ),
         WakatimeRuntimeState::Error(error) => (format!("⏱ WakaTime: error ({error})"), Color::Red),
+    };
+
+    if matches!(runtime_state, WakatimeRuntimeState::NotConfigured) {
+        return (status_text, status_color);
     }
+
+    (
+        format!("{status_text} · {}", wakatime_last_success_text(app)),
+        status_color,
+    )
+}
+
+fn wakatime_last_success_text(app: &App) -> String {
+    match app.wakatime.last_successful_heartbeat_epoch_secs() {
+        Some(epoch_secs) => format!(
+            "last success {}",
+            format_wakatime_heartbeat_timestamp(epoch_secs)
+        ),
+        None => "last success not yet sent".to_string(),
+    }
+}
+
+fn format_wakatime_heartbeat_timestamp(epoch_secs: u64) -> String {
+    i64::try_from(epoch_secs)
+        .ok()
+        .and_then(|secs| Local.timestamp_opt(secs, 0).single())
+        .map(|datetime| datetime.format("%H:%M:%S").to_string())
+        .unwrap_or_else(|| epoch_secs.to_string())
 }
 
 fn render_timer_hints(frame: &mut Frame, app: &App, area: Rect) {
@@ -758,4 +787,46 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
             Constraint::Percentage(h_outer_right),
         ])
         .split(popup_layout[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wakatime::WakatimeTracker;
+
+    #[test]
+    fn wakatime_status_line_shows_not_yet_sent_when_no_success_exists() {
+        let mut app = App::default();
+        app.wakatime = WakatimeTracker::new_configured_for_tests();
+
+        let (text, color) = wakatime_status_line(&app);
+
+        assert_eq!(text, "⏱ WakaTime: idle · last success not yet sent");
+        assert_eq!(color, Color::DarkGray);
+    }
+
+    #[test]
+    fn wakatime_status_line_shows_last_success_time_after_success_event() {
+        let mut app = App::default();
+        app.wakatime = WakatimeTracker::new_configured_for_tests();
+        app.wakatime.push_sent_event_for_tests();
+        app.wakatime.poll_events();
+
+        let (text, color) = wakatime_status_line(&app);
+
+        assert!(text.starts_with("⏱ WakaTime: idle · last success "));
+        assert!(!text.contains("not yet sent"));
+        assert_eq!(color, Color::DarkGray);
+    }
+
+    #[test]
+    fn wakatime_status_line_for_not_configured_omits_last_success_suffix() {
+        let mut app = App::default();
+        app.wakatime = WakatimeTracker::new_unconfigured_for_tests();
+
+        let (text, color) = wakatime_status_line(&app);
+
+        assert_eq!(text, "⏱ WakaTime: not configured");
+        assert_eq!(color, Color::DarkGray);
+    }
 }

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -37,6 +37,13 @@ pub enum WakatimeRuntimeState {
     Error(String),
 }
 
+fn current_unix_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RetryState {
     attempt: u8,
@@ -163,6 +170,8 @@ pub struct WakatimeTracker {
     retry_state: Option<RetryState>,
     /// Last terminal heartbeat failure message.
     last_error: Option<String>,
+    /// Unix timestamp (seconds) of the most recent successful heartbeat.
+    last_successful_heartbeat_epoch_secs: Option<u64>,
     /// Latches an immediate heartbeat request while another worker is in flight.
     pending_immediate_heartbeat: bool,
     #[cfg(test)]
@@ -183,6 +192,7 @@ impl WakatimeTracker {
             heartbeat_in_flight: false,
             retry_state: None,
             last_error: None,
+            last_successful_heartbeat_epoch_secs: None,
             pending_immediate_heartbeat: false,
             #[cfg(test)]
             disable_network_io: false,
@@ -219,6 +229,10 @@ impl WakatimeTracker {
         }
     }
 
+    pub fn last_successful_heartbeat_epoch_secs(&self) -> Option<u64> {
+        self.last_successful_heartbeat_epoch_secs
+    }
+
     /// Drains heartbeat events from worker threads and updates tracker status.
     pub fn poll_events(&mut self) {
         while let Ok(event) = self.result_rx.try_recv() {
@@ -227,6 +241,7 @@ impl WakatimeTracker {
                     self.heartbeat_in_flight = false;
                     self.retry_state = None;
                     self.last_error = None;
+                    self.last_successful_heartbeat_epoch_secs = Some(current_unix_epoch_secs());
                     self.dispatch_pending_immediate_heartbeat();
                 }
                 HeartbeatEvent::Retrying {
@@ -366,9 +381,34 @@ impl WakatimeTracker {
             heartbeat_in_flight: false,
             retry_state: None,
             last_error: None,
+            last_successful_heartbeat_epoch_secs: None,
             pending_immediate_heartbeat: false,
             disable_network_io: true,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_unconfigured_for_tests() -> Self {
+        let (result_tx, result_rx) = mpsc::channel();
+        Self {
+            api_key: None,
+            api_url: DEFAULT_API_URL.to_string(),
+            secs_since_last_heartbeat: 0,
+            tracking: false,
+            result_tx,
+            result_rx,
+            heartbeat_in_flight: false,
+            retry_state: None,
+            last_error: None,
+            last_successful_heartbeat_epoch_secs: None,
+            pending_immediate_heartbeat: false,
+            disable_network_io: true,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn push_sent_event_for_tests(&self) {
+        let _ = self.result_tx.send(HeartbeatEvent::Sent);
     }
 
     #[cfg(test)]
@@ -486,6 +526,7 @@ mod tests {
             heartbeat_in_flight: false,
             retry_state: None,
             last_error: None,
+            last_successful_heartbeat_epoch_secs: None,
             pending_immediate_heartbeat: false,
             disable_network_io: true,
         }
@@ -703,6 +744,37 @@ mod tests {
         tracker.poll_events();
 
         assert_eq!(tracker.runtime_state(), WakatimeRuntimeState::Tracking);
+        assert!(tracker.last_successful_heartbeat_epoch_secs.is_some());
+    }
+
+    #[test]
+    fn success_event_records_last_success_timestamp() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        assert!(tracker.last_successful_heartbeat_epoch_secs.is_none());
+
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Sent)
+            .expect("test event send must succeed");
+        tracker.poll_events();
+
+        assert!(tracker.last_successful_heartbeat_epoch_secs.is_some());
+    }
+
+    #[test]
+    fn failure_event_preserves_last_success_timestamp() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        tracker.last_successful_heartbeat_epoch_secs = Some(123);
+
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Failed {
+                error: "HTTP 500".to_string(),
+            })
+            .expect("test event send must succeed");
+        tracker.poll_events();
+
+        assert_eq!(tracker.last_successful_heartbeat_epoch_secs, Some(123));
     }
 
     #[test]


### PR DESCRIPTION
## What

Show the timestamp of the most recent successful WakaTime heartbeat in the timer status line.

- `WakatimeTracker` now stores the last successful heartbeat timestamp and exposes it to the UI.
- Timer status text now appends `last success HH:MM:SS` or `last success not yet sent` when WakaTime is configured.
- Added unit tests for tracker timestamp behavior and UI status-line rendering, and updated README documentation.

## Why

Issue #83 requests visibility into the last successful heartbeat, not only transient runtime states like sending or retrying. This makes it easier to detect stale or failing tracking during focus sessions.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable) (N/A)
- [ ] Site blocking behavior was verified for this change (if applicable) (N/A)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed) (N/A)
- [x] Breaking behavior changes are clearly described in this PR (none)

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WakaTime status line now displays the timestamp of the last successful heartbeat (in HH:MM:SS format) or "not yet sent" if no heartbeat has been recorded, providing improved visibility into sync status.

* **Documentation**
  * Updated documentation to describe the new last successful heartbeat timestamp display in the WakaTime status line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->