### PR TITLE
Add weekly summaries to history

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,13 +213,14 @@ When strict mode is enabled during an active focus session:
 - `p` (profile manager) is disabled, so profile switching is locked
 - quit shortcuts (`q`, `Esc`, `Ctrl-C`) are disabled until focus is no longer active
 
-## Session stats and daily history
+## Session stats and history
 
 `focustime` tracks:
 
 - completed pomodoros for the current app session
 - focused minutes for the current app session
 - daily aggregates persisted in `stats.toml` (in the same config directory as `config.toml`)
+- weekly totals derived from daily aggregates in the History view
 - current streak and best streak based on completed daily goals
 
 If a daily goal is configured, timer and history views also show live progress for
@@ -234,7 +235,7 @@ inactive when today's goal is off.
 
 From timer view:
 
-- press **`h`** to open the daily history panel
+- press **`h`** to open the history panel with weekly and daily summaries
 - press **`h`** or **`Esc`** to return to timer view
 
 ## The way the system works

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,8 @@ use crate::config::{
 };
 use crate::notifications::PhaseNotifier;
 use crate::stats::{
-    DailyGoalSnapshot, DailyStats, FocusStats, GoalStreak, SessionStats, current_day_key,
+    DailyGoalSnapshot, DailyStats, FocusStats, GoalStreak, SessionStats, WeeklyStats,
+    current_day_key,
 };
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
@@ -435,6 +436,15 @@ impl App {
 
     pub fn recent_daily_stats(&self, limit: usize) -> Vec<(String, DailyStats)> {
         self.stats.recent_daily(limit)
+    }
+
+    pub fn recent_weekly_stats(&self, limit: usize) -> Vec<WeeklyStats> {
+        self.stats.recent_weekly(limit)
+    }
+
+    #[cfg(test)]
+    pub fn insert_daily_stats_for_tests(&mut self, day_key: &str, stats: DailyStats) {
+        self.stats.insert_daily_for_tests(day_key, stats);
     }
 
     pub fn profile_edit_field_value(&self, field_index: usize) -> String {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io;
 
+use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(test, allow(dead_code))]
@@ -43,6 +44,20 @@ impl DailyGoalSnapshot {
 pub struct GoalStreak {
     pub current: u32,
     pub best: u32,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct WeeklyStats {
+    pub year: i32,
+    pub week: u32,
+    pub pomodoros_completed: u32,
+    pub focused_seconds: u64,
+}
+
+impl WeeklyStats {
+    pub fn focused_minutes(self) -> u64 {
+        self.focused_seconds / 60
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -203,6 +218,35 @@ impl FocusStats {
             .collect()
     }
 
+    pub fn recent_weekly(&self, limit: usize) -> Vec<WeeklyStats> {
+        let mut weekly = BTreeMap::new();
+
+        for (day_key, stats) in &self.daily {
+            let Ok(day) = chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d") else {
+                continue;
+            };
+            let iso_week = day.iso_week();
+            let entry = weekly
+                .entry((iso_week.year(), iso_week.week()))
+                .or_insert_with(|| WeeklyStats {
+                    year: iso_week.year(),
+                    week: iso_week.week(),
+                    ..WeeklyStats::default()
+                });
+            entry.pomodoros_completed = entry
+                .pomodoros_completed
+                .saturating_add(stats.pomodoros_completed);
+            entry.focused_seconds = entry.focused_seconds.saturating_add(stats.focused_seconds);
+        }
+
+        weekly
+            .into_iter()
+            .rev()
+            .take(limit)
+            .map(|(_, stats)| stats)
+            .collect()
+    }
+
     #[cfg(test)]
     pub fn insert_daily_for_tests(&mut self, day_key: &str, stats: DailyStats) {
         self.daily.insert(day_key.to_string(), stats);
@@ -347,6 +391,79 @@ mod tests {
         let recent = stats.recent_daily(2);
         assert_eq!(recent[0].0, "2026-04-09");
         assert_eq!(recent[1].0, "2026-04-08");
+    }
+
+    #[test]
+    fn recent_weekly_aggregates_days_in_same_iso_week() {
+        let mut stats = FocusStats::default();
+        stats.insert_daily_for_tests(
+            "2026-04-06",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 30 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2026-04-08",
+            DailyStats {
+                pomodoros_completed: 2,
+                focused_seconds: 45 * 60,
+                goal: None,
+            },
+        );
+
+        let recent = stats.recent_weekly(1);
+        let iso_week = chrono::NaiveDate::from_ymd_opt(2026, 4, 6)
+            .unwrap()
+            .iso_week();
+
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].year, iso_week.year());
+        assert_eq!(recent[0].week, iso_week.week());
+        assert_eq!(recent[0].pomodoros_completed, 3);
+        assert_eq!(recent[0].focused_minutes(), 75);
+    }
+
+    #[test]
+    fn recent_weekly_is_sorted_newest_first_across_iso_year_boundaries() {
+        let mut stats = FocusStats::default();
+        stats.insert_daily_for_tests(
+            "2020-12-31",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 30 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2021-01-01",
+            DailyStats {
+                pomodoros_completed: 2,
+                focused_seconds: 60 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2021-01-04",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 15 * 60,
+                goal: None,
+            },
+        );
+
+        let recent = stats.recent_weekly(2);
+
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].year, 2021);
+        assert_eq!(recent[0].week, 1);
+        assert_eq!(recent[0].pomodoros_completed, 1);
+        assert_eq!(recent[0].focused_minutes(), 15);
+        assert_eq!(recent[1].year, 2020);
+        assert_eq!(recent[1].week, 53);
+        assert_eq!(recent[1].pomodoros_completed, 3);
+        assert_eq!(recent[1].focused_minutes(), 90);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -617,7 +617,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(" Daily Focus History ")
+        .title(" Focus History ")
         .title_alignment(Alignment::Center)
         .style(Style::default().fg(Color::Cyan));
     frame.render_widget(block, outer);
@@ -655,8 +655,33 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(goal_summary, inner[1]);
 
+    let history_sections = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(42), Constraint::Percentage(58)])
+        .split(inner[3]);
+
+    let weekly_items: Vec<ListItem> = app
+        .recent_weekly_stats(6)
+        .into_iter()
+        .map(|stats| {
+            ListItem::new(format!(
+                "  {}   🍅{}   {}m",
+                format_week_label(stats.year, stats.week),
+                stats.pomodoros_completed,
+                stats.focused_minutes()
+            ))
+        })
+        .collect();
+    render_history_panel(
+        frame,
+        history_sections[0],
+        " Weekly Totals ",
+        weekly_items,
+        "  No weekly totals yet.",
+    );
+
     let history_items: Vec<ListItem> = app
-        .recent_daily_stats(14)
+        .recent_daily_stats(10)
         .into_iter()
         .map(|(day, stats)| {
             ListItem::new(format!(
@@ -666,26 +691,13 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
             ))
         })
         .collect();
-
-    if history_items.is_empty() {
-        let empty = Paragraph::new("  No completed focus history yet.")
-            .style(Style::default().fg(Color::DarkGray))
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" Recent Days "),
-            );
-        frame.render_widget(empty, inner[3]);
-    } else {
-        let list = List::new(history_items)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" Recent Days "),
-            )
-            .style(Style::default().fg(Color::Gray));
-        frame.render_widget(list, inner[3]);
-    }
+    render_history_panel(
+        frame,
+        history_sections[1],
+        " Recent Days ",
+        history_items,
+        "  No completed focus history yet.",
+    );
 
     if let Some(err) = app.stats_error.as_ref() {
         render_centered_error(frame, inner[4], format!("⚠  {err}"));
@@ -699,6 +711,26 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
     .alignment(Alignment::Center)
     .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(hints, inner[5]);
+}
+
+fn render_history_panel(
+    frame: &mut Frame,
+    area: Rect,
+    title: &'static str,
+    items: Vec<ListItem>,
+    empty_message: &'static str,
+) {
+    if items.is_empty() {
+        let empty = Paragraph::new(empty_message)
+            .style(Style::default().fg(Color::DarkGray))
+            .block(Block::default().borders(Borders::ALL).title(title));
+        frame.render_widget(empty, area);
+    } else {
+        let list = List::new(items)
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .style(Style::default().fg(Color::Gray));
+        frame.render_widget(list, area);
+    }
 }
 
 fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
@@ -841,6 +873,10 @@ fn format_history_goal_streak_line(app: &App) -> String {
     }
 }
 
+fn format_week_label(year: i32, week: u32) -> String {
+    format!("{year:04}-W{week:02}")
+}
+
 fn phase_color(phase: TimerPhase) -> Color {
     match phase {
         TimerPhase::Focus => Color::Red,
@@ -956,6 +992,46 @@ mod tests {
 
         let text = terminal_text(&terminal, width, height);
         assert!(text.contains("WRAP-END"));
+    }
+
+    #[test]
+    fn history_view_renders_weekly_summary_panel() {
+        let width = 100;
+        let height = 24;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.mode = AppMode::StatsHistory;
+        app.insert_daily_stats_for_tests(
+            "2026-04-06",
+            crate::stats::DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 30 * 60,
+                goal: None,
+            },
+        );
+        app.insert_daily_stats_for_tests(
+            "2026-04-08",
+            crate::stats::DailyStats {
+                pomodoros_completed: 2,
+                focused_seconds: 45 * 60,
+                goal: None,
+            },
+        );
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("Weekly Totals"));
+        assert!(text.contains(&format_week_label(2026, 15)));
+        assert!(text.contains("75m"));
+    }
+
+    #[test]
+    fn week_label_uses_zero_padded_iso_format() {
+        assert_eq!(format_week_label(2026, 5), "2026-W05");
     }
 
     #[test]


### PR DESCRIPTION
## What

Add weekly summaries to the History view by deriving ISO-week rollups from the existing daily stats and rendering them alongside recent daily entries.

## Why

The history screen only showed individual recent days, so it was hard to understand progress at the weekly level. This addresses #86 without changing the persisted stats schema by computing weekly totals from the daily source of truth.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * History panel now displays weekly totals alongside daily summaries, showing focus minutes and pomodoros completed per week.

* **Changes**
  * Adjusted daily history view to show 10 most recent entries (previously 14).
  * Updated documentation to reflect new weekly and daily summary capabilities in the history panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->