### PR TITLE
Configure WakaTime project and language labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,14 @@ break_to_focus = false
 [daily_goal]
 minutes = 120
 pomodoros = 4
+
+[wakatime]
+project = "focustime"
+language = "Pomodoro"
 ```
+
+`[wakatime]` is optional. If omitted (or set to blank values), `focustime` uses
+the defaults above for heartbeat metadata labels.
 
 ## Site manager workflow
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,8 @@ use crate::blocker::{
     BulkAddResult, EditSiteResult, HostsFileDiagnostics, InvalidSiteInput, SiteBlocker,
 };
 use crate::config::{
-    AppConfig, AutoStartConfig, CustomProfileConfig, DailyGoalConfig, NotificationConfig, ProfileId,
+    AppConfig, AutoStartConfig, CustomProfileConfig, DailyGoalConfig, NotificationConfig,
+    ProfileId, WakatimeMetadataConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::stats::{
@@ -17,7 +18,7 @@ use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
     DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerState, TimerStatus,
 };
-use crate::wakatime::{WakatimeConfigStatus, WakatimeTracker};
+use crate::wakatime::{WakatimeConfigStatus, WakatimeHeartbeatMetadata, WakatimeTracker};
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
@@ -265,6 +266,7 @@ pub struct App {
     auto_start: AutoStartConfig,
     pub strict_mode: bool,
     daily_goal: DailyGoalConfig,
+    wakatime_metadata: WakatimeMetadataConfig,
     pending_timer_action: Option<PendingTimerAction>,
     notifier: PhaseNotifier,
     stats: FocusStats,
@@ -291,6 +293,7 @@ impl App {
         let auto_start = config.auto_start;
         let strict_mode = config.strict_mode;
         let daily_goal = config.daily_goal;
+        let wakatime_metadata = config.wakatime;
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
         let (stats, stats_error) = match FocusStats::load() {
             Ok(stats) => (stats, None),
@@ -323,7 +326,10 @@ impl App {
             stats_error,
             history_feedback: None,
             phase_notification: None,
-            wakatime: WakatimeTracker::new(),
+            wakatime: WakatimeTracker::new_with_metadata(WakatimeHeartbeatMetadata {
+                project: wakatime_metadata.project.clone(),
+                language: wakatime_metadata.language.clone(),
+            }),
             selected_profile,
             custom_profile,
             profile_selection_index: profile_index(selected_profile),
@@ -334,6 +340,7 @@ impl App {
             auto_start,
             strict_mode,
             daily_goal,
+            wakatime_metadata,
             pending_timer_action: None,
             notifier: PhaseNotifier::new(notification_settings),
             stats,
@@ -517,6 +524,7 @@ impl App {
             auto_start: self.auto_start,
             strict_mode: self.strict_mode,
             daily_goal: self.daily_goal,
+            wakatime: self.wakatime_metadata.clone(),
         }
     }
 
@@ -1572,6 +1580,7 @@ mod tests {
             auto_start: AutoStartConfig::default(),
             strict_mode: false,
             daily_goal: DailyGoalConfig::default(),
+            wakatime: WakatimeMetadataConfig::default(),
         };
         let app = App::from_config(config);
         assert_eq!(app.selected_profile, ProfileId::Classic);
@@ -1777,6 +1786,28 @@ mod tests {
         assert_eq!(persisted.auto_start, AutoStartConfig::default());
         assert!(persisted.strict_mode);
         assert_eq!(persisted.daily_goal, DailyGoalConfig::default());
+        assert_eq!(persisted.wakatime, WakatimeMetadataConfig::default());
+    }
+
+    #[test]
+    fn persisted_config_preserves_wakatime_metadata() {
+        let config = AppConfig {
+            wakatime: WakatimeMetadataConfig {
+                project: "Team Focus".to_string(),
+                language: "Deep Work".to_string(),
+            },
+            ..AppConfig::default()
+        };
+        let app = App::from_config(config);
+
+        let persisted = app.persisted_config();
+        assert_eq!(
+            persisted.wakatime,
+            WakatimeMetadataConfig {
+                project: "Team Focus".to_string(),
+                language: "Deep Work".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,9 @@ pub struct AppConfig {
     /// A value of `0` disables the corresponding goal.
     #[serde(default)]
     pub daily_goal: DailyGoalConfig,
+    /// WakaTime heartbeat metadata labels.
+    #[serde(default)]
+    pub wakatime: WakatimeMetadataConfig,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -81,6 +84,38 @@ pub struct DailyGoalConfig {
     pub pomodoros: u32,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WakatimeMetadataConfig {
+    #[serde(default = "default_wakatime_project")]
+    pub project: String,
+    #[serde(default = "default_wakatime_language")]
+    pub language: String,
+}
+
+impl WakatimeMetadataConfig {
+    pub fn normalized(&self) -> Self {
+        Self {
+            project: normalize_nonempty_or_default_string(
+                &self.project,
+                &default_wakatime_project(),
+            ),
+            language: normalize_nonempty_or_default_string(
+                &self.language,
+                &default_wakatime_language(),
+            ),
+        }
+    }
+}
+
+impl Default for WakatimeMetadataConfig {
+    fn default() -> Self {
+        Self {
+            project: default_wakatime_project(),
+            language: default_wakatime_language(),
+        }
+    }
+}
+
 impl Default for NotificationConfig {
     fn default() -> Self {
         Self {
@@ -92,6 +127,14 @@ impl Default for NotificationConfig {
 
 fn default_notification_enabled() -> bool {
     true
+}
+
+fn default_wakatime_project() -> String {
+    "focustime".to_string()
+}
+
+fn default_wakatime_language() -> String {
+    "Pomodoro".to_string()
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
@@ -202,6 +245,7 @@ impl Default for AppConfig {
             auto_start: AutoStartConfig::default(),
             strict_mode: false,
             daily_goal: DailyGoalConfig::default(),
+            wakatime: WakatimeMetadataConfig::default(),
         }
     }
 }
@@ -293,6 +337,7 @@ impl AppConfig {
         self.long_break_interval =
             nonzero_or_default_u32(self.long_break_interval, default_long_break_interval());
         self.custom_profile = self.custom_profile.map(|profile| profile.normalized());
+        self.wakatime = self.wakatime.normalized();
         self
     }
 
@@ -358,6 +403,15 @@ fn nonzero_or_default_u32(value: u32, default: u32) -> u32 {
     if value == 0 { default } else { value }
 }
 
+fn normalize_nonempty_or_default_string(value: &str, default: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        default.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -382,6 +436,7 @@ mod tests {
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
+        assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }
 
     #[test]
@@ -412,6 +467,10 @@ mod tests {
                 minutes: 180,
                 pomodoros: 6,
             },
+            wakatime: WakatimeMetadataConfig {
+                project: "Team Focus".to_string(),
+                language: "Focus Session".to_string(),
+            },
         };
         let toml_str = toml::to_string_pretty(&original).unwrap();
         let parsed: AppConfig = toml::from_str(&toml_str).unwrap();
@@ -426,6 +485,7 @@ mod tests {
         assert_eq!(parsed.auto_start, original.auto_start);
         assert_eq!(parsed.strict_mode, original.strict_mode);
         assert_eq!(parsed.daily_goal, original.daily_goal);
+        assert_eq!(parsed.wakatime, original.wakatime);
     }
 
     #[test]
@@ -443,6 +503,7 @@ mod tests {
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
+        assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }
 
     #[test]
@@ -476,6 +537,7 @@ blocked_sites = ["reddit.com", "youtube.com"]
         assert_eq!(parsed.blocked_sites, vec!["reddit.com", "youtube.com"]);
         assert_eq!(parsed.auto_start, AutoStartConfig::default());
         assert_eq!(parsed.daily_goal, DailyGoalConfig::default());
+        assert_eq!(parsed.wakatime, WakatimeMetadataConfig::default());
     }
 
     #[test]
@@ -513,6 +575,7 @@ long_break_interval = 3
             auto_start: AutoStartConfig::default(),
             strict_mode: false,
             daily_goal: DailyGoalConfig::default(),
+            wakatime: WakatimeMetadataConfig::default(),
         };
         let custom = cfg.effective_custom_profile();
         assert_eq!(custom.focus_secs, 40 * 60);
@@ -557,6 +620,21 @@ long_break_interval = 3
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
+        assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
+    }
+
+    #[test]
+    fn wakatime_metadata_normalizes_blank_fields_to_defaults() {
+        let cfg: AppConfig = toml::from_str(
+            r#"
+[wakatime]
+project = "   "
+language = ""
+"#,
+        )
+        .unwrap();
+        let normalized = cfg.normalize();
+        assert_eq!(normalized.wakatime, WakatimeMetadataConfig::default());
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -12,6 +12,9 @@ const HEARTBEAT_INTERVAL_SECS: u64 = 120;
 const HEARTBEAT_RETRY_BACKOFF_SECS: [u64; 2] = [1, 2];
 const HEARTBEAT_MAX_ATTEMPTS: u8 = 3;
 const DEFAULT_API_URL: &str = "https://wakatime.com";
+const DEFAULT_HEARTBEAT_ENTITY: &str = "focustime";
+const DEFAULT_HEARTBEAT_PROJECT: &str = "focustime";
+const DEFAULT_HEARTBEAT_LANGUAGE: &str = "Pomodoro";
 
 #[derive(Debug, Serialize)]
 struct Heartbeat {
@@ -53,6 +56,30 @@ pub struct WakatimeConfigDiagnostics {
     pub config_path: Option<String>,
     pub status: WakatimeConfigStatus,
     pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WakatimeHeartbeatMetadata {
+    pub project: String,
+    pub language: String,
+}
+
+impl WakatimeHeartbeatMetadata {
+    pub fn normalized(&self) -> Self {
+        Self {
+            project: normalize_nonempty_or_default(&self.project, DEFAULT_HEARTBEAT_PROJECT),
+            language: normalize_nonempty_or_default(&self.language, DEFAULT_HEARTBEAT_LANGUAGE),
+        }
+    }
+}
+
+impl Default for WakatimeHeartbeatMetadata {
+    fn default() -> Self {
+        Self {
+            project: DEFAULT_HEARTBEAT_PROJECT.to_string(),
+            language: DEFAULT_HEARTBEAT_LANGUAGE.to_string(),
+        }
+    }
 }
 
 fn current_unix_epoch_secs() -> u64 {
@@ -196,12 +223,17 @@ pub struct WakatimeTracker {
     last_successful_heartbeat_epoch_secs: Option<u64>,
     /// Latches an immediate heartbeat request while another worker is in flight.
     pending_immediate_heartbeat: bool,
+    heartbeat_metadata: WakatimeHeartbeatMetadata,
     #[cfg(test)]
     disable_network_io: bool,
 }
 
 impl WakatimeTracker {
     pub fn new() -> Self {
+        Self::new_with_metadata(WakatimeHeartbeatMetadata::default())
+    }
+
+    pub fn new_with_metadata(metadata: WakatimeHeartbeatMetadata) -> Self {
         let config = WakatimeConfig::load();
         let (result_tx, result_rx) = mpsc::channel();
         Self {
@@ -216,6 +248,7 @@ impl WakatimeTracker {
             last_error: None,
             last_successful_heartbeat_epoch_secs: None,
             pending_immediate_heartbeat: false,
+            heartbeat_metadata: metadata.normalized(),
             #[cfg(test)]
             disable_network_io: false,
         }
@@ -379,14 +412,7 @@ impl WakatimeTracker {
             .map(|d| d.as_secs_f64())
             .unwrap_or(0.0);
 
-        let heartbeat = Heartbeat {
-            entity: "focustime".to_string(),
-            entity_type: "app".to_string(),
-            time: now,
-            project: "focustime".to_string(),
-            language: "Pomodoro".to_string(),
-            is_write: false,
-        };
+        let heartbeat = build_heartbeat_payload(now, &self.heartbeat_metadata);
         let result_tx = self.result_tx.clone();
 
         std::thread::spawn(move || {
@@ -416,6 +442,7 @@ impl WakatimeTracker {
             last_error: None,
             last_successful_heartbeat_epoch_secs: None,
             pending_immediate_heartbeat: false,
+            heartbeat_metadata: WakatimeHeartbeatMetadata::default(),
             disable_network_io: true,
         }
     }
@@ -435,6 +462,7 @@ impl WakatimeTracker {
             last_error: None,
             last_successful_heartbeat_epoch_secs: None,
             pending_immediate_heartbeat: false,
+            heartbeat_metadata: WakatimeHeartbeatMetadata::default(),
             disable_network_io: true,
         }
     }
@@ -530,6 +558,18 @@ impl Default for WakatimeTracker {
     }
 }
 
+fn build_heartbeat_payload(now: f64, metadata: &WakatimeHeartbeatMetadata) -> Heartbeat {
+    let metadata = metadata.normalized();
+    Heartbeat {
+        entity: DEFAULT_HEARTBEAT_ENTITY.to_string(),
+        entity_type: "app".to_string(),
+        time: now,
+        project: metadata.project,
+        language: metadata.language,
+        is_write: false,
+    }
+}
+
 fn parse_setting_line(line: &str) -> Option<(&str, &str)> {
     let (key, value) = line.split_once('=')?;
     let value = value.trim();
@@ -537,6 +577,15 @@ fn parse_setting_line(line: &str) -> Option<(&str, &str)> {
         return None;
     }
     Some((key.trim(), value))
+}
+
+fn normalize_nonempty_or_default(value: &str, default: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        default.to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 fn config_diagnostics_from_read_result(
@@ -598,8 +647,39 @@ mod tests {
             last_error: None,
             last_successful_heartbeat_epoch_secs: None,
             pending_immediate_heartbeat: false,
+            heartbeat_metadata: WakatimeHeartbeatMetadata::default(),
             disable_network_io: true,
         }
+    }
+
+    #[test]
+    fn heartbeat_payload_uses_configured_metadata() {
+        let metadata = WakatimeHeartbeatMetadata {
+            project: "Team Focus".to_string(),
+            language: "Deep Work".to_string(),
+        };
+
+        let payload = build_heartbeat_payload(123.0, &metadata);
+
+        assert_eq!(payload.entity, DEFAULT_HEARTBEAT_ENTITY.to_string());
+        assert_eq!(payload.entity_type, "app");
+        assert_eq!(payload.time, 123.0);
+        assert_eq!(payload.project, "Team Focus");
+        assert_eq!(payload.language, "Deep Work");
+        assert!(!payload.is_write);
+    }
+
+    #[test]
+    fn heartbeat_payload_normalizes_blank_metadata_to_defaults() {
+        let metadata = WakatimeHeartbeatMetadata {
+            project: "   ".to_string(),
+            language: "".to_string(),
+        };
+
+        let payload = build_heartbeat_payload(123.0, &metadata);
+
+        assert_eq!(payload.project, DEFAULT_HEARTBEAT_PROJECT);
+        assert_eq!(payload.language, DEFAULT_HEARTBEAT_LANGUAGE);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds config-file support for WakaTime heartbeat metadata labels by introducing `[wakatime]` `project` and `language` settings with backward-compatible defaults. `WakatimeTracker` now builds heartbeat payload metadata from configured values, and app config persistence now preserves these fields across saves.

## Why

Hardcoded WakaTime labels prevented users from matching heartbeat metadata to their own reporting conventions. This change makes project/language labels customizable while keeping existing behavior unchanged for users who do not set new fields.

Closes #88

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable) (N/A, unchanged)
- [x] Site blocking behavior was verified for this change (if applicable) (N/A, unchanged)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) (N/A, no new dependencies)
- [x] Breaking behavior changes are clearly described in this PR (N/A, no breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WakaTime integration now supports optional custom project and language metadata via the new `[wakatime]` configuration section.
  * Sensible defaults are automatically applied when configuration is omitted or left blank.

* **Documentation**
  * README updated to document the new optional WakaTime metadata configuration section and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->