### PR TITLE
Prepare v0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.1] - 2026-04-15
 
-### Changed
-- **v0.3.1 release metadata refresh (#103):** updated crate version metadata, README release references, and changelog links for the `v0.3.1` release.
+### Added
+- **Streak tracking (#101):** added current-streak and best-streak tracking based on completed daily focus goals while preserving historical accuracy when goals change later.
+- **Weekly history summaries (#102):** added weekly aggregation of focused minutes and completed Pomodoros in the History view.
 
 ## [0.3.0] - 2026-04-15
 
 ### Added
 - **Daily focus goals and live progress (#92):** introduced configurable daily minute/pomodoro goals with live progress shown in timer and history views.
-- **Streak tracking (#85):** added current-streak and best-streak tracking based on completed daily focus goals.
-- **Weekly history summaries (#86):** added weekly aggregation of focused minutes and completed Pomodoros in the History view.
 - **Auto-start phase options (#93):** added opt-in auto-start controls for focus-to-break and break-to-focus transitions on natural (non-catchup) completions.
 - **Setup diagnostics screen (#96):** added in-app diagnostics for blocking permissions, hosts file write access, and WakaTime configuration readiness.
 - **WakaTime success timestamp visibility (#95):** surfaced the last successful heartbeat time in the timer status line when tracking is configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-15
+
+### Changed
+- **v0.3.1 release metadata refresh (#103):** updated crate version metadata, README release references, and changelog links for the `v0.3.1` release.
+
 ## [0.3.0] - 2026-04-15
 
 ### Added
@@ -47,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/utilForever/focustime/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/utilForever/focustime/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/utilForever/focustime/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/utilForever/focustime/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Daily focus goals and live progress (#92):** introduced configurable daily minute/pomodoro goals with live progress shown in timer and history views.
+- **Streak tracking (#85):** added current-streak and best-streak tracking based on completed daily focus goals.
+- **Weekly history summaries (#86):** added weekly aggregation of focused minutes and completed Pomodoros in the History view.
 - **Auto-start phase options (#93):** added opt-in auto-start controls for focus-to-break and break-to-focus transitions on natural (non-catchup) completions.
 - **Setup diagnostics screen (#96):** added in-app diagnostics for blocking permissions, hosts file write access, and WakaTime configuration readiness.
 - **WakaTime success timestamp visibility (#95):** surfaced the last successful heartbeat time in the timer status line when tracking is configured.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -287,12 +287,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.3.0`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.3.1`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.3.0](https://github.com/utilForever/focustime/releases/tag/v0.3.0).
+The latest stable release is [v0.3.1](https://github.com/utilForever/focustime/releases/tag/v0.3.1).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the `v0.3.1` release by syncing the crate version metadata and public release references across `Cargo.toml`, `Cargo.lock`, `README.md`, and `CHANGELOG.md`.

## Why

The repository still referenced `0.3.0` in release-facing metadata and documentation. This updates those references for the `v0.3.1` release and closes the tracked release-prep issue.

Closes #103

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

N/A - this PR only updates release metadata and documentation.

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

N/A - no security-sensitive or breaking behavior changes are introduced by this release metadata update.

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.1 and updated package version and release metadata
  * Added a 0.3.1 changelog entry and adjusted comparison links

* **Documentation**
  * Updated README and release automation examples to reference v0.3.1 and the latest stable release link
<!-- end of auto-generated comment: release notes by coderabbit.ai -->