### PR TITLE
History v2: monthly trend, heatmap, profile totals

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,8 @@ use crate::config::{
 use crate::notifications::PhaseNotifier;
 use crate::stats::{
     BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles, FocusStats,
-    GoalStreak, SessionStats, WeeklyStats, current_day_key,
+    GoalStreak, MonthlyHeatmap, MonthlyStats, ProfileTotals, SessionStats, WeeklyStats,
+    current_day_key,
 };
 use crate::task_labels::{normalize_task_label, task_label_index};
 use crate::timer::{
@@ -288,6 +289,7 @@ pub struct App {
     pub planner_input_active: bool,
     pub planner_feedback: Option<PlannerFeedback>,
     active_focus_task_label: Option<String>,
+    active_focus_profile: Option<ProfileId>,
     /// Index of the highlighted site in the SiteManager list.
     pub selected_site: usize,
     /// Last error from a block/unblock operation (e.g. permission denied).
@@ -387,6 +389,7 @@ impl App {
             planner_input_active: false,
             planner_feedback: None,
             active_focus_task_label: None,
+            active_focus_profile: None,
             selected_site: 0,
             block_error: None,
             setup_diagnostics,
@@ -459,6 +462,7 @@ impl App {
         if self.should_record_completed_focus_session(completed_phase, is_catchup) {
             self.record_completed_focus_session(completed_focus_secs);
             self.active_focus_task_label = None;
+            self.active_focus_profile = None;
         }
 
         let blocked_focus_autostart =
@@ -471,6 +475,7 @@ impl App {
 
         if self.timer.phase != TimerPhase::Focus {
             self.active_focus_task_label = None;
+            self.active_focus_profile = None;
             self.break_glass_expires_at = None;
         }
         self.apply_blocking_for_phase();
@@ -492,6 +497,7 @@ impl App {
         self.timer.status = TimerStatus::Running;
         if self.timer.phase == TimerPhase::Focus {
             self.active_focus_task_label = self.selected_task_label.clone();
+            self.active_focus_profile = Some(self.selected_profile);
         }
         false
     }
@@ -608,8 +614,21 @@ impl App {
         self.stats.recent_daily(limit)
     }
 
+    #[allow(dead_code)]
     pub fn recent_weekly_stats(&self, limit: usize) -> Vec<WeeklyStats> {
         self.stats.recent_weekly(limit)
+    }
+
+    pub fn recent_monthly_stats(&self, limit: usize) -> Vec<MonthlyStats> {
+        self.stats.recent_monthly(limit)
+    }
+
+    pub fn latest_monthly_heatmap(&self) -> MonthlyHeatmap {
+        self.stats.latest_monthly_heatmap()
+    }
+
+    pub fn profile_focus_totals(&self) -> Vec<ProfileTotals> {
+        self.stats.profile_totals()
     }
 
     #[cfg(test)]
@@ -1177,6 +1196,7 @@ impl App {
             profile_spec.long_break_interval,
         );
         self.active_focus_task_label = None;
+        self.active_focus_profile = None;
         self.selected_profile = profile;
         self.profile_selection_index = profile_index(profile);
         self.pending_timer_action = None;
@@ -1716,8 +1736,10 @@ impl App {
         let is_focus_active = self.focus_session_active_for_current_state();
         if !was_focus_active && is_focus_active {
             self.active_focus_task_label = self.selected_task_label.clone();
+            self.active_focus_profile = Some(self.selected_profile);
         } else if was_focus_active && !is_focus_active {
             self.active_focus_task_label = None;
+            self.active_focus_profile = None;
             self.break_glass_expires_at = None;
         }
         self.apply_blocking_for_phase();
@@ -1873,6 +1895,7 @@ impl App {
                 goal,
                 self.active_focus_task_label.as_deref(),
                 focused_seconds,
+                self.active_focus_profile,
             );
         } else {
             self.stats.record_completed_pomodoro(&day_key, goal);
@@ -3751,6 +3774,27 @@ mod tests {
 
         assert_eq!(app.session_stats().focused_minutes(), 2);
         assert_eq!(app.today_stats().focused_minutes(), 2);
+    }
+
+    #[test]
+    fn completed_focus_session_tracks_active_profile_for_history_totals() {
+        let config = AppConfig {
+            selected_profile: ProfileId::DeepWork,
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.task_labels = vec!["Project A".to_string()];
+        app.selected_task_label = Some("Project A".to_string());
+
+        app.handle_key(key(KeyCode::Char(' ')));
+        app.timer.remaining_secs = 1;
+        app.on_tick(false);
+
+        let totals = app.profile_focus_totals();
+        assert_eq!(totals.len(), 1);
+        assert_eq!(totals[0].profile, crate::stats::ProfileBucket::DeepWork);
+        assert_eq!(totals[0].pomodoros_completed, 1);
+        assert_eq!(totals[0].focused_minutes(), 50);
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -10,6 +10,7 @@ use std::{
 use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 
+use crate::config::ProfileId;
 use crate::task_labels::{canonical_task_label, normalize_task_label, task_label_index};
 
 #[cfg_attr(test, allow(dead_code))]
@@ -70,6 +71,43 @@ impl WeeklyStats {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MonthlyStats {
+    pub year: i32,
+    pub month: u32,
+    pub pomodoros_completed: u32,
+    pub focused_seconds: u64,
+}
+
+impl MonthlyStats {
+    pub fn focused_minutes(self) -> u64 {
+        self.focused_seconds / 60
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HeatmapDayStats {
+    pub day: u32,
+    pub pomodoros_completed: u32,
+    pub focused_seconds: u64,
+}
+
+impl HeatmapDayStats {
+    pub fn focused_minutes(self) -> u64 {
+        self.focused_seconds / 60
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MonthlyHeatmap {
+    pub year: i32,
+    pub month: u32,
+    pub first_weekday_monday0: u32,
+    pub days_in_month: u32,
+    pub max_focused_minutes: u64,
+    pub days: Vec<HeatmapDayStats>,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct DailyStats {
     #[serde(default)]
@@ -97,6 +135,40 @@ pub struct FocusSessionRecord {
     pub date: String,
     pub task_label: String,
     pub focused_seconds: u64,
+    #[serde(default)]
+    pub profile: Option<ProfileId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ProfileBucket {
+    Classic,
+    DeepWork,
+    Custom,
+    Unknown,
+}
+
+impl ProfileBucket {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Classic => "Classic",
+            Self::DeepWork => "Deep Work",
+            Self::Custom => "Custom",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProfileTotals {
+    pub profile: ProfileBucket,
+    pub pomodoros_completed: u32,
+    pub focused_seconds: u64,
+}
+
+impl ProfileTotals {
+    pub fn focused_minutes(self) -> u64 {
+        self.focused_seconds / 60
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -141,6 +213,7 @@ struct SessionExportRow {
     task_label: String,
     focused_seconds: u64,
     focused_minutes: u64,
+    profile: Option<ProfileId>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -232,6 +305,7 @@ impl FocusStats {
                     date: session.date.trim().to_string(),
                     task_label,
                     focused_seconds: session.focused_seconds,
+                    profile: session.profile,
                 });
             }
         }
@@ -297,7 +371,7 @@ impl FocusStats {
     }
 
     pub fn record_completed_pomodoro(&mut self, day_key: &str, goal: DailyGoalSnapshot) {
-        self.record_completed_pomodoro_with_task(day_key, goal, None, 0);
+        self.record_completed_pomodoro_with_task(day_key, goal, None, 0, None);
     }
 
     pub fn record_completed_pomodoro_with_task(
@@ -306,6 +380,7 @@ impl FocusStats {
         goal: DailyGoalSnapshot,
         task_label: Option<&str>,
         focused_seconds: u64,
+        profile: Option<ProfileId>,
     ) {
         self.session.pomodoros_completed = self.session.pomodoros_completed.saturating_add(1);
         let daily = self.daily.entry(day_key.to_string()).or_default();
@@ -321,6 +396,7 @@ impl FocusStats {
                 date: day_key.to_string(),
                 task_label,
                 focused_seconds,
+                profile,
             });
         }
     }
@@ -400,11 +476,58 @@ impl FocusStats {
             .collect()
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn recent_weekly(&self, limit: usize) -> Vec<WeeklyStats> {
         let mut weekly = self.weekly_stats();
         weekly.reverse();
         weekly.truncate(limit);
         weekly
+    }
+
+    pub fn recent_monthly(&self, limit: usize) -> Vec<MonthlyStats> {
+        let mut monthly = self.monthly_stats();
+        monthly.reverse();
+        monthly.truncate(limit);
+        monthly
+    }
+
+    pub fn latest_monthly_heatmap(&self) -> MonthlyHeatmap {
+        let (year, month) = self.latest_recorded_month_key().unwrap_or_else(|| {
+            let now = chrono::Local::now().date_naive();
+            (now.year(), now.month())
+        });
+        self.monthly_heatmap(year, month)
+    }
+
+    pub fn profile_totals(&self) -> Vec<ProfileTotals> {
+        let mut by_profile: BTreeMap<ProfileBucket, ProfileTotals> = BTreeMap::new();
+        for session in &self.focus_sessions {
+            let profile = match session.profile {
+                Some(ProfileId::Classic) => ProfileBucket::Classic,
+                Some(ProfileId::DeepWork) => ProfileBucket::DeepWork,
+                Some(ProfileId::Custom) => ProfileBucket::Custom,
+                None => ProfileBucket::Unknown,
+            };
+            let entry = by_profile.entry(profile).or_insert(ProfileTotals {
+                profile,
+                pomodoros_completed: 0,
+                focused_seconds: 0,
+            });
+            entry.pomodoros_completed = entry.pomodoros_completed.saturating_add(1);
+            entry.focused_seconds = entry
+                .focused_seconds
+                .saturating_add(session.focused_seconds);
+        }
+
+        let mut totals: Vec<ProfileTotals> = by_profile.into_values().collect();
+        totals.sort_by(|left, right| {
+            right
+                .focused_seconds
+                .cmp(&left.focused_seconds)
+                .then_with(|| right.pomodoros_completed.cmp(&left.pomodoros_completed))
+                .then_with(|| left.profile.cmp(&right.profile))
+        });
+        totals
     }
 
     pub fn recent_break_glass_overrides(&self, limit: usize) -> Vec<BreakGlassOverrideEvent> {
@@ -483,6 +606,7 @@ impl FocusStats {
                 task_label: session.task_label.clone(),
                 focused_seconds: session.focused_seconds,
                 focused_minutes: session.focused_seconds / 60,
+                profile: session.profile,
             })
             .collect()
     }
@@ -522,6 +646,72 @@ impl FocusStats {
         }
 
         weekly.into_values().collect()
+    }
+
+    fn monthly_stats(&self) -> Vec<MonthlyStats> {
+        let mut monthly = BTreeMap::new();
+
+        for (day_key, stats) in &self.daily {
+            let Ok(day) = chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d") else {
+                continue;
+            };
+            let entry = monthly
+                .entry((day.year(), day.month()))
+                .or_insert_with(|| MonthlyStats {
+                    year: day.year(),
+                    month: day.month(),
+                    ..MonthlyStats::default()
+                });
+            entry.pomodoros_completed = entry
+                .pomodoros_completed
+                .saturating_add(stats.pomodoros_completed);
+            entry.focused_seconds = entry.focused_seconds.saturating_add(stats.focused_seconds);
+        }
+
+        monthly.into_values().collect()
+    }
+
+    fn latest_recorded_month_key(&self) -> Option<(i32, u32)> {
+        self.daily
+            .keys()
+            .rev()
+            .find_map(|day_key| chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d").ok())
+            .map(|day| (day.year(), day.month()))
+    }
+
+    fn monthly_heatmap(&self, year: i32, month: u32) -> MonthlyHeatmap {
+        let (year, month) = if chrono::NaiveDate::from_ymd_opt(year, month, 1).is_some() {
+            (year, month)
+        } else {
+            let now = chrono::Local::now().date_naive();
+            (now.year(), now.month())
+        };
+
+        let month_start = chrono::NaiveDate::from_ymd_opt(year, month, 1)
+            .expect("validated month/year should produce valid first day");
+        let days_in_month = days_in_month(year, month);
+        let mut max_focused_minutes = 0;
+        let mut days = Vec::with_capacity(days_in_month as usize);
+        for day in 1..=days_in_month {
+            let day_key = format!("{year:04}-{month:02}-{day:02}");
+            let stats = self.daily_for(&day_key);
+            let focused_minutes = stats.focused_minutes();
+            max_focused_minutes = max_focused_minutes.max(focused_minutes);
+            days.push(HeatmapDayStats {
+                day,
+                pomodoros_completed: stats.pomodoros_completed,
+                focused_seconds: stats.focused_seconds,
+            });
+        }
+
+        MonthlyHeatmap {
+            year,
+            month,
+            first_weekday_monday0: month_start.weekday().num_days_from_monday(),
+            days_in_month,
+            max_focused_minutes,
+            days,
+        }
     }
 
     #[cfg(test)]
@@ -843,6 +1033,20 @@ fn create_unique_temp_path(path: &Path) -> PathBuf {
     parent.join(format!(".{target_name}.{pid}.{nanos}.{seq}.tmp"))
 }
 
+fn days_in_month(year: i32, month: u32) -> u32 {
+    let (next_year, next_month) = if month == 12 {
+        (year.saturating_add(1), 1)
+    } else {
+        (year, month.saturating_add(1))
+    };
+    let next_month_start = chrono::NaiveDate::from_ymd_opt(next_year, next_month, 1)
+        .expect("validated month rollover should produce next month start");
+    next_month_start
+        .pred_opt()
+        .expect("month start should have a predecessor")
+        .day()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1024,6 +1228,33 @@ mod tests {
     }
 
     #[test]
+    fn persisted_stats_round_trip_preserves_focus_session_profile() {
+        let mut original = FocusStats::default();
+        let goal = DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        };
+        original.record_focus_elapsed("2026-04-09", 25 * 60, goal);
+        original.record_completed_pomodoro_with_task(
+            "2026-04-09",
+            goal,
+            Some("Project A"),
+            25 * 60,
+            Some(ProfileId::DeepWork),
+        );
+
+        let persisted = original.to_persisted();
+        let toml_str = toml::to_string_pretty(&persisted).unwrap();
+        let restored = FocusStats::try_from_toml(&toml_str).unwrap();
+        let profile_totals = restored.profile_totals();
+
+        assert_eq!(profile_totals.len(), 1);
+        assert_eq!(profile_totals[0].profile, ProfileBucket::DeepWork);
+        assert_eq!(profile_totals[0].pomodoros_completed, 1);
+        assert_eq!(profile_totals[0].focused_minutes(), 25);
+    }
+
+    #[test]
     fn invalid_toml_returns_parse_error() {
         assert!(FocusStats::try_from_toml("this is not valid toml").is_err());
     }
@@ -1107,6 +1338,143 @@ mod tests {
     }
 
     #[test]
+    fn recent_monthly_aggregates_and_orders_newest_first() {
+        let mut stats = FocusStats::default();
+        stats.insert_daily_for_tests(
+            "2026-03-31",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 15 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2026-04-01",
+            DailyStats {
+                pomodoros_completed: 2,
+                focused_seconds: 60 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2026-04-08",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 30 * 60,
+                goal: None,
+            },
+        );
+
+        let recent = stats.recent_monthly(2);
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].year, 2026);
+        assert_eq!(recent[0].month, 4);
+        assert_eq!(recent[0].pomodoros_completed, 3);
+        assert_eq!(recent[0].focused_minutes(), 90);
+        assert_eq!(recent[1].year, 2026);
+        assert_eq!(recent[1].month, 3);
+        assert_eq!(recent[1].pomodoros_completed, 1);
+        assert_eq!(recent[1].focused_minutes(), 15);
+    }
+
+    #[test]
+    fn latest_monthly_heatmap_uses_latest_recorded_month_data() {
+        let mut stats = FocusStats::default();
+        stats.insert_daily_for_tests(
+            "2026-03-31",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 15 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2026-04-01",
+            DailyStats {
+                pomodoros_completed: 2,
+                focused_seconds: 60 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2026-04-03",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 45 * 60,
+                goal: None,
+            },
+        );
+
+        let heatmap = stats.latest_monthly_heatmap();
+        assert_eq!(heatmap.year, 2026);
+        assert_eq!(heatmap.month, 4);
+        assert_eq!(heatmap.days_in_month, 30);
+        assert_eq!(heatmap.max_focused_minutes, 60);
+        assert_eq!(heatmap.days[0].day, 1);
+        assert_eq!(heatmap.days[0].pomodoros_completed, 2);
+        assert_eq!(heatmap.days[0].focused_minutes(), 60);
+        assert_eq!(heatmap.days[1].day, 2);
+        assert_eq!(heatmap.days[1].focused_minutes(), 0);
+        assert_eq!(heatmap.days[2].day, 3);
+        assert_eq!(heatmap.days[2].focused_minutes(), 45);
+    }
+
+    #[test]
+    fn profile_totals_groups_by_profile_and_unknown() {
+        let mut stats = FocusStats::default();
+        let goal = DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        };
+        stats.record_completed_pomodoro_with_task(
+            "2026-04-09",
+            goal,
+            Some("Project A"),
+            50 * 60,
+            Some(ProfileId::DeepWork),
+        );
+        stats.record_completed_pomodoro_with_task(
+            "2026-04-10",
+            goal,
+            Some("Project B"),
+            25 * 60,
+            Some(ProfileId::Classic),
+        );
+        stats.record_completed_pomodoro_with_task(
+            "2026-04-11",
+            goal,
+            Some("Project C"),
+            40 * 60,
+            None,
+        );
+
+        let totals = stats.profile_totals();
+        assert_eq!(totals.len(), 3);
+        let deep_work = totals
+            .iter()
+            .find(|entry| entry.profile == ProfileBucket::DeepWork)
+            .copied()
+            .unwrap();
+        let classic = totals
+            .iter()
+            .find(|entry| entry.profile == ProfileBucket::Classic)
+            .copied()
+            .unwrap();
+        let unknown = totals
+            .iter()
+            .find(|entry| entry.profile == ProfileBucket::Unknown)
+            .copied()
+            .unwrap();
+
+        assert_eq!(deep_work.pomodoros_completed, 1);
+        assert_eq!(deep_work.focused_minutes(), 50);
+        assert_eq!(classic.pomodoros_completed, 1);
+        assert_eq!(classic.focused_minutes(), 25);
+        assert_eq!(unknown.pomodoros_completed, 1);
+        assert_eq!(unknown.focused_minutes(), 40);
+    }
+
+    #[test]
     fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
         let mut stats = FocusStats::default();
         let goal = DailyGoalSnapshot {
@@ -1114,7 +1482,13 @@ mod tests {
             pomodoros: 1,
         };
         stats.record_focus_elapsed("2026-04-06", 30 * 60, goal);
-        stats.record_completed_pomodoro_with_task("2026-04-06", goal, Some("Project A"), 30 * 60);
+        stats.record_completed_pomodoro_with_task(
+            "2026-04-06",
+            goal,
+            Some("Project A"),
+            30 * 60,
+            Some(ProfileId::Classic),
+        );
         stats.record_break_glass_override_event(
             "2026-04-06",
             1_711_000_000,
@@ -1149,6 +1523,7 @@ mod tests {
         assert_eq!(weekly[0]["focused_minutes"], 75);
         assert_eq!(sessions[0]["task_label"], "Project A");
         assert_eq!(sessions[0]["focused_minutes"], 30);
+        assert_eq!(sessions[0]["profile"], "classic");
         assert_eq!(overrides[0]["duration_seconds"], 300);
         assert_eq!(overrides[0]["task_label"], "Project A");
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1152,7 +1152,7 @@ fn render_monthly_heatmap_panel(frame: &mut Frame, area: Rect, app: &App) {
     }
 
     lines.push(Line::styled(
-        "  Low  .  :  *  O  #  High",
+        "  None  .   Low  :  *  O  #  High",
         Style::default().fg(Color::DarkGray),
     ));
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -917,7 +917,7 @@ fn render_session_planner_hints(frame: &mut Frame, app: &App, area: Rect) {
 
 fn render_stats_history(frame: &mut Frame, app: &App) {
     let area = frame.area();
-    let outer = centered_rect(65, 80, area);
+    let outer = centered_rect(86, 84, area);
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -933,7 +933,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
             Constraint::Length(1), // session + today summary
             Constraint::Length(1), // goal + streak summary
             Constraint::Length(1), // spacer
-            Constraint::Min(3),    // history list
+            Constraint::Min(8),    // history panels
             Constraint::Length(2), // status line
             Constraint::Length(2), // hints
         ])
@@ -961,21 +961,25 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
 
     let history_layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
+        .constraints([Constraint::Percentage(56), Constraint::Percentage(44)])
         .split(inner[3]);
 
-    let history_sections = Layout::default()
+    let top_sections = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(42), Constraint::Percentage(58)])
+        .constraints([
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
         .split(history_layout[0]);
 
-    let weekly_items: Vec<ListItem> = app
-        .recent_weekly_stats(6)
+    let monthly_items: Vec<ListItem> = app
+        .recent_monthly_stats(6)
         .into_iter()
         .map(|stats| {
             ListItem::new(format!(
                 "  {}   🍅{}   {}m",
-                format_week_label(stats.year, stats.week),
+                format_month_label(stats.year, stats.month),
                 stats.pomodoros_completed,
                 stats.focused_minutes()
             ))
@@ -983,11 +987,38 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .collect();
     render_history_panel(
         frame,
-        history_sections[0],
-        " Weekly Totals ",
-        weekly_items,
-        "  No weekly totals yet.",
+        top_sections[0],
+        " Monthly Trend ",
+        monthly_items,
+        "  No monthly totals yet.",
     );
+
+    render_monthly_heatmap_panel(frame, top_sections[1], app);
+
+    let profile_items: Vec<ListItem> = app
+        .profile_focus_totals()
+        .into_iter()
+        .map(|stats| {
+            ListItem::new(format!(
+                "  {:<9}  🍅{}   {}m",
+                stats.profile.label(),
+                stats.pomodoros_completed,
+                stats.focused_minutes()
+            ))
+        })
+        .collect();
+    render_history_panel(
+        frame,
+        top_sections[2],
+        " Profile Totals ",
+        profile_items,
+        "  No profile totals yet.",
+    );
+
+    let bottom_sections = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(56), Constraint::Percentage(44)])
+        .split(history_layout[1]);
 
     let history_items: Vec<ListItem> = app
         .recent_daily_stats(10)
@@ -1002,7 +1033,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .collect();
     render_history_panel(
         frame,
-        history_sections[1],
+        bottom_sections[0],
         " Recent Days ",
         history_items,
         "  No completed focus history yet.",
@@ -1024,7 +1055,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .collect();
     render_history_panel(
         frame,
-        history_layout[1],
+        bottom_sections[1],
         " Break-glass Audit ",
         override_items,
         "  No break-glass overrides yet.",
@@ -1080,6 +1111,56 @@ fn render_history_panel(
             .style(Style::default().fg(Color::Gray));
         frame.render_widget(list, area);
     }
+}
+
+fn render_monthly_heatmap_panel(frame: &mut Frame, area: Rect, app: &App) {
+    let heatmap = app.latest_monthly_heatmap();
+    let title = format!(
+        " Heatmap {} ",
+        format_month_label(heatmap.year, heatmap.month)
+    );
+    let mut lines: Vec<Line> = vec![Line::styled(
+        "  Mo Tu We Th Fr Sa Su",
+        Style::default().fg(Color::DarkGray),
+    )];
+
+    let mut weekday = heatmap.first_weekday_monday0 as usize;
+    let mut week_spans = vec![Span::raw("  ")];
+    for _ in 0..weekday {
+        week_spans.push(Span::raw("   "));
+    }
+    for day in heatmap.days {
+        let (symbol, color) =
+            heatmap_cell_symbol(day.focused_minutes(), heatmap.max_focused_minutes);
+        week_spans.push(Span::styled(
+            format!("{symbol}  "),
+            Style::default().fg(color),
+        ));
+        if weekday == 6 {
+            lines.push(Line::from(week_spans));
+            week_spans = vec![Span::raw("  ")];
+            weekday = 0;
+        } else {
+            weekday += 1;
+        }
+    }
+    if weekday != 0 {
+        for _ in weekday..7 {
+            week_spans.push(Span::raw("   "));
+        }
+        lines.push(Line::from(week_spans));
+    }
+
+    lines.push(Line::styled(
+        "  Low  .  :  *  O  #  High",
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    let widget = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .style(Style::default().fg(Color::Gray))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(widget, area);
 }
 
 fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
@@ -1222,8 +1303,24 @@ fn format_history_goal_streak_line(app: &App) -> String {
     }
 }
 
-fn format_week_label(year: i32, week: u32) -> String {
-    format!("{year:04}-W{week:02}")
+fn heatmap_cell_symbol(focused_minutes: u64, max_focused_minutes: u64) -> (char, Color) {
+    if focused_minutes == 0 || max_focused_minutes == 0 {
+        return ('.', Color::DarkGray);
+    }
+
+    let scaled = (focused_minutes.saturating_mul(4))
+        .saturating_add(max_focused_minutes.saturating_sub(1))
+        / max_focused_minutes;
+    match scaled.clamp(1, 4) {
+        1 => (':', Color::Green),
+        2 => ('*', Color::Yellow),
+        3 => ('O', Color::LightRed),
+        _ => ('#', Color::Red),
+    }
+}
+
+fn format_month_label(year: i32, month: u32) -> String {
+    format!("{year:04}-{month:02}")
 }
 
 fn phase_color(phase: TimerPhase) -> Color {
@@ -1401,7 +1498,7 @@ mod tests {
     }
 
     #[test]
-    fn history_view_renders_weekly_summary_panel() {
+    fn history_view_renders_monthly_heatmap_and_profile_panels() {
         let width = 100;
         let height = 24;
         let backend = TestBackend::new(width, height);
@@ -1430,9 +1527,11 @@ mod tests {
             .expect("render should succeed");
 
         let text = terminal_text(&terminal, width, height);
-        assert!(text.contains("Weekly Totals"));
+        assert!(text.contains("Monthly Trend"));
+        assert!(text.contains("Heatmap 2026-04"));
+        assert!(text.contains("Profile Totals"));
         assert!(text.contains("Break-glass Audit"));
-        assert!(text.contains(&format_week_label(2026, 15)));
+        assert!(text.contains(&format_month_label(2026, 4)));
         assert!(text.contains("75m"));
     }
 
@@ -1489,8 +1588,8 @@ mod tests {
     }
 
     #[test]
-    fn week_label_uses_zero_padded_iso_format() {
-        assert_eq!(format_week_label(2026, 5), "2026-W05");
+    fn month_label_uses_zero_padded_iso_format() {
+        assert_eq!(format_month_label(2026, 5), "2026-05");
     }
 
     #[test]


### PR DESCRIPTION
## What

Implements History v2 with richer insights in the TUI history screen.

- Adds monthly trend aggregation and rendering.
- Adds a monthly calendar heatmap panel for daily focus intensity.
- Adds per-profile focus totals (Classic, Deep Work, Custom, Unknown).
- Persists active profile metadata on completed focus sessions to power profile totals.
- Expands history tests across stats, app, and UI to cover new behavior and legacy compatibility.

## Why

Issue #112 requests richer historical summaries beyond recent days and weekly totals. This update makes long-term progress and profile-level patterns visible directly in the History view while preserving existing history/export workflows.

Closes #112

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable) - N/A (unchanged)
- [x] WakaTime integration behavior was verified for this change (if applicable) - N/A (unchanged)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable) - N/A (no shortcut or workflow changes)
- [x] New dependencies/configuration are documented (if applicable) - N/A (none added)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) - N/A (no security-sensitive surface changes)
- [x] Breaking behavior changes are clearly described in this PR - N/A (no breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monthly statistics view replaces weekly summaries.
  * Visual heatmap showing daily focus patterns for the latest month.
  * Profile Totals panel showing cumulative focus time per profile type.
  * Focus session tracking now attributes completed sessions to the active profile.

* **UI**
  * History layout and panels rebalanced to surface monthly trend, heatmap, and profile totals.

* **Tests**
  * Updated tests to cover new monthly/heatmap/profile UI labels and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->