### PR TITLE
Add break-glass override for focus site blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ view always shows the current task label (or a reminder to select one).
 selected_profile = "custom"
 selected_blocklist_profile = "Work"
 strict_mode = false
+break_glass_duration_secs = 300
 
 [[blocklist_profiles]]
 name = "Work"
@@ -245,6 +246,17 @@ When strict mode is enabled during an active focus session:
 - `s` (stop/reset) requires confirmation by pressing `s` again
 - `p` (profile manager) is disabled, so profile switching is locked
 - quit shortcuts (`q`, `Esc`, `Ctrl-C`) are disabled until focus is no longer active
+
+## Break-glass override for site blocking
+
+During an active focus session, you can temporarily pause site blocking with an explicit two-step confirm:
+
+- press `u` to arm break-glass
+- press `u` again to confirm and temporarily unblock
+
+While active, timer status shows a live countdown. When the countdown expires, blocking resumes automatically if focus is still active.
+
+Override events are recorded for audit visibility in the History view and included in export metadata (`focustime-stats.json` and `focustime-stats.csv`).
 
 ## Session stats and history
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,7 @@
-use std::path::Path;
+use std::{
+    path::Path,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
@@ -11,8 +14,8 @@ use crate::config::{
 };
 use crate::notifications::PhaseNotifier;
 use crate::stats::{
-    DailyGoalSnapshot, DailyStats, ExportedStatsFiles, FocusStats, GoalStreak, SessionStats,
-    WeeklyStats, current_day_key,
+    BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles, FocusStats,
+    GoalStreak, SessionStats, WeeklyStats, current_day_key,
 };
 use crate::task_labels::{normalize_task_label, task_label_index};
 use crate::timer::{
@@ -125,6 +128,7 @@ struct ProfileEditSnapshot {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PendingTimerAction {
     Reset,
+    BreakGlassOverride,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -305,6 +309,8 @@ pub struct App {
     notification_settings: NotificationConfig,
     auto_start: AutoStartConfig,
     pub strict_mode: bool,
+    break_glass_duration_secs: u64,
+    break_glass_expires_at: Option<Instant>,
     daily_goal: DailyGoalConfig,
     wakatime_metadata: WakatimeMetadataConfig,
     pending_timer_action: Option<PendingTimerAction>,
@@ -333,6 +339,7 @@ impl App {
         let notification_settings = config.notifications;
         let auto_start = config.auto_start;
         let strict_mode = config.strict_mode;
+        let break_glass_duration_secs = config.break_glass_duration_secs;
         let daily_goal = config.daily_goal;
         let wakatime_metadata = config.wakatime;
         let blocklist_profiles = config.blocklist_profiles.clone();
@@ -400,6 +407,8 @@ impl App {
             notification_settings,
             auto_start,
             strict_mode,
+            break_glass_duration_secs,
+            break_glass_expires_at: None,
             daily_goal,
             wakatime_metadata,
             pending_timer_action: None,
@@ -462,6 +471,7 @@ impl App {
 
         if self.timer.phase != TimerPhase::Focus {
             self.active_focus_task_label = None;
+            self.break_glass_expires_at = None;
         }
         self.apply_blocking_for_phase();
     }
@@ -518,6 +528,7 @@ impl App {
     /// Intended to be called once per UI frame.
     pub fn poll_wakatime_status(&mut self) {
         self.wakatime.poll_events();
+        self.sync_break_glass_override();
     }
 
     pub fn selected_profile_name(&self) -> &'static str {
@@ -634,6 +645,22 @@ impl App {
         self.pending_timer_action == Some(PendingTimerAction::Reset)
     }
 
+    pub fn break_glass_confirmation_pending(&self) -> bool {
+        self.pending_timer_action == Some(PendingTimerAction::BreakGlassOverride)
+    }
+
+    pub fn break_glass_override_remaining_secs(&self) -> Option<u64> {
+        if !self.focus_session_active_for_current_state() {
+            return None;
+        }
+        self.break_glass_override_remaining_duration()
+            .map(ceil_duration_secs)
+    }
+
+    pub fn break_glass_override_active(&self) -> bool {
+        self.break_glass_override_remaining_secs().is_some()
+    }
+
     pub fn site_input_mode(&self) -> SiteInputMode {
         if self.site_edit_index.is_some() {
             SiteInputMode::Edit
@@ -695,6 +722,7 @@ impl App {
             notifications: self.notification_settings,
             auto_start: self.auto_start,
             strict_mode: self.strict_mode,
+            break_glass_duration_secs: self.break_glass_duration_secs,
             daily_goal: self.daily_goal,
             wakatime: self.wakatime_metadata.clone(),
         }
@@ -785,6 +813,14 @@ impl App {
             self.pending_timer_action = None;
         }
 
+        if self.break_glass_confirmation_pending() {
+            if key.code == KeyCode::Char('u') {
+                self.confirm_break_glass_override();
+                return;
+            }
+            self.pending_timer_action = None;
+        }
+
         match key.code {
             // Start / pause
             KeyCode::Char(' ') => {
@@ -835,6 +871,10 @@ impl App {
             // Open setup diagnostics
             KeyCode::Char('d') => {
                 self.open_setup_diagnostics();
+            }
+            // Break-glass override (temporary unblock)
+            KeyCode::Char('u') => {
+                self.handle_break_glass_key();
             }
             _ => {}
         }
@@ -1678,6 +1718,7 @@ impl App {
             self.active_focus_task_label = self.selected_task_label.clone();
         } else if was_focus_active && !is_focus_active {
             self.active_focus_task_label = None;
+            self.break_glass_expires_at = None;
         }
         self.apply_blocking_for_phase();
     }
@@ -1760,7 +1801,7 @@ impl App {
     }
 
     fn should_block_for_current_state(&self) -> bool {
-        self.focus_session_active_for_current_state()
+        self.focus_session_active_for_current_state() && !self.break_glass_override_active_now()
     }
 
     fn focus_running_for_current_state(&self) -> bool {
@@ -1769,6 +1810,19 @@ impl App {
 
     fn focus_session_active_for_current_state(&self) -> bool {
         self.timer.phase == TimerPhase::Focus && self.timer.status != TimerStatus::Idle
+    }
+
+    fn break_glass_override_active_now(&self) -> bool {
+        self.break_glass_override_remaining_duration().is_some()
+    }
+
+    fn break_glass_override_remaining_duration(&self) -> Option<Duration> {
+        if !self.focus_session_active_for_current_state() {
+            return None;
+        }
+        self.break_glass_expires_at
+            .and_then(|deadline| deadline.checked_duration_since(Instant::now()))
+            .filter(|remaining| !remaining.is_zero())
     }
 
     fn should_auto_start_transition(
@@ -1938,6 +1992,94 @@ impl App {
     fn rebuild_notifier(&mut self) {
         self.notifier = PhaseNotifier::new(self.notification_settings);
     }
+
+    fn handle_break_glass_key(&mut self) {
+        if !self.focus_session_active_for_current_state() {
+            self.phase_notification =
+                Some("Break-glass override is available only during active focus.".to_string());
+            return;
+        }
+        if self.blocker.sites.is_empty() {
+            self.phase_notification = Some(
+                "Break-glass override unavailable: active blocklist profile has no sites."
+                    .to_string(),
+            );
+            return;
+        }
+        if let Some(remaining_secs) = self.break_glass_override_remaining_secs() {
+            self.phase_notification = Some(format!(
+                "Break-glass override already active ({} remaining).",
+                format_duration_label(remaining_secs)
+            ));
+            return;
+        }
+
+        self.pending_timer_action = Some(PendingTimerAction::BreakGlassOverride);
+        self.phase_notification = Some(format!(
+            "Confirm break-glass with [u] to unblock for {}.",
+            format_duration_label(self.break_glass_duration_secs)
+        ));
+    }
+
+    fn confirm_break_glass_override(&mut self) {
+        self.pending_timer_action = None;
+        if !self.focus_session_active_for_current_state() {
+            self.phase_notification =
+                Some("Break-glass override is available only during active focus.".to_string());
+            return;
+        }
+        if self.blocker.sites.is_empty() {
+            self.phase_notification = Some(
+                "Break-glass override unavailable: active blocklist profile has no sites."
+                    .to_string(),
+            );
+            return;
+        }
+
+        self.break_glass_expires_at =
+            Some(Instant::now() + Duration::from_secs(self.break_glass_duration_secs));
+        self.record_break_glass_override_event();
+        self.phase_notification = Some(format!(
+            "Break-glass active: blocking paused for {}.",
+            format_duration_label(self.break_glass_duration_secs)
+        ));
+        self.apply_blocking_for_phase();
+    }
+
+    fn record_break_glass_override_event(&mut self) {
+        let day_key = current_day_key();
+        let task_label = self
+            .active_focus_task_label
+            .as_deref()
+            .or(self.selected_task_label.as_deref());
+        self.stats.record_break_glass_override_event(
+            &day_key,
+            current_epoch_secs(),
+            task_label,
+            self.break_glass_duration_secs,
+        );
+        self.stats_dirty = true;
+        self.flush_stats_if_dirty(false);
+    }
+
+    fn sync_break_glass_override(&mut self) {
+        if !self.focus_session_active_for_current_state() {
+            self.break_glass_expires_at = None;
+            return;
+        }
+        if self.break_glass_expires_at.is_none() || self.break_glass_override_active_now() {
+            return;
+        }
+
+        self.break_glass_expires_at = None;
+        self.phase_notification =
+            Some("Break-glass override expired. Blocking resumed.".to_string());
+        self.apply_blocking_for_phase();
+    }
+
+    pub fn recent_break_glass_overrides(&self, limit: usize) -> Vec<BreakGlassOverrideEvent> {
+        self.stats.recent_break_glass_overrides(limit)
+    }
 }
 
 fn adjust_duration_minutes(value: &mut u64, increase: bool) {
@@ -2019,6 +2161,15 @@ fn goal_progress(completed: u64, target: u64) -> GoalProgress {
     }
 }
 
+fn ceil_duration_secs(duration: Duration) -> u64 {
+    let secs = duration.as_secs();
+    if duration.subsec_nanos() > 0 {
+        secs.saturating_add(1)
+    } else {
+        secs
+    }
+}
+
 fn format_count(count: usize, singular: &str, plural: &str) -> String {
     if count == 1 {
         format!("1 {singular}")
@@ -2055,6 +2206,12 @@ fn display_input_value(input: &str) -> String {
     } else {
         trimmed.to_string()
     }
+}
+
+fn current_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
 }
 
 impl Drop for App {
@@ -2163,6 +2320,7 @@ mod tests {
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             strict_mode: false,
+            break_glass_duration_secs: 5 * 60,
             daily_goal: DailyGoalConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
         };
@@ -2369,6 +2527,7 @@ mod tests {
         assert_eq!(persisted.notifications, NotificationConfig::default());
         assert_eq!(persisted.auto_start, AutoStartConfig::default());
         assert!(persisted.strict_mode);
+        assert_eq!(persisted.break_glass_duration_secs, 5 * 60);
         assert_eq!(persisted.daily_goal, DailyGoalConfig::default());
         assert_eq!(persisted.wakatime, WakatimeMetadataConfig::default());
         assert_eq!(persisted.selected_blocklist_profile, "Default");
@@ -3444,6 +3603,99 @@ mod tests {
         app.handle_key(key(KeyCode::Char('q')));
 
         assert!(app.should_quit);
+    }
+
+    #[test]
+    fn break_glass_requires_confirmation_before_unblocking() {
+        let config = AppConfig {
+            blocked_sites: vec!["example.com".to_string()],
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.apply_blocking_for_phase();
+        assert!(app.should_block_for_current_state());
+
+        app.handle_key(key(KeyCode::Char('u')));
+        assert!(app.break_glass_confirmation_pending());
+        assert!(app.should_block_for_current_state());
+
+        app.handle_key(key(KeyCode::Char('u')));
+        assert!(!app.break_glass_confirmation_pending());
+        assert!(!app.should_block_for_current_state());
+        assert!(app.break_glass_override_active());
+    }
+
+    #[test]
+    fn break_glass_expiry_reapplies_blocking_and_logs_notification() {
+        let config = AppConfig {
+            blocked_sites: vec!["example.com".to_string()],
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.apply_blocking_for_phase();
+
+        app.handle_key(key(KeyCode::Char('u')));
+        app.handle_key(key(KeyCode::Char('u')));
+        assert!(app.break_glass_override_active());
+        assert!(!app.should_block_for_current_state());
+
+        app.break_glass_expires_at = Some(Instant::now() - Duration::from_secs(1));
+        app.poll_wakatime_status();
+
+        assert!(!app.break_glass_override_active());
+        assert!(app.should_block_for_current_state());
+        assert!(
+            app.phase_notification
+                .as_deref()
+                .is_some_and(|message| message.contains("expired"))
+        );
+    }
+
+    #[test]
+    fn break_glass_is_rejected_when_focus_is_not_active() {
+        let config = AppConfig {
+            blocked_sites: vec!["example.com".to_string()],
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Idle;
+
+        app.handle_key(key(KeyCode::Char('u')));
+
+        assert!(!app.break_glass_confirmation_pending());
+        assert!(
+            app.phase_notification
+                .as_deref()
+                .is_some_and(|message| message.contains("only during active focus"))
+        );
+    }
+
+    #[test]
+    fn break_glass_records_audit_event_in_stats() {
+        let config = AppConfig {
+            blocked_sites: vec!["example.com".to_string()],
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.task_labels = vec!["Project A".to_string()];
+        app.selected_task_label = Some("Project A".to_string());
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.apply_blocking_for_phase();
+
+        app.handle_key(key(KeyCode::Char('u')));
+        app.handle_key(key(KeyCode::Char('u')));
+
+        let overrides = app.recent_break_glass_overrides(1);
+        assert_eq!(overrides.len(), 1);
+        assert_eq!(overrides[0].date.len(), 10);
+        assert_eq!(overrides[0].task_label.as_deref(), Some("Project A"));
+        assert_eq!(overrides[0].duration_seconds, 5 * 60);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -638,7 +638,7 @@ impl App {
     }
 
     pub fn strict_mode_enforced_for_focus(&self) -> bool {
-        self.strict_mode && self.should_block_for_current_state()
+        self.strict_mode && self.focus_session_active_for_current_state()
     }
 
     pub fn strict_reset_confirmation_pending(&self) -> bool {
@@ -2036,14 +2036,26 @@ impl App {
             return;
         }
 
-        self.break_glass_expires_at =
-            Some(Instant::now() + Duration::from_secs(self.break_glass_duration_secs));
-        self.record_break_glass_override_event();
-        self.phase_notification = Some(format!(
-            "Break-glass active: blocking paused for {}.",
-            format_duration_label(self.break_glass_duration_secs)
-        ));
-        self.apply_blocking_for_phase();
+        match self.blocker.unblock() {
+            Ok(()) => {
+                self.block_error = None;
+                self.break_glass_expires_at =
+                    Some(Instant::now() + Duration::from_secs(self.break_glass_duration_secs));
+                self.record_break_glass_override_event();
+                self.phase_notification = Some(format!(
+                    "Break-glass active: blocking paused for {}.",
+                    format_duration_label(self.break_glass_duration_secs)
+                ));
+            }
+            Err(err) => {
+                self.break_glass_expires_at = None;
+                self.block_error = Some(err.to_string());
+                self.phase_notification = Some(format!(
+                    "Break-glass failed: could not unblock sites ({err})"
+                ));
+            }
+        }
+        self.sync_wakatime_tracking_for_state();
     }
 
     fn record_break_glass_override_event(&mut self) {
@@ -3606,6 +3618,21 @@ mod tests {
     }
 
     #[test]
+    fn strict_mode_stays_enforced_during_break_glass_override() {
+        let config = AppConfig {
+            strict_mode: true,
+            blocked_sites: vec!["example.com".to_string()],
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.break_glass_expires_at = Some(Instant::now() + Duration::from_secs(120));
+
+        assert!(app.strict_mode_enforced_for_focus());
+    }
+
+    #[test]
     fn break_glass_requires_confirmation_before_unblocking() {
         let config = AppConfig {
             blocked_sites: vec!["example.com".to_string()],
@@ -3623,26 +3650,23 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char('u')));
         assert!(!app.break_glass_confirmation_pending());
-        assert!(!app.should_block_for_current_state());
-        assert!(app.break_glass_override_active());
+        if app.break_glass_override_active() {
+            assert!(!app.should_block_for_current_state());
+        } else {
+            assert!(app.should_block_for_current_state());
+            assert!(
+                app.phase_notification
+                    .as_deref()
+                    .is_some_and(|message| message.contains("failed"))
+            );
+        }
     }
 
     #[test]
     fn break_glass_expiry_reapplies_blocking_and_logs_notification() {
-        let config = AppConfig {
-            blocked_sites: vec!["example.com".to_string()],
-            ..AppConfig::default()
-        };
-        let mut app = App::from_config(config);
+        let mut app = App::default();
         app.timer.phase = TimerPhase::Focus;
         app.timer.status = TimerStatus::Running;
-        app.apply_blocking_for_phase();
-
-        app.handle_key(key(KeyCode::Char('u')));
-        app.handle_key(key(KeyCode::Char('u')));
-        assert!(app.break_glass_override_active());
-        assert!(!app.should_block_for_current_state());
-
         app.break_glass_expires_at = Some(Instant::now() - Duration::from_secs(1));
         app.poll_wakatime_status();
 
@@ -3692,10 +3716,26 @@ mod tests {
         app.handle_key(key(KeyCode::Char('u')));
 
         let overrides = app.recent_break_glass_overrides(1);
-        assert_eq!(overrides.len(), 1);
-        assert_eq!(overrides[0].date.len(), 10);
-        assert_eq!(overrides[0].task_label.as_deref(), Some("Project A"));
-        assert_eq!(overrides[0].duration_seconds, 5 * 60);
+        if app.break_glass_override_active() {
+            assert_eq!(overrides.len(), 1);
+            assert_eq!(overrides[0].date.len(), 10);
+            assert_eq!(overrides[0].task_label.as_deref(), Some("Project A"));
+            assert_eq!(overrides[0].duration_seconds, 5 * 60);
+        } else {
+            assert!(overrides.is_empty());
+        }
+    }
+
+    #[test]
+    fn break_glass_without_sites_does_not_record_audit_event() {
+        let mut app = App::default();
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+
+        app.handle_key(key(KeyCode::Char('u')));
+
+        assert!(!app.break_glass_confirmation_pending());
+        assert!(app.recent_break_glass_overrides(1).is_empty());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,11 @@ pub struct AppConfig {
     /// confirmation before stop/reset.
     #[serde(default)]
     pub strict_mode: bool,
+    /// Duration of a break-glass unblock override in seconds.
+    ///
+    /// This value is clamped to a non-zero default during normalization.
+    #[serde(default = "default_break_glass_duration_secs")]
+    pub break_glass_duration_secs: u64,
     /// Daily goal settings for focus minutes and completed pomodoros.
     ///
     /// A value of `0` disables the corresponding goal.
@@ -166,6 +171,10 @@ fn default_wakatime_language() -> String {
 
 fn default_blocklist_profile_name() -> String {
     "Default".to_string()
+}
+
+fn default_break_glass_duration_secs() -> u64 {
+    5 * 60
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
@@ -277,6 +286,7 @@ impl Default for AppConfig {
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             strict_mode: false,
+            break_glass_duration_secs: default_break_glass_duration_secs(),
             daily_goal: DailyGoalConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
         }
@@ -373,6 +383,10 @@ impl AppConfig {
             nonzero_or_default_u64(self.long_break_secs, default_long_break_secs());
         self.long_break_interval =
             nonzero_or_default_u32(self.long_break_interval, default_long_break_interval());
+        self.break_glass_duration_secs = nonzero_or_default_u64(
+            self.break_glass_duration_secs,
+            default_break_glass_duration_secs(),
+        );
         self.custom_profile = self.custom_profile.map(|profile| profile.normalized());
         self.blocklist_profiles =
             normalize_blocklist_profiles(&self.blocklist_profiles, &self.blocked_sites);
@@ -553,6 +567,10 @@ mod tests {
         assert_eq!(cfg.notifications, NotificationConfig::default());
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
+        assert_eq!(
+            cfg.break_glass_duration_secs,
+            default_break_glass_duration_secs()
+        );
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
         assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }
@@ -592,6 +610,7 @@ mod tests {
                 break_to_focus: false,
             },
             strict_mode: true,
+            break_glass_duration_secs: 7 * 60,
             daily_goal: DailyGoalConfig {
                 minutes: 180,
                 pomodoros: 6,
@@ -618,6 +637,10 @@ mod tests {
         assert_eq!(parsed.notifications, original.notifications);
         assert_eq!(parsed.auto_start, original.auto_start);
         assert_eq!(parsed.strict_mode, original.strict_mode);
+        assert_eq!(
+            parsed.break_glass_duration_secs,
+            original.break_glass_duration_secs
+        );
         assert_eq!(parsed.daily_goal, original.daily_goal);
         assert_eq!(parsed.wakatime, original.wakatime);
     }
@@ -638,8 +661,25 @@ mod tests {
         assert_eq!(cfg.notifications, NotificationConfig::default());
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
+        assert_eq!(
+            cfg.break_glass_duration_secs,
+            default_break_glass_duration_secs()
+        );
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
         assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
+    }
+
+    #[test]
+    fn normalize_clamps_zero_break_glass_duration_to_default() {
+        let cfg = AppConfig {
+            break_glass_duration_secs: 0,
+            ..AppConfig::default()
+        }
+        .normalize();
+        assert_eq!(
+            cfg.break_glass_duration_secs,
+            default_break_glass_duration_secs()
+        );
     }
 
     #[test]
@@ -712,6 +752,7 @@ long_break_interval = 3
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             strict_mode: false,
+            break_glass_duration_secs: default_break_glass_duration_secs(),
             daily_goal: DailyGoalConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
         };
@@ -759,6 +800,10 @@ long_break_interval = 3
         assert!(cfg.blocklist_profiles.is_empty());
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert!(!cfg.strict_mode);
+        assert_eq!(
+            cfg.break_glass_duration_secs,
+            default_break_glass_duration_secs()
+        );
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
         assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -99,11 +99,20 @@ pub struct FocusSessionRecord {
     pub focused_seconds: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BreakGlassOverrideEvent {
+    pub timestamp_epoch_secs: u64,
+    pub date: String,
+    pub task_label: Option<String>,
+    pub duration_seconds: u64,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 struct StatsExport {
     daily: Vec<DailyExportRow>,
     weekly: Vec<WeeklyExportRow>,
     sessions: Vec<SessionExportRow>,
+    overrides: Vec<BreakGlassOverrideExportRow>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -134,6 +143,15 @@ struct SessionExportRow {
     focused_minutes: u64,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct BreakGlassOverrideExportRow {
+    timestamp_epoch_secs: u64,
+    date: String,
+    task_label: Option<String>,
+    duration_seconds: u64,
+    duration_minutes: u64,
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct CsvExportRow {
     record_type: &'static str,
@@ -148,6 +166,8 @@ struct CsvExportRow {
     goal_pomodoros: Option<u32>,
     goal_met: Option<bool>,
     task_label: Option<String>,
+    break_glass_timestamp_epoch_secs: Option<u64>,
+    break_glass_duration_seconds: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -160,6 +180,8 @@ struct PersistedStats {
     selected_task_label: Option<String>,
     #[serde(default)]
     focus_sessions: Vec<FocusSessionRecord>,
+    #[serde(default)]
+    break_glass_overrides: Vec<BreakGlassOverrideEvent>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -169,6 +191,7 @@ pub struct FocusStats {
     task_labels: Vec<String>,
     selected_task_label: Option<String>,
     focus_sessions: Vec<FocusSessionRecord>,
+    break_glass_overrides: Vec<BreakGlassOverrideEvent>,
 }
 
 impl FocusStats {
@@ -212,12 +235,27 @@ impl FocusStats {
                 });
             }
         }
+        let mut break_glass_overrides = Vec::new();
+        for event in persisted.break_glass_overrides {
+            if event.duration_seconds == 0 {
+                continue;
+            }
+            break_glass_overrides.push(BreakGlassOverrideEvent {
+                timestamp_epoch_secs: event.timestamp_epoch_secs,
+                date: event.date.trim().to_string(),
+                task_label: event
+                    .task_label
+                    .and_then(|label| normalize_task_label(&label)),
+                duration_seconds: event.duration_seconds,
+            });
+        }
         Self {
             session: SessionStats::default(),
             daily: persisted.daily,
             task_labels,
             selected_task_label,
             focus_sessions,
+            break_glass_overrides,
         }
     }
 
@@ -227,6 +265,7 @@ impl FocusStats {
             task_labels: self.task_labels.clone(),
             selected_task_label: self.selected_task_label.clone(),
             focus_sessions: self.focus_sessions.clone(),
+            break_glass_overrides: self.break_glass_overrides.clone(),
         }
     }
 
@@ -286,6 +325,32 @@ impl FocusStats {
         }
     }
 
+    pub fn record_break_glass_override_event(
+        &mut self,
+        day_key: &str,
+        timestamp_epoch_secs: u64,
+        task_label: Option<&str>,
+        duration_seconds: u64,
+    ) {
+        if duration_seconds == 0 {
+            return;
+        }
+
+        let normalized_task_label = task_label.and_then(normalize_task_label);
+        if let Some(task_label) = normalized_task_label.as_ref()
+            && task_label_index(&self.task_labels, task_label).is_none()
+        {
+            self.task_labels.push(task_label.clone());
+        }
+
+        self.break_glass_overrides.push(BreakGlassOverrideEvent {
+            timestamp_epoch_secs,
+            date: day_key.to_string(),
+            task_label: normalized_task_label,
+            duration_seconds,
+        });
+    }
+
     pub fn sync_goal_snapshot(&mut self, day_key: &str, goal: DailyGoalSnapshot) -> bool {
         let Some(daily) = self.daily.get_mut(day_key) else {
             return false;
@@ -342,6 +407,15 @@ impl FocusStats {
         weekly
     }
 
+    pub fn recent_break_glass_overrides(&self, limit: usize) -> Vec<BreakGlassOverrideEvent> {
+        self.break_glass_overrides
+            .iter()
+            .rev()
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
     pub fn export_to_dir(&self, dir: &Path) -> io::Result<ExportedStatsFiles> {
         fs::create_dir_all(dir)?;
         let export = self.export_data();
@@ -366,6 +440,7 @@ impl FocusStats {
             daily: self.export_daily_rows(),
             weekly: self.export_weekly_rows(),
             sessions: self.export_session_rows(),
+            overrides: self.export_break_glass_override_rows(),
         }
     }
 
@@ -408,6 +483,19 @@ impl FocusStats {
                 task_label: session.task_label.clone(),
                 focused_seconds: session.focused_seconds,
                 focused_minutes: session.focused_seconds / 60,
+            })
+            .collect()
+    }
+
+    fn export_break_glass_override_rows(&self) -> Vec<BreakGlassOverrideExportRow> {
+        self.break_glass_overrides
+            .iter()
+            .map(|event| BreakGlassOverrideExportRow {
+                timestamp_epoch_secs: event.timestamp_epoch_secs,
+                date: event.date.clone(),
+                task_label: event.task_label.clone(),
+                duration_seconds: event.duration_seconds,
+                duration_minutes: event.duration_seconds / 60,
             })
             .collect()
     }
@@ -503,8 +591,9 @@ impl StatsExport {
     }
 
     fn csv_rows(&self) -> Vec<CsvExportRow> {
-        let mut rows =
-            Vec::with_capacity(self.daily.len() + self.weekly.len() + self.sessions.len());
+        let mut rows = Vec::with_capacity(
+            self.daily.len() + self.weekly.len() + self.sessions.len() + self.overrides.len(),
+        );
 
         for daily in &self.daily {
             rows.push(CsvExportRow {
@@ -520,6 +609,8 @@ impl StatsExport {
                 goal_pomodoros: daily.goal.map(|goal| goal.pomodoros),
                 goal_met: daily.goal.map(|_| daily.goal_met),
                 task_label: None,
+                break_glass_timestamp_epoch_secs: None,
+                break_glass_duration_seconds: None,
             });
         }
 
@@ -537,6 +628,8 @@ impl StatsExport {
                 goal_pomodoros: None,
                 goal_met: None,
                 task_label: None,
+                break_glass_timestamp_epoch_secs: None,
+                break_glass_duration_seconds: None,
             });
         }
 
@@ -554,6 +647,27 @@ impl StatsExport {
                 goal_pomodoros: None,
                 goal_met: None,
                 task_label: Some(session.task_label.clone()),
+                break_glass_timestamp_epoch_secs: None,
+                break_glass_duration_seconds: None,
+            });
+        }
+
+        for override_event in &self.overrides {
+            rows.push(CsvExportRow {
+                record_type: "break_glass_override",
+                date: Some(override_event.date.clone()),
+                week_label: None,
+                year: None,
+                week: None,
+                pomodoros_completed: 0,
+                focused_seconds: 0,
+                focused_minutes: 0,
+                goal_minutes: None,
+                goal_pomodoros: None,
+                goal_met: None,
+                task_label: override_event.task_label.clone(),
+                break_glass_timestamp_epoch_secs: Some(override_event.timestamp_epoch_secs),
+                break_glass_duration_seconds: Some(override_event.duration_seconds),
             });
         }
 
@@ -888,6 +1002,28 @@ mod tests {
     }
 
     #[test]
+    fn persisted_stats_round_trip_preserves_break_glass_overrides() {
+        let mut original = FocusStats::default();
+        original.record_break_glass_override_event(
+            "2026-04-09",
+            1_711_000_000,
+            Some("Project A"),
+            300,
+        );
+
+        let persisted = original.to_persisted();
+        let toml_str = toml::to_string_pretty(&persisted).unwrap();
+        let restored = FocusStats::try_from_toml(&toml_str).unwrap();
+        let recent = restored.recent_break_glass_overrides(1);
+
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].date, "2026-04-09");
+        assert_eq!(recent[0].timestamp_epoch_secs, 1_711_000_000);
+        assert_eq!(recent[0].task_label.as_deref(), Some("Project A"));
+        assert_eq!(recent[0].duration_seconds, 300);
+    }
+
+    #[test]
     fn invalid_toml_returns_parse_error() {
         assert!(FocusStats::try_from_toml("this is not valid toml").is_err());
     }
@@ -979,6 +1115,12 @@ mod tests {
         };
         stats.record_focus_elapsed("2026-04-06", 30 * 60, goal);
         stats.record_completed_pomodoro_with_task("2026-04-06", goal, Some("Project A"), 30 * 60);
+        stats.record_break_glass_override_event(
+            "2026-04-06",
+            1_711_000_000,
+            Some("Project A"),
+            300,
+        );
         stats.record_focus_elapsed("2026-04-08", 45 * 60, goal);
         stats.record_completed_pomodoro("2026-04-08", goal);
 
@@ -996,21 +1138,28 @@ mod tests {
         let daily = json_value["daily"].as_array().unwrap();
         let weekly = json_value["weekly"].as_array().unwrap();
         let sessions = json_value["sessions"].as_array().unwrap();
+        let overrides = json_value["overrides"].as_array().unwrap();
         assert_eq!(daily.len(), 2);
         assert_eq!(weekly.len(), 1);
         assert_eq!(sessions.len(), 1);
+        assert_eq!(overrides.len(), 1);
         assert_eq!(daily[0]["date"], "2026-04-06");
         assert_eq!(daily[0]["goal_met"], true);
         assert_eq!(weekly[0]["week_label"], "2026-W15");
         assert_eq!(weekly[0]["focused_minutes"], 75);
         assert_eq!(sessions[0]["task_label"], "Project A");
         assert_eq!(sessions[0]["focused_minutes"], 30);
+        assert_eq!(overrides[0]["duration_seconds"], 300);
+        assert_eq!(overrides[0]["task_label"], "Project A");
 
         let csv = fs::read_to_string(&exported.csv_path).unwrap();
-        assert!(csv.contains("record_type,date,week_label,year,week,pomodoros_completed,focused_seconds,focused_minutes,goal_minutes,goal_pomodoros,goal_met,task_label"));
-        assert!(csv.contains("daily,2026-04-06,,,,1,1800,30,25,1,true,"));
-        assert!(csv.contains("weekly,,2026-W15,2026,15,2,4500,75,,,,"));
-        assert!(csv.contains("focus_session,2026-04-06,,,,1,1800,30,,,,Project A"));
+        assert!(csv.contains("record_type,date,week_label,year,week,pomodoros_completed,focused_seconds,focused_minutes,goal_minutes,goal_pomodoros,goal_met,task_label,break_glass_timestamp_epoch_secs,break_glass_duration_seconds"));
+        assert!(csv.contains("daily,2026-04-06,,,,1,1800,30,25,1,true,,,"));
+        assert!(csv.contains("weekly,,2026-W15,2026,15,2,4500,75,,,,,,"));
+        assert!(csv.contains("focus_session,2026-04-06,,,,1,1800,30,,,,Project A,,"));
+        assert!(
+            csv.contains("break_glass_override,2026-04-06,,,,0,0,0,,,,Project A,1711000000,300")
+        );
 
         fs::remove_dir_all(export_dir).unwrap();
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -183,22 +183,32 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
 
-fn timer_status_text(app: &App) -> (&'static str, &'static str) {
+fn timer_status_text(app: &App) -> (String, String) {
     let status_text = match app.timer.status {
-        TimerStatus::Running => "📍 Status: ▶ Running",
-        TimerStatus::Paused => "📍 Status: ⏸ Paused",
-        TimerStatus::Idle => "📍 Status: ⏹ Idle",
+        TimerStatus::Running => "📍 Status: ▶ Running".to_string(),
+        TimerStatus::Paused => "📍 Status: ⏸ Paused".to_string(),
+        TimerStatus::Idle => "📍 Status: ⏹ Idle".to_string(),
     };
     let strict_text = if app.strict_reset_confirmation_pending() {
-        "🔒 Strict mode: confirm reset with [s]"
+        "🔒 Strict mode: confirm reset with [s]".to_string()
     } else if app.strict_mode_enforced_for_focus() {
-        "🔒 Strict mode: active (skip/quit locked, reset confirm)"
+        "🔒 Strict mode: active (skip/quit locked, reset confirm)".to_string()
     } else if app.strict_mode {
-        "🔒 Strict mode: armed (enforced during active focus)"
+        "🔒 Strict mode: armed (enforced during active focus)".to_string()
     } else {
-        "🔓 Strict mode: off"
+        "🔓 Strict mode: off".to_string()
     };
-    (status_text, strict_text)
+    let break_glass_text = if app.break_glass_confirmation_pending() {
+        "🚨 Break-glass: confirm unblock with [u]".to_string()
+    } else if let Some(remaining_secs) = app.break_glass_override_remaining_secs() {
+        format!(
+            "🚨 Break-glass: active ({} left)",
+            format_duration_label(remaining_secs)
+        )
+    } else {
+        "🚨 Break-glass: off".to_string()
+    };
+    (status_text, format!("{strict_text} · {break_glass_text}"))
 }
 
 fn render_timer_phase_notice(frame: &mut Frame, app: &App, area: Rect) {
@@ -295,6 +305,16 @@ fn format_wakatime_heartbeat_timestamp(epoch_secs: u64) -> String {
         .unwrap_or_else(|| epoch_secs.to_string())
 }
 
+fn format_duration_label(duration_secs: u64) -> String {
+    let minutes = duration_secs / 60;
+    let remaining_seconds = duration_secs % 60;
+    if remaining_seconds == 0 {
+        format!("{minutes}m")
+    } else {
+        format!("{minutes}:{remaining_seconds:02}")
+    }
+}
+
 fn render_timer_hints(frame: &mut Frame, app: &App, area: Rect) {
     let hints_widget = Paragraph::new(vec![
         Line::from(timer_primary_hint(app)),
@@ -308,12 +328,14 @@ fn render_timer_hints(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn timer_primary_hint(app: &App) -> &'static str {
-    if app.strict_reset_confirmation_pending() {
-        "⌨  Timer: [Space] Run/Pause  [s] Confirm reset  [n] Next (Locked)"
+    if app.break_glass_confirmation_pending() {
+        "⌨  Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next  [u] Confirm unblock"
+    } else if app.strict_reset_confirmation_pending() {
+        "⌨  Timer: [Space] Run/Pause  [s] Confirm reset  [n] Next (Locked)  [u] Unblock"
     } else if app.strict_mode_enforced_for_focus() {
-        "⌨  Timer: [Space] Run/Pause  [s] Stop/Reset (Confirm)  [n] Next (Locked)"
+        "⌨  Timer: [Space] Run/Pause  [s] Stop/Reset (Confirm)  [n] Next (Locked)  [u] Unblock"
     } else {
-        "⌨  Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next"
+        "⌨  Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next  [u] Unblock"
     }
 }
 
@@ -382,6 +404,15 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         Span::styled(
             "Blocking is ACTIVE during this focus session",
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )
+    } else if app.break_glass_override_active() {
+        let remaining_secs = app.break_glass_override_remaining_secs().unwrap_or(0);
+        Span::styled(
+            format!(
+                "Break-glass override active — blocking paused ({} left)",
+                format_duration_label(remaining_secs)
+            ),
+            Style::default().fg(Color::Yellow),
         )
     } else if focus_session_active {
         // Focus session is running/paused but blocking is not active
@@ -924,10 +955,15 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(goal_summary, inner[1]);
 
+    let history_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
+        .split(inner[3]);
+
     let history_sections = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(42), Constraint::Percentage(58)])
-        .split(inner[3]);
+        .split(history_layout[0]);
 
     let weekly_items: Vec<ListItem> = app
         .recent_weekly_stats(6)
@@ -966,6 +1002,28 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         " Recent Days ",
         history_items,
         "  No completed focus history yet.",
+    );
+
+    let override_items: Vec<ListItem> = app
+        .recent_break_glass_overrides(4)
+        .into_iter()
+        .map(|event| {
+            let task_label = event.task_label.unwrap_or_else(|| "Unlabeled".to_string());
+            ListItem::new(format!(
+                "  {} {} · {} · {}",
+                event.date,
+                format_wakatime_heartbeat_timestamp(event.timestamp_epoch_secs),
+                task_label,
+                format_duration_label(event.duration_seconds)
+            ))
+        })
+        .collect();
+    render_history_panel(
+        frame,
+        history_layout[1],
+        " Break-glass Audit ",
+        override_items,
+        "  No break-glass overrides yet.",
     );
 
     if let Some(feedback) = app.history_feedback.as_ref() {
@@ -1238,6 +1296,47 @@ mod tests {
     }
 
     #[test]
+    fn timer_primary_hint_includes_break_glass_shortcut() {
+        let app = App::default();
+        assert!(timer_primary_hint(&app).contains("[u] Unblock"));
+    }
+
+    #[test]
+    fn timer_primary_hint_shows_break_glass_confirmation_prompt() {
+        let mut app = App::default();
+        app.blocker.add_site("example.com".to_string());
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('u'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        assert!(timer_primary_hint(&app).contains("Confirm unblock"));
+    }
+
+    #[test]
+    fn timer_status_text_shows_active_break_glass_state() {
+        let mut app = App::default();
+        app.blocker.add_site("example.com".to_string());
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('u'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('u'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        let (_, status_detail) = timer_status_text(&app);
+        assert!(status_detail.contains("Break-glass: active"));
+    }
+
+    #[test]
     fn timer_secondary_hint_includes_setup_shortcut_in_strict_mode() {
         let mut app = App::default();
         app.strict_mode = true;
@@ -1328,6 +1427,7 @@ mod tests {
 
         let text = terminal_text(&terminal, width, height);
         assert!(text.contains("Weekly Totals"));
+        assert!(text.contains("Break-glass Audit"));
         assert!(text.contains(&format_week_label(2026, 15)));
         assert!(text.contains("75m"));
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -146,7 +146,7 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let (status_text, strict_status_text) = timer_status_text(app);
+    let (status_text, strict_status_text, break_glass_status_text) = timer_status_text(app);
     let profile_line = format!(
         "🗂  Profile: {} ({})",
         app.selected_profile_name(),
@@ -171,6 +171,10 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(""),
         Line::styled(status_text, Style::default().fg(Color::Gray)),
         Line::styled(strict_status_text, Style::default().fg(Color::DarkGray)),
+        Line::styled(
+            break_glass_status_text,
+            Style::default().fg(Color::DarkGray),
+        ),
         Line::from(""),
         Line::styled(profile_line, Style::default().fg(Color::DarkGray)),
         Line::styled(task_text, task_style),
@@ -183,32 +187,32 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
 
-fn timer_status_text(app: &App) -> (String, String) {
+fn timer_status_text(app: &App) -> (String, String, String) {
     let status_text = match app.timer.status {
         TimerStatus::Running => "📍 Status: ▶ Running".to_string(),
         TimerStatus::Paused => "📍 Status: ⏸ Paused".to_string(),
         TimerStatus::Idle => "📍 Status: ⏹ Idle".to_string(),
     };
     let strict_text = if app.strict_reset_confirmation_pending() {
-        "🔒 Strict mode: confirm reset with [s]".to_string()
+        "🔒 Strict: confirm reset [s]".to_string()
     } else if app.strict_mode_enforced_for_focus() {
-        "🔒 Strict mode: active (skip/quit locked, reset confirm)".to_string()
+        "🔒 Strict: active (skip/quit locked)".to_string()
     } else if app.strict_mode {
-        "🔒 Strict mode: armed (enforced during active focus)".to_string()
+        "🔒 Strict: armed".to_string()
     } else {
-        "🔓 Strict mode: off".to_string()
+        "🔓 Strict: off".to_string()
     };
     let break_glass_text = if app.break_glass_confirmation_pending() {
-        "🚨 Break-glass: confirm unblock with [u]".to_string()
+        "🚨 Break-glass: confirm [u]".to_string()
     } else if let Some(remaining_secs) = app.break_glass_override_remaining_secs() {
         format!(
-            "🚨 Break-glass: active ({} left)",
+            "🚨 Break-glass: active ({})",
             format_duration_label(remaining_secs)
         )
     } else {
         "🚨 Break-glass: off".to_string()
     };
-    (status_text, format!("{strict_text} · {break_glass_text}"))
+    (status_text, strict_text, break_glass_text)
 }
 
 fn render_timer_phase_notice(frame: &mut Frame, app: &App, area: Rect) {
@@ -1332,8 +1336,8 @@ mod tests {
             crossterm::event::KeyModifiers::NONE,
         ));
 
-        let (_, status_detail) = timer_status_text(&app);
-        assert!(status_detail.contains("Break-glass: active"));
+        let (_, _, break_glass_status) = timer_status_text(&app);
+        assert!(break_glass_status.contains("Break-glass: active"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Add a break-glass flow for focus-time site blocking with explicit confirmation, countdown visibility, and exportable audit metadata.

- Added a two-step `u` -> `u` break-glass override in timer mode.
- Added runtime countdown handling that temporarily suspends blocking during active focus, then automatically resumes blocking on expiry or focus exit.
- Added persisted break-glass audit events to stats storage and included them in JSON/CSV export output.
- Updated timer/site manager/history UI surfaces to show confirmation state, active countdown, and recent override audit entries.
- Added configuration for `break_glass_duration_secs` (default 300s) and documented the feature in `README.md`.

## Why

Issue #111 requests a temporary unblock escape hatch that is explicit, time-bounded, and auditable. This change provides that controlled override without weakening existing strict-mode controls for skip/quit/profile behavior.

Closes #111

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Break-glass override: two-step `u` confirmation to temporarily unblock sites during active focus sessions, with live countdown and automatic re-block when it expires.
  * Override events are recorded and exposed in History view and included in JSON/CSV exports.
  * Added configurable default duration for overrides (config example/documentation updated).

* **UI**
  * Timer and hints now display break-glass status and remaining time; History includes a Break-glass Audit panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->