### PR TITLE
Add blocklist profiles to site manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,16 @@ view always shows the current task label (or a reminder to select one).
 
 ```toml
 selected_profile = "custom"
+selected_blocklist_profile = "Work"
 strict_mode = false
+
+[[blocklist_profiles]]
+name = "Work"
+sites = ["youtube.com", "reddit.com"]
+
+[[blocklist_profiles]]
+name = "Study"
+sites = ["x.com", "news.ycombinator.com"]
 
 [custom_profile]
 focus_secs = 1800
@@ -169,6 +178,10 @@ Open the site manager from timer view with **`b`**.
 - `a`: add/import hostnames
 - `e`: edit the selected hostname
 - `d` or `Delete`: remove the selected hostname
+- `[` / `]`: switch active blocklist profile
+- `n`: create a blocklist profile
+- `r`: rename the active blocklist profile
+- `x`: delete the active blocklist profile
 - `↑/↓`: move selection
 - `b`: return to timer view
 - `Esc`: return to timer view only when add/edit mode is not active

--- a/src/app.rs
+++ b/src/app.rs
@@ -760,6 +760,11 @@ impl App {
             return;
         }
 
+        if self.blocklist_profile_input_active {
+            self.blocklist_profile_input.push_str(&text);
+            return;
+        }
+
         if !self.site_input_active {
             self.start_site_input(SiteInputMode::Add);
         }
@@ -1233,6 +1238,7 @@ impl App {
     }
 
     fn start_site_input(&mut self, mode: SiteInputMode) {
+        self.cancel_blocklist_profile_input();
         self.site_input_active = true;
         self.site_feedback = None;
         match mode {
@@ -1260,6 +1266,7 @@ impl App {
     }
 
     fn start_blocklist_profile_input(&mut self, mode: BlocklistProfileInputMode) {
+        self.cancel_site_input();
         self.blocklist_profile_input_active = true;
         self.blocklist_profile_input_mode = Some(mode);
         self.site_feedback = None;
@@ -2847,6 +2854,40 @@ mod tests {
         assert_eq!(feedback.level, SiteFeedbackLevel::Warning);
         assert!(feedback.message.contains("Added 2 sites"));
         assert!(feedback.message.contains("invalid hostname"));
+    }
+
+    #[test]
+    fn site_manager_paste_targets_blocklist_profile_input_when_active() {
+        let mut app = App::default();
+        app.handle_key(key(KeyCode::Char('b')));
+        app.handle_key(key(KeyCode::Char('n')));
+
+        app.handle_paste("Work".to_string());
+
+        assert!(app.blocklist_profile_input_active);
+        assert_eq!(app.blocklist_profile_input, "Work");
+        assert!(!app.site_input_active);
+        assert!(app.site_input.is_empty());
+    }
+
+    #[test]
+    fn site_manager_input_modes_are_mutually_exclusive() {
+        let mut app = App::default();
+        app.mode = AppMode::SiteManager;
+
+        app.start_blocklist_profile_input(BlocklistProfileInputMode::Create);
+        assert!(app.blocklist_profile_input_active);
+        assert!(!app.site_input_active);
+
+        app.start_site_input(SiteInputMode::Add);
+        assert!(app.site_input_active);
+        assert!(!app.blocklist_profile_input_active);
+        assert!(app.blocklist_profile_input.is_empty());
+
+        app.start_blocklist_profile_input(BlocklistProfileInputMode::Rename);
+        assert!(app.blocklist_profile_input_active);
+        assert!(!app.site_input_active);
+        assert!(app.site_input.is_empty());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -666,14 +666,14 @@ impl App {
     fn persisted_config(&self) -> AppConfig {
         let custom_profile = self.custom_profile.normalized();
         let mut blocklist_profiles = self.blocklist_profiles.clone();
+        if blocklist_profiles.is_empty() {
+            blocklist_profiles.push(BlocklistProfileConfig::default());
+        }
         let active_index = self
             .active_blocklist_profile
             .min(blocklist_profiles.len().saturating_sub(1));
         if let Some(active_profile) = blocklist_profiles.get_mut(active_index) {
             active_profile.sites = self.blocker.sites.clone();
-        }
-        if blocklist_profiles.is_empty() {
-            blocklist_profiles.push(BlocklistProfileConfig::default());
         }
         let selected_blocklist_profile = blocklist_profiles
             .get(active_index)
@@ -2394,6 +2394,27 @@ mod tests {
                 project: "Team Focus".to_string(),
                 language: "Deep Work".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn persisted_config_seeds_fallback_profile_with_active_sites() {
+        let mut app = App::default();
+        app.blocklist_profiles.clear();
+        app.blocker.sites = vec!["example.com".to_string(), "github.com".to_string()];
+
+        let persisted = app.persisted_config();
+
+        assert_eq!(persisted.selected_blocklist_profile, "Default");
+        assert_eq!(persisted.blocklist_profiles.len(), 1);
+        assert_eq!(persisted.blocklist_profiles[0].name, "Default");
+        assert_eq!(
+            persisted.blocklist_profiles[0].sites,
+            vec!["example.com".to_string(), "github.com".to_string()]
+        );
+        assert_eq!(
+            persisted.blocked_sites,
+            vec!["example.com".to_string(), "github.com".to_string()]
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,8 +6,8 @@ use crate::blocker::{
     BulkAddResult, EditSiteResult, HostsFileDiagnostics, InvalidSiteInput, SiteBlocker,
 };
 use crate::config::{
-    AppConfig, AutoStartConfig, CustomProfileConfig, DailyGoalConfig, NotificationConfig,
-    ProfileId, WakatimeMetadataConfig,
+    AppConfig, AutoStartConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
+    NotificationConfig, ProfileId, WakatimeMetadataConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::stats::{
@@ -38,6 +38,7 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 11] = [
 ];
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
+const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppMode {
@@ -105,6 +106,13 @@ fn profile_for_index(index: usize) -> ProfileId {
         .unwrap_or(PROFILE_IDS[PROFILE_IDS.len() - 1])
 }
 
+fn blocklist_profile_index(profiles: &[BlocklistProfileConfig], selected_name: &str) -> usize {
+    profiles
+        .iter()
+        .position(|profile| profile.name.eq_ignore_ascii_case(selected_name))
+        .unwrap_or(0)
+}
+
 #[derive(Debug, Clone)]
 struct ProfileEditSnapshot {
     custom_profile: CustomProfileConfig,
@@ -123,6 +131,12 @@ enum PendingTimerAction {
 pub enum SiteInputMode {
     Add,
     Edit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlocklistProfileInputMode {
+    Create,
+    Rename,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -257,6 +271,11 @@ pub struct App {
     /// Whether the user is currently typing a new site.
     pub site_input_active: bool,
     site_edit_index: Option<usize>,
+    pub blocklist_profiles: Vec<BlocklistProfileConfig>,
+    active_blocklist_profile: usize,
+    pub blocklist_profile_input: String,
+    pub blocklist_profile_input_active: bool,
+    blocklist_profile_input_mode: Option<BlocklistProfileInputMode>,
     pub site_feedback: Option<SiteFeedback>,
     pub task_labels: Vec<String>,
     pub selected_task_label: Option<String>,
@@ -308,6 +327,7 @@ impl App {
     }
 
     fn from_config(config: AppConfig) -> Self {
+        let config = config.normalized();
         let selected_profile = config.selected_profile;
         let custom_profile = config.effective_custom_profile();
         let notification_settings = config.notifications;
@@ -315,6 +335,9 @@ impl App {
         let strict_mode = config.strict_mode;
         let daily_goal = config.daily_goal;
         let wakatime_metadata = config.wakatime;
+        let blocklist_profiles = config.blocklist_profiles.clone();
+        let active_blocklist_profile =
+            blocklist_profile_index(&blocklist_profiles, &config.selected_blocklist_profile);
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
         let (stats, stats_error) = match FocusStats::load() {
             Ok(stats) => (stats, None),
@@ -332,7 +355,7 @@ impl App {
             profile_spec.long_break_interval,
         );
         let mut blocker = SiteBlocker::new();
-        for site in &config.blocked_sites {
+        for site in &blocklist_profiles[active_blocklist_profile].sites {
             blocker.add_site(site.clone());
         }
         let setup_diagnostics = SetupDiagnostics::collect(&blocker);
@@ -344,6 +367,11 @@ impl App {
             site_input: String::new(),
             site_input_active: false,
             site_edit_index: None,
+            blocklist_profiles,
+            active_blocklist_profile,
+            blocklist_profile_input: String::new(),
+            blocklist_profile_input_active: false,
+            blocklist_profile_input_mode: None,
             site_feedback: None,
             task_labels,
             selected_task_label,
@@ -614,10 +642,44 @@ impl App {
         }
     }
 
+    pub fn blocklist_profile_input_mode(&self) -> Option<BlocklistProfileInputMode> {
+        self.blocklist_profile_input_mode
+    }
+
+    pub fn active_blocklist_profile_name(&self) -> &str {
+        self.blocklist_profiles
+            .get(self.active_blocklist_profile)
+            .map(|profile| profile.name.as_str())
+            .unwrap_or(DEFAULT_BLOCKLIST_PROFILE_NAME)
+    }
+
+    pub fn active_blocklist_profile_position(&self) -> usize {
+        self.active_blocklist_profile.saturating_add(1)
+    }
+
+    pub fn blocklist_profile_count(&self) -> usize {
+        self.blocklist_profiles.len()
+    }
+
     /// Persist the current blocked-sites list and timer preferences to disk.
     /// Failures are best-effort; the error is surfaced through `config_error`.
     fn persisted_config(&self) -> AppConfig {
         let custom_profile = self.custom_profile.normalized();
+        let mut blocklist_profiles = self.blocklist_profiles.clone();
+        let active_index = self
+            .active_blocklist_profile
+            .min(blocklist_profiles.len().saturating_sub(1));
+        if let Some(active_profile) = blocklist_profiles.get_mut(active_index) {
+            active_profile.sites = self.blocker.sites.clone();
+        }
+        if blocklist_profiles.is_empty() {
+            blocklist_profiles.push(BlocklistProfileConfig::default());
+        }
+        let selected_blocklist_profile = blocklist_profiles
+            .get(active_index)
+            .or_else(|| blocklist_profiles.first())
+            .map(|profile| profile.name.clone())
+            .unwrap_or_else(|| DEFAULT_BLOCKLIST_PROFILE_NAME.to_string());
         AppConfig {
             // Keep legacy fields aligned with the editable custom profile so
             // older releases retain user-configured values.
@@ -626,6 +688,8 @@ impl App {
             long_break_secs: custom_profile.long_break_secs,
             long_break_interval: custom_profile.long_break_interval,
             blocked_sites: self.blocker.sites.clone(),
+            blocklist_profiles,
+            selected_blocklist_profile,
             selected_profile: self.selected_profile,
             custom_profile: Some(custom_profile),
             notifications: self.notification_settings,
@@ -1077,6 +1141,25 @@ impl App {
     }
 
     fn handle_key_site_manager(&mut self, key: KeyEvent) {
+        if self.blocklist_profile_input_active {
+            match key.code {
+                KeyCode::Enter => {
+                    self.commit_blocklist_profile_input();
+                }
+                KeyCode::Esc => {
+                    self.cancel_blocklist_profile_input();
+                }
+                KeyCode::Backspace => {
+                    self.blocklist_profile_input.pop();
+                }
+                KeyCode::Char(c) => {
+                    self.blocklist_profile_input.push(c);
+                }
+                _ => {}
+            }
+            return;
+        }
+
         if self.site_input_active {
             match key.code {
                 KeyCode::Enter => {
@@ -1125,6 +1208,26 @@ impl App {
             KeyCode::Char('d') | KeyCode::Delete => {
                 self.remove_selected_site();
             }
+            // Previous blocklist profile
+            KeyCode::Char('[') => {
+                self.select_previous_blocklist_profile();
+            }
+            // Next blocklist profile
+            KeyCode::Char(']') => {
+                self.select_next_blocklist_profile();
+            }
+            // Create blocklist profile
+            KeyCode::Char('n') => {
+                self.start_blocklist_profile_input(BlocklistProfileInputMode::Create);
+            }
+            // Rename active blocklist profile
+            KeyCode::Char('r') => {
+                self.start_blocklist_profile_input(BlocklistProfileInputMode::Rename);
+            }
+            // Delete active blocklist profile
+            KeyCode::Char('x') => {
+                self.delete_active_blocklist_profile();
+            }
             _ => {}
         }
     }
@@ -1156,6 +1259,26 @@ impl App {
         self.site_edit_index = None;
     }
 
+    fn start_blocklist_profile_input(&mut self, mode: BlocklistProfileInputMode) {
+        self.blocklist_profile_input_active = true;
+        self.blocklist_profile_input_mode = Some(mode);
+        self.site_feedback = None;
+        match mode {
+            BlocklistProfileInputMode::Create => {
+                self.blocklist_profile_input.clear();
+            }
+            BlocklistProfileInputMode::Rename => {
+                self.blocklist_profile_input = self.active_blocklist_profile_name().to_string();
+            }
+        }
+    }
+
+    fn cancel_blocklist_profile_input(&mut self) {
+        self.blocklist_profile_input.clear();
+        self.blocklist_profile_input_active = false;
+        self.blocklist_profile_input_mode = None;
+    }
+
     fn commit_site_input(&mut self) {
         let input = self.site_input.clone();
 
@@ -1169,6 +1292,77 @@ impl App {
 
         if committed {
             self.cancel_site_input();
+        }
+    }
+
+    fn commit_blocklist_profile_input(&mut self) {
+        let Some(mode) = self.blocklist_profile_input_mode else {
+            return;
+        };
+
+        let name = self.blocklist_profile_input.trim().to_string();
+        if name.is_empty() {
+            self.set_site_feedback(SiteFeedbackLevel::Warning, "Profile name cannot be empty");
+            return;
+        }
+
+        let has_duplicate = self
+            .blocklist_profiles
+            .iter()
+            .enumerate()
+            .any(|(index, profile)| {
+                let is_current = mode == BlocklistProfileInputMode::Rename
+                    && index == self.active_blocklist_profile;
+                !is_current && profile.name.eq_ignore_ascii_case(&name)
+            });
+        if has_duplicate {
+            self.set_site_feedback(
+                SiteFeedbackLevel::Warning,
+                format!("Profile `{name}` already exists"),
+            );
+            return;
+        }
+
+        match mode {
+            BlocklistProfileInputMode::Create => {
+                self.sync_active_profile_sites_from_blocker();
+                self.blocklist_profiles.push(BlocklistProfileConfig {
+                    name: name.clone(),
+                    sites: Vec::new(),
+                });
+                self.active_blocklist_profile = self.blocklist_profiles.len().saturating_sub(1);
+                self.load_active_profile_sites_into_blocker();
+                self.clamp_selection();
+                self.cancel_blocklist_profile_input();
+                self.save_config();
+                self.sync_blocking_after_site_mutation();
+                self.set_site_feedback(
+                    SiteFeedbackLevel::Success,
+                    format!("Created profile `{name}`"),
+                );
+            }
+            BlocklistProfileInputMode::Rename => {
+                let old_name = self.active_blocklist_profile_name().to_string();
+                if old_name == name {
+                    self.set_site_feedback(
+                        SiteFeedbackLevel::Warning,
+                        format!("No change for profile `{name}`"),
+                    );
+                    return;
+                }
+                if let Some(profile) = self
+                    .blocklist_profiles
+                    .get_mut(self.active_blocklist_profile)
+                {
+                    profile.name = name.clone();
+                }
+                self.cancel_blocklist_profile_input();
+                self.save_config();
+                self.set_site_feedback(
+                    SiteFeedbackLevel::Success,
+                    format!("Renamed profile `{old_name}` -> `{name}`"),
+                );
+            }
         }
     }
 
@@ -1277,6 +1471,78 @@ impl App {
         }
     }
 
+    fn select_previous_blocklist_profile(&mut self) {
+        if self.blocklist_profiles.len() <= 1 {
+            return;
+        }
+        let next = if self.active_blocklist_profile == 0 {
+            self.blocklist_profiles.len().saturating_sub(1)
+        } else {
+            self.active_blocklist_profile.saturating_sub(1)
+        };
+        self.switch_blocklist_profile(next);
+    }
+
+    fn select_next_blocklist_profile(&mut self) {
+        if self.blocklist_profiles.len() <= 1 {
+            return;
+        }
+        let next = (self.active_blocklist_profile + 1) % self.blocklist_profiles.len();
+        self.switch_blocklist_profile(next);
+    }
+
+    fn switch_blocklist_profile(&mut self, next_index: usize) {
+        if next_index >= self.blocklist_profiles.len()
+            || next_index == self.active_blocklist_profile
+        {
+            return;
+        }
+
+        self.sync_active_profile_sites_from_blocker();
+        self.active_blocklist_profile = next_index;
+        self.load_active_profile_sites_into_blocker();
+        self.clamp_selection();
+        self.save_config();
+        self.sync_blocking_after_site_mutation();
+        self.set_site_feedback(
+            SiteFeedbackLevel::Success,
+            format!(
+                "Switched to profile `{}`",
+                self.active_blocklist_profile_name()
+            ),
+        );
+    }
+
+    fn delete_active_blocklist_profile(&mut self) {
+        if self.blocklist_profiles.len() <= 1 {
+            self.set_site_feedback(
+                SiteFeedbackLevel::Warning,
+                "At least one blocklist profile is required",
+            );
+            return;
+        }
+
+        self.sync_active_profile_sites_from_blocker();
+        let removed = self
+            .blocklist_profiles
+            .remove(self.active_blocklist_profile);
+        if self.active_blocklist_profile >= self.blocklist_profiles.len() {
+            self.active_blocklist_profile = self.blocklist_profiles.len().saturating_sub(1);
+        }
+        self.load_active_profile_sites_into_blocker();
+        self.clamp_selection();
+        self.save_config();
+        self.sync_blocking_after_site_mutation();
+        self.set_site_feedback(
+            SiteFeedbackLevel::Success,
+            format!(
+                "Deleted profile `{}` (active: `{}`)",
+                removed.name,
+                self.active_blocklist_profile_name()
+            ),
+        );
+    }
+
     pub fn is_running(&self) -> bool {
         self.timer.status == TimerStatus::Running
     }
@@ -1302,6 +1568,38 @@ impl App {
             self.selected_site = 0;
         } else {
             self.selected_site = self.selected_site.min(self.blocker.sites.len() - 1);
+        }
+    }
+
+    fn clamp_blocklist_profile_selection(&mut self) {
+        if self.blocklist_profiles.is_empty() {
+            self.blocklist_profiles
+                .push(BlocklistProfileConfig::default());
+            self.active_blocklist_profile = 0;
+            return;
+        }
+        self.active_blocklist_profile = self
+            .active_blocklist_profile
+            .min(self.blocklist_profiles.len().saturating_sub(1));
+    }
+
+    fn sync_active_profile_sites_from_blocker(&mut self) {
+        self.clamp_blocklist_profile_selection();
+        if let Some(active_profile) = self
+            .blocklist_profiles
+            .get_mut(self.active_blocklist_profile)
+        {
+            active_profile.sites = self.blocker.sites.clone();
+        }
+    }
+
+    fn load_active_profile_sites_into_blocker(&mut self) {
+        self.clamp_blocklist_profile_selection();
+        self.blocker.sites.clear();
+        if let Some(active_profile) = self.blocklist_profiles.get(self.active_blocklist_profile) {
+            for site in &active_profile.sites {
+                self.blocker.add_site(site.clone());
+            }
         }
     }
 
@@ -1381,6 +1679,8 @@ impl App {
         self.pending_timer_action = None;
         self.mode = AppMode::SiteManager;
         self.cancel_site_input();
+        self.cancel_blocklist_profile_input();
+        self.clamp_blocklist_profile_selection();
         self.clamp_selection();
     }
 
@@ -1425,6 +1725,7 @@ impl App {
 
     fn finalize_site_mutation(&mut self) {
         self.clamp_selection();
+        self.sync_active_profile_sites_from_blocker();
         self.save_config();
         self.sync_blocking_after_site_mutation();
     }
@@ -1824,6 +2125,8 @@ mod tests {
         let app = App::default();
 
         assert!(app.blocker.sites.is_empty());
+        assert_eq!(app.blocklist_profile_count(), 1);
+        assert_eq!(app.active_blocklist_profile_name(), "Default");
         assert_eq!(app.timer.focus_secs, DEFAULT_FOCUS_SECS);
         assert_eq!(app.timer.short_break_secs, DEFAULT_SHORT_BREAK_SECS);
         assert_eq!(app.timer.long_break_secs, DEFAULT_LONG_BREAK_SECS);
@@ -1841,6 +2144,8 @@ mod tests {
             long_break_secs: 8 * 60,
             long_break_interval: 2,
             blocked_sites: Vec::new(),
+            blocklist_profiles: vec![BlocklistProfileConfig::default()],
+            selected_blocklist_profile: "Default".to_string(),
             selected_profile: ProfileId::Classic,
             custom_profile: Some(CustomProfileConfig {
                 focus_secs: 40 * 60,
@@ -2059,6 +2364,9 @@ mod tests {
         assert!(persisted.strict_mode);
         assert_eq!(persisted.daily_goal, DailyGoalConfig::default());
         assert_eq!(persisted.wakatime, WakatimeMetadataConfig::default());
+        assert_eq!(persisted.selected_blocklist_profile, "Default");
+        assert_eq!(persisted.blocklist_profiles.len(), 1);
+        assert_eq!(persisted.blocklist_profiles[0].name, "Default");
     }
 
     #[test]
@@ -2624,6 +2932,89 @@ mod tests {
         app.timer.phase = TimerPhase::Focus;
         app.timer.status = TimerStatus::Running;
         assert!(app.should_resync_blocking_after_site_mutation());
+    }
+
+    #[test]
+    fn site_manager_switches_between_blocklist_profiles() {
+        let config = AppConfig {
+            blocklist_profiles: vec![
+                BlocklistProfileConfig {
+                    name: "Work".to_string(),
+                    sites: vec!["a.com".to_string()],
+                },
+                BlocklistProfileConfig {
+                    name: "Study".to_string(),
+                    sites: vec!["b.com".to_string(), "c.com".to_string()],
+                },
+            ],
+            selected_blocklist_profile: "Work".to_string(),
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.handle_key(key(KeyCode::Char('b')));
+
+        assert_eq!(app.active_blocklist_profile_name(), "Work");
+        assert_eq!(app.blocker.sites, vec!["a.com".to_string()]);
+
+        app.handle_key(key(KeyCode::Char(']')));
+
+        assert_eq!(app.active_blocklist_profile_name(), "Study");
+        assert_eq!(
+            app.blocker.sites,
+            vec!["b.com".to_string(), "c.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn site_manager_create_rename_and_delete_blocklist_profile() {
+        let mut app = App::default();
+        app.handle_key(key(KeyCode::Char('b')));
+
+        app.handle_key(key(KeyCode::Char('n')));
+        for c in "Work".chars() {
+            app.handle_key(key(KeyCode::Char(c)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(app.blocklist_profile_count(), 2);
+        assert_eq!(app.active_blocklist_profile_name(), "Work");
+        assert!(app.blocker.sites.is_empty());
+
+        app.handle_key(key(KeyCode::Char('r')));
+        for _ in 0.."Work".len() {
+            app.handle_key(key(KeyCode::Backspace));
+        }
+        for c in "Deep Work".chars() {
+            app.handle_key(key(KeyCode::Char(c)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(app.active_blocklist_profile_name(), "Deep Work");
+
+        app.handle_key(key(KeyCode::Char('x')));
+
+        assert_eq!(app.blocklist_profile_count(), 1);
+        assert_eq!(app.active_blocklist_profile_name(), "Default");
+    }
+
+    #[test]
+    fn persisted_config_mirrors_active_profile_sites_to_legacy_blocked_sites() {
+        let mut app = App::default();
+        app.handle_key(key(KeyCode::Char('b')));
+        app.handle_key(key(KeyCode::Char('a')));
+        for c in "example.com".chars() {
+            app.handle_key(key(KeyCode::Char(c)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+
+        let persisted = app.persisted_config();
+        assert_eq!(persisted.selected_blocklist_profile, "Default");
+        assert_eq!(persisted.blocked_sites, vec!["example.com".to_string()]);
+        assert_eq!(persisted.blocklist_profiles.len(), 1);
+        assert_eq!(
+            persisted.blocklist_profiles[0].sites,
+            vec!["example.com".to_string()]
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::fs;
 use std::io;
@@ -28,6 +29,15 @@ pub struct AppConfig {
     /// Sites that should be blocked during focus sessions.
     #[serde(default)]
     pub blocked_sites: Vec<String>,
+    /// Named blocklist profiles.
+    ///
+    /// Each profile stores a separate blocked-sites list. This field supports
+    /// issue #110 and supersedes `blocked_sites` as the primary representation.
+    #[serde(default)]
+    pub blocklist_profiles: Vec<BlocklistProfileConfig>,
+    /// Name of the active blocklist profile.
+    #[serde(default = "default_blocklist_profile_name")]
+    pub selected_blocklist_profile: String,
     /// Selected profile identifier.
     #[serde(default)]
     pub selected_profile: ProfileId,
@@ -56,6 +66,23 @@ pub struct AppConfig {
     /// WakaTime heartbeat metadata labels.
     #[serde(default)]
     pub wakatime: WakatimeMetadataConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlocklistProfileConfig {
+    #[serde(default = "default_blocklist_profile_name")]
+    pub name: String,
+    #[serde(default)]
+    pub sites: Vec<String>,
+}
+
+impl Default for BlocklistProfileConfig {
+    fn default() -> Self {
+        Self {
+            name: default_blocklist_profile_name(),
+            sites: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -135,6 +162,10 @@ fn default_wakatime_project() -> String {
 
 fn default_wakatime_language() -> String {
     "Pomodoro".to_string()
+}
+
+fn default_blocklist_profile_name() -> String {
+    "Default".to_string()
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
@@ -239,6 +270,8 @@ impl Default for AppConfig {
             long_break_secs: default_long_break_secs(),
             long_break_interval: default_long_break_interval(),
             blocked_sites: Vec::new(),
+            blocklist_profiles: Vec::new(),
+            selected_blocklist_profile: default_blocklist_profile_name(),
             selected_profile: ProfileId::default(),
             custom_profile: None,
             notifications: NotificationConfig::default(),
@@ -251,6 +284,10 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
+    pub fn normalized(self) -> Self {
+        self.normalize()
+    }
+
     /// Load the config from disk, falling back to [`AppConfig::default`] on any
     /// error (missing file, parse error, corrupt data, etc.).
     #[cfg_attr(test, allow(dead_code))]
@@ -337,6 +374,18 @@ impl AppConfig {
         self.long_break_interval =
             nonzero_or_default_u32(self.long_break_interval, default_long_break_interval());
         self.custom_profile = self.custom_profile.map(|profile| profile.normalized());
+        self.blocklist_profiles =
+            normalize_blocklist_profiles(&self.blocklist_profiles, &self.blocked_sites);
+        self.selected_blocklist_profile = normalize_selected_blocklist_profile(
+            &self.selected_blocklist_profile,
+            &self.blocklist_profiles,
+        );
+        self.blocked_sites = self
+            .blocklist_profiles
+            .iter()
+            .find(|profile| profile.name == self.selected_blocklist_profile)
+            .map(|profile| profile.sites.clone())
+            .unwrap_or_default();
         self.wakatime = self.wakatime.normalized();
         self
     }
@@ -412,6 +461,73 @@ fn normalize_nonempty_or_default_string(value: &str, default: &str) -> String {
     }
 }
 
+fn normalize_blocklist_profiles(
+    profiles: &[BlocklistProfileConfig],
+    legacy_blocked_sites: &[String],
+) -> Vec<BlocklistProfileConfig> {
+    let mut normalized = Vec::new();
+    let mut seen_names = HashSet::new();
+
+    for profile in profiles {
+        let base_name =
+            normalize_nonempty_or_default_string(&profile.name, &default_blocklist_profile_name());
+        let name = make_unique_profile_name(&base_name, &mut seen_names);
+        normalized.push(BlocklistProfileConfig {
+            name,
+            sites: profile.sites.clone(),
+        });
+    }
+
+    if normalized.is_empty() {
+        return vec![BlocklistProfileConfig {
+            name: default_blocklist_profile_name(),
+            sites: legacy_blocked_sites.to_vec(),
+        }];
+    }
+
+    normalized
+}
+
+fn normalize_selected_blocklist_profile(
+    selected_name: &str,
+    profiles: &[BlocklistProfileConfig],
+) -> String {
+    let selected_name = selected_name.trim();
+    if selected_name.is_empty() {
+        return profiles
+            .first()
+            .map(|profile| profile.name.clone())
+            .unwrap_or_else(default_blocklist_profile_name);
+    }
+
+    if let Some(profile) = profiles
+        .iter()
+        .find(|profile| profile.name.eq_ignore_ascii_case(selected_name))
+    {
+        profile.name.clone()
+    } else {
+        profiles
+            .first()
+            .map(|profile| profile.name.clone())
+            .unwrap_or_else(default_blocklist_profile_name)
+    }
+}
+
+fn make_unique_profile_name(base_name: &str, seen_names: &mut HashSet<String>) -> String {
+    if seen_names.insert(base_name.to_ascii_lowercase()) {
+        return base_name.to_string();
+    }
+
+    let mut suffix = 2usize;
+    loop {
+        let candidate = format!("{base_name} ({suffix})");
+        if seen_names.insert(candidate.to_ascii_lowercase()) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -432,6 +548,8 @@ mod tests {
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
         assert!(cfg.blocked_sites.is_empty());
+        assert_eq!(cfg.selected_blocklist_profile, "Default");
+        assert!(cfg.blocklist_profiles.is_empty());
         assert_eq!(cfg.notifications, NotificationConfig::default());
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
@@ -447,6 +565,17 @@ mod tests {
             long_break_secs: 20 * 60,
             long_break_interval: 3,
             blocked_sites: vec!["example.com".to_string(), "reddit.com".to_string()],
+            blocklist_profiles: vec![
+                BlocklistProfileConfig {
+                    name: "Work".to_string(),
+                    sites: vec!["example.com".to_string(), "reddit.com".to_string()],
+                },
+                BlocklistProfileConfig {
+                    name: "Study".to_string(),
+                    sites: vec!["x.com".to_string()],
+                },
+            ],
+            selected_blocklist_profile: "Study".to_string(),
             selected_profile: ProfileId::DeepWork,
             custom_profile: Some(CustomProfileConfig {
                 focus_secs: 30 * 60,
@@ -479,6 +608,11 @@ mod tests {
         assert_eq!(parsed.long_break_secs, original.long_break_secs);
         assert_eq!(parsed.long_break_interval, original.long_break_interval);
         assert_eq!(parsed.blocked_sites, original.blocked_sites);
+        assert_eq!(parsed.blocklist_profiles, original.blocklist_profiles);
+        assert_eq!(
+            parsed.selected_blocklist_profile,
+            original.selected_blocklist_profile
+        );
         assert_eq!(parsed.selected_profile, original.selected_profile);
         assert_eq!(parsed.custom_profile, original.custom_profile);
         assert_eq!(parsed.notifications, original.notifications);
@@ -499,6 +633,8 @@ mod tests {
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
         assert!(cfg.blocked_sites.is_empty());
+        assert!(cfg.blocklist_profiles.is_empty());
+        assert_eq!(cfg.selected_blocklist_profile, "Default");
         assert_eq!(cfg.notifications, NotificationConfig::default());
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
@@ -564,6 +700,8 @@ long_break_interval = 3
             long_break_secs: 15 * 60,
             long_break_interval: 4,
             blocked_sites: Vec::new(),
+            blocklist_profiles: vec![BlocklistProfileConfig::default()],
+            selected_blocklist_profile: "Default".to_string(),
             selected_profile: ProfileId::Custom,
             custom_profile: Some(CustomProfileConfig {
                 focus_secs: 40 * 60,
@@ -617,6 +755,8 @@ long_break_interval = 3
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
         assert!(cfg.blocked_sites.is_empty());
+        assert_eq!(cfg.selected_blocklist_profile, "Default");
+        assert!(cfg.blocklist_profiles.is_empty());
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
@@ -692,5 +832,51 @@ language = ""
         let toml_str = toml::to_string_pretty(&original).unwrap();
         let parsed: AppConfig = toml::from_str(&toml_str).unwrap();
         assert!(parsed.blocked_sites.is_empty());
+        assert_eq!(parsed.selected_blocklist_profile, "Default");
+        assert!(parsed.blocklist_profiles.is_empty());
+    }
+
+    #[test]
+    fn normalize_migrates_legacy_blocked_sites_into_default_profile() {
+        let cfg = AppConfig {
+            blocked_sites: vec!["reddit.com".to_string(), "youtube.com".to_string()],
+            blocklist_profiles: Vec::new(),
+            selected_blocklist_profile: String::new(),
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        assert_eq!(cfg.blocklist_profiles.len(), 1);
+        assert_eq!(cfg.blocklist_profiles[0].name, "Default");
+        assert_eq!(
+            cfg.blocklist_profiles[0].sites,
+            vec!["reddit.com".to_string(), "youtube.com".to_string()]
+        );
+        assert_eq!(cfg.selected_blocklist_profile, "Default");
+        assert_eq!(cfg.blocked_sites, cfg.blocklist_profiles[0].sites);
+    }
+
+    #[test]
+    fn normalize_deduplicates_profile_names_and_fixes_selection() {
+        let cfg = AppConfig {
+            blocklist_profiles: vec![
+                BlocklistProfileConfig {
+                    name: "Work".to_string(),
+                    sites: vec!["a.com".to_string()],
+                },
+                BlocklistProfileConfig {
+                    name: "work".to_string(),
+                    sites: vec!["b.com".to_string()],
+                },
+            ],
+            selected_blocklist_profile: "missing".to_string(),
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        assert_eq!(cfg.blocklist_profiles[0].name, "Work");
+        assert_eq!(cfg.blocklist_profiles[1].name, "work (2)");
+        assert_eq!(cfg.selected_blocklist_profile, "Work");
+        assert_eq!(cfg.blocked_sites, vec!["a.com".to_string()]);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,8 +8,9 @@ use ratatui::{
 };
 
 use crate::app::{
-    App, AppMode, DailyGoalProgress, HistoryFeedbackLevel, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS,
-    PlannerFeedbackLevel, SetupCheck, SetupCheckLevel, SiteFeedbackLevel, SiteInputMode,
+    App, AppMode, BlocklistProfileInputMode, DailyGoalProgress, HistoryFeedbackLevel,
+    PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, PlannerFeedbackLevel, SetupCheck, SetupCheckLevel,
+    SiteFeedbackLevel, SiteInputMode,
 };
 use crate::timer::{TimerPhase, TimerStatus};
 use crate::wakatime::WakatimeRuntimeState;
@@ -360,11 +361,13 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         .margin(2)
         .constraints([
             Constraint::Length(1), // status line
+            Constraint::Length(1), // profile line
             Constraint::Length(1), // DoH warning
             Constraint::Length(1), // spacer
             Constraint::Min(3),    // site list
             Constraint::Length(1), // spacer
-            Constraint::Length(3), // input area
+            Constraint::Length(3), // site input area
+            Constraint::Length(3), // profile input area
             Constraint::Length(1), // error line
             Constraint::Length(1), // spacer
             Constraint::Length(2), // key hints
@@ -398,17 +401,35 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         inner[0],
     );
 
+    let profile_text = format!(
+        "Profile: {} ({}/{})",
+        app.active_blocklist_profile_name(),
+        app.active_blocklist_profile_position(),
+        app.blocklist_profile_count()
+    );
+    frame.render_widget(
+        Paragraph::new(profile_text)
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::Cyan)),
+        inner[1],
+    );
+
     // DoH warning
     let doh_warning =
         Paragraph::new("⚠ Disable DNS-over-HTTPS in your browser for blocking to work")
             .alignment(Alignment::Center)
             .style(Style::default().fg(Color::Yellow));
-    frame.render_widget(doh_warning, inner[1]);
+    frame.render_widget(doh_warning, inner[2]);
 
     let input_mode = app.site_input_mode();
+    let profile_input_mode = app.blocklist_profile_input_mode();
 
     // Site list
-    let list_title = format!(" Blocked Sites ({}) ", app.blocker.sites.len());
+    let list_title = format!(
+        " Blocked Sites · {} ({}) ",
+        app.active_blocklist_profile_name(),
+        app.blocker.sites.len()
+    );
     let list_block = Block::default()
         .borders(Borders::ALL)
         .title(list_title)
@@ -418,7 +439,7 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         let empty = Paragraph::new("  No sites blocked yet. Press [a] to add one.")
             .style(Style::default().fg(Color::DarkGray))
             .block(list_block);
-        frame.render_widget(empty, inner[3]);
+        frame.render_widget(empty, inner[4]);
     } else {
         let items: Vec<ListItem> = app
             .blocker
@@ -439,7 +460,7 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
 
         let mut list_state = ListState::default();
         list_state.select(Some(app.selected_site));
-        frame.render_stateful_widget(list, inner[3], &mut list_state);
+        frame.render_stateful_widget(list, inner[4], &mut list_state);
     }
 
     // Input area
@@ -469,7 +490,36 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
             } else {
                 Style::default().fg(Color::DarkGray)
             });
-    frame.render_widget(input_widget, inner[5]);
+    frame.render_widget(input_widget, inner[6]);
+
+    let profile_input_title = match profile_input_mode {
+        Some(BlocklistProfileInputMode::Create) => " New Blocklist Profile ",
+        Some(BlocklistProfileInputMode::Rename) => " Rename Blocklist Profile ",
+        None => " Blocklist Profiles ",
+    };
+    let profile_input_block = Block::default()
+        .borders(Borders::ALL)
+        .title(profile_input_title)
+        .style(if app.blocklist_profile_input_active {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        });
+    let profile_input_text = if app.blocklist_profile_input_active {
+        format!("{}_", app.blocklist_profile_input)
+    } else {
+        "Use [n] to create, [r] to rename, [x] to delete, [[ ] to switch".to_string()
+    };
+    frame.render_widget(
+        Paragraph::new(profile_input_text)
+            .block(profile_input_block)
+            .style(if app.blocklist_profile_input_active {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            }),
+        inner[7],
+    );
 
     // Error line
     if let Some(err) = app.block_error.as_ref() {
@@ -478,9 +528,9 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         } else {
             " (try running with elevated privileges)"
         };
-        render_centered_error(frame, inner[6], format!("⚠  {err}{privilege_hint}"));
+        render_centered_error(frame, inner[8], format!("⚠  {err}{privilege_hint}"));
     } else if let Some(err) = app.config_error.as_ref() {
-        render_centered_error(frame, inner[6], format!("⚠  {err}"));
+        render_centered_error(frame, inner[8], format!("⚠  {err}"));
     } else if let Some(feedback) = app.site_feedback.as_ref() {
         let (prefix, color) = match feedback.level {
             SiteFeedbackLevel::Success => ("✓", Color::Green),
@@ -489,7 +539,7 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         let feedback_widget = Paragraph::new(format!("{prefix}  {}", feedback.message))
             .alignment(Alignment::Center)
             .style(Style::default().fg(color));
-        frame.render_widget(feedback_widget, inner[6]);
+        frame.render_widget(feedback_widget, inner[8]);
     }
 
     // Key hints
@@ -504,21 +554,26 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
                 SiteInputMode::Edit => "Tip: enter one hostname, then press [Enter]",
             }),
         ]
+    } else if app.blocklist_profile_input_active {
+        vec![
+            Line::from("Profile: [Enter] Save  [Esc] Cancel"),
+            Line::from("Tip: use descriptive names like Work, Study, or Deep Work"),
+        ]
     } else if app.strict_mode_enforced_for_focus() {
         vec![
             Line::from("Sites: [a] Add  [e] Edit  [d/Del] Remove  [↑/↓] Move"),
-            Line::from("View: [b/Esc] Back  [q] Quit (Locked)"),
+            Line::from("Profiles: [[ ] Switch  [n] New  [r] Rename  [x] Delete  [q] Quit (Locked)"),
         ]
     } else {
         vec![
             Line::from("Sites: [a] Add  [e] Edit  [d/Del] Remove  [↑/↓] Move"),
-            Line::from("View: [b/Esc] Back  [q] Quit"),
+            Line::from("Profiles: [[ ] Switch  [n] New  [r] Rename  [x] Delete  [b/Esc] Back"),
         ]
     };
     let hints_widget = Paragraph::new(hint_lines)
         .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(hints_widget, inner[8]);
+    frame.render_widget(hints_widget, inner[10]);
 }
 
 fn render_profile_manager(frame: &mut Frame, app: &App) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -562,7 +562,9 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
     } else if app.strict_mode_enforced_for_focus() {
         vec![
             Line::from("Sites: [a] Add  [e] Edit  [d/Del] Remove  [↑/↓] Move"),
-            Line::from("Profiles: [[ ] Switch  [n] New  [r] Rename  [x] Delete  [q] Quit (Locked)"),
+            Line::from(
+                "Profiles: [[ ] Switch  [n] New  [r] Rename  [x] Delete  [b/Esc] Back  [q] Quit (Locked)",
+            ),
         ]
     } else {
         vec![


### PR DESCRIPTION
## What

Add support for named blocklist profiles in Site Manager, including profile switching and profile management from the TUI. This also persists profile data in config while keeping legacy compatibility.

## Why

Issue #110 requests multiple saved blocklists (for example Work/Study/Deep Work) with in-app switching and persistence. This change introduces that workflow directly in the existing Site Manager UX and keeps `blocked_sites` mirrored to the active profile for backward compatibility with older config readers.

Closes #110

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-profile blocklist management: create, rename, delete, and switch profiles; UI shows active profile name, position, and a profile input panel with mode-specific prompts.
  * Keybindings: [ / ] to switch, n to create, r to rename, x to delete.

* **Bug Fixes**
  * Prevent duplicate/empty profile names, require at least one profile, and persist active profile selection and site syncing.

* **Documentation**
  * README updated with example profiles and new keybindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->