### PR TITLE
Add setup diagnostics screen for blocking and WakaTime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@ flowchart LR
 | `blocker.rs` | Hosts-file based site blocking/unblocking and DNS cache flush integration | `app`, OS commands/filesystem |
 | `wakatime.rs` | WakaTime config parsing and heartbeat scheduling/sending | `app`, HTTP (`ureq`) |
 | `notifications.rs` | Phase completion notifications and optional sound alerts | `app`, OS notification commands |
-| `ui.rs` | Ratatui rendering for Timer and Site Manager screens | `app`, `timer` |
+| `ui.rs` | Ratatui rendering for Timer, Site Manager, Profile, History, and Setup Diagnostics screens | `app`, `timer` |
 
 ## Related explanation
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ Add/import input supports:
 
 Invalid and duplicate entries are reported inline so you can fix them without leaving the view.
 
+## Setup diagnostics
+
+Open the setup diagnostics screen from timer view with **`d`**.
+
+- `r`: refresh diagnostics checks
+- `d` or `Esc`: return to timer view
+
+The diagnostics screen reports:
+
+- blocking permissions
+- hosts file write capability
+- WakaTime config status (`~/.wakatime.cfg` and `api_key` availability)
+
 ## Phase notifications
 
 `focustime` emits a phase notification when a phase naturally completes at `00:00`:
@@ -217,7 +230,7 @@ From timer view:
 - `src/blocker.rs`: hosts-file site blocking and unblocking.
 - `src/wakatime.rs`: heartbeat tracking integration.
 - `src/notifications.rs`: phase transition notifications and optional sound.
-- `src/ui.rs`: Ratatui rendering for timer and site manager views.
+- `src/ui.rs`: Ratatui rendering for timer, site manager, profile, history, and setup diagnostics views.
 
 WakaTime tracking is optional and activates only when an API key is configured
 (read from `~/.wakatime.cfg`).

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,8 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
-use crate::blocker::{BulkAddResult, EditSiteResult, InvalidSiteInput, SiteBlocker};
+use crate::blocker::{
+    BulkAddResult, EditSiteResult, HostsFileDiagnostics, InvalidSiteInput, SiteBlocker,
+};
 use crate::config::{
     AppConfig, AutoStartConfig, CustomProfileConfig, DailyGoalConfig, NotificationConfig, ProfileId,
 };
@@ -10,7 +12,7 @@ use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
     DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerState, TimerStatus,
 };
-use crate::wakatime::WakatimeTracker;
+use crate::wakatime::{WakatimeConfigStatus, WakatimeTracker};
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
@@ -36,6 +38,7 @@ pub enum AppMode {
     SiteManager,
     ProfileManager,
     StatsHistory,
+    SetupDiagnostics,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -151,6 +154,67 @@ impl DailyGoalProgress {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetupCheckLevel {
+    Ok,
+    Warning,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetupCheck {
+    pub level: SetupCheckLevel,
+    pub message: String,
+}
+
+impl SetupCheck {
+    fn ok(message: impl Into<String>) -> Self {
+        Self {
+            level: SetupCheckLevel::Ok,
+            message: message.into(),
+        }
+    }
+
+    fn warning(message: impl Into<String>) -> Self {
+        Self {
+            level: SetupCheckLevel::Warning,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetupDiagnostics {
+    pub hosts_file_path: String,
+    pub blocking_permissions: SetupCheck,
+    pub hosts_write_capability: SetupCheck,
+    pub wakatime_config: SetupCheck,
+}
+
+impl SetupDiagnostics {
+    fn collect(blocker: &SiteBlocker) -> Self {
+        let hosts_diagnostics = blocker.hosts_file_diagnostics();
+        let blocking_permissions = blocking_permissions_check(&hosts_diagnostics);
+        let hosts_write_capability = hosts_write_capability_check(&hosts_diagnostics);
+        let hosts_file_path = hosts_diagnostics.path.clone();
+        let wakatime_diagnostics = WakatimeTracker::config_diagnostics();
+        let wakatime_config = match wakatime_diagnostics.status {
+            WakatimeConfigStatus::Configured => SetupCheck::ok(wakatime_diagnostics.detail),
+            WakatimeConfigStatus::MissingConfigFile
+            | WakatimeConfigStatus::MissingApiKey
+            | WakatimeConfigStatus::UnreadableConfig
+            | WakatimeConfigStatus::HomeDirectoryUnavailable => {
+                SetupCheck::warning(wakatime_diagnostics.detail)
+            }
+        };
+        Self {
+            hosts_file_path,
+            blocking_permissions,
+            hosts_write_capability,
+            wakatime_config,
+        }
+    }
+}
+
 pub struct App {
     pub timer: TimerState,
     pub should_quit: bool,
@@ -166,6 +230,7 @@ pub struct App {
     pub selected_site: usize,
     /// Last error from a block/unblock operation (e.g. permission denied).
     pub block_error: Option<String>,
+    pub setup_diagnostics: SetupDiagnostics,
     /// Last error from persisting timer/site configuration.
     pub config_error: Option<String>,
     /// Last error from persisting focus stats.
@@ -223,6 +288,7 @@ impl App {
         for site in &config.blocked_sites {
             blocker.add_site(site.clone());
         }
+        let setup_diagnostics = SetupDiagnostics::collect(&blocker);
         Self {
             timer,
             should_quit: false,
@@ -234,6 +300,7 @@ impl App {
             site_feedback: None,
             selected_site: 0,
             block_error: None,
+            setup_diagnostics,
             config_error: None,
             stats_error,
             phase_notification: None,
@@ -459,6 +526,7 @@ impl App {
             AppMode::SiteManager => self.handle_key_site_manager(key),
             AppMode::ProfileManager => self.handle_key_profile_manager(key),
             AppMode::StatsHistory => self.handle_key_stats_history(key),
+            AppMode::SetupDiagnostics => self.handle_key_setup_diagnostics(key),
         }
     }
 
@@ -522,6 +590,10 @@ impl App {
             KeyCode::Char('h') => {
                 self.open_stats_history();
             }
+            // Open setup diagnostics
+            KeyCode::Char('d') => {
+                self.open_setup_diagnostics();
+            }
             _ => {}
         }
     }
@@ -534,6 +606,22 @@ impl App {
         match key.code {
             KeyCode::Esc | KeyCode::Char('h') => {
                 self.mode = AppMode::Timer;
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_key_setup_diagnostics(&mut self, key: KeyEvent) {
+        if self.handle_quit_key(&key, false) {
+            return;
+        }
+
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('d') => {
+                self.mode = AppMode::Timer;
+            }
+            KeyCode::Char('r') => {
+                self.refresh_setup_diagnostics();
             }
             _ => {}
         }
@@ -1009,6 +1097,12 @@ impl App {
         self.mode = AppMode::StatsHistory;
     }
 
+    fn open_setup_diagnostics(&mut self) {
+        self.pending_timer_action = None;
+        self.refresh_setup_diagnostics();
+        self.mode = AppMode::SetupDiagnostics;
+    }
+
     fn exit_profile_manager(&mut self) {
         self.mode = AppMode::Timer;
         self.profile_edit_snapshot = None;
@@ -1114,6 +1208,10 @@ impl App {
             level,
             message: message.into(),
         });
+    }
+
+    fn refresh_setup_diagnostics(&mut self) {
+        self.setup_diagnostics = SetupDiagnostics::collect(&self.blocker);
     }
 
     fn rebuild_notifier(&mut self) {
@@ -1240,6 +1338,41 @@ impl Drop for App {
         // Ensure hosts-file block entries are removed on every exit path,
         // including early returns caused by I/O errors in run_app.
         self.blocker.cleanup();
+    }
+}
+
+fn blocking_permissions_check(hosts_diagnostics: &HostsFileDiagnostics) -> SetupCheck {
+    if hosts_diagnostics.can_write() {
+        SetupCheck::ok("Ready: hosts file can be opened for write access")
+    } else {
+        let reason = hosts_diagnostics
+            .write_error
+            .as_deref()
+            .unwrap_or("unknown write error");
+        SetupCheck::warning(format!("Blocked: write permission unavailable ({reason})"))
+    }
+}
+
+fn hosts_write_capability_check(hosts_diagnostics: &HostsFileDiagnostics) -> SetupCheck {
+    let can_read = hosts_diagnostics.can_read();
+    let can_write = hosts_diagnostics.can_write();
+    match (
+        can_read,
+        can_write,
+        hosts_diagnostics.read_error.as_deref(),
+        hosts_diagnostics.write_error.as_deref(),
+    ) {
+        (true, true, _, _) => SetupCheck::ok("Ready: hosts file is readable and writable"),
+        (false, true, Some(read_error), _) => {
+            SetupCheck::warning(format!("Blocked: cannot read hosts file ({read_error})"))
+        }
+        (true, false, _, Some(write_error)) => {
+            SetupCheck::warning(format!("Blocked: cannot write hosts file ({write_error})"))
+        }
+        (false, false, Some(read_error), Some(write_error)) => SetupCheck::warning(format!(
+            "Blocked: read error ({read_error}); write error ({write_error})"
+        )),
+        _ => SetupCheck::warning("Blocked: hosts access diagnostics unavailable"),
     }
 }
 
@@ -2255,6 +2388,36 @@ mod tests {
 
         app.handle_key(key(KeyCode::Esc));
         assert_eq!(app.mode, AppMode::Timer);
+    }
+
+    #[test]
+    fn diagnostics_view_toggles_from_timer_mode() {
+        let mut app = App::default();
+
+        app.handle_key(key(KeyCode::Char('d')));
+        assert_eq!(app.mode, AppMode::SetupDiagnostics);
+
+        app.handle_key(key(KeyCode::Esc));
+        assert_eq!(app.mode, AppMode::Timer);
+    }
+
+    #[test]
+    fn pending_strict_reset_confirmation_clears_when_opening_setup_diagnostics() {
+        let config = AppConfig {
+            strict_mode: true,
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+
+        app.handle_key(key(KeyCode::Char('s')));
+        assert!(app.strict_reset_confirmation_pending());
+
+        app.handle_key(key(KeyCode::Char('d')));
+
+        assert_eq!(app.mode, AppMode::SetupDiagnostics);
+        assert!(!app.strict_reset_confirmation_pending());
     }
 
     #[test]

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io;
 use std::path::Path;
 use std::process::Command;
@@ -14,6 +14,23 @@ const BLOCK_MARKER_END: &str = "# focustime-block-end";
 pub struct SiteBlocker {
     pub sites: Vec<String>,
     pub is_blocking: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostsFileDiagnostics {
+    pub path: String,
+    pub read_error: Option<String>,
+    pub write_error: Option<String>,
+}
+
+impl HostsFileDiagnostics {
+    pub fn can_read(&self) -> bool {
+        self.read_error.is_none()
+    }
+
+    pub fn can_write(&self) -> bool {
+        self.write_error.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -237,6 +254,10 @@ impl SiteBlocker {
         None
     }
 
+    pub fn hosts_file_diagnostics(&self) -> HostsFileDiagnostics {
+        hosts_file_diagnostics_for(Path::new(HOSTS_FILE))
+    }
+
     /// Activate blocking by writing entries into the hosts file.
     /// Returns an error if the file is not writable (e.g. needs sudo).
     pub fn block(&mut self) -> io::Result<()> {
@@ -386,6 +407,20 @@ fn split_hostname_candidates(input: &str) -> Vec<String> {
         .collect()
 }
 
+fn hosts_file_diagnostics_for(path: &Path) -> HostsFileDiagnostics {
+    let read_error = fs::File::open(path).err().map(|error| error.to_string());
+    let write_error = OpenOptions::new()
+        .append(true)
+        .open(path)
+        .err()
+        .map(|error| error.to_string());
+    HostsFileDiagnostics {
+        path: path.display().to_string(),
+        read_error,
+        write_error,
+    }
+}
+
 /// Write `content` to the hosts file atomically via a temp file + rename so
 /// an interrupted write cannot corrupt the file or leave it truncated.
 /// On non-Windows the original file's permissions are copied to the replacement.
@@ -442,6 +477,7 @@ fn flush_dns_cache() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn strip_unterminated_start_marker_leaves_content_unchanged() {
@@ -641,5 +677,41 @@ mod tests {
         b.add_site("a.com".to_string());
         assert!(b.remove_site(5).is_none()); // should not panic
         assert_eq!(b.sites.len(), 1);
+    }
+
+    #[test]
+    fn hosts_file_diagnostics_reports_read_and_write_success_for_temp_file() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("focustime-hosts-diagnostics-{unique}.tmp"));
+        fs::write(&path, "127.0.0.1 localhost\n").expect("temp hosts file should be writable");
+
+        let diagnostics = hosts_file_diagnostics_for(&path);
+
+        assert!(diagnostics.can_read());
+        assert!(diagnostics.can_write());
+        assert!(diagnostics.read_error.is_none());
+        assert!(diagnostics.write_error.is_none());
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn hosts_file_diagnostics_reports_missing_file_errors() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("focustime-hosts-diagnostics-missing-{unique}.tmp"));
+        let _ = fs::remove_file(&path);
+
+        let diagnostics = hosts_file_diagnostics_for(&path);
+
+        assert!(!diagnostics.can_read());
+        assert!(!diagnostics.can_write());
+        assert!(diagnostics.read_error.is_some());
+        assert!(diagnostics.write_error.is_some());
     }
 }

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -409,9 +409,7 @@ fn split_hostname_candidates(input: &str) -> Vec<String> {
 
 fn hosts_file_diagnostics_for(path: &Path) -> HostsFileDiagnostics {
     let read_error = fs::File::open(path).err().map(|error| error.to_string());
-    let write_error = OpenOptions::new()
-        .append(true)
-        .open(path)
+    let write_error = probe_hosts_write_path(path)
         .err()
         .map(|error| error.to_string());
     HostsFileDiagnostics {
@@ -419,6 +417,30 @@ fn hosts_file_diagnostics_for(path: &Path) -> HostsFileDiagnostics {
         read_error,
         write_error,
     }
+}
+
+#[cfg(target_os = "windows")]
+fn probe_hosts_write_path(path: &Path) -> io::Result<()> {
+    OpenOptions::new().append(true).open(path).map(|_| ())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn probe_hosts_write_path(path: &Path) -> io::Result<()> {
+    let dir = path.parent().unwrap_or(Path::new("."));
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let probe = dir.join(format!(
+        ".focustime_hosts_probe_{}_{}",
+        std::process::id(),
+        nanos
+    ));
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe)?;
+    fs::remove_file(&probe)
 }
 
 /// Write `content` to the hosts file atomically via a temp file + rename so
@@ -710,8 +732,16 @@ mod tests {
         let diagnostics = hosts_file_diagnostics_for(&path);
 
         assert!(!diagnostics.can_read());
-        assert!(!diagnostics.can_write());
         assert!(diagnostics.read_error.is_some());
-        assert!(diagnostics.write_error.is_some());
+        #[cfg(target_os = "windows")]
+        {
+            assert!(!diagnostics.can_write());
+            assert!(diagnostics.write_error.is_some());
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            assert!(diagnostics.can_write());
+            assert!(diagnostics.write_error.is_none());
+        }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph},
+    widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph, Wrap},
 };
 
 use crate::app::{
@@ -736,9 +736,9 @@ fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         .constraints([
             Constraint::Length(1), // hosts path
             Constraint::Length(1), // spacer
-            Constraint::Length(1), // blocking permissions
-            Constraint::Length(1), // hosts write capability
-            Constraint::Length(1), // wakatime config status
+            Constraint::Length(2), // blocking permissions
+            Constraint::Length(2), // hosts write capability
+            Constraint::Length(2), // wakatime config status
             Constraint::Min(0),    // spacer
             Constraint::Length(2), // key hints
         ])
@@ -797,7 +797,7 @@ fn render_setup_check(frame: &mut Frame, area: Rect, label: &str, check: &SetupC
         ),
         Span::styled(check.message.as_str(), Style::default().fg(Color::Gray)),
     ]);
-    frame.render_widget(Paragraph::new(line), area);
+    frame.render_widget(Paragraph::new(line).wrap(Wrap { trim: true }), area);
 }
 
 fn format_goal_progress_line(progress: DailyGoalProgress) -> String {
@@ -874,7 +874,21 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
     use crate::wakatime::WakatimeTracker;
+
+    fn terminal_text(terminal: &Terminal<TestBackend>, width: u16, height: u16) -> String {
+        let buffer = terminal.backend().buffer();
+        let mut text = String::new();
+        for y in 0..height {
+            for x in 0..width {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
+        text
+    }
 
     #[test]
     fn timer_secondary_hint_includes_setup_shortcut() {
@@ -890,6 +904,46 @@ mod tests {
         app.timer.status = TimerStatus::Running;
 
         assert!(timer_secondary_hint(&app).contains("[d] Setup"));
+    }
+
+    #[test]
+    fn render_setup_check_wraps_long_warning_message() {
+        let width = 38;
+        let height = 3;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let check = SetupCheck {
+            level: SetupCheckLevel::Warning,
+            message: "wrapped output should include TAIL-END".to_string(),
+        };
+
+        terminal
+            .draw(|frame| render_setup_check(frame, frame.area(), "Check", &check))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("TAIL-END"));
+    }
+
+    #[test]
+    fn setup_diagnostics_view_wraps_long_status_messages() {
+        let width = 80;
+        let height = 24;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.mode = AppMode::SetupDiagnostics;
+        app.setup_diagnostics.blocking_permissions = SetupCheck {
+            level: SetupCheckLevel::Warning,
+            message: "permission denied while probing parent directory WRAP-END".to_string(),
+        };
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("WRAP-END"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,8 +8,8 @@ use ratatui::{
 };
 
 use crate::app::{
-    App, AppMode, DailyGoalProgress, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, SiteFeedbackLevel,
-    SiteInputMode,
+    App, AppMode, DailyGoalProgress, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, SetupCheck,
+    SetupCheckLevel, SiteFeedbackLevel, SiteInputMode,
 };
 use crate::timer::{TimerPhase, TimerStatus};
 use crate::wakatime::WakatimeRuntimeState;
@@ -20,6 +20,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         AppMode::SiteManager => render_site_manager(frame, app),
         AppMode::ProfileManager => render_profile_manager(frame, app),
         AppMode::StatsHistory => render_stats_history(frame, app),
+        AppMode::SetupDiagnostics => render_setup_diagnostics(frame, app),
     }
 }
 
@@ -294,9 +295,9 @@ fn timer_primary_hint(app: &App) -> &'static str {
 
 fn timer_secondary_hint(app: &App) -> &'static str {
     if app.strict_mode_enforced_for_focus() {
-        "Views: [h] History  [p] Profiles (Locked)  [b] Sites  [q/Esc] Quit (Locked)"
+        "Views: [h] History  [p] Profiles (Locked)  [b] Sites  [d] Setup  [q/Esc] Quit (Locked)"
     } else {
-        "Views: [h] History  [p] Profiles  [b] Sites  [q/Esc] Quit"
+        "Views: [h] History  [p] Profiles  [b] Sites  [d] Setup  [q/Esc] Quit"
     }
 }
 
@@ -718,6 +719,87 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
     frame.render_widget(hints, inner[6]);
 }
 
+fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+    let outer = centered_rect(72, 68, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Setup Diagnostics ")
+        .title_alignment(Alignment::Center)
+        .style(Style::default().fg(Color::Cyan));
+    frame.render_widget(block, outer);
+
+    let inner = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints([
+            Constraint::Length(1), // hosts path
+            Constraint::Length(1), // spacer
+            Constraint::Length(1), // blocking permissions
+            Constraint::Length(1), // hosts write capability
+            Constraint::Length(1), // wakatime config status
+            Constraint::Min(0),    // spacer
+            Constraint::Length(2), // key hints
+        ])
+        .split(outer);
+
+    let hosts_path = Paragraph::new(format!(
+        "Hosts file: {}",
+        app.setup_diagnostics.hosts_file_path
+    ))
+    .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(hosts_path, inner[0]);
+
+    render_setup_check(
+        frame,
+        inner[2],
+        "Blocking permissions",
+        &app.setup_diagnostics.blocking_permissions,
+    );
+    render_setup_check(
+        frame,
+        inner[3],
+        "Hosts write capability",
+        &app.setup_diagnostics.hosts_write_capability,
+    );
+    render_setup_check(
+        frame,
+        inner[4],
+        "WakaTime config status",
+        &app.setup_diagnostics.wakatime_config,
+    );
+
+    let hints = Paragraph::new(vec![
+        Line::from("Diagnostics: [r] Refresh"),
+        Line::from(if app.strict_mode_enforced_for_focus() {
+            "View: [d/Esc] Back  [q/Ctrl-C] Quit (Locked)"
+        } else {
+            "View: [d/Esc] Back  [q/Ctrl-C] Quit"
+        }),
+    ])
+    .alignment(Alignment::Center)
+    .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(hints, inner[6]);
+}
+
+fn render_setup_check(frame: &mut Frame, area: Rect, label: &str, check: &SetupCheck) {
+    let (icon, status_color) = match check.level {
+        SetupCheckLevel::Ok => ("✓", Color::Green),
+        SetupCheckLevel::Warning => ("⚠", Color::Yellow),
+    };
+    let line = Line::from(vec![
+        Span::styled(
+            format!("{icon} {label}: "),
+            Style::default()
+                .fg(status_color)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(check.message.as_str(), Style::default().fg(Color::Gray)),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+}
+
 fn format_goal_progress_line(progress: DailyGoalProgress) -> String {
     let pomodoros = format_goal_metric_progress(
         "🍅",
@@ -793,6 +875,22 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 mod tests {
     use super::*;
     use crate::wakatime::WakatimeTracker;
+
+    #[test]
+    fn timer_secondary_hint_includes_setup_shortcut() {
+        let app = App::default();
+        assert!(timer_secondary_hint(&app).contains("[d] Setup"));
+    }
+
+    #[test]
+    fn timer_secondary_hint_includes_setup_shortcut_in_strict_mode() {
+        let mut app = App::default();
+        app.strict_mode = true;
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+
+        assert!(timer_secondary_hint(&app).contains("[d] Setup"));
+    }
 
     #[test]
     fn wakatime_status_line_shows_not_yet_sent_when_no_success_exists() {

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -1,4 +1,6 @@
 use std::fs;
+use std::io;
+use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -35,6 +37,22 @@ pub enum WakatimeRuntimeState {
         error: String,
     },
     Error(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WakatimeConfigStatus {
+    Configured,
+    MissingConfigFile,
+    MissingApiKey,
+    UnreadableConfig,
+    HomeDirectoryUnavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WakatimeConfigDiagnostics {
+    pub config_path: Option<String>,
+    pub status: WakatimeConfigStatus,
+    pub detail: String,
 }
 
 fn current_unix_epoch_secs() -> u64 {
@@ -95,11 +113,15 @@ impl WakatimeConfig {
         }
     }
 
+    fn config_file_path() -> Option<PathBuf> {
+        let home = dirs_home()?;
+        Some(home.join(".wakatime.cfg"))
+    }
+
     /// Parse `~/.wakatime.cfg` as a simple INI file.
     /// Returns `(api_key, api_url)` from the `[settings]` section.
     fn parse_config_file() -> Option<(Option<String>, Option<String>)> {
-        let home = dirs_home()?;
-        let cfg_path = home.join(".wakatime.cfg");
+        let cfg_path = Self::config_file_path()?;
         let content = fs::read_to_string(cfg_path).ok()?;
         Some(Self::parse_config_str(&content))
     }
@@ -227,6 +249,17 @@ impl WakatimeTracker {
         } else {
             WakatimeRuntimeState::Idle
         }
+    }
+
+    pub fn config_diagnostics() -> WakatimeConfigDiagnostics {
+        let Some(config_path) = WakatimeConfig::config_file_path() else {
+            return WakatimeConfigDiagnostics {
+                config_path: None,
+                status: WakatimeConfigStatus::HomeDirectoryUnavailable,
+                detail: "WakaTime config check unavailable: home directory not found".to_string(),
+            };
+        };
+        config_diagnostics_from_read_result(config_path.clone(), fs::read_to_string(config_path))
     }
 
     pub fn last_successful_heartbeat_epoch_secs(&self) -> Option<u64> {
@@ -506,6 +539,43 @@ fn parse_setting_line(line: &str) -> Option<(&str, &str)> {
     Some((key.trim(), value))
 }
 
+fn config_diagnostics_from_read_result(
+    config_path: PathBuf,
+    read_result: io::Result<String>,
+) -> WakatimeConfigDiagnostics {
+    let config_path_text = config_path.display().to_string();
+    match read_result {
+        Ok(content) => {
+            let (api_key, _) = WakatimeConfig::parse_config_str(&content);
+            if api_key.is_some() {
+                WakatimeConfigDiagnostics {
+                    config_path: Some(config_path_text.clone()),
+                    status: WakatimeConfigStatus::Configured,
+                    detail: format!("Configured ({config_path_text})"),
+                }
+            } else {
+                WakatimeConfigDiagnostics {
+                    config_path: Some(config_path_text.clone()),
+                    status: WakatimeConfigStatus::MissingApiKey,
+                    detail: format!(
+                        "Config found at {config_path_text}, but [settings].api_key is missing"
+                    ),
+                }
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => WakatimeConfigDiagnostics {
+            config_path: Some(config_path_text.clone()),
+            status: WakatimeConfigStatus::MissingConfigFile,
+            detail: format!("Config file not found ({config_path_text})"),
+        },
+        Err(error) => WakatimeConfigDiagnostics {
+            config_path: Some(config_path_text),
+            status: WakatimeConfigStatus::UnreadableConfig,
+            detail: format!("Unable to read WakaTime config: {error}"),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -555,6 +625,36 @@ mod tests {
             "[other]\napi_key = wrong\n[settings]\napi_key = correct\n",
         );
         assert_eq!(api_key, Some("correct".to_string()));
+    }
+
+    #[test]
+    fn config_diagnostics_reports_configured_state() {
+        let diagnostics = config_diagnostics_from_read_result(
+            PathBuf::from(".wakatime.cfg"),
+            Ok("[settings]\napi_key = test-key\n".to_string()),
+        );
+        assert_eq!(diagnostics.status, WakatimeConfigStatus::Configured);
+        assert!(diagnostics.detail.contains("Configured"));
+    }
+
+    #[test]
+    fn config_diagnostics_reports_missing_api_key() {
+        let diagnostics = config_diagnostics_from_read_result(
+            PathBuf::from(".wakatime.cfg"),
+            Ok("[settings]\napi_url = https://wakatime.example.com\n".to_string()),
+        );
+        assert_eq!(diagnostics.status, WakatimeConfigStatus::MissingApiKey);
+        assert!(diagnostics.detail.contains("api_key is missing"));
+    }
+
+    #[test]
+    fn config_diagnostics_reports_missing_file() {
+        let diagnostics = config_diagnostics_from_read_result(
+            PathBuf::from(".wakatime.cfg"),
+            Err(io::Error::new(io::ErrorKind::NotFound, "not found")),
+        );
+        assert_eq!(diagnostics.status, WakatimeConfigStatus::MissingConfigFile);
+        assert!(diagnostics.detail.contains("not found"));
     }
 
     #[test]


### PR DESCRIPTION
## What

- Add a new Setup Diagnostics screen in the TUI, opened from timer view with `d`.
- Show three checks: blocking permissions, hosts file write capability, and WakaTime config status.
- Add refresh and back controls in diagnostics view (`r` refresh, `d`/`Esc` back).
- Add diagnostics helpers in blocker and WakaTime modules, plus app/ui wiring and tests.
- Update README and ARCHITECTURE docs for the new screen.

## Why

This adds a quick way to confirm setup prerequisites before users rely on focus-time blocking and WakaTime tracking. It addresses issue #84 by surfacing actionable setup status in-app instead of waiting for runtime failures.

Closes #84

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup Diagnostics screen from the timer view (press `d`): shows blocking permissions, hosts-file path and write capability, and WakaTime configuration status. Refresh with `r`; exit with `d` or `Esc`. Timer hint now includes `[d] Setup`.

* **Documentation**
  * README and architecture docs updated to describe the new Setup Diagnostics screen and expanded UI views (Profile, History, Setup Diagnostics).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->