### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-18
+
+### Added
+- **Session planner workflow (#120):** introduced timer-integrated task labeling with required task selection before starting focus sessions.
+- **Blocklist profile management (#121):** added create/rename/delete/switch flows for named site-blocking profiles in the site manager.
+- **Break-glass override for focus blocking (#122):** added explicit two-step temporary unblock control with automatic re-enable countdown during active focus sessions.
+
+### Changed
+- **Timer layout and UX polish:** improved timer screen readability and spacing in timer and session-planner views.
+- **v0.4.0 documentation refresh (#127):** updated README demo screenshots to reflect the latest UI.
+
 ## [0.3.2] - 2026-04-16
 
 ### Added
@@ -62,7 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/utilForever/focustime/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/utilForever/focustime/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/utilForever/focustime/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/utilForever/focustime/compare/v0.2.1...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -336,12 +336,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.3.2`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.4.0`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.3.2](https://github.com/utilForever/focustime/releases/tag/v0.3.2).
+The latest stable release is [v0.4.0](https://github.com/utilForever/focustime/releases/tag/v0.4.0).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the v0.4.0 release metadata and documentation surfaces so version references are consistent across package metadata and public docs.

## Why

We need to publish v0.4.0 with aligned version/changelog information so users and automation point to the correct release artifacts.

Closes #124.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.4.0
  * Changelog and README updated to reflect new release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->