### PR TITLE
Add goal-based current and best streak tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/README.md
+++ b/README.md
@@ -220,12 +220,17 @@ When strict mode is enabled during an active focus session:
 - completed pomodoros for the current app session
 - focused minutes for the current app session
 - daily aggregates persisted in `stats.toml` (in the same config directory as `config.toml`)
+- current streak and best streak based on completed daily goals
 
 If a daily goal is configured, timer and history views also show live progress for
 both:
 
 - target focused minutes
 - target completed pomodoros
+
+Streaks are evaluated against the goal that was active on each day. Changing the
+daily goal later does not rewrite newer tracked days, and streak tracking stays
+inactive when today's goal is off.
 
 From timer view:
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ both:
 - target completed pomodoros
 
 Streaks are evaluated against the goal that was active on each day. Changing the
-daily goal later does not rewrite newer tracked days, and streak tracking stays
+daily goal later does not rewrite older tracked days, and streak tracking stays
 inactive when today's goal is off.
 
 From timer view:

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,10 @@ use crate::config::{
     AppConfig, AutoStartConfig, CustomProfileConfig, DailyGoalConfig, NotificationConfig, ProfileId,
 };
 use crate::notifications::PhaseNotifier;
-use crate::stats::{DailyStats, FocusStats, SessionStats, current_day_key};
+use crate::stats::{
+    DailyGoalSnapshot, DailyStats, FocusStats, GoalStreak, SessionStats, current_day_date,
+    current_day_key,
+};
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
     DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerState, TimerStatus,
@@ -405,6 +408,14 @@ impl App {
         self.daily_goal_progress_for(self.today_stats())
     }
 
+    pub fn goal_streak(&self) -> GoalStreak {
+        self.stats.goal_streak(
+            current_day_date(),
+            self.current_goal_snapshot(),
+            self.today_stats(),
+        )
+    }
+
     pub fn daily_goal_progress_for(&self, stats: DailyStats) -> DailyGoalProgress {
         DailyGoalProgress {
             minutes: goal_progress(stats.focused_minutes(), self.daily_goal.minutes),
@@ -715,6 +726,10 @@ impl App {
         let custom_profile_changed = self.profile_edit_snapshot.as_ref().is_some_and(|snapshot| {
             snapshot.custom_profile.normalized() != self.custom_profile.normalized()
         });
+        let daily_goal_changed = self
+            .profile_edit_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.daily_goal != self.daily_goal);
         self.custom_profile = self.custom_profile.normalized();
         if self.selected_profile == ProfileId::Custom {
             if custom_profile_changed {
@@ -728,6 +743,9 @@ impl App {
             self.save_config();
         }
         self.rebuild_notifier();
+        if daily_goal_changed {
+            self.sync_today_goal_snapshot();
+        }
         self.profile_edit_active = false;
         self.profile_edit_field = 0;
         self.profile_edit_snapshot = None;
@@ -1166,10 +1184,12 @@ impl App {
         }
 
         let day_key = current_day_key();
+        let goal_snapshot = self.current_goal_snapshot();
         let session_minutes_before = self.stats.session().focused_minutes();
         let today_minutes_before = self.stats.daily_for(&day_key).focused_minutes();
 
-        self.stats.record_focus_elapsed(&day_key, elapsed_secs);
+        self.stats
+            .record_focus_elapsed(&day_key, elapsed_secs, goal_snapshot);
         self.stats_has_unsaved_elapsed = true;
 
         let session_minutes_after = self.stats.session().focused_minutes();
@@ -1183,8 +1203,27 @@ impl App {
 
     fn record_completed_focus_session(&mut self) {
         let day_key = current_day_key();
-        self.stats.record_completed_pomodoro(&day_key);
+        self.stats
+            .record_completed_pomodoro(&day_key, self.current_goal_snapshot());
         self.stats_dirty = true;
+    }
+
+    fn current_goal_snapshot(&self) -> DailyGoalSnapshot {
+        DailyGoalSnapshot {
+            minutes: self.daily_goal.minutes,
+            pomodoros: self.daily_goal.pomodoros,
+        }
+    }
+
+    fn sync_today_goal_snapshot(&mut self) {
+        let day_key = current_day_key();
+        if self
+            .stats
+            .sync_goal_snapshot(&day_key, self.current_goal_snapshot())
+        {
+            self.stats_dirty = true;
+            self.flush_stats_if_dirty(false);
+        }
     }
 
     fn sync_wakatime_tracking_for_state(&mut self) {
@@ -1792,8 +1831,10 @@ mod tests {
         };
         let mut app = App::from_config(config);
         let day_key = current_day_key();
-        app.stats.record_focus_elapsed(&day_key, 30 * 60);
-        app.stats.record_completed_pomodoro(&day_key);
+        app.stats
+            .record_focus_elapsed(&day_key, 30 * 60, app.current_goal_snapshot());
+        app.stats
+            .record_completed_pomodoro(&day_key, app.current_goal_snapshot());
 
         let progress = app.today_goal_progress();
         assert_eq!(progress.minutes.completed, 30);
@@ -1802,6 +1843,59 @@ mod tests {
         assert_eq!(progress.pomodoros.completed, 1);
         assert_eq!(progress.pomodoros.target, 4);
         assert!((progress.pomodoros.ratio - 0.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn goal_streak_counts_yesterday_until_today_is_missed() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 1,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let goal = app.current_goal_snapshot();
+        let yesterday = current_day_date().pred_opt().unwrap();
+        let day_before = yesterday.pred_opt().unwrap();
+
+        for day in [day_before, yesterday] {
+            let day_key = day.format("%Y-%m-%d").to_string();
+            app.stats.record_focus_elapsed(&day_key, 60 * 60, goal);
+            app.stats.record_completed_pomodoro(&day_key, goal);
+        }
+
+        let streak = app.goal_streak();
+        assert_eq!(streak.current, 2);
+        assert_eq!(streak.best, 2);
+    }
+
+    #[test]
+    fn committing_goal_edit_updates_today_goal_snapshot() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 1,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let day_key = current_day_key();
+
+        app.stats
+            .record_focus_elapsed(&day_key, 30 * 60, app.current_goal_snapshot());
+
+        app.begin_profile_edit();
+        app.daily_goal.minutes = 90;
+        app.commit_profile_edit();
+
+        assert_eq!(
+            app.today_stats().goal,
+            Some(DailyGoalSnapshot {
+                minutes: 90,
+                pomodoros: 1,
+            })
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -409,10 +409,14 @@ impl App {
     }
 
     pub fn goal_streak(&self) -> GoalStreak {
+        self.goal_streak_for_day_key(&current_day_key())
+    }
+
+    fn goal_streak_for_day_key(&self, day_key: &str) -> GoalStreak {
         self.stats.goal_streak(
-            current_day_date(),
+            parse_day_key(day_key).unwrap_or_else(current_day_date),
             self.current_goal_snapshot(),
-            self.today_stats(),
+            self.stats.daily_for(day_key),
         )
     }
 
@@ -1320,6 +1324,10 @@ fn bool_label(value: bool) -> &'static str {
     if value { "On" } else { "Off" }
 }
 
+fn parse_day_key(day_key: &str) -> Option<chrono::NaiveDate> {
+    chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d").ok()
+}
+
 fn goal_progress(completed: u64, target: u64) -> GoalProgress {
     let ratio = if target == 0 {
         0.0
@@ -1896,6 +1904,28 @@ mod tests {
                 pomodoros: 1,
             })
         );
+    }
+
+    #[test]
+    fn goal_streak_for_day_key_uses_the_same_day_for_date_and_stats_lookup() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 1,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let goal = app.current_goal_snapshot();
+
+        for day_key in ["2026-04-08", "2026-04-09"] {
+            app.stats.record_focus_elapsed(day_key, 60 * 60, goal);
+            app.stats.record_completed_pomodoro(day_key, goal);
+        }
+
+        let streak = app.goal_streak_for_day_key("2026-04-09");
+        assert_eq!(streak.current, 2);
+        assert_eq!(streak.best, 2);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,8 +8,7 @@ use crate::config::{
 };
 use crate::notifications::PhaseNotifier;
 use crate::stats::{
-    DailyGoalSnapshot, DailyStats, FocusStats, GoalStreak, SessionStats, current_day_date,
-    current_day_key,
+    DailyGoalSnapshot, DailyStats, FocusStats, GoalStreak, SessionStats, current_day_key,
 };
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
@@ -413,8 +412,12 @@ impl App {
     }
 
     fn goal_streak_for_day_key(&self, day_key: &str) -> GoalStreak {
+        let Some(day) = parse_day_key(day_key) else {
+            return GoalStreak::default();
+        };
+
         self.stats.goal_streak(
-            parse_day_key(day_key).unwrap_or_else(current_day_date),
+            day,
             self.current_goal_snapshot(),
             self.stats.daily_for(day_key),
         )
@@ -1864,7 +1867,7 @@ mod tests {
         };
         let mut app = App::from_config(config);
         let goal = app.current_goal_snapshot();
-        let yesterday = current_day_date().pred_opt().unwrap();
+        let yesterday = chrono::Local::now().date_naive().pred_opt().unwrap();
         let day_before = yesterday.pred_opt().unwrap();
 
         for day in [day_before, yesterday] {
@@ -1922,6 +1925,53 @@ mod tests {
             app.stats.record_focus_elapsed(day_key, 60 * 60, goal);
             app.stats.record_completed_pomodoro(day_key, goal);
         }
+
+        let streak = app.goal_streak_for_day_key("2026-04-09");
+        assert_eq!(streak.current, 2);
+        assert_eq!(streak.best, 2);
+    }
+
+    #[test]
+    fn goal_streak_for_day_key_fails_closed_for_invalid_day_keys() {
+        let app = App::from_config(AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 1,
+            },
+            ..AppConfig::default()
+        });
+
+        let streak = app.goal_streak_for_day_key("not-a-day");
+        assert_eq!(streak, GoalStreak::default());
+    }
+
+    #[test]
+    fn goal_streak_for_day_key_handles_legacy_entries_without_goal_snapshots() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 1,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.stats.insert_daily_for_tests(
+            "2026-04-08",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 60 * 60,
+                goal: None,
+            },
+        );
+        app.stats.insert_daily_for_tests(
+            "2026-04-09",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 60 * 60,
+                goal: None,
+            },
+        );
 
         let streak = app.goal_streak_for_day_key("2026-04-09");
         assert_eq!(streak.current, 2);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io;
 
@@ -20,11 +20,39 @@ impl SessionStats {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct DailyGoalSnapshot {
+    #[serde(default)]
+    pub minutes: u64,
+    #[serde(default)]
+    pub pomodoros: u32,
+}
+
+impl DailyGoalSnapshot {
+    pub fn has_any_target(self) -> bool {
+        self.minutes > 0 || self.pomodoros > 0
+    }
+
+    pub fn is_met_by(self, stats: DailyStats) -> bool {
+        self.has_any_target()
+            && (self.minutes == 0 || stats.focused_minutes() >= self.minutes)
+            && (self.pomodoros == 0 || stats.pomodoros_completed >= self.pomodoros)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GoalStreak {
+    pub current: u32,
+    pub best: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct DailyStats {
     #[serde(default)]
     pub pomodoros_completed: u32,
     #[serde(default)]
     pub focused_seconds: u64,
+    #[serde(default)]
+    pub goal: Option<DailyGoalSnapshot>,
 }
 
 impl DailyStats {
@@ -122,7 +150,12 @@ impl FocusStats {
         }
     }
 
-    pub fn record_focus_elapsed(&mut self, day_key: &str, elapsed_secs: u64) {
+    pub fn record_focus_elapsed(
+        &mut self,
+        day_key: &str,
+        elapsed_secs: u64,
+        goal: DailyGoalSnapshot,
+    ) {
         if elapsed_secs == 0 {
             return;
         }
@@ -130,12 +163,27 @@ impl FocusStats {
         self.session.focused_seconds = self.session.focused_seconds.saturating_add(elapsed_secs);
         let daily = self.daily.entry(day_key.to_string()).or_default();
         daily.focused_seconds = daily.focused_seconds.saturating_add(elapsed_secs);
+        daily.goal = Some(goal);
     }
 
-    pub fn record_completed_pomodoro(&mut self, day_key: &str) {
+    pub fn record_completed_pomodoro(&mut self, day_key: &str, goal: DailyGoalSnapshot) {
         self.session.pomodoros_completed = self.session.pomodoros_completed.saturating_add(1);
         let daily = self.daily.entry(day_key.to_string()).or_default();
         daily.pomodoros_completed = daily.pomodoros_completed.saturating_add(1);
+        daily.goal = Some(goal);
+    }
+
+    pub fn sync_goal_snapshot(&mut self, day_key: &str, goal: DailyGoalSnapshot) -> bool {
+        let Some(daily) = self.daily.get_mut(day_key) else {
+            return false;
+        };
+
+        if daily.goal == Some(goal) {
+            return false;
+        }
+
+        daily.goal = Some(goal);
+        true
     }
 
     pub fn session(&self) -> SessionStats {
@@ -154,6 +202,50 @@ impl FocusStats {
             .map(|(day, stats)| (day.clone(), *stats))
             .collect()
     }
+
+    pub fn goal_streak(
+        &self,
+        today: chrono::NaiveDate,
+        current_goal: DailyGoalSnapshot,
+        today_stats: DailyStats,
+    ) -> GoalStreak {
+        let completed_days = self.completed_goal_days(today, current_goal, today_stats);
+        GoalStreak {
+            current: current_goal_streak(&completed_days, today, current_goal, today_stats),
+            best: best_goal_streak(&completed_days),
+        }
+    }
+
+    fn completed_goal_days(
+        &self,
+        today: chrono::NaiveDate,
+        current_goal: DailyGoalSnapshot,
+        today_stats: DailyStats,
+    ) -> BTreeSet<chrono::NaiveDate> {
+        let mut completed_days = BTreeSet::new();
+
+        for (day_key, stats) in &self.daily {
+            let Ok(day) = chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d") else {
+                continue;
+            };
+            if day == today {
+                continue;
+            }
+
+            let snapshot = stats
+                .goal
+                .or(current_goal.has_any_target().then_some(current_goal));
+            if snapshot.is_some_and(|goal| goal.is_met_by(*stats)) {
+                completed_days.insert(day);
+            }
+        }
+
+        if current_goal.is_met_by(today_stats) {
+            completed_days.insert(today);
+        }
+
+        completed_days
+    }
 }
 
 pub fn current_day_key() -> String {
@@ -163,6 +255,57 @@ pub fn current_day_key() -> String {
         .to_string()
 }
 
+pub fn current_day_date() -> chrono::NaiveDate {
+    chrono::Local::now().date_naive()
+}
+
+fn current_goal_streak(
+    completed_days: &BTreeSet<chrono::NaiveDate>,
+    today: chrono::NaiveDate,
+    current_goal: DailyGoalSnapshot,
+    today_stats: DailyStats,
+) -> u32 {
+    if !current_goal.has_any_target() {
+        return 0;
+    }
+
+    let mut streak = 0;
+    let mut cursor = if current_goal.is_met_by(today_stats) {
+        Some(today)
+    } else {
+        today.pred_opt()
+    };
+
+    while let Some(day) = cursor {
+        if !completed_days.contains(&day) {
+            break;
+        }
+        streak += 1;
+        cursor = day.pred_opt();
+    }
+
+    streak
+}
+
+fn best_goal_streak(completed_days: &BTreeSet<chrono::NaiveDate>) -> u32 {
+    let mut best = 0;
+    let mut streak = 0;
+    let mut previous_day: Option<chrono::NaiveDate> = None;
+
+    for day in completed_days {
+        if previous_day.is_some_and(|previous| previous.succ_opt() == Some(*day)) {
+            streak += 1;
+        } else {
+            streak = 1;
+        }
+
+        best = best.max(streak);
+        previous_day = Some(*day);
+    }
+
+    best
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,9 +313,13 @@ mod tests {
     #[test]
     fn recording_updates_session_and_daily_totals() {
         let mut stats = FocusStats::default();
+        let goal = DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        };
 
-        stats.record_focus_elapsed("2026-04-09", 125);
-        stats.record_completed_pomodoro("2026-04-09");
+        stats.record_focus_elapsed("2026-04-09", 125, goal);
+        stats.record_completed_pomodoro("2026-04-09", goal);
 
         let session = stats.session();
         assert_eq!(session.pomodoros_completed, 1);
@@ -183,13 +330,18 @@ mod tests {
         assert_eq!(day.pomodoros_completed, 1);
         assert_eq!(day.focused_seconds, 125);
         assert_eq!(day.focused_minutes(), 2);
+        assert_eq!(day.goal, Some(goal));
     }
 
     #[test]
     fn recent_daily_is_sorted_newest_first() {
         let mut stats = FocusStats::default();
-        stats.record_focus_elapsed("2026-04-08", 60);
-        stats.record_focus_elapsed("2026-04-09", 120);
+        let goal = DailyGoalSnapshot {
+            minutes: 30,
+            pomodoros: 1,
+        };
+        stats.record_focus_elapsed("2026-04-08", 60, goal);
+        stats.record_focus_elapsed("2026-04-09", 120, goal);
 
         let recent = stats.recent_daily(2);
         assert_eq!(recent[0].0, "2026-04-09");
@@ -199,8 +351,12 @@ mod tests {
     #[test]
     fn persisted_stats_round_trip_preserves_daily_history() {
         let mut original = FocusStats::default();
-        original.record_focus_elapsed("2026-04-09", 300);
-        original.record_completed_pomodoro("2026-04-09");
+        let goal = DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        };
+        original.record_focus_elapsed("2026-04-09", 300, goal);
+        original.record_completed_pomodoro("2026-04-09", goal);
 
         let persisted = original.to_persisted();
         let toml_str = toml::to_string_pretty(&persisted).unwrap();
@@ -211,6 +367,7 @@ mod tests {
         let day = restored.daily_for("2026-04-09");
         assert_eq!(day.pomodoros_completed, 1);
         assert_eq!(day.focused_seconds, 300);
+        assert_eq!(day.goal, Some(goal));
     }
 
     #[test]
@@ -224,5 +381,75 @@ mod tests {
         assert_eq!(key.len(), 10);
         assert_eq!(&key[4..5], "-");
         assert_eq!(&key[7..8], "-");
+    }
+
+    #[test]
+    fn goal_streak_counts_consecutive_completed_days() {
+        let mut stats = FocusStats::default();
+        let goal = DailyGoalSnapshot {
+            minutes: 30,
+            pomodoros: 1,
+        };
+
+        for day in ["2026-04-07", "2026-04-08", "2026-04-09"] {
+            stats.record_focus_elapsed(day, 30 * 60, goal);
+            stats.record_completed_pomodoro(day, goal);
+        }
+
+        let streak = stats.goal_streak(
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 9).unwrap(),
+            goal,
+            stats.daily_for("2026-04-09"),
+        );
+
+        assert_eq!(streak.current, 3);
+        assert_eq!(streak.best, 3);
+    }
+
+    #[test]
+    fn goal_streak_keeps_running_until_today_is_missed() {
+        let mut stats = FocusStats::default();
+        let goal = DailyGoalSnapshot {
+            minutes: 60,
+            pomodoros: 1,
+        };
+
+        for day in ["2026-04-07", "2026-04-08"] {
+            stats.record_focus_elapsed(day, 60 * 60, goal);
+            stats.record_completed_pomodoro(day, goal);
+        }
+
+        let streak = stats.goal_streak(
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 9).unwrap(),
+            goal,
+            DailyStats::default(),
+        );
+
+        assert_eq!(streak.current, 2);
+        assert_eq!(streak.best, 2);
+    }
+
+    #[test]
+    fn goal_streak_uses_current_goal_as_legacy_fallback() {
+        let mut stats = FocusStats::default();
+        {
+            let day = stats.daily.entry("2026-04-09".to_string()).or_default();
+            day.focused_seconds = 45 * 60;
+            day.pomodoros_completed = 2;
+        }
+
+        let goal = DailyGoalSnapshot {
+            minutes: 30,
+            pomodoros: 1,
+        };
+        let today_stats = stats.daily_for("2026-04-09");
+        let streak = stats.goal_streak(
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 9).unwrap(),
+            goal,
+            today_stats,
+        );
+
+        assert_eq!(streak.current, 1);
+        assert_eq!(streak.best, 1);
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -203,6 +203,11 @@ impl FocusStats {
             .collect()
     }
 
+    #[cfg(test)]
+    pub fn insert_daily_for_tests(&mut self, day_key: &str, stats: DailyStats) {
+        self.daily.insert(day_key.to_string(), stats);
+    }
+
     pub fn goal_streak(
         &self,
         today: chrono::NaiveDate,
@@ -253,10 +258,6 @@ pub fn current_day_key() -> String {
         .date_naive()
         .format("%Y-%m-%d")
         .to_string()
-}
-
-pub fn current_day_date() -> chrono::NaiveDate {
-    chrono::Local::now().date_naive()
 }
 
 fn current_goal_streak(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -47,6 +47,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
             Constraint::Length(1), // latest phase notification
             Constraint::Length(1), // stats summary
             Constraint::Length(1), // daily goal progress
+            Constraint::Length(1), // streak summary
             Constraint::Length(1), // wakatime status
             Constraint::Min(0),    // spacer
             Constraint::Length(2), // key hints
@@ -61,8 +62,9 @@ fn render_timer(frame: &mut Frame, app: &App) {
     render_timer_phase_notice(frame, app, inner[5]);
     render_timer_stats_summary(frame, app, inner[6]);
     render_timer_goal_summary(frame, app, inner[7]);
-    render_timer_wakatime_status(frame, app, inner[8]);
-    render_timer_hints(frame, app, inner[10]);
+    render_timer_streak_summary(frame, app, inner[8]);
+    render_timer_wakatime_status(frame, app, inner[9]);
+    render_timer_hints(frame, app, inner[11]);
 }
 
 fn render_timer_phase_header(frame: &mut Frame, app: &App, area: Rect) {
@@ -210,6 +212,13 @@ fn render_timer_goal_summary(frame: &mut Frame, app: &App, area: Rect) {
         .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(goal_widget, area);
+}
+
+fn render_timer_streak_summary(frame: &mut Frame, app: &App, area: Rect) {
+    let streak_widget = Paragraph::new(format_streak_summary_line(app))
+        .alignment(Alignment::Center)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(streak_widget, area);
 }
 
 fn render_timer_wakatime_status(frame: &mut Frame, app: &App, area: Rect) {
@@ -635,6 +644,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
             Constraint::Length(1), // session summary
             Constraint::Length(1), // today summary
             Constraint::Length(1), // daily goal progress
+            Constraint::Length(1), // streak summary
             Constraint::Length(1), // spacer
             Constraint::Min(3),    // history list
             Constraint::Length(1), // error line
@@ -673,6 +683,10 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
     let goal_summary = Paragraph::new(goal_line).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(goal_summary, inner[2]);
 
+    let streak_summary =
+        Paragraph::new(format_streak_summary_line(app)).style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(streak_summary, inner[3]);
+
     let history_items: Vec<ListItem> = app
         .recent_daily_stats(14)
         .into_iter()
@@ -693,7 +707,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
                     .borders(Borders::ALL)
                     .title(" Recent Days "),
             );
-        frame.render_widget(empty, inner[4]);
+        frame.render_widget(empty, inner[5]);
     } else {
         let list = List::new(history_items)
             .block(
@@ -702,11 +716,11 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
                     .title(" Recent Days "),
             )
             .style(Style::default().fg(Color::Gray));
-        frame.render_widget(list, inner[4]);
+        frame.render_widget(list, inner[5]);
     }
 
     if let Some(err) = app.stats_error.as_ref() {
-        render_centered_error(frame, inner[5], format!("⚠  {err}"));
+        render_centered_error(frame, inner[6], format!("⚠  {err}"));
     }
 
     let hints = Paragraph::new(if app.strict_mode_enforced_for_focus() {
@@ -716,7 +730,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
     })
     .alignment(Alignment::Center)
     .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(hints, inner[6]);
+    frame.render_widget(hints, inner[7]);
 }
 
 fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
@@ -827,6 +841,19 @@ fn format_goal_metric_progress(
     } else {
         format!("{label} {completed}/{target}{unit_suffix}")
     }
+}
+
+fn format_streak_summary_line(app: &App) -> String {
+    let streak = app.goal_streak();
+    let suffix = if app.today_goal_progress().has_any_target() {
+        ""
+    } else {
+        " (goal off)"
+    };
+    format!(
+        "Streaks: current {}d · best {}d{}",
+        streak.current, streak.best, suffix
+    )
 }
 
 fn phase_color(phase: TimerPhase) -> Color {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -46,8 +46,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
             Constraint::Length(2), // status
             Constraint::Length(1), // latest phase notification
             Constraint::Length(1), // stats summary
-            Constraint::Length(1), // daily goal progress
-            Constraint::Length(1), // streak summary
+            Constraint::Length(1), // goal + streak summary
             Constraint::Length(1), // wakatime status
             Constraint::Min(0),    // spacer
             Constraint::Length(2), // key hints
@@ -61,10 +60,9 @@ fn render_timer(frame: &mut Frame, app: &App) {
     render_timer_status(frame, app, inner[4]);
     render_timer_phase_notice(frame, app, inner[5]);
     render_timer_stats_summary(frame, app, inner[6]);
-    render_timer_goal_summary(frame, app, inner[7]);
-    render_timer_streak_summary(frame, app, inner[8]);
-    render_timer_wakatime_status(frame, app, inner[9]);
-    render_timer_hints(frame, app, inner[11]);
+    render_timer_goal_streak_summary(frame, app, inner[7]);
+    render_timer_wakatime_status(frame, app, inner[8]);
+    render_timer_hints(frame, app, inner[10]);
 }
 
 fn render_timer_phase_header(frame: &mut Frame, app: &App, area: Rect) {
@@ -201,24 +199,11 @@ fn timer_stats_line(app: &App) -> (String, Style) {
     }
 }
 
-fn render_timer_goal_summary(frame: &mut Frame, app: &App, area: Rect) {
-    let goal_progress = app.today_goal_progress();
-    let goal_line = if goal_progress.has_any_target() {
-        format_goal_progress_line(goal_progress)
-    } else {
-        "Goal: Off ([p] Profiles -> [e] Edit)".to_string()
-    };
-    let goal_widget = Paragraph::new(goal_line)
+fn render_timer_goal_streak_summary(frame: &mut Frame, app: &App, area: Rect) {
+    let goal_widget = Paragraph::new(format_timer_goal_streak_line(app))
         .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(goal_widget, area);
-}
-
-fn render_timer_streak_summary(frame: &mut Frame, app: &App, area: Rect) {
-    let streak_widget = Paragraph::new(format_streak_summary_line(app))
-        .alignment(Alignment::Center)
-        .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(streak_widget, area);
 }
 
 fn render_timer_wakatime_status(frame: &mut Frame, app: &App, area: Rect) {
@@ -641,10 +626,8 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(1), // session summary
-            Constraint::Length(1), // today summary
-            Constraint::Length(1), // daily goal progress
-            Constraint::Length(1), // streak summary
+            Constraint::Length(1), // session + today summary
+            Constraint::Length(1), // goal + streak summary
             Constraint::Length(1), // spacer
             Constraint::Min(3),    // history list
             Constraint::Length(1), // error line
@@ -655,9 +638,11 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
     let session_stats = app.session_stats();
     let today_stats = app.today_stats();
     let session_summary = Paragraph::new(format!(
-        "This session: 🍅{} · {}m",
+        "This session: 🍅{} · {}m   Today: 🍅{} · {}m",
         session_stats.pomodoros_completed,
-        session_stats.focused_minutes()
+        session_stats.focused_minutes(),
+        today_stats.pomodoros_completed,
+        today_stats.focused_minutes()
     ))
     .style(
         Style::default()
@@ -666,26 +651,9 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
     );
     frame.render_widget(session_summary, inner[0]);
 
-    let today_summary = Paragraph::new(format!(
-        "Today: 🍅{} · {}m",
-        today_stats.pomodoros_completed,
-        today_stats.focused_minutes()
-    ))
-    .style(Style::default().fg(Color::Gray));
-    frame.render_widget(today_summary, inner[1]);
-
-    let goal_progress = app.today_goal_progress();
-    let goal_line = if goal_progress.has_any_target() {
-        format_goal_progress_line(goal_progress)
-    } else {
-        "Daily goal: Off".to_string()
-    };
-    let goal_summary = Paragraph::new(goal_line).style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(goal_summary, inner[2]);
-
-    let streak_summary =
-        Paragraph::new(format_streak_summary_line(app)).style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(streak_summary, inner[3]);
+    let goal_summary = Paragraph::new(format_history_goal_streak_line(app))
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(goal_summary, inner[1]);
 
     let history_items: Vec<ListItem> = app
         .recent_daily_stats(14)
@@ -707,7 +675,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
                     .borders(Borders::ALL)
                     .title(" Recent Days "),
             );
-        frame.render_widget(empty, inner[5]);
+        frame.render_widget(empty, inner[3]);
     } else {
         let list = List::new(history_items)
             .block(
@@ -716,11 +684,11 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
                     .title(" Recent Days "),
             )
             .style(Style::default().fg(Color::Gray));
-        frame.render_widget(list, inner[5]);
+        frame.render_widget(list, inner[3]);
     }
 
     if let Some(err) = app.stats_error.as_ref() {
-        render_centered_error(frame, inner[6], format!("⚠  {err}"));
+        render_centered_error(frame, inner[4], format!("⚠  {err}"));
     }
 
     let hints = Paragraph::new(if app.strict_mode_enforced_for_focus() {
@@ -730,7 +698,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
     })
     .alignment(Alignment::Center)
     .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(hints, inner[7]);
+    frame.render_widget(hints, inner[5]);
 }
 
 fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
@@ -843,17 +811,34 @@ fn format_goal_metric_progress(
     }
 }
 
-fn format_streak_summary_line(app: &App) -> String {
+fn format_timer_goal_streak_line(app: &App) -> String {
+    let goal_progress = app.today_goal_progress();
     let streak = app.goal_streak();
-    let suffix = if app.today_goal_progress().has_any_target() {
-        ""
+    if goal_progress.has_any_target() {
+        format!(
+            "{}   Streaks: {}d current · {}d best",
+            format_goal_progress_line(goal_progress),
+            streak.current,
+            streak.best
+        )
     } else {
-        " (goal off)"
-    };
-    format!(
-        "Streaks: current {}d · best {}d{}",
-        streak.current, streak.best, suffix
-    )
+        "Goal: Off (set via [p] -> [e])   Streaks: Off".to_string()
+    }
+}
+
+fn format_history_goal_streak_line(app: &App) -> String {
+    let goal_progress = app.today_goal_progress();
+    let streak = app.goal_streak();
+    if goal_progress.has_any_target() {
+        format!(
+            "{}   Streaks: {}d current · {}d best",
+            format_goal_progress_line(goal_progress),
+            streak.current,
+            streak.best
+        )
+    } else {
+        "Daily goal: Off   Streaks: Off".to_string()
+    }
 }
 
 fn phase_color(phase: TimerPhase) -> Color {


### PR DESCRIPTION
## What

Add current and best streak tracking based on daily goal completion, persist per-day goal snapshots for historical accuracy, update the timer/history summaries, and harden the new streak logic against malformed day keys and legacy stats entries without saved goal snapshots.

## Why

Users can already configure daily goals and review daily focus history, but they could not see consistency over time. This implements streak tracking for issue #85 while preserving historical correctness when goals change later.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

N/A: Site blocking and WakaTime behavior are unchanged by this PR.

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

N/A: No new user-facing configuration was added. The only dependency-related change is a lockfile refresh to resolve the audit failure.

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

N/A: No breaking behavior changes.

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streak tracking: shows current and best streaks based on completed daily goals.
  * UI: combined goal + streak summary added to timer and daily history; displays "Off" when no daily goal is set.
  * Streak semantics: streaks use the daily goal that was active on each historical day; changing a goal later does not retroactively alter past days; streak tracking is inactive when today's goal is off.

* **Documentation**
  * README updated with session stats and daily history details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->