### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,64 +10,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.1] - 2026-04-20
 
 ### Added
+
 - **History v2 monthly insights (#129):** introduced monthly trend and heatmap views in History for faster long-horizon focus analysis.
 - **In-app WakaTime metadata editor (#130):** added editable WakaTime project/language fields in the profile settings flow.
-- **Focus intention export fields (#131):** exported `focus_intention` and `task_note` alongside `task_label` in stats export outputs.
+- **Focus intention export fields (#131):** added `focus_intention` and `task_note` alongside `task_label` in stats export file outputs (JSON/CSV)
 
 ### Changed
+
 - **WakaTime metadata editor quit handling:** preserved timer-view quit behavior while editing metadata fields.
 
 ## [0.4.0] - 2026-04-18
 
 ### Added
+
 - **Session planner workflow (#120):** introduced timer-integrated task labeling with required task selection before starting focus sessions.
 - **Blocklist profile management (#121):** added create/rename/delete/switch flows for named site-blocking profiles in the site manager.
 - **Break-glass override for focus blocking (#122):** added explicit two-step temporary unblock control with automatic re-enable countdown during active focus sessions.
 
 ### Changed
+
 - **Timer layout and UX polish:** improved timer screen readability and spacing in timer and session-planner views.
 - **v0.4.0 documentation refresh (#127):** updated README demo screenshots to reflect the latest UI.
 
 ## [0.3.2] - 2026-04-16
 
 ### Added
+
 - **Stats export from History (#105):** added `e` shortcut in History view to export persisted focus data as `focustime-stats.json` and `focustime-stats.csv` in the current working directory.
 - **Configurable WakaTime metadata labels (#106):** added optional `[wakatime]` `project` and `language` config fields so heartbeat labels can be customized while preserving default behavior.
 
 ### Changed
+
 - **Stats export documentation polish:** clarified Windows export overwrite behavior in user-facing docs.
 
 ## [0.3.1] - 2026-04-16
 
 ### Added
+
 - **Streak tracking (#101):** added current-streak and best-streak tracking based on completed daily focus goals while preserving historical accuracy when goals change later.
 - **Weekly history summaries (#102):** added weekly aggregation of focused minutes and completed Pomodoros in the History view.
 
 ## [0.3.0] - 2026-04-15
 
 ### Added
+
 - **Daily focus goals and live progress (#92):** introduced configurable daily minute/pomodoro goals with live progress shown in timer and history views.
 - **Auto-start phase options (#93):** added opt-in auto-start controls for focus-to-break and break-to-focus transitions on natural (non-catchup) completions.
 - **Setup diagnostics screen (#96):** added in-app diagnostics for blocking permissions, hosts file write access, and WakaTime configuration readiness.
 - **WakaTime success timestamp visibility (#95):** surfaced the last successful heartbeat time in the timer status line when tracking is configured.
 
 ### Changed
+
 - **Windows keyboard input handling (#94):** fixed duplicate key processing on Windows and added regression coverage for key filtering behavior.
 - **v0.3.0 visual documentation refresh (#99):** updated README screenshots to reflect current UI and workflows.
 
 ## [0.2.1] - 2026-04-13
 
 ### Added
+
 - **Strict focus mode safeguards (#74):** optional strict mode now blocks skip/profile/quit shortcuts during active focus and requires explicit confirmation before stop/reset.
 - **SonarCloud analysis pipeline (#75):** added SonarCloud workflow and project configuration for continuous quality checks on pushes and pull requests.
 
 ### Changed
+
 - **WakaTime tracking reliability and visibility (#72):** improved heartbeat retry behavior and surfaced clearer runtime tracking/retrying/error status in the timer view.
 - **Site manager bulk import and editing flow (#73):** added comma/newline batch input support with stronger inline validation and duplicate handling.
 
 ## [0.2.0] - 2026-04-10
 
 ### Added
+
 - **Persistent settings and blocked sites (#50):** timer preferences, selected profile, notification settings, and blocked-site lists are now saved to `config.toml` and restored at startup with safe fallback defaults for missing/corrupt config.
 - **Configurable Pomodoro profiles (#51):** includes built-in **Classic** and **Deep Work** presets plus an editable **Custom** profile with configurable focus/short-break/long-break durations and long-break cadence.
 - **Session stats and daily history (#52):** tracks focused time and completed Pomodoros for the active session and per-day aggregates, then surfaces them in the timer summary and history view.
@@ -77,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2026-04-06
 
 ### Added
+
 - Initial release of `focustime` as a Rust TUI application.
 - Pomodoro timer with focus, short break, and long break session flow.
 - Distraction website blocking through hosts file updates during focus sessions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-20
+
+### Added
+- **History v2 monthly insights (#129):** introduced monthly trend and heatmap views in History for faster long-horizon focus analysis.
+- **In-app WakaTime metadata editor (#130):** added editable WakaTime project/language fields in the profile settings flow.
+- **Focus intention export fields (#131):** exported `focus_intention` and `task_note` alongside `task_label` in stats export outputs.
+
+### Changed
+- **WakaTime metadata editor quit handling:** preserved timer-view quit behavior while editing metadata fields.
+
 ## [0.4.0] - 2026-04-18
 
 ### Added
@@ -73,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/utilForever/focustime/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/utilForever/focustime/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/utilForever/focustime/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/utilForever/focustime/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -337,12 +337,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.4.0`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.4.1`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.4.0](https://github.com/utilForever/focustime/releases/tag/v0.4.0).
+The latest stable release is [v0.4.1](https://github.com/utilForever/focustime/releases/tag/v0.4.1).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Bumps project release metadata and user-facing release references from `v0.4.0` to `v0.4.1`, and adds a `0.4.1` changelog section with compare-link roll-forward.

## Why

Issue #125 requested the v0.4.1 release update across the manifest and documentation so versioned release information is consistent and current.

Closes #125

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable) - N/A (no runtime behavior changes)
- [x] Site blocking behavior was verified for this change (if applicable) - N/A (no runtime behavior changes)
- [x] WakaTime integration behavior was verified for this change (if applicable) - N/A (no runtime behavior changes)
- [x] I added or updated tests for changed behavior (if applicable) - N/A (release metadata/docs only)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) - N/A
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) - N/A for this scope
- [x] Breaking behavior changes are clearly described in this PR - N/A (no breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monthly trend and heatmap insights in History v2
  * In-app WakaTime metadata editor (editable project and language)
  * Additional exported fields: focus_intention and task_note (JSON/CSV)

* **Behavior Changes**
  * Timer-view quit behavior is preserved while editing WakaTime metadata

* **Chore**
  * Release bumped to v0.4.1 and changelog/README updated
<!-- end of auto-generated comment: release notes by coderabbit.ai -->