### PR TITLE
Prepare v0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.1] - 2026-04-15
+## [0.3.2] - 2026-04-16
 
 ### Added
-- **Streak tracking (#85):** added current-streak and best-streak tracking based on completed daily focus goals while preserving historical accuracy when goals change later.
-- **Weekly history summaries (#86):** added weekly aggregation of focused minutes and completed Pomodoros in the History view.
+- **Stats export from History (#105):** added `e` shortcut in History view to export persisted focus data as `focustime-stats.json` and `focustime-stats.csv` in the current working directory.
+- **Configurable WakaTime metadata labels (#106):** added optional `[wakatime]` `project` and `language` config fields so heartbeat labels can be customized while preserving default behavior.
+
+### Changed
+- **Stats export documentation polish:** clarified Windows export overwrite behavior in user-facing docs.
+
+## [0.3.1] - 2026-04-16
+
+### Added
+- **Streak tracking (#101):** added current-streak and best-streak tracking based on completed daily focus goals while preserving historical accuracy when goals change later.
+- **Weekly history summaries (#102):** added weekly aggregation of focused minutes and completed Pomodoros in the History view.
 
 ## [0.3.0] - 2026-04-15
 
@@ -53,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/utilForever/focustime/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/utilForever/focustime/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/utilForever/focustime/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/utilForever/focustime/compare/v0.2.0...v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -295,12 +295,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.3.1`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.3.2`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.3.1](https://github.com/utilForever/focustime/releases/tag/v0.3.1).
+The latest stable release is [v0.3.2](https://github.com/utilForever/focustime/releases/tag/v0.3.2).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare release metadata for v0.3.2 by:
- bumping crate/package version to `0.3.2` in `Cargo.toml` (and syncing `Cargo.lock`)
- updating README release references from `v0.3.1` to `v0.3.2`
- updating `CHANGELOG.md` with a `0.3.2` section, correcting the `0.3.1` date, and replacing issue-number references with PR-number references for `0.3.1` and `0.3.2` entries

## Why

Issue #107 requests release-prep metadata updates across Cargo/README/changelog. This also fixes changelog reference accuracy so released items point to the merged PRs.

Closes #107

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable) (N/A, release metadata/docs only)
- [x] Site blocking behavior was verified for this change (if applicable) (N/A, release metadata/docs only)
- [x] WakaTime integration behavior was verified for this change (if applicable) (N/A, release metadata/docs only)
- [x] I added or updated tests for changed behavior (if applicable) (N/A, no behavior change)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A, none)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) (N/A, docs/version metadata only)
- [x] Breaking behavior changes are clearly described in this PR (N/A, none)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added history-view stats export functionality accessible via the 'e' shortcut, generating JSON and CSV statistics files to the current working directory.
  * Added configurable WakaTime metadata options.

* **Changed**
  * Clarified Windows stats export overwrite behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->