### PR TITLE
Add session planner MVP for task-labeled focus sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ Open profile manager from timer view with **`p`**.
 
 Profile selection and custom values are persisted in `config.toml`.
 
+## Session planner
+
+Open the session planner from timer view with **`t`**.
+
+- `a`: add a new task label
+- `↑/↓`: move selection
+- `Enter`: select highlighted task label
+- `t` or `Esc`: return to timer view
+- while adding a label, `Enter` saves and `Esc` cancels
+
+Starting a focus session from idle now requires a selected task label. The timer
+view always shows the current task label (or a reminder to select one).
+
 ### Example config
 
 ```toml
@@ -246,6 +259,9 @@ From timer view:
 - while the history panel is open, press **`e`** to export `focustime-stats.json` and `focustime-stats.csv` into the current working directory
 - press **`h`** or **`Esc`** to return to timer view
 
+Exports include daily/weekly aggregates plus labeled focus-session records where
+task labels were attached.
+
 ## The way the system works
 
 `focustime` is a single-binary Rust TUI app composed of seven modules in `src/`:
@@ -256,7 +272,7 @@ From timer view:
 - `src/blocker.rs`: hosts-file site blocking and unblocking.
 - `src/wakatime.rs`: heartbeat tracking integration.
 - `src/notifications.rs`: phase transition notifications and optional sound.
-- `src/ui.rs`: Ratatui rendering for timer, site manager, profile, history, and setup diagnostics views.
+- `src/ui.rs`: Ratatui rendering for timer, session planner, site manager, profile, history, and setup diagnostics views.
 
 WakaTime tracking is optional and activates only when an API key is configured
 (read from `~/.wakatime.cfg`).
@@ -264,7 +280,7 @@ WakaTime tracking is optional and activates only when an API key is configured
 Runtime flow (high-level):
 
 1. The main loop renders UI and reads keyboard input.
-2. `App` handles key events (`start/pause`, `stop`, `next`, site manager actions).
+2. `App` handles key events (`start/pause`, `stop`, `next`, session planner actions, site manager actions).
 3. Timer ticks advance every elapsed second while running.
 4. Phase-completion notifications are dispatched asynchronously.
 5. Blocking is applied during focus phases and removed outside focus.

--- a/src/app.rs
+++ b/src/app.rs
@@ -382,48 +382,96 @@ impl App {
     }
 
     pub fn on_tick(&mut self, is_catchup: bool) {
-        let was_focus_running = self.focus_running_for_current_state();
-        let was_focus_phase = self.timer.phase == TimerPhase::Focus;
         let completed_phase = self.timer.phase;
         let completed_focus_secs = self.timer.focus_secs;
-        if was_focus_running && !is_catchup {
+        if self.should_record_focus_elapsed(is_catchup) {
             self.record_focus_elapsed(1);
         }
 
         let phase_changed = self.timer.tick();
-        if !is_catchup && phase_changed && was_focus_phase && self.timer.phase != TimerPhase::Focus
-        {
+        if phase_changed {
+            self.handle_phase_change(completed_phase, completed_focus_secs, is_catchup);
+        }
+        self.flush_stats_if_dirty(false);
+    }
+
+    fn should_record_focus_elapsed(&self, is_catchup: bool) -> bool {
+        !is_catchup && self.focus_running_for_current_state()
+    }
+
+    fn should_record_completed_focus_session(
+        &self,
+        completed_phase: TimerPhase,
+        is_catchup: bool,
+    ) -> bool {
+        !is_catchup && completed_phase == TimerPhase::Focus && self.timer.phase != TimerPhase::Focus
+    }
+
+    fn should_block_focus_autostart(&self) -> bool {
+        self.timer.phase == TimerPhase::Focus && self.selected_task_label.is_none()
+    }
+
+    fn handle_phase_change(
+        &mut self,
+        completed_phase: TimerPhase,
+        completed_focus_secs: u64,
+        is_catchup: bool,
+    ) {
+        self.pending_timer_action = None;
+        if self.should_record_completed_focus_session(completed_phase, is_catchup) {
             self.record_completed_focus_session(completed_focus_secs);
             self.active_focus_task_label = None;
         }
-        if phase_changed {
-            self.pending_timer_action = None;
-            let mut blocked_focus_autostart = false;
-            if !is_catchup && self.should_auto_start_transition(completed_phase, self.timer.phase) {
-                if self.timer.phase == TimerPhase::Focus && self.selected_task_label.is_none() {
-                    blocked_focus_autostart = true;
-                } else {
-                    self.timer.status = TimerStatus::Running;
-                    if self.timer.phase == TimerPhase::Focus {
-                        self.active_focus_task_label = self.selected_task_label.clone();
-                    }
-                }
-            }
-            if !is_catchup {
-                self.phase_notification = self
-                    .notifier
-                    .notify_phase_completion(completed_phase, self.timer.phase);
-            }
-            if blocked_focus_autostart {
-                self.phase_notification =
-                    Some("Select a task label with [t] before starting focus.".to_string());
-            }
-            if self.timer.phase != TimerPhase::Focus {
-                self.active_focus_task_label = None;
-            }
-            self.apply_blocking_for_phase();
+
+        let blocked_focus_autostart =
+            self.apply_auto_start_after_phase_change(completed_phase, is_catchup);
+        self.update_phase_notification_after_phase_change(
+            completed_phase,
+            is_catchup,
+            blocked_focus_autostart,
+        );
+
+        if self.timer.phase != TimerPhase::Focus {
+            self.active_focus_task_label = None;
         }
-        self.flush_stats_if_dirty(false);
+        self.apply_blocking_for_phase();
+    }
+
+    fn apply_auto_start_after_phase_change(
+        &mut self,
+        completed_phase: TimerPhase,
+        is_catchup: bool,
+    ) -> bool {
+        if is_catchup || !self.should_auto_start_transition(completed_phase, self.timer.phase) {
+            return false;
+        }
+
+        if self.should_block_focus_autostart() {
+            return true;
+        }
+
+        self.timer.status = TimerStatus::Running;
+        if self.timer.phase == TimerPhase::Focus {
+            self.active_focus_task_label = self.selected_task_label.clone();
+        }
+        false
+    }
+
+    fn update_phase_notification_after_phase_change(
+        &mut self,
+        completed_phase: TimerPhase,
+        is_catchup: bool,
+        blocked_focus_autostart: bool,
+    ) {
+        if !is_catchup {
+            self.phase_notification = self
+                .notifier
+                .notify_phase_completion(completed_phase, self.timer.phase);
+        }
+        if blocked_focus_autostart {
+            self.phase_notification =
+                Some("Select a task label with [t] before starting focus.".to_string());
+        }
     }
 
     /// Advance WakaTime tracking by `elapsed_secs` simulated seconds.
@@ -840,11 +888,9 @@ impl App {
             KeyCode::Up | KeyCode::Char('k') => {
                 self.planner_selection_index = self.planner_selection_index.saturating_sub(1);
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if !self.task_labels.is_empty() {
-                    self.planner_selection_index =
-                        (self.planner_selection_index + 1).min(self.task_labels.len() - 1);
-                }
+            KeyCode::Down | KeyCode::Char('j') if !self.task_labels.is_empty() => {
+                self.planner_selection_index =
+                    (self.planner_selection_index + 1).min(self.task_labels.len() - 1);
             }
             KeyCode::Char('a') => self.start_planner_input(),
             KeyCode::Enter => self.select_planner_label(),
@@ -1059,10 +1105,8 @@ impl App {
                 self.mode = AppMode::Timer;
             }
             // Navigate down
-            KeyCode::Down | KeyCode::Char('j') => {
-                if !self.blocker.sites.is_empty() {
-                    self.selected_site = (self.selected_site + 1).min(self.blocker.sites.len() - 1);
-                }
+            KeyCode::Down | KeyCode::Char('j') if !self.blocker.sites.is_empty() => {
+                self.selected_site = (self.selected_site + 1).min(self.blocker.sites.len() - 1);
             }
             // Navigate up
             KeyCode::Up | KeyCode::Char('k') => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ use crate::stats::{
     DailyGoalSnapshot, DailyStats, ExportedStatsFiles, FocusStats, GoalStreak, SessionStats,
     WeeklyStats, current_day_key,
 };
+use crate::task_labels::{normalize_task_label, task_label_index};
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
     DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerState, TimerStatus,
@@ -1746,21 +1747,6 @@ fn display_input_value(input: &str) -> String {
     } else {
         trimmed.to_string()
     }
-}
-
-fn normalize_task_label(input: &str) -> Option<String> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
-fn task_label_index(labels: &[String], label: &str) -> Option<usize> {
-    labels
-        .iter()
-        .position(|existing| existing.eq_ignore_ascii_case(label))
 }
 
 impl Drop for App {

--- a/src/app.rs
+++ b/src/app.rs
@@ -43,6 +43,7 @@ pub enum AppMode {
     Timer,
     SiteManager,
     ProfileManager,
+    SessionPlanner,
     StatsHistory,
     SetupDiagnostics,
 }
@@ -135,9 +136,21 @@ pub enum HistoryFeedbackLevel {
     Warning,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlannerFeedbackLevel {
+    Success,
+    Warning,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SiteFeedback {
     pub level: SiteFeedbackLevel,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannerFeedback {
+    pub level: PlannerFeedbackLevel,
     pub message: String,
 }
 
@@ -244,6 +257,13 @@ pub struct App {
     pub site_input_active: bool,
     site_edit_index: Option<usize>,
     pub site_feedback: Option<SiteFeedback>,
+    pub task_labels: Vec<String>,
+    pub selected_task_label: Option<String>,
+    pub planner_selection_index: usize,
+    pub planner_input: String,
+    pub planner_input_active: bool,
+    pub planner_feedback: Option<PlannerFeedback>,
+    active_focus_task_label: Option<String>,
     /// Index of the highlighted site in the SiteManager list.
     pub selected_site: usize,
     /// Last error from a block/unblock operation (e.g. permission denied).
@@ -299,6 +319,11 @@ impl App {
             Ok(stats) => (stats, None),
             Err(e) => (FocusStats::default(), Some(e)),
         };
+        let (task_labels, selected_task_label) = stats.task_planner_state();
+        let planner_selection_index = selected_task_label
+            .as_ref()
+            .and_then(|label| task_label_index(&task_labels, label))
+            .unwrap_or(0);
         let timer = TimerState::with_profile(
             profile_spec.focus_secs,
             profile_spec.short_break_secs,
@@ -319,6 +344,13 @@ impl App {
             site_input_active: false,
             site_edit_index: None,
             site_feedback: None,
+            task_labels,
+            selected_task_label,
+            planner_selection_index,
+            planner_input: String::new(),
+            planner_input_active: false,
+            planner_feedback: None,
+            active_focus_task_label: None,
             selected_site: 0,
             block_error: None,
             setup_diagnostics,
@@ -353,6 +385,7 @@ impl App {
         let was_focus_running = self.focus_running_for_current_state();
         let was_focus_phase = self.timer.phase == TimerPhase::Focus;
         let completed_phase = self.timer.phase;
+        let completed_focus_secs = self.timer.focus_secs;
         if was_focus_running && !is_catchup {
             self.record_focus_elapsed(1);
         }
@@ -360,17 +393,33 @@ impl App {
         let phase_changed = self.timer.tick();
         if !is_catchup && phase_changed && was_focus_phase && self.timer.phase != TimerPhase::Focus
         {
-            self.record_completed_focus_session();
+            self.record_completed_focus_session(completed_focus_secs);
+            self.active_focus_task_label = None;
         }
         if phase_changed {
             self.pending_timer_action = None;
+            let mut blocked_focus_autostart = false;
             if !is_catchup && self.should_auto_start_transition(completed_phase, self.timer.phase) {
-                self.timer.status = TimerStatus::Running;
+                if self.timer.phase == TimerPhase::Focus && self.selected_task_label.is_none() {
+                    blocked_focus_autostart = true;
+                } else {
+                    self.timer.status = TimerStatus::Running;
+                    if self.timer.phase == TimerPhase::Focus {
+                        self.active_focus_task_label = self.selected_task_label.clone();
+                    }
+                }
             }
             if !is_catchup {
                 self.phase_notification = self
                     .notifier
                     .notify_phase_completion(completed_phase, self.timer.phase);
+            }
+            if blocked_focus_autostart {
+                self.phase_notification =
+                    Some("Select a task label with [t] before starting focus.".to_string());
+            }
+            if self.timer.phase != TimerPhase::Focus {
+                self.active_focus_task_label = None;
             }
             self.apply_blocking_for_phase();
         }
@@ -396,6 +445,16 @@ impl App {
 
     pub fn selected_profile_name(&self) -> &'static str {
         self.selected_profile.label()
+    }
+
+    pub fn current_task_label(&self) -> Option<&str> {
+        if self.focus_session_active_for_current_state() {
+            self.active_focus_task_label
+                .as_deref()
+                .or(self.selected_task_label.as_deref())
+        } else {
+            self.selected_task_label.as_deref()
+        }
     }
 
     pub fn profile_values(&self, profile: ProfileId) -> (u64, u64, u64, u32) {
@@ -577,6 +636,7 @@ impl App {
             AppMode::Timer => self.handle_key_timer(key),
             AppMode::SiteManager => self.handle_key_site_manager(key),
             AppMode::ProfileManager => self.handle_key_profile_manager(key),
+            AppMode::SessionPlanner => self.handle_key_session_planner(key),
             AppMode::StatsHistory => self.handle_key_stats_history(key),
             AppMode::SetupDiagnostics => self.handle_key_setup_diagnostics(key),
         }
@@ -610,6 +670,14 @@ impl App {
         match key.code {
             // Start / pause
             KeyCode::Char(' ') => {
+                if self.timer.phase == TimerPhase::Focus
+                    && self.timer.status == TimerStatus::Idle
+                    && self.selected_task_label.is_none()
+                {
+                    self.phase_notification =
+                        Some("Select a task label with [t] before starting focus.".to_string());
+                    return;
+                }
                 self.update_timer_and_sync(TimerState::toggle_pause);
             }
             // Stop / reset current phase
@@ -637,6 +705,10 @@ impl App {
                     return;
                 }
                 self.open_profile_manager();
+            }
+            // Open session planner
+            KeyCode::Char('t') => {
+                self.open_session_planner();
             }
             // Open stats history
             KeyCode::Char('h') => {
@@ -738,6 +810,100 @@ impl App {
                 self.begin_profile_edit();
             }
             _ => {}
+        }
+    }
+
+    fn handle_key_session_planner(&mut self, key: KeyEvent) {
+        if self.planner_input_active {
+            match key.code {
+                KeyCode::Enter => self.commit_planner_input(),
+                KeyCode::Esc => self.cancel_planner_input(),
+                KeyCode::Backspace => {
+                    self.planner_input.pop();
+                }
+                KeyCode::Char(c) => {
+                    self.planner_input.push(c);
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        if self.handle_quit_key(&key, false) {
+            return;
+        }
+
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('t') => {
+                self.mode = AppMode::Timer;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.planner_selection_index = self.planner_selection_index.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.task_labels.is_empty() {
+                    self.planner_selection_index =
+                        (self.planner_selection_index + 1).min(self.task_labels.len() - 1);
+                }
+            }
+            KeyCode::Char('a') => self.start_planner_input(),
+            KeyCode::Enter => self.select_planner_label(),
+            _ => {}
+        }
+    }
+
+    fn start_planner_input(&mut self) {
+        self.planner_input.clear();
+        self.planner_input_active = true;
+        self.planner_feedback = None;
+    }
+
+    fn cancel_planner_input(&mut self) {
+        self.planner_input.clear();
+        self.planner_input_active = false;
+    }
+
+    fn commit_planner_input(&mut self) {
+        let Some(label) = normalize_task_label(&self.planner_input) else {
+            self.set_planner_feedback(PlannerFeedbackLevel::Warning, "Task label cannot be empty");
+            return;
+        };
+        self.planner_input_active = false;
+        self.planner_input.clear();
+
+        if let Some(existing_index) = task_label_index(&self.task_labels, &label) {
+            self.planner_selection_index = existing_index;
+            self.selected_task_label = self.task_labels.get(existing_index).cloned();
+            self.sync_task_planner_state();
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                format!("`{label}` already exists, selected existing label"),
+            );
+            return;
+        }
+
+        self.task_labels.push(label.clone());
+        self.clamp_planner_selection();
+        self.planner_selection_index = self.task_labels.len().saturating_sub(1);
+        self.selected_task_label = Some(label.clone());
+        self.sync_task_planner_state();
+        self.set_planner_feedback(
+            PlannerFeedbackLevel::Success,
+            format!("Added and selected `{label}`"),
+        );
+    }
+
+    fn select_planner_label(&mut self) {
+        if self.task_labels.is_empty() {
+            self.set_planner_feedback(PlannerFeedbackLevel::Warning, "No task labels available");
+            return;
+        }
+
+        self.clamp_planner_selection();
+        if let Some(label) = self.task_labels.get(self.planner_selection_index).cloned() {
+            self.selected_task_label = Some(label.clone());
+            self.sync_task_planner_state();
+            self.set_planner_feedback(PlannerFeedbackLevel::Success, format!("Selected `{label}`"));
         }
     }
 
@@ -854,6 +1020,7 @@ impl App {
             profile_spec.long_break_secs,
             profile_spec.long_break_interval,
         );
+        self.active_focus_task_label = None;
         self.selected_profile = profile;
         self.profile_selection_index = profile_index(profile);
         self.pending_timer_action = None;
@@ -1103,6 +1270,26 @@ impl App {
         }
     }
 
+    fn clamp_planner_selection(&mut self) {
+        if self.task_labels.is_empty() {
+            self.planner_selection_index = 0;
+        } else {
+            self.planner_selection_index = self
+                .planner_selection_index
+                .min(self.task_labels.len().saturating_sub(1));
+        }
+    }
+
+    fn sync_task_planner_state(&mut self) {
+        if self
+            .stats
+            .update_task_planner_state(self.task_labels.clone(), self.selected_task_label.clone())
+        {
+            self.stats_dirty = true;
+            self.flush_stats_if_dirty(false);
+        }
+    }
+
     fn handle_quit_key(&mut self, key: &KeyEvent, esc_quits: bool) -> bool {
         let is_quit_key = matches!(
             key.code,
@@ -1133,8 +1320,15 @@ impl App {
     }
 
     fn update_timer_and_sync(&mut self, action: fn(&mut TimerState)) {
+        let was_focus_active = self.focus_session_active_for_current_state();
         self.pending_timer_action = None;
         action(&mut self.timer);
+        let is_focus_active = self.focus_session_active_for_current_state();
+        if !was_focus_active && is_focus_active {
+            self.active_focus_task_label = self.selected_task_label.clone();
+        } else if was_focus_active && !is_focus_active {
+            self.active_focus_task_label = None;
+        }
         self.apply_blocking_for_phase();
     }
 
@@ -1152,6 +1346,19 @@ impl App {
         self.profile_edit_snapshot = None;
         self.profile_selection_index = profile_index(self.selected_profile);
         self.clamp_profile_selection();
+    }
+
+    fn open_session_planner(&mut self) {
+        self.mode = AppMode::SessionPlanner;
+        self.planner_feedback = None;
+        self.planner_input.clear();
+        self.planner_input_active = false;
+        if let Some(selected) = self.selected_task_label.as_ref()
+            && let Some(index) = task_label_index(&self.task_labels, selected)
+        {
+            self.planner_selection_index = index;
+        }
+        self.clamp_planner_selection();
     }
 
     fn open_stats_history(&mut self) {
@@ -1200,11 +1407,15 @@ impl App {
     }
 
     fn should_block_for_current_state(&self) -> bool {
-        self.timer.phase == TimerPhase::Focus && self.timer.status != TimerStatus::Idle
+        self.focus_session_active_for_current_state()
     }
 
     fn focus_running_for_current_state(&self) -> bool {
         self.timer.phase == TimerPhase::Focus && self.timer.status == TimerStatus::Running
+    }
+
+    fn focus_session_active_for_current_state(&self) -> bool {
+        self.timer.phase == TimerPhase::Focus && self.timer.status != TimerStatus::Idle
     }
 
     fn should_auto_start_transition(
@@ -1246,10 +1457,19 @@ impl App {
         }
     }
 
-    fn record_completed_focus_session(&mut self) {
+    fn record_completed_focus_session(&mut self, focused_seconds: u64) {
         let day_key = current_day_key();
-        self.stats
-            .record_completed_pomodoro(&day_key, self.current_goal_snapshot());
+        let goal = self.current_goal_snapshot();
+        if self.active_focus_task_label.is_some() {
+            self.stats.record_completed_pomodoro_with_task(
+                &day_key,
+                goal,
+                self.active_focus_task_label.as_deref(),
+                focused_seconds,
+            );
+        } else {
+            self.stats.record_completed_pomodoro(&day_key, goal);
+        }
         self.stats_dirty = true;
     }
 
@@ -1312,6 +1532,13 @@ impl App {
 
     fn set_site_feedback(&mut self, level: SiteFeedbackLevel, message: impl Into<String>) {
         self.site_feedback = Some(SiteFeedback {
+            level,
+            message: message.into(),
+        });
+    }
+
+    fn set_planner_feedback(&mut self, level: PlannerFeedbackLevel, message: impl Into<String>) {
+        self.planner_feedback = Some(PlannerFeedback {
             level,
             message: message.into(),
         });
@@ -1475,6 +1702,21 @@ fn display_input_value(input: &str) -> String {
     } else {
         trimmed.to_string()
     }
+}
+
+fn normalize_task_label(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn task_label_index(labels: &[String], label: &str) -> Option<usize> {
+    labels
+        .iter()
+        .position(|existing| existing.eq_ignore_ascii_case(label))
 }
 
 impl Drop for App {
@@ -2413,6 +2655,8 @@ mod tests {
             ..AppConfig::default()
         };
         let mut app = App::from_config(config);
+        app.task_labels = vec!["Auto Task".to_string()];
+        app.selected_task_label = Some("Auto Task".to_string());
         app.timer.phase = TimerPhase::ShortBreak;
         app.timer.status = TimerStatus::Running;
         app.timer.remaining_secs = 1;
@@ -2832,6 +3076,42 @@ mod tests {
             app.wakatime.runtime_state(),
             crate::wakatime::WakatimeRuntimeState::Error("HTTP 503".to_string())
         );
+    }
+
+    #[test]
+    fn focus_does_not_start_without_selected_task_label() {
+        let mut app = App::default();
+
+        app.handle_key(key(KeyCode::Char(' ')));
+
+        assert_eq!(app.timer.status, TimerStatus::Idle);
+        assert_eq!(
+            app.phase_notification.as_deref(),
+            Some("Select a task label with [t] before starting focus.")
+        );
+    }
+
+    #[test]
+    fn session_planner_adds_label_and_allows_focus_start() {
+        let mut app = App::default();
+
+        app.handle_key(key(KeyCode::Char('t')));
+        assert_eq!(app.mode, AppMode::SessionPlanner);
+
+        app.handle_key(key(KeyCode::Char('a')));
+        for c in "Docs".chars() {
+            app.handle_key(key(KeyCode::Char(c)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
+        assert_eq!(app.current_task_label(), Some("Docs"));
+
+        app.handle_key(key(KeyCode::Char('t')));
+        assert_eq!(app.mode, AppMode::Timer);
+
+        app.handle_key(key(KeyCode::Char(' ')));
+        assert_eq!(app.timer.status, TimerStatus::Running);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod blocker;
 mod config;
 mod notifications;
 mod stats;
+mod task_labels;
 mod timer;
 mod ui;
 mod wakatime;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -10,6 +10,8 @@ use std::{
 use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 
+use crate::task_labels::{canonical_task_label, normalize_task_label, task_label_index};
+
 #[cfg_attr(test, allow(dead_code))]
 const STATS_FILE_NAME: &str = "stats.toml";
 const JSON_EXPORT_FILE_NAME: &str = "focustime-stats.json";
@@ -559,21 +561,6 @@ impl StatsExport {
     }
 }
 
-fn normalize_task_label(value: &str) -> Option<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
-fn task_label_index(labels: &[String], candidate: &str) -> Option<usize> {
-    labels
-        .iter()
-        .position(|label| label.eq_ignore_ascii_case(candidate))
-}
-
 fn normalize_task_planner_state(
     labels: Vec<String>,
     selected: Option<String>,
@@ -590,7 +577,9 @@ fn normalize_task_planner_state(
         }
     }
 
-    let normalized_selected = selected.and_then(|value| normalize_task_label(&value));
+    let normalized_selected = selected
+        .and_then(|value| normalize_task_label(&value))
+        .map(|value| canonical_task_label(&normalized_labels, &value).unwrap_or(value));
     if let Some(selected_label) = normalized_selected.as_ref() {
         let key = selected_label.to_ascii_lowercase();
         if seen.insert(key) {
@@ -785,7 +774,7 @@ mod tests {
 
         let (labels, selected) = stats.task_planner_state();
         assert_eq!(labels, vec!["Docs".to_string(), "Bugfix".to_string()]);
-        assert_eq!(selected, Some("docs".to_string()));
+        assert_eq!(selected, Some("Docs".to_string()));
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -90,10 +90,18 @@ pub struct ExportedStatsFiles {
     pub csv_path: PathBuf,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FocusSessionRecord {
+    pub date: String,
+    pub task_label: String,
+    pub focused_seconds: u64,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 struct StatsExport {
     daily: Vec<DailyExportRow>,
     weekly: Vec<WeeklyExportRow>,
+    sessions: Vec<SessionExportRow>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -116,6 +124,14 @@ struct WeeklyExportRow {
     focused_minutes: u64,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct SessionExportRow {
+    date: String,
+    task_label: String,
+    focused_seconds: u64,
+    focused_minutes: u64,
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct CsvExportRow {
     record_type: &'static str,
@@ -129,18 +145,28 @@ struct CsvExportRow {
     goal_minutes: Option<u64>,
     goal_pomodoros: Option<u32>,
     goal_met: Option<bool>,
+    task_label: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 struct PersistedStats {
     #[serde(default)]
     daily: BTreeMap<String, DailyStats>,
+    #[serde(default)]
+    task_labels: Vec<String>,
+    #[serde(default)]
+    selected_task_label: Option<String>,
+    #[serde(default)]
+    focus_sessions: Vec<FocusSessionRecord>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct FocusStats {
     session: SessionStats,
     daily: BTreeMap<String, DailyStats>,
+    task_labels: Vec<String>,
+    selected_task_label: Option<String>,
+    focus_sessions: Vec<FocusSessionRecord>,
 }
 
 impl FocusStats {
@@ -172,15 +198,33 @@ impl FocusStats {
     }
 
     fn from_persisted(persisted: PersistedStats) -> Self {
+        let (task_labels, selected_task_label) =
+            normalize_task_planner_state(persisted.task_labels, persisted.selected_task_label);
+        let mut focus_sessions = Vec::new();
+        for session in persisted.focus_sessions {
+            if let Some(task_label) = normalize_task_label(&session.task_label) {
+                focus_sessions.push(FocusSessionRecord {
+                    date: session.date.trim().to_string(),
+                    task_label,
+                    focused_seconds: session.focused_seconds,
+                });
+            }
+        }
         Self {
             session: SessionStats::default(),
             daily: persisted.daily,
+            task_labels,
+            selected_task_label,
+            focus_sessions,
         }
     }
 
     fn to_persisted(&self) -> PersistedStats {
         PersistedStats {
             daily: self.daily.clone(),
+            task_labels: self.task_labels.clone(),
+            selected_task_label: self.selected_task_label.clone(),
+            focus_sessions: self.focus_sessions.clone(),
         }
     }
 
@@ -212,10 +256,32 @@ impl FocusStats {
     }
 
     pub fn record_completed_pomodoro(&mut self, day_key: &str, goal: DailyGoalSnapshot) {
+        self.record_completed_pomodoro_with_task(day_key, goal, None, 0);
+    }
+
+    pub fn record_completed_pomodoro_with_task(
+        &mut self,
+        day_key: &str,
+        goal: DailyGoalSnapshot,
+        task_label: Option<&str>,
+        focused_seconds: u64,
+    ) {
         self.session.pomodoros_completed = self.session.pomodoros_completed.saturating_add(1);
         let daily = self.daily.entry(day_key.to_string()).or_default();
         daily.pomodoros_completed = daily.pomodoros_completed.saturating_add(1);
         daily.goal = Some(goal);
+
+        if let Some(task_label) = task_label.and_then(normalize_task_label) {
+            if task_label_index(&self.task_labels, &task_label).is_none() {
+                self.task_labels.push(task_label.clone());
+            }
+            self.selected_task_label = Some(task_label.clone());
+            self.focus_sessions.push(FocusSessionRecord {
+                date: day_key.to_string(),
+                task_label,
+                focused_seconds,
+            });
+        }
     }
 
     pub fn sync_goal_snapshot(&mut self, day_key: &str, goal: DailyGoalSnapshot) -> bool {
@@ -237,6 +303,25 @@ impl FocusStats {
 
     pub fn daily_for(&self, day_key: &str) -> DailyStats {
         self.daily.get(day_key).copied().unwrap_or_default()
+    }
+
+    pub fn task_planner_state(&self) -> (Vec<String>, Option<String>) {
+        (self.task_labels.clone(), self.selected_task_label.clone())
+    }
+
+    pub fn update_task_planner_state(
+        &mut self,
+        labels: Vec<String>,
+        selected: Option<String>,
+    ) -> bool {
+        let (task_labels, selected_task_label) = normalize_task_planner_state(labels, selected);
+        if self.task_labels == task_labels && self.selected_task_label == selected_task_label {
+            return false;
+        }
+
+        self.task_labels = task_labels;
+        self.selected_task_label = selected_task_label;
+        true
     }
 
     pub fn recent_daily(&self, limit: usize) -> Vec<(String, DailyStats)> {
@@ -278,6 +363,7 @@ impl FocusStats {
         StatsExport {
             daily: self.export_daily_rows(),
             weekly: self.export_weekly_rows(),
+            sessions: self.export_session_rows(),
         }
     }
 
@@ -308,6 +394,18 @@ impl FocusStats {
                 pomodoros_completed: stats.pomodoros_completed,
                 focused_seconds: stats.focused_seconds,
                 focused_minutes: stats.focused_minutes(),
+            })
+            .collect()
+    }
+
+    fn export_session_rows(&self) -> Vec<SessionExportRow> {
+        self.focus_sessions
+            .iter()
+            .map(|session| SessionExportRow {
+                date: session.date.clone(),
+                task_label: session.task_label.clone(),
+                focused_seconds: session.focused_seconds,
+                focused_minutes: session.focused_seconds / 60,
             })
             .collect()
     }
@@ -403,7 +501,8 @@ impl StatsExport {
     }
 
     fn csv_rows(&self) -> Vec<CsvExportRow> {
-        let mut rows = Vec::with_capacity(self.daily.len() + self.weekly.len());
+        let mut rows =
+            Vec::with_capacity(self.daily.len() + self.weekly.len() + self.sessions.len());
 
         for daily in &self.daily {
             rows.push(CsvExportRow {
@@ -418,6 +517,7 @@ impl StatsExport {
                 goal_minutes: daily.goal.map(|goal| goal.minutes),
                 goal_pomodoros: daily.goal.map(|goal| goal.pomodoros),
                 goal_met: daily.goal.map(|_| daily.goal_met),
+                task_label: None,
             });
         }
 
@@ -434,11 +534,71 @@ impl StatsExport {
                 goal_minutes: None,
                 goal_pomodoros: None,
                 goal_met: None,
+                task_label: None,
+            });
+        }
+
+        for session in &self.sessions {
+            rows.push(CsvExportRow {
+                record_type: "focus_session",
+                date: Some(session.date.clone()),
+                week_label: None,
+                year: None,
+                week: None,
+                pomodoros_completed: 1,
+                focused_seconds: session.focused_seconds,
+                focused_minutes: session.focused_minutes,
+                goal_minutes: None,
+                goal_pomodoros: None,
+                goal_met: None,
+                task_label: Some(session.task_label.clone()),
             });
         }
 
         rows
     }
+}
+
+fn normalize_task_label(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn task_label_index(labels: &[String], candidate: &str) -> Option<usize> {
+    labels
+        .iter()
+        .position(|label| label.eq_ignore_ascii_case(candidate))
+}
+
+fn normalize_task_planner_state(
+    labels: Vec<String>,
+    selected: Option<String>,
+) -> (Vec<String>, Option<String>) {
+    let mut normalized_labels = Vec::new();
+    let mut seen = BTreeSet::new();
+    for label in labels {
+        let Some(label) = normalize_task_label(&label) else {
+            continue;
+        };
+        let key = label.to_ascii_lowercase();
+        if seen.insert(key) {
+            normalized_labels.push(label);
+        }
+    }
+
+    let normalized_selected = selected.and_then(|value| normalize_task_label(&value));
+    if let Some(selected_label) = normalized_selected.as_ref() {
+        let key = selected_label.to_ascii_lowercase();
+        if seen.insert(key) {
+            normalized_labels.push(selected_label.clone());
+        }
+    }
+
+    (normalized_labels, normalized_selected)
 }
 
 pub fn current_day_key() -> String {
@@ -607,6 +767,25 @@ mod tests {
         assert_eq!(day.focused_seconds, 125);
         assert_eq!(day.focused_minutes(), 2);
         assert_eq!(day.goal, Some(goal));
+    }
+
+    #[test]
+    fn task_planner_state_normalizes_and_deduplicates_labels() {
+        let mut stats = FocusStats::default();
+        let changed = stats.update_task_planner_state(
+            vec![
+                "  Docs  ".to_string(),
+                "docs".to_string(),
+                "".to_string(),
+                "Bugfix".to_string(),
+            ],
+            Some("  docs ".to_string()),
+        );
+        assert!(changed);
+
+        let (labels, selected) = stats.task_planner_state();
+        assert_eq!(labels, vec!["Docs".to_string(), "Bugfix".to_string()]);
+        assert_eq!(selected, Some("docs".to_string()));
     }
 
     #[test]
@@ -810,7 +989,7 @@ mod tests {
             pomodoros: 1,
         };
         stats.record_focus_elapsed("2026-04-06", 30 * 60, goal);
-        stats.record_completed_pomodoro("2026-04-06", goal);
+        stats.record_completed_pomodoro_with_task("2026-04-06", goal, Some("Project A"), 30 * 60);
         stats.record_focus_elapsed("2026-04-08", 45 * 60, goal);
         stats.record_completed_pomodoro("2026-04-08", goal);
 
@@ -827,17 +1006,22 @@ mod tests {
         let json_value: serde_json::Value = serde_json::from_str(&json).unwrap();
         let daily = json_value["daily"].as_array().unwrap();
         let weekly = json_value["weekly"].as_array().unwrap();
+        let sessions = json_value["sessions"].as_array().unwrap();
         assert_eq!(daily.len(), 2);
         assert_eq!(weekly.len(), 1);
+        assert_eq!(sessions.len(), 1);
         assert_eq!(daily[0]["date"], "2026-04-06");
         assert_eq!(daily[0]["goal_met"], true);
         assert_eq!(weekly[0]["week_label"], "2026-W15");
         assert_eq!(weekly[0]["focused_minutes"], 75);
+        assert_eq!(sessions[0]["task_label"], "Project A");
+        assert_eq!(sessions[0]["focused_minutes"], 30);
 
         let csv = fs::read_to_string(&exported.csv_path).unwrap();
-        assert!(csv.contains("record_type,date,week_label,year,week,pomodoros_completed,focused_seconds,focused_minutes,goal_minutes,goal_pomodoros,goal_met"));
-        assert!(csv.contains("daily,2026-04-06,,,,1,1800,30,25,1,true"));
-        assert!(csv.contains("weekly,,2026-W15,2026,15,2,4500,75,,,"));
+        assert!(csv.contains("record_type,date,week_label,year,week,pomodoros_completed,focused_seconds,focused_minutes,goal_minutes,goal_pomodoros,goal_met,task_label"));
+        assert!(csv.contains("daily,2026-04-06,,,,1,1800,30,25,1,true,"));
+        assert!(csv.contains("weekly,,2026-W15,2026,15,2,4500,75,,,,"));
+        assert!(csv.contains("focus_session,2026-04-06,,,,1,1800,30,,,,Project A"));
 
         fs::remove_dir_all(export_dir).unwrap();
     }

--- a/src/task_labels.rs
+++ b/src/task_labels.rs
@@ -16,3 +16,59 @@ pub fn task_label_index(labels: &[String], label: &str) -> Option<usize> {
 pub fn canonical_task_label(labels: &[String], label: &str) -> Option<String> {
     task_label_index(labels, label).map(|index| labels[index].clone())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{canonical_task_label, normalize_task_label, task_label_index};
+
+    #[test]
+    fn normalize_task_label_returns_none_for_empty_input() {
+        assert_eq!(normalize_task_label(""), None);
+    }
+
+    #[test]
+    fn normalize_task_label_returns_none_for_whitespace_only_input() {
+        assert_eq!(normalize_task_label("   \t  "), None);
+    }
+
+    #[test]
+    fn normalize_task_label_trims_and_returns_value() {
+        assert_eq!(
+            normalize_task_label("  Feature Work  "),
+            Some("Feature Work".to_string())
+        );
+    }
+
+    #[test]
+    fn task_label_index_returns_index_for_exact_match() {
+        let labels = vec!["Docs".to_string(), "Bugfix".to_string()];
+        assert_eq!(task_label_index(&labels, "Docs"), Some(0));
+    }
+
+    #[test]
+    fn task_label_index_returns_index_for_case_insensitive_match() {
+        let labels = vec!["Label".to_string(), "Other".to_string()];
+        assert_eq!(task_label_index(&labels, "label"), Some(0));
+    }
+
+    #[test]
+    fn task_label_index_returns_none_for_missing_label() {
+        let labels = vec!["Docs".to_string(), "Bugfix".to_string()];
+        assert_eq!(task_label_index(&labels, "Planning"), None);
+    }
+
+    #[test]
+    fn canonical_task_label_returns_canonical_stored_value_when_found() {
+        let labels = vec!["Deep Work".to_string(), "Review".to_string()];
+        assert_eq!(
+            canonical_task_label(&labels, "deep work"),
+            Some("Deep Work".to_string())
+        );
+    }
+
+    #[test]
+    fn canonical_task_label_returns_none_when_not_found() {
+        let labels = vec!["Deep Work".to_string(), "Review".to_string()];
+        assert_eq!(canonical_task_label(&labels, "Planning"), None);
+    }
+}

--- a/src/task_labels.rs
+++ b/src/task_labels.rs
@@ -1,0 +1,18 @@
+pub fn normalize_task_label(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+pub fn task_label_index(labels: &[String], label: &str) -> Option<usize> {
+    labels
+        .iter()
+        .position(|existing| existing.eq_ignore_ascii_case(label))
+}
+
+pub fn canonical_task_label(labels: &[String], label: &str) -> Option<String> {
+    task_label_index(labels, label).map(|index| labels[index].clone())
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -672,7 +672,15 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
         ])
         .split(outer);
 
-    let current_text = app.selected_task_label.as_ref().map_or_else(
+    render_session_planner_selected_task(frame, app, inner[0]);
+    render_session_planner_labels(frame, app, inner[2]);
+    render_session_planner_input(frame, app, inner[3]);
+    render_session_planner_feedback(frame, app, inner[4]);
+    render_session_planner_hints(frame, app, inner[5]);
+}
+
+fn render_session_planner_selected_task(frame: &mut Frame, app: &App, area: Rect) {
+    let selected_text = app.selected_task_label.as_ref().map_or_else(
         || {
             vec![
                 Line::from("Selected task:"),
@@ -687,12 +695,14 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
         },
     );
     frame.render_widget(
-        Paragraph::new(current_text)
+        Paragraph::new(selected_text)
             .style(Style::default().fg(Color::White))
             .wrap(Wrap { trim: true }),
-        inner[0],
+        area,
     );
+}
 
+fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {
     if app.task_labels.is_empty() {
         frame.render_widget(
             Paragraph::new("No task labels yet. Press [a] to add one.")
@@ -702,46 +712,49 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
                         .borders(Borders::ALL)
                         .title(" Task Labels "),
                 ),
-            inner[2],
+            area,
         );
-    } else {
-        let items: Vec<ListItem> = app
-            .task_labels
-            .iter()
-            .map(|label| {
-                let marker = if app
-                    .selected_task_label
-                    .as_ref()
-                    .is_some_and(|selected| selected.eq_ignore_ascii_case(label))
-                {
-                    "✓"
-                } else {
-                    " "
-                };
-                ListItem::new(format!(" {marker} {label}"))
-            })
-            .collect();
-        let list = List::new(items)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" Task Labels "),
-            )
-            .highlight_style(
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .highlight_symbol("▶ ");
-        let mut state = ListState::default();
-        state.select(Some(
-            app.planner_selection_index
-                .min(app.task_labels.len().saturating_sub(1)),
-        ));
-        frame.render_stateful_widget(list, inner[2], &mut state);
+        return;
     }
 
+    let items: Vec<ListItem> = app
+        .task_labels
+        .iter()
+        .map(|label| {
+            let marker = if app
+                .selected_task_label
+                .as_ref()
+                .is_some_and(|selected| selected.eq_ignore_ascii_case(label))
+            {
+                "✓"
+            } else {
+                " "
+            };
+            ListItem::new(format!(" {marker} {label}"))
+        })
+        .collect();
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Task Labels "),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+    let mut state = ListState::default();
+    state.select(Some(
+        app.planner_selection_index
+            .min(app.task_labels.len().saturating_sub(1)),
+    ));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn render_session_planner_input(frame: &mut Frame, app: &App, area: Rect) {
     let input_title = if app.planner_input_active {
         " Add task label "
     } else {
@@ -760,9 +773,11 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
                 Style::default().fg(Color::DarkGray)
             })
             .block(Block::default().borders(Borders::ALL).title(input_title)),
-        inner[3],
+        area,
     );
+}
 
+fn render_session_planner_feedback(frame: &mut Frame, app: &App, area: Rect) {
     if let Some(feedback) = app.planner_feedback.as_ref() {
         let (prefix, color) = match feedback.level {
             PlannerFeedbackLevel::Success => ("✓", Color::Green),
@@ -773,10 +788,12 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
                 .style(Style::default().fg(color))
                 .alignment(Alignment::Center)
                 .wrap(Wrap { trim: true }),
-            inner[4],
+            area,
         );
     }
+}
 
+fn render_session_planner_hints(frame: &mut Frame, app: &App, area: Rect) {
     let hints = if app.planner_input_active {
         vec![
             Line::from("Input: type task label, then [Enter]"),
@@ -802,7 +819,7 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
         Paragraph::new(hints)
             .alignment(Alignment::Center)
             .style(Style::default().fg(Color::DarkGray)),
-        inner[5],
+        area,
     );
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,7 +9,7 @@ use ratatui::{
 
 use crate::app::{
     App, AppMode, DailyGoalProgress, HistoryFeedbackLevel, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS,
-    SetupCheck, SetupCheckLevel, SiteFeedbackLevel, SiteInputMode,
+    PlannerFeedbackLevel, SetupCheck, SetupCheckLevel, SiteFeedbackLevel, SiteInputMode,
 };
 use crate::timer::{TimerPhase, TimerStatus};
 use crate::wakatime::WakatimeRuntimeState;
@@ -19,6 +19,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         AppMode::Timer => render_timer(frame, app),
         AppMode::SiteManager => render_site_manager(frame, app),
         AppMode::ProfileManager => render_profile_manager(frame, app),
+        AppMode::SessionPlanner => render_session_planner(frame, app),
         AppMode::StatsHistory => render_stats_history(frame, app),
         AppMode::SetupDiagnostics => render_setup_diagnostics(frame, app),
     }
@@ -42,6 +43,7 @@ fn render_timer(frame: &mut Frame, app: &App) {
             Constraint::Length(2), // phase + pomodoro count
             Constraint::Length(3), // MM:SS
             Constraint::Length(1), // active profile
+            Constraint::Length(1), // selected task label
             Constraint::Length(3), // progress bar
             Constraint::Length(2), // status
             Constraint::Length(1), // latest phase notification
@@ -56,13 +58,14 @@ fn render_timer(frame: &mut Frame, app: &App) {
     render_timer_phase_header(frame, app, inner[0]);
     render_timer_countdown(frame, app, inner[1]);
     render_timer_profile(frame, app, inner[2]);
-    render_timer_progress_bar(frame, app, inner[3]);
-    render_timer_status(frame, app, inner[4]);
-    render_timer_phase_notice(frame, app, inner[5]);
-    render_timer_stats_summary(frame, app, inner[6]);
-    render_timer_goal_streak_summary(frame, app, inner[7]);
-    render_timer_wakatime_status(frame, app, inner[8]);
-    render_timer_hints(frame, app, inner[10]);
+    render_timer_task_label(frame, app, inner[3]);
+    render_timer_progress_bar(frame, app, inner[4]);
+    render_timer_status(frame, app, inner[5]);
+    render_timer_phase_notice(frame, app, inner[6]);
+    render_timer_stats_summary(frame, app, inner[7]);
+    render_timer_goal_streak_summary(frame, app, inner[8]);
+    render_timer_wakatime_status(frame, app, inner[9]);
+    render_timer_hints(frame, app, inner[11]);
 }
 
 fn render_timer_phase_header(frame: &mut Frame, app: &App, area: Rect) {
@@ -106,6 +109,24 @@ fn render_timer_profile(frame: &mut Frame, app: &App, area: Rect) {
         .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(profile_widget, area);
+}
+
+fn render_timer_task_label(frame: &mut Frame, app: &App, area: Rect) {
+    let (text, style) = if let Some(label) = app.current_task_label() {
+        (
+            format!("Task: {label}"),
+            Style::default().fg(Color::LightYellow),
+        )
+    } else {
+        (
+            "Task: not selected ([t] Planner)".to_string(),
+            Style::default().fg(Color::Yellow),
+        )
+    };
+    let widget = Paragraph::new(text)
+        .alignment(Alignment::Center)
+        .style(style);
+    frame.render_widget(widget, area);
 }
 
 fn render_timer_progress_bar(frame: &mut Frame, app: &App, area: Rect) {
@@ -289,9 +310,9 @@ fn timer_primary_hint(app: &App) -> &'static str {
 
 fn timer_secondary_hint(app: &App) -> &'static str {
     if app.strict_mode_enforced_for_focus() {
-        "Views: [h] History  [p] Profiles (Locked)  [b] Sites  [d] Setup  [q/Esc] Quit (Locked)"
+        "Views: [h] History  [p] Profiles (Locked)  [t] Planner  [b] Sites  [d] Setup  [q/Esc] Quit (Locked)"
     } else {
-        "Views: [h] History  [p] Profiles  [b] Sites  [d] Setup  [q/Esc] Quit"
+        "Views: [h] History  [p] Profiles  [t] Planner  [b] Sites  [d] Setup  [q/Esc] Quit"
     }
 }
 
@@ -609,6 +630,151 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
         .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(hints_widget, inner[7]);
+}
+
+fn render_session_planner(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+    let outer = centered_rect(62, 78, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Session Planner ")
+        .title_alignment(Alignment::Center)
+        .style(Style::default().fg(Color::Cyan));
+    frame.render_widget(block, outer);
+
+    let inner = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints([
+            Constraint::Length(1), // current task
+            Constraint::Length(1), // spacer
+            Constraint::Min(4),    // task labels list
+            Constraint::Length(3), // add input
+            Constraint::Length(2), // feedback
+            Constraint::Length(2), // hints
+        ])
+        .split(outer);
+
+    let current_text = app
+        .selected_task_label
+        .as_ref()
+        .map(|label| format!("Selected task: {label}"))
+        .unwrap_or_else(|| "Selected task: none (required before focus starts)".to_string());
+    frame.render_widget(
+        Paragraph::new(current_text).style(Style::default().fg(Color::White)),
+        inner[0],
+    );
+
+    if app.task_labels.is_empty() {
+        frame.render_widget(
+            Paragraph::new("No task labels yet. Press [a] to add one.")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" Task Labels "),
+                ),
+            inner[2],
+        );
+    } else {
+        let items: Vec<ListItem> = app
+            .task_labels
+            .iter()
+            .map(|label| {
+                let marker = if app
+                    .selected_task_label
+                    .as_ref()
+                    .is_some_and(|selected| selected.eq_ignore_ascii_case(label))
+                {
+                    "✓"
+                } else {
+                    " "
+                };
+                ListItem::new(format!(" {marker} {label}"))
+            })
+            .collect();
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Task Labels "),
+            )
+            .highlight_style(
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("▶ ");
+        let mut state = ListState::default();
+        state.select(Some(
+            app.planner_selection_index
+                .min(app.task_labels.len().saturating_sub(1)),
+        ));
+        frame.render_stateful_widget(list, inner[2], &mut state);
+    }
+
+    let input_title = if app.planner_input_active {
+        " Add task label "
+    } else {
+        " Add task label ([a] to type) "
+    };
+    let input_text = if app.planner_input_active {
+        app.planner_input.clone()
+    } else {
+        "Type a label and press [Enter] to add + select".to_string()
+    };
+    frame.render_widget(
+        Paragraph::new(input_text)
+            .style(if app.planner_input_active {
+                Style::default().fg(Color::White)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            })
+            .block(Block::default().borders(Borders::ALL).title(input_title)),
+        inner[3],
+    );
+
+    if let Some(feedback) = app.planner_feedback.as_ref() {
+        let (prefix, color) = match feedback.level {
+            PlannerFeedbackLevel::Success => ("✓", Color::Green),
+            PlannerFeedbackLevel::Warning => ("⚠", Color::Yellow),
+        };
+        frame.render_widget(
+            Paragraph::new(format!("{prefix}  {}", feedback.message))
+                .style(Style::default().fg(color))
+                .alignment(Alignment::Center)
+                .wrap(Wrap { trim: true }),
+            inner[4],
+        );
+    }
+
+    let hints = if app.planner_input_active {
+        vec![
+            Line::from("Input: type task label, then [Enter] to save"),
+            Line::from(if app.strict_mode_enforced_for_focus() {
+                "Input: [Esc] Cancel  [q/Ctrl-C] Quit (Locked)"
+            } else {
+                "Input: [Esc] Cancel  [q/Ctrl-C] Quit"
+            }),
+        ]
+    } else {
+        vec![
+            Line::from("Planner: [↑/↓] Move  [Enter] Select  [a] Add"),
+            Line::from(if app.strict_mode_enforced_for_focus() {
+                "View: [t/Esc] Back  [q/Ctrl-C] Quit (Locked)"
+            } else {
+                "View: [t/Esc] Back  [q/Ctrl-C] Quit"
+            }),
+        ]
+    };
+    frame.render_widget(
+        Paragraph::new(hints)
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::DarkGray)),
+        inner[5],
+    );
 }
 
 fn render_stats_history(frame: &mut Frame, app: &App) {
@@ -963,6 +1129,12 @@ mod tests {
     }
 
     #[test]
+    fn timer_secondary_hint_includes_planner_shortcut() {
+        let app = App::default();
+        assert!(timer_secondary_hint(&app).contains("[t] Planner"));
+    }
+
+    #[test]
     fn timer_secondary_hint_includes_setup_shortcut_in_strict_mode() {
         let mut app = App::default();
         app.strict_mode = true;
@@ -970,6 +1142,16 @@ mod tests {
         app.timer.status = TimerStatus::Running;
 
         assert!(timer_secondary_hint(&app).contains("[d] Setup"));
+    }
+
+    #[test]
+    fn timer_secondary_hint_includes_planner_shortcut_in_strict_mode() {
+        let mut app = App::default();
+        app.strict_mode = true;
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+
+        assert!(timer_secondary_hint(&app).contains("[t] Planner"));
     }
 
     #[test]
@@ -1062,6 +1244,41 @@ mod tests {
 
         let text = terminal_text(&terminal, width, height);
         assert!(text.contains("[e] Export CSV + JSON"));
+    }
+
+    #[test]
+    fn timer_view_renders_selected_task_label() {
+        let width = 100;
+        let height = 24;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("Task: Docs"));
+    }
+
+    #[test]
+    fn session_planner_view_renders_title() {
+        let width = 100;
+        let height = 24;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.mode = AppMode::SessionPlanner;
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("Session Planner"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -28,7 +28,7 @@ pub fn render(frame: &mut Frame, app: &App) {
 fn render_timer(frame: &mut Frame, app: &App) {
     let area = frame.area();
 
-    let outer = centered_rect(72, 72, area);
+    let outer = centered_rect(88, 90, area);
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" focustime ")
@@ -38,34 +38,26 @@ fn render_timer(frame: &mut Frame, app: &App) {
 
     let inner = Layout::default()
         .direction(Direction::Vertical)
-        .margin(2)
+        .margin(1)
         .constraints([
             Constraint::Length(2), // phase + pomodoro count
-            Constraint::Length(3), // MM:SS
-            Constraint::Length(1), // active profile
-            Constraint::Length(1), // selected task label
-            Constraint::Length(3), // progress bar
-            Constraint::Length(2), // status
+            Constraint::Min(10),   // body
             Constraint::Length(1), // latest phase notification
-            Constraint::Length(1), // stats summary
-            Constraint::Length(1), // goal + streak summary
-            Constraint::Length(1), // wakatime status
-            Constraint::Min(0),    // spacer
-            Constraint::Length(2), // key hints
+            Constraint::Length(4), // key hints
         ])
         .split(outer);
 
     render_timer_phase_header(frame, app, inner[0]);
-    render_timer_countdown(frame, app, inner[1]);
-    render_timer_profile(frame, app, inner[2]);
-    render_timer_task_label(frame, app, inner[3]);
-    render_timer_progress_bar(frame, app, inner[4]);
-    render_timer_status(frame, app, inner[5]);
-    render_timer_phase_notice(frame, app, inner[6]);
-    render_timer_stats_summary(frame, app, inner[7]);
-    render_timer_goal_streak_summary(frame, app, inner[8]);
-    render_timer_wakatime_status(frame, app, inner[9]);
-    render_timer_hints(frame, app, inner[11]);
+
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+        .split(inner[1]);
+    render_timer_focus_panel(frame, app, body[0]);
+    render_timer_session_panel(frame, app, body[1]);
+
+    render_timer_phase_notice(frame, app, inner[2]);
+    render_timer_hints(frame, app, inner[3]);
 }
 
 fn render_timer_phase_header(frame: &mut Frame, app: &App, area: Rect) {
@@ -99,37 +91,41 @@ fn render_timer_countdown(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(time_widget, area);
 }
 
-fn render_timer_profile(frame: &mut Frame, app: &App, area: Rect) {
-    let profile_text = format!(
-        "Profile: {} ({})",
-        app.selected_profile_name(),
-        app.profile_summary(app.selected_profile)
-    );
-    let profile_widget = Paragraph::new(profile_text)
-        .alignment(Alignment::Center)
-        .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(profile_widget, area);
-}
+fn render_timer_focus_panel(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title(" ⏱  Timer ");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
 
-fn render_timer_task_label(frame: &mut Frame, app: &App, area: Rect) {
-    let (text, style) = if let Some(label) = app.current_task_label() {
-        (
-            format!("Task: {label}"),
-            Style::default().fg(Color::LightYellow),
-        )
-    } else {
-        (
-            "Task: not selected ([t] Planner)".to_string(),
-            Style::default().fg(Color::Yellow),
-        )
-    };
-    let widget = Paragraph::new(text)
-        .alignment(Alignment::Center)
-        .style(style);
-    frame.render_widget(widget, area);
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // countdown
+            Constraint::Length(1), // spacer
+            Constraint::Length(5), // progress
+            Constraint::Min(0),    // spacer
+        ])
+        .split(inner);
+
+    render_timer_countdown(frame, app, layout[0]);
+    render_timer_progress_bar(frame, app, layout[2]);
 }
 
 fn render_timer_progress_bar(frame: &mut Frame, app: &App, area: Rect) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // progress label
+            Constraint::Length(1), // empty line
+            Constraint::Length(3), // progress bar
+        ])
+        .split(area);
+    frame.render_widget(
+        Paragraph::new("⏳ Progress")
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::DarkGray)),
+        layout[0],
+    );
+
     let elapsed_ratio = 1.0 - app.timer.progress();
     let gauge = Gauge::default()
         .block(Block::default().borders(Borders::NONE))
@@ -139,34 +135,67 @@ fn render_timer_progress_bar(frame: &mut Frame, app: &App, area: Rect) {
                 .bg(Color::DarkGray),
         )
         .ratio(elapsed_ratio);
-    frame.render_widget(gauge, area);
+    frame.render_widget(gauge, layout[2]);
 }
 
-fn render_timer_status(frame: &mut Frame, app: &App, area: Rect) {
+fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" 🧭 Session Overview ");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
     let (status_text, strict_status_text) = timer_status_text(app);
-    let status_widget = Paragraph::new(vec![
-        Line::from(status_text),
-        Line::from(strict_status_text),
-    ])
-    .alignment(Alignment::Center)
-    .style(Style::default().fg(Color::Gray));
-    frame.render_widget(status_widget, area);
+    let profile_line = format!(
+        "🗂  Profile: {} ({})",
+        app.selected_profile_name(),
+        app.profile_summary(app.selected_profile)
+    );
+    let (task_text, task_style) = if let Some(label) = app.current_task_label() {
+        (
+            format!("🎯 Task: {label}"),
+            Style::default().fg(Color::LightYellow),
+        )
+    } else {
+        (
+            "🎯 Task: not selected ([t] Planner)".to_string(),
+            Style::default().fg(Color::Yellow),
+        )
+    };
+    let (stats_text, stats_style) = timer_stats_line(app);
+    let goal_line = format!("🔥 {}", format_timer_goal_streak_line(app));
+    let (waka_text, waka_color) = wakatime_status_line(app);
+
+    let lines = vec![
+        Line::from(""),
+        Line::styled(status_text, Style::default().fg(Color::Gray)),
+        Line::styled(strict_status_text, Style::default().fg(Color::DarkGray)),
+        Line::from(""),
+        Line::styled(profile_line, Style::default().fg(Color::DarkGray)),
+        Line::styled(task_text, task_style),
+        Line::from(""),
+        Line::styled(format!("📈 {stats_text}"), stats_style),
+        Line::styled(goal_line, Style::default().fg(Color::DarkGray)),
+        Line::styled(waka_text, Style::default().fg(waka_color)),
+    ];
+
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
 
 fn timer_status_text(app: &App) -> (&'static str, &'static str) {
     let status_text = match app.timer.status {
-        TimerStatus::Running => "▶  Running",
-        TimerStatus::Paused => "⏸  Paused",
-        TimerStatus::Idle => "⏹  Idle",
+        TimerStatus::Running => "📍 Status: ▶ Running",
+        TimerStatus::Paused => "📍 Status: ⏸ Paused",
+        TimerStatus::Idle => "📍 Status: ⏹ Idle",
     };
     let strict_text = if app.strict_reset_confirmation_pending() {
-        "🔒 Strict mode: press [s] again to confirm stop/reset"
+        "🔒 Strict mode: confirm reset with [s]"
     } else if app.strict_mode_enforced_for_focus() {
-        "🔒 Strict mode active: skip locked, stop requires confirmation"
+        "🔒 Strict mode: active (skip/quit locked, reset confirm)"
     } else if app.strict_mode {
-        "🔒 Strict mode armed: enforced during active focus only"
+        "🔒 Strict mode: armed (enforced during active focus)"
     } else {
-        "🔓 Strict mode off"
+        "🔓 Strict mode: off"
     };
     (status_text, strict_text)
 }
@@ -188,14 +217,6 @@ fn phase_notice_line(app: &App) -> (String, Style) {
             Style::default().fg(Color::DarkGray),
         )
     }
-}
-
-fn render_timer_stats_summary(frame: &mut Frame, app: &App, area: Rect) {
-    let (text, style) = timer_stats_line(app);
-    let stats_widget = Paragraph::new(text)
-        .alignment(Alignment::Center)
-        .style(style);
-    frame.render_widget(stats_widget, area);
 }
 
 fn timer_stats_line(app: &App) -> (String, Style) {
@@ -220,31 +241,16 @@ fn timer_stats_line(app: &App) -> (String, Style) {
     }
 }
 
-fn render_timer_goal_streak_summary(frame: &mut Frame, app: &App, area: Rect) {
-    let goal_widget = Paragraph::new(format_timer_goal_streak_line(app))
-        .alignment(Alignment::Center)
-        .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(goal_widget, area);
-}
-
-fn render_timer_wakatime_status(frame: &mut Frame, app: &App, area: Rect) {
-    let (waka_text, waka_color) = wakatime_status_line(app);
-    let waka_widget = Paragraph::new(waka_text)
-        .alignment(Alignment::Center)
-        .style(Style::default().fg(waka_color));
-    frame.render_widget(waka_widget, area);
-}
-
 fn wakatime_status_line(app: &App) -> (String, Color) {
     let runtime_state = app.wakatime.runtime_state();
     let (status_text, status_color) = match &runtime_state {
         WakatimeRuntimeState::NotConfigured => {
-            ("⏱ WakaTime: not configured".to_string(), Color::DarkGray)
+            ("⏱  WakaTime: not configured".to_string(), Color::DarkGray)
         }
-        WakatimeRuntimeState::Idle => ("⏱ WakaTime: idle".to_string(), Color::DarkGray),
-        WakatimeRuntimeState::Tracking => ("⏱ WakaTime: tracking".to_string(), Color::Green),
+        WakatimeRuntimeState::Idle => ("⏱  WakaTime: idle".to_string(), Color::DarkGray),
+        WakatimeRuntimeState::Tracking => ("⏱  WakaTime: tracking".to_string(), Color::Green),
         WakatimeRuntimeState::Sending => {
-            ("⏱ WakaTime: sending heartbeat...".to_string(), Color::Cyan)
+            ("⏱  WakaTime: sending heartbeat...".to_string(), Color::Cyan)
         }
         WakatimeRuntimeState::Retrying {
             attempt,
@@ -253,11 +259,11 @@ fn wakatime_status_line(app: &App) -> (String, Color) {
             error,
         } => (
             format!(
-                "⏱ WakaTime: retrying ({attempt}/{max_attempts}) in {next_backoff_secs}s ({error})"
+                "⏱  WakaTime: retrying ({attempt}/{max_attempts}) in {next_backoff_secs}s ({error})"
             ),
             Color::Yellow,
         ),
-        WakatimeRuntimeState::Error(error) => (format!("⏱ WakaTime: error ({error})"), Color::Red),
+        WakatimeRuntimeState::Error(error) => (format!("⏱  WakaTime: error ({error})"), Color::Red),
     };
 
     if matches!(runtime_state, WakatimeRuntimeState::NotConfigured) {
@@ -292,27 +298,37 @@ fn render_timer_hints(frame: &mut Frame, app: &App, area: Rect) {
     let hints_widget = Paragraph::new(vec![
         Line::from(timer_primary_hint(app)),
         Line::from(timer_secondary_hint(app)),
+        Line::from(timer_tertiary_hint(app)),
     ])
     .alignment(Alignment::Center)
-    .style(Style::default().fg(Color::DarkGray));
+    .style(Style::default().fg(Color::DarkGray))
+    .wrap(Wrap { trim: true });
     frame.render_widget(hints_widget, area);
 }
 
 fn timer_primary_hint(app: &App) -> &'static str {
     if app.strict_reset_confirmation_pending() {
-        "Timer: [Space] Run/Pause  [s] Confirm Stop/Reset  [n] Next (Locked)"
+        "⌨  Timer: [Space] Run/Pause  [s] Confirm reset  [n] Next (Locked)"
     } else if app.strict_mode_enforced_for_focus() {
-        "Timer: [Space] Run/Pause  [s] Stop/Reset (Confirm)  [n] Next (Locked)"
+        "⌨  Timer: [Space] Run/Pause  [s] Stop/Reset (Confirm)  [n] Next (Locked)"
     } else {
-        "Timer: [Space] Run/Pause  [s] Stop  [n] Next"
+        "⌨  Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next"
     }
 }
 
 fn timer_secondary_hint(app: &App) -> &'static str {
     if app.strict_mode_enforced_for_focus() {
-        "Views: [h] History  [p] Profiles (Locked)  [t] Planner  [b] Sites  [d] Setup  [q/Esc] Quit (Locked)"
+        "🧭 Views: [t] Planner  [h] History  [p] Profiles (Locked)  [b] Sites  [d] Setup"
     } else {
-        "Views: [h] History  [p] Profiles  [t] Planner  [b] Sites  [d] Setup  [q/Esc] Quit"
+        "🧭 Views: [t] Planner  [h] History  [p] Profiles  [b] Sites  [d] Setup"
+    }
+}
+
+fn timer_tertiary_hint(app: &App) -> &'static str {
+    if app.strict_mode_enforced_for_focus() {
+        "🚪 Quit: [q/Esc] Locked during active focus"
+    } else {
+        "🚪 Quit: [q/Esc]"
     }
 }
 
@@ -1306,7 +1322,7 @@ mod tests {
 
         let (text, color) = wakatime_status_line(&app);
 
-        assert_eq!(text, "⏱ WakaTime: idle · last success not yet sent");
+        assert_eq!(text, "⏱  WakaTime: idle · last success not yet sent");
         assert_eq!(color, Color::DarkGray);
     }
 
@@ -1319,7 +1335,7 @@ mod tests {
 
         let (text, color) = wakatime_status_line(&app);
 
-        assert!(text.starts_with("⏱ WakaTime: idle · last success "));
+        assert!(text.starts_with("⏱  WakaTime: idle · last success "));
         assert!(!text.contains("not yet sent"));
         assert_eq!(color, Color::DarkGray);
     }
@@ -1331,7 +1347,7 @@ mod tests {
 
         let (text, color) = wakatime_status_line(&app);
 
-        assert_eq!(text, "⏱ WakaTime: not configured");
+        assert_eq!(text, "⏱  WakaTime: not configured");
         assert_eq!(color, Color::DarkGray);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -761,7 +761,7 @@ fn render_session_planner_input(frame: &mut Frame, app: &App, area: Rect) {
         " Add task label ([a] to type) "
     };
     let input_text = if app.planner_input_active {
-        app.planner_input.clone()
+        format!("{}|", app.planner_input)
     } else {
         "Type a label, then press [Enter] to add and select".to_string()
     };
@@ -799,9 +799,9 @@ fn render_session_planner_hints(frame: &mut Frame, app: &App, area: Rect) {
             Line::from("Input: type task label, then [Enter]"),
             Line::from("Input: [Esc] Cancel"),
             Line::from(if app.strict_mode_enforced_for_focus() {
-                "View: [t/Esc] Back  [q/Ctrl-C] Quit (Locked)"
+                "View: [q/Ctrl-C] Quit (Locked)"
             } else {
-                "View: [t/Esc] Back  [q/Ctrl-C] Quit"
+                "View: [q/Ctrl-C] Quit"
             }),
         ]
     } else {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -634,7 +634,7 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
 
 fn render_session_planner(frame: &mut Frame, app: &App) {
     let area = frame.area();
-    let outer = centered_rect(62, 78, area);
+    let outer = centered_rect(66, 82, area);
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -647,22 +647,33 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(1), // current task
+            Constraint::Length(2), // current task
             Constraint::Length(1), // spacer
-            Constraint::Min(4),    // task labels list
+            Constraint::Min(5),    // task labels list
             Constraint::Length(3), // add input
             Constraint::Length(2), // feedback
-            Constraint::Length(2), // hints
+            Constraint::Length(3), // hints
         ])
         .split(outer);
 
-    let current_text = app
-        .selected_task_label
-        .as_ref()
-        .map(|label| format!("Selected task: {label}"))
-        .unwrap_or_else(|| "Selected task: none (required before focus starts)".to_string());
+    let current_text = app.selected_task_label.as_ref().map_or_else(
+        || {
+            vec![
+                Line::from("Selected task:"),
+                Line::from("  none (required before focus starts)"),
+            ]
+        },
+        |label| {
+            vec![
+                Line::from("Selected task:"),
+                Line::from(format!("  {label}")),
+            ]
+        },
+    );
     frame.render_widget(
-        Paragraph::new(current_text).style(Style::default().fg(Color::White)),
+        Paragraph::new(current_text)
+            .style(Style::default().fg(Color::White))
+            .wrap(Wrap { trim: true }),
         inner[0],
     );
 
@@ -723,7 +734,7 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
     let input_text = if app.planner_input_active {
         app.planner_input.clone()
     } else {
-        "Type a label and press [Enter] to add + select".to_string()
+        "Type a label, then press [Enter] to add and select".to_string()
     };
     frame.render_widget(
         Paragraph::new(input_text)
@@ -752,16 +763,18 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
 
     let hints = if app.planner_input_active {
         vec![
-            Line::from("Input: type task label, then [Enter] to save"),
+            Line::from("Input: type task label, then [Enter]"),
+            Line::from("Input: [Esc] Cancel"),
             Line::from(if app.strict_mode_enforced_for_focus() {
-                "Input: [Esc] Cancel  [q/Ctrl-C] Quit (Locked)"
+                "View: [t/Esc] Back  [q/Ctrl-C] Quit (Locked)"
             } else {
-                "Input: [Esc] Cancel  [q/Ctrl-C] Quit"
+                "View: [t/Esc] Back  [q/Ctrl-C] Quit"
             }),
         ]
     } else {
         vec![
-            Line::from("Planner: [↑/↓] Move  [Enter] Select  [a] Add"),
+            Line::from("Planner: [↑/↓] Move"),
+            Line::from("Planner: [Enter] Select  [a] Add label"),
             Line::from(if app.strict_mode_enforced_for_focus() {
                 "View: [t/Esc] Back  [q/Ctrl-C] Quit (Locked)"
             } else {


### PR DESCRIPTION
## What

Add a Session Planner MVP that lets users create/select a task label before focus, shows the active task in the timer UI, and persists/exports task-labeled focus sessions.

## Why

Issue #109 requests a lightweight planning flow so focus sessions are tied to a task context. This improves session intent tracking in-app and carries that context into exported history.

Closes #109

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable) (N/A)
- [ ] WakaTime integration behavior was verified for this change (if applicable) (N/A)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed) (N/A)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session Planner UI with task-label management via keyboard; selecting a task label is now required to start a focus session.
  * Exports (CSV/JSON) include per-focus-session records with task labels and focused duration.

* **UI**
  * Timer reorganized into a focus panel + session overview; timer always shows current task label or a reminder; hint wording/formatting updated.

* **Documentation**
  * Added Session Planner docs and updated session export docs.

* **Tests**
  * Added unit and UI tests for planner and export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->