### PR TITLE
Add CLI automation commands for start/profile/status/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ cargo run -- --start
 # Show or set the active profile
 cargo run -- --profile
 cargo run -- --profile deep-work
+cargo run -- --profile --json
 
 # Show persisted status (text or JSON)
 cargo run -- --status

--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ cd focustime
 cargo run
 ```
 
+## CLI automation commands
+
+`focustime` supports non-interactive CLI commands for scripting and automation.
+
+```sh
+# Launch TUI with focus timer already started
+cargo run -- --start
+
+# Show or set the active profile
+cargo run -- --profile
+cargo run -- --profile deep-work
+
+# Show persisted status (text or JSON)
+cargo run -- --status
+cargo run -- --status --json
+
+# Export stats to current directory or a target directory
+cargo run -- --export
+cargo run -- --export=./reports --json
+```
+
+When no CLI command is provided, `focustime` keeps the default interactive TUI mode.
+
 > Site blocking updates your OS hosts file and may require elevated privileges
 > (`sudo`/Administrator). If permissions are insufficient, timer functionality
 > still works, but blocking operations can fail.

--- a/src/app.rs
+++ b/src/app.rs
@@ -542,6 +542,20 @@ impl App {
         self.sync_break_glass_override();
     }
 
+    pub fn start_focus_for_cli(&mut self) -> Result<(), String> {
+        if self.timer.phase != TimerPhase::Focus || self.timer.status != TimerStatus::Idle {
+            return Err("Cannot start focus: timer is not idle in focus phase.".to_string());
+        }
+        if self.selected_task_label.is_none() {
+            return Err(
+                "Cannot start focus: select a task label first (run TUI and press [t])."
+                    .to_string(),
+            );
+        }
+        self.update_timer_and_sync(TimerState::toggle_pause);
+        Ok(())
+    }
+
     pub fn selected_profile_name(&self) -> &'static str {
         self.selected_profile.label()
     }
@@ -4093,6 +4107,28 @@ mod tests {
             app.phase_notification.as_deref(),
             Some("Select a task label with [t] before starting focus.")
         );
+    }
+
+    #[test]
+    fn cli_start_fails_without_selected_task_label() {
+        let mut app = App::default();
+
+        let result = app.start_focus_for_cli();
+
+        assert!(result.is_err());
+        assert_eq!(app.timer.status, TimerStatus::Idle);
+    }
+
+    #[test]
+    fn cli_start_begins_focus_when_task_label_exists() {
+        let mut app = App::default();
+        app.selected_task_label = Some("Docs".to_string());
+
+        let result = app.start_focus_for_cli();
+
+        assert!(result.is_ok());
+        assert_eq!(app.timer.status, TimerStatus::Running);
+        assert_eq!(app.active_focus_task_label, Some("Docs".to_string()));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,18 @@ enum PrimaryCommand {
     Export(Option<PathBuf>),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ParsedToken {
+    Help,
+    Json,
+    Start,
+    Status,
+    Profile(Option<ProfileId>),
+    Export(Option<PathBuf>),
+    UnknownOption(String),
+    Positional(String),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 struct ProfileSpec {
     focus_secs: u64,
@@ -135,74 +147,113 @@ where
         .into_iter()
         .map(|arg| arg.to_string_lossy().to_string())
         .collect();
-    let mut output = OutputMode::Text;
-    let mut show_help = false;
-    let mut primary: Option<PrimaryCommand> = None;
-    let mut index = 0usize;
+    let tokens = classify_args(&args)?;
+    let (show_help, output) = parse_global_tokens(&tokens)?;
+    let primary = parse_primary_command(&tokens)?;
+    finalize_cli_action(show_help, output, primary)
+}
 
+fn classify_args(args: &[String]) -> Result<Vec<ParsedToken>, String> {
+    let mut tokens = Vec::new();
+    let mut index = 0usize;
     while index < args.len() {
         let arg = &args[index];
-        match arg.as_str() {
-            "-h" | "--help" => {
-                show_help = true;
+        if arg == "-h" || arg == "--help" {
+            tokens.push(ParsedToken::Help);
+        } else if arg == "--json" {
+            tokens.push(ParsedToken::Json);
+        } else if arg == "--start" {
+            tokens.push(ParsedToken::Start);
+        } else if arg == "--status" {
+            tokens.push(ParsedToken::Status);
+        } else if arg == "--profile" {
+            let mut selected = None;
+            if let Some(next) = args.get(index + 1)
+                && !next.starts_with('-')
+            {
+                selected = Some(parse_profile_id(next)?);
+                index += 1;
             }
-            "--json" => {
-                output = OutputMode::Json;
+            tokens.push(ParsedToken::Profile(selected));
+        } else if arg == "--export" {
+            let mut export_dir = None;
+            if let Some(next) = args.get(index + 1)
+                && !next.starts_with('-')
+            {
+                export_dir = Some(PathBuf::from(next));
+                index += 1;
             }
-            "--start" => {
-                set_primary_command(&mut primary, PrimaryCommand::Start)?;
+            tokens.push(ParsedToken::Export(export_dir));
+        } else if let Some(value) = arg.strip_prefix("--profile=") {
+            if value.trim().is_empty() {
+                return Err(invalid_usage("`--profile=` requires a profile value."));
             }
-            "--status" => {
-                set_primary_command(&mut primary, PrimaryCommand::Status)?;
+            tokens.push(ParsedToken::Profile(Some(parse_profile_id(value)?)));
+        } else if let Some(value) = arg.strip_prefix("--export=") {
+            if value.trim().is_empty() {
+                return Err(invalid_usage("`--export=` requires a target directory."));
             }
-            "--profile" => {
-                let mut selected = None;
-                if let Some(next) = args.get(index + 1)
-                    && !next.starts_with('-')
-                {
-                    selected = Some(parse_profile_id(next)?);
-                    index += 1;
-                }
-                set_primary_command(&mut primary, PrimaryCommand::Profile(selected))?;
-            }
-            "--export" => {
-                let mut export_dir = None;
-                if let Some(next) = args.get(index + 1)
-                    && !next.starts_with('-')
-                {
-                    export_dir = Some(PathBuf::from(next));
-                    index += 1;
-                }
-                set_primary_command(&mut primary, PrimaryCommand::Export(export_dir))?;
-            }
-            _ => {
-                if let Some(value) = arg.strip_prefix("--profile=") {
-                    if value.trim().is_empty() {
-                        return Err(invalid_usage("`--profile=` requires a profile value."));
-                    }
-                    let parsed = parse_profile_id(value)?;
-                    set_primary_command(&mut primary, PrimaryCommand::Profile(Some(parsed)))?;
-                } else if let Some(value) = arg.strip_prefix("--export=") {
-                    if value.trim().is_empty() {
-                        return Err(invalid_usage("`--export=` requires a target directory."));
-                    }
-                    set_primary_command(
-                        &mut primary,
-                        PrimaryCommand::Export(Some(PathBuf::from(value))),
-                    )?;
-                } else if arg.starts_with('-') {
-                    return Err(invalid_usage(&format!("Unknown option `{arg}`.")));
-                } else {
-                    return Err(invalid_usage(&format!(
-                        "Unexpected positional argument `{arg}`."
-                    )));
-                }
-            }
+            tokens.push(ParsedToken::Export(Some(PathBuf::from(value))));
+        } else if arg.starts_with('-') {
+            tokens.push(ParsedToken::UnknownOption(arg.clone()));
+        } else {
+            tokens.push(ParsedToken::Positional(arg.clone()));
         }
-
         index += 1;
     }
+    Ok(tokens)
+}
 
+fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), String> {
+    let mut show_help = false;
+    let mut output = OutputMode::Text;
+    for token in tokens {
+        match token {
+            ParsedToken::Help => show_help = true,
+            ParsedToken::Json => output = OutputMode::Json,
+            ParsedToken::UnknownOption(option) => {
+                return Err(invalid_usage(&format!("Unknown option `{option}`.")));
+            }
+            ParsedToken::Positional(value) => {
+                return Err(invalid_usage(&format!(
+                    "Unexpected positional argument `{value}`."
+                )));
+            }
+            ParsedToken::Start
+            | ParsedToken::Status
+            | ParsedToken::Profile(_)
+            | ParsedToken::Export(_) => {}
+        }
+    }
+    Ok((show_help, output))
+}
+
+fn parse_primary_command(tokens: &[ParsedToken]) -> Result<Option<PrimaryCommand>, String> {
+    let mut primary: Option<PrimaryCommand> = None;
+    for token in tokens {
+        match token {
+            ParsedToken::Start => set_primary_command(&mut primary, PrimaryCommand::Start)?,
+            ParsedToken::Status => set_primary_command(&mut primary, PrimaryCommand::Status)?,
+            ParsedToken::Profile(profile) => {
+                set_primary_command(&mut primary, PrimaryCommand::Profile(*profile))?
+            }
+            ParsedToken::Export(dir) => {
+                set_primary_command(&mut primary, PrimaryCommand::Export(dir.clone()))?
+            }
+            ParsedToken::Help
+            | ParsedToken::Json
+            | ParsedToken::UnknownOption(_)
+            | ParsedToken::Positional(_) => {}
+        }
+    }
+    Ok(primary)
+}
+
+fn finalize_cli_action(
+    show_help: bool,
+    output: OutputMode,
+    primary: Option<PrimaryCommand>,
+) -> Result<CliAction, String> {
     if show_help {
         return Ok(CliAction::ShowHelp);
     }
@@ -326,7 +377,11 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let active_sites_count = config
         .blocklist_profiles
         .iter()
-        .find(|profile| profile.name == config.selected_blocklist_profile)
+        .find(|profile| {
+            profile
+                .name
+                .eq_ignore_ascii_case(&config.selected_blocklist_profile)
+        })
         .map(|profile| profile.sites.len())
         .unwrap_or_default();
 
@@ -657,5 +712,22 @@ mod tests {
     fn parse_rejects_json_with_start() {
         let error = parse(&["--start", "--json"]).unwrap_err();
         assert!(error.contains("not supported with `--start`"));
+    }
+
+    #[test]
+    fn build_status_output_matches_blocklist_profile_case_insensitively() {
+        let config = AppConfig {
+            blocklist_profiles: vec![crate::config::BlocklistProfileConfig {
+                name: "Work".to_string(),
+                sites: vec!["youtube.com".to_string(), "reddit.com".to_string()],
+            }],
+            selected_blocklist_profile: "work".to_string(),
+            ..AppConfig::default()
+        };
+        let stats = FocusStats::default();
+
+        let output = build_status_output(&config, &stats);
+
+        assert_eq!(output.blocked_sites_count, 2);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -157,51 +157,76 @@ fn classify_args(args: &[String]) -> Result<Vec<ParsedToken>, String> {
     let mut tokens = Vec::new();
     let mut index = 0usize;
     while index < args.len() {
-        let arg = &args[index];
-        if arg == "-h" || arg == "--help" {
-            tokens.push(ParsedToken::Help);
-        } else if arg == "--json" {
-            tokens.push(ParsedToken::Json);
-        } else if arg == "--start" {
-            tokens.push(ParsedToken::Start);
-        } else if arg == "--status" {
-            tokens.push(ParsedToken::Status);
-        } else if arg == "--profile" {
-            let mut selected = None;
-            if let Some(next) = args.get(index + 1)
-                && !next.starts_with('-')
-            {
-                selected = Some(parse_profile_id(next)?);
-                index += 1;
-            }
-            tokens.push(ParsedToken::Profile(selected));
-        } else if arg == "--export" {
-            let mut export_dir = None;
-            if let Some(next) = args.get(index + 1)
-                && !next.starts_with('-')
-            {
-                export_dir = Some(PathBuf::from(next));
-                index += 1;
-            }
-            tokens.push(ParsedToken::Export(export_dir));
-        } else if let Some(value) = arg.strip_prefix("--profile=") {
-            if value.trim().is_empty() {
-                return Err(invalid_usage("`--profile=` requires a profile value."));
-            }
-            tokens.push(ParsedToken::Profile(Some(parse_profile_id(value)?)));
-        } else if let Some(value) = arg.strip_prefix("--export=") {
-            if value.trim().is_empty() {
-                return Err(invalid_usage("`--export=` requires a target directory."));
-            }
-            tokens.push(ParsedToken::Export(Some(PathBuf::from(value))));
-        } else if arg.starts_with('-') {
-            tokens.push(ParsedToken::UnknownOption(arg.clone()));
-        } else {
-            tokens.push(ParsedToken::Positional(arg.clone()));
-        }
-        index += 1;
+        let (token, consumed) = classify_arg(args, index)?;
+        tokens.push(token);
+        index += consumed;
     }
     Ok(tokens)
+}
+
+fn classify_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    let arg = &args[index];
+    if let Some(token) = classify_simple_flag(arg) {
+        return Ok((token, 1));
+    }
+    if arg == "--profile" {
+        return classify_profile_arg(args, index);
+    }
+    if arg == "--export" {
+        return classify_export_arg(args, index);
+    }
+    if let Some(token) = classify_key_value_arg(arg)? {
+        return Ok((token, 1));
+    }
+    if arg.starts_with('-') {
+        return Ok((ParsedToken::UnknownOption(arg.clone()), 1));
+    }
+    Ok((ParsedToken::Positional(arg.clone()), 1))
+}
+
+fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
+    match arg {
+        "-h" | "--help" => Some(ParsedToken::Help),
+        "--json" => Some(ParsedToken::Json),
+        "--start" => Some(ParsedToken::Start),
+        "--status" => Some(ParsedToken::Status),
+        _ => None,
+    }
+}
+
+fn classify_profile_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let selected = parse_profile_id(next)?;
+        return Ok((ParsedToken::Profile(Some(selected)), 2));
+    }
+    Ok((ParsedToken::Profile(None), 1))
+}
+
+fn classify_export_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((ParsedToken::Export(Some(PathBuf::from(next))), 2));
+    }
+    Ok((ParsedToken::Export(None), 1))
+}
+
+fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--profile=") {
+        if value.trim().is_empty() {
+            return Err(invalid_usage("`--profile=` requires a profile value."));
+        }
+        return Ok(Some(ParsedToken::Profile(Some(parse_profile_id(value)?))));
+    }
+    if let Some(value) = arg.strip_prefix("--export=") {
+        if value.trim().is_empty() {
+            return Err(invalid_usage("`--export=` requires a target directory."));
+        }
+        return Ok(Some(ParsedToken::Export(Some(PathBuf::from(value)))));
+    }
+    Ok(None)
 }
 
 fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,8 +145,11 @@ where
 {
     let args: Vec<String> = args
         .into_iter()
-        .map(|arg| arg.to_string_lossy().to_string())
-        .collect();
+        .map(|arg| {
+            arg.into_string()
+                .map_err(|_| invalid_usage("Arguments must be valid UTF-8."))
+        })
+        .collect::<Result<_, _>>()?;
     let tokens = classify_args(&args)?;
     let (show_help, output) = parse_global_tokens(&tokens)?;
     let primary = parse_primary_command(&tokens)?;
@@ -707,6 +710,50 @@ mod tests {
                 output: OutputMode::Text
             })
         );
+    }
+
+    #[test]
+    fn parse_export_with_equals_accepts_directory() {
+        let parsed = parse(&["--export=reports"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Export {
+                    dir: Some(PathBuf::from("reports"))
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn classify_key_value_arg_accepts_profile_equals_value() {
+        let parsed = classify_key_value_arg("--profile=deep-work").unwrap();
+        assert_eq!(
+            parsed,
+            Some(ParsedToken::Profile(Some(ProfileId::DeepWork)))
+        );
+    }
+
+    #[test]
+    fn classify_key_value_arg_rejects_empty_profile_equals_value() {
+        let error = classify_key_value_arg("--profile=").unwrap_err();
+        assert!(error.contains("`--profile=` requires a profile value."));
+    }
+
+    #[test]
+    fn classify_key_value_arg_accepts_export_equals_value() {
+        let parsed = classify_key_value_arg("--export=reports").unwrap();
+        assert_eq!(
+            parsed,
+            Some(ParsedToken::Export(Some(PathBuf::from("reports"))))
+        );
+    }
+
+    #[test]
+    fn classify_key_value_arg_rejects_empty_export_equals_value() {
+        let error = classify_key_value_arg("--export=").unwrap_err();
+        assert!(error.contains("`--export=` requires a target directory."));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -233,11 +233,17 @@ fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
 }
 
 fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), String> {
-    let mut show_help = false;
+    let show_help = tokens
+        .iter()
+        .any(|token| matches!(token, ParsedToken::Help));
+    if show_help {
+        return Ok((true, OutputMode::Text));
+    }
+
     let mut output = OutputMode::Text;
     for token in tokens {
         match token {
-            ParsedToken::Help => show_help = true,
+            ParsedToken::Help => {}
             ParsedToken::Json => output = OutputMode::Json,
             ParsedToken::UnknownOption(option) => {
                 return Err(invalid_usage(&format!("Unknown option `{option}`.")));
@@ -619,6 +625,8 @@ fn invalid_usage(message: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStringExt;
 
     fn parse(values: &[&str]) -> Result<CliAction, String> {
         parse_args(values.iter().map(OsString::from))
@@ -653,6 +661,18 @@ mod tests {
             parsed,
             CliAction::RunCommand(CliCommand {
                 kind: CommandKind::Status,
+                output: OutputMode::Json
+            })
+        );
+    }
+
+    #[test]
+    fn parse_profile_supports_json_mode() {
+        let parsed = parse(&["--profile", "--json"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Profile { profile: None },
                 output: OutputMode::Json
             })
         );
@@ -763,6 +783,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_help_short_circuits_unknown_arguments() {
+        let parsed = parse(&["--help", "--unknown"]).unwrap();
+        assert_eq!(parsed, CliAction::ShowHelp);
+    }
+
+    #[test]
     fn parse_rejects_multiple_primary_commands() {
         let error = parse(&["--status", "--export"]).unwrap_err();
         assert!(error.contains("Multiple primary commands"));
@@ -784,6 +810,14 @@ mod tests {
     fn parse_rejects_json_with_start() {
         let error = parse(&["--start", "--json"]).unwrap_err();
         assert!(error.contains("not supported with `--start`"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parse_rejects_non_utf8_arguments() {
+        let invalid = OsString::from_vec(vec![0x66, 0x6f, 0x80]);
+        let error = parse_args(vec![invalid]).unwrap_err();
+        assert!(error.contains("Arguments must be valid UTF-8."));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,661 @@
+use std::{env, ffi::OsString, path::PathBuf};
+
+use serde::Serialize;
+
+use crate::config::{AppConfig, CustomProfileConfig, ProfileId};
+use crate::stats::{DailyGoalSnapshot, FocusStats, current_day_key};
+use crate::timer::{
+    DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
+    DEFAULT_SHORT_BREAK_SECS,
+};
+
+const USAGE_TEXT: &str = r#"Usage:
+  focustime
+  focustime --start
+  focustime --profile [classic|deep-work|custom]
+  focustime --status [--json]
+  focustime --export[=DIR] [--json]
+
+Options:
+  --start    Launch TUI with focus timer already started
+  --profile  Show current profile, or set it when value is provided
+  --status   Print persisted status summary
+  --export   Export stats to current directory or DIR
+  --json     Emit machine-readable JSON output
+  -h, --help Show this help"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputMode {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandKind {
+    Profile { profile: Option<ProfileId> },
+    Status,
+    Export { dir: Option<PathBuf> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliCommand {
+    pub kind: CommandKind,
+    pub output: OutputMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CliAction {
+    RunTui { start_immediately: bool },
+    RunCommand(CliCommand),
+    ShowHelp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PrimaryCommand {
+    Start,
+    Profile(Option<ProfileId>),
+    Status,
+    Export(Option<PathBuf>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct ProfileSpec {
+    focus_secs: u64,
+    short_break_secs: u64,
+    long_break_secs: u64,
+    long_break_interval: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ProfileView {
+    id: &'static str,
+    label: &'static str,
+    focus_secs: u64,
+    short_break_secs: u64,
+    long_break_secs: u64,
+    long_break_interval: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ProfileOutput {
+    updated: bool,
+    selected: ProfileView,
+    available: Vec<ProfileView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct GoalOutput {
+    configured: bool,
+    minutes_target: u64,
+    pomodoros_target: u32,
+    met: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SessionOutput {
+    focused_minutes: u64,
+    pomodoros_completed: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TodayOutput {
+    focused_minutes: u64,
+    pomodoros_completed: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct StatusOutput {
+    day: String,
+    selected_profile: ProfileView,
+    selected_task_label: Option<String>,
+    selected_blocklist_profile: String,
+    blocked_sites_count: usize,
+    strict_mode: bool,
+    goal: GoalOutput,
+    session: SessionOutput,
+    today: TodayOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ExportOutput {
+    export_dir: PathBuf,
+    json_path: PathBuf,
+    csv_path: PathBuf,
+}
+
+pub fn usage_text() -> &'static str {
+    USAGE_TEXT
+}
+
+pub fn parse_args<I>(args: I) -> Result<CliAction, String>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let args: Vec<String> = args
+        .into_iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+    let mut output = OutputMode::Text;
+    let mut show_help = false;
+    let mut primary: Option<PrimaryCommand> = None;
+    let mut index = 0usize;
+
+    while index < args.len() {
+        let arg = &args[index];
+        match arg.as_str() {
+            "-h" | "--help" => {
+                show_help = true;
+            }
+            "--json" => {
+                output = OutputMode::Json;
+            }
+            "--start" => {
+                set_primary_command(&mut primary, PrimaryCommand::Start)?;
+            }
+            "--status" => {
+                set_primary_command(&mut primary, PrimaryCommand::Status)?;
+            }
+            "--profile" => {
+                let mut selected = None;
+                if let Some(next) = args.get(index + 1)
+                    && !next.starts_with('-')
+                {
+                    selected = Some(parse_profile_id(next)?);
+                    index += 1;
+                }
+                set_primary_command(&mut primary, PrimaryCommand::Profile(selected))?;
+            }
+            "--export" => {
+                let mut export_dir = None;
+                if let Some(next) = args.get(index + 1)
+                    && !next.starts_with('-')
+                {
+                    export_dir = Some(PathBuf::from(next));
+                    index += 1;
+                }
+                set_primary_command(&mut primary, PrimaryCommand::Export(export_dir))?;
+            }
+            _ => {
+                if let Some(value) = arg.strip_prefix("--profile=") {
+                    if value.trim().is_empty() {
+                        return Err(invalid_usage("`--profile=` requires a profile value."));
+                    }
+                    let parsed = parse_profile_id(value)?;
+                    set_primary_command(&mut primary, PrimaryCommand::Profile(Some(parsed)))?;
+                } else if let Some(value) = arg.strip_prefix("--export=") {
+                    if value.trim().is_empty() {
+                        return Err(invalid_usage("`--export=` requires a target directory."));
+                    }
+                    set_primary_command(
+                        &mut primary,
+                        PrimaryCommand::Export(Some(PathBuf::from(value))),
+                    )?;
+                } else if arg.starts_with('-') {
+                    return Err(invalid_usage(&format!("Unknown option `{arg}`.")));
+                } else {
+                    return Err(invalid_usage(&format!(
+                        "Unexpected positional argument `{arg}`."
+                    )));
+                }
+            }
+        }
+
+        index += 1;
+    }
+
+    if show_help {
+        return Ok(CliAction::ShowHelp);
+    }
+
+    match primary {
+        None => {
+            if output == OutputMode::Json {
+                return Err(invalid_usage(
+                    "`--json` is only valid with `--status`, `--profile`, or `--export`.",
+                ));
+            }
+            Ok(CliAction::RunTui {
+                start_immediately: false,
+            })
+        }
+        Some(PrimaryCommand::Start) => {
+            if output == OutputMode::Json {
+                return Err(invalid_usage("`--json` is not supported with `--start`."));
+            }
+            Ok(CliAction::RunTui {
+                start_immediately: true,
+            })
+        }
+        Some(PrimaryCommand::Profile(profile)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Profile { profile },
+            output,
+        })),
+        Some(PrimaryCommand::Status) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Status,
+            output,
+        })),
+        Some(PrimaryCommand::Export(dir)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Export { dir },
+            output,
+        })),
+    }
+}
+
+pub fn execute_command(command: CliCommand) -> Result<(), String> {
+    match command.kind {
+        CommandKind::Profile { profile } => execute_profile_command(profile, command.output),
+        CommandKind::Status => execute_status_command(command.output),
+        CommandKind::Export { dir } => execute_export_command(dir, command.output),
+    }
+}
+
+fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let mut updated = false;
+    if let Some(profile) = profile {
+        config.selected_profile = profile;
+        config
+            .save()
+            .map_err(|error| format!("Failed to save selected profile: {error}"))?;
+        updated = true;
+    }
+
+    let custom = config.effective_custom_profile();
+    let selected = profile_view(config.selected_profile, &custom);
+    let available = [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom]
+        .into_iter()
+        .map(|candidate| profile_view(candidate, &custom))
+        .collect();
+    let payload = ProfileOutput {
+        updated,
+        selected,
+        available,
+    };
+
+    match output {
+        OutputMode::Text => print_profile_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_status_command(output: OutputMode) -> Result<(), String> {
+    let config = AppConfig::load().normalized();
+    let stats = FocusStats::load().map_err(|error| format!("Failed to load stats: {error}"))?;
+    let payload = build_status_output(&config, &stats);
+
+    match output {
+        OutputMode::Text => print_status_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
+    let stats = FocusStats::load().map_err(|error| format!("Failed to load stats: {error}"))?;
+    let target_dir = match dir {
+        Some(path) => path,
+        None => env::current_dir()
+            .map_err(|error| format!("Failed to determine current directory: {error}"))?,
+    };
+    let exported = stats
+        .export_to_dir(&target_dir)
+        .map_err(|error| format!("Export failed: {error}"))?;
+
+    let payload = ExportOutput {
+        export_dir: target_dir,
+        json_path: exported.json_path,
+        csv_path: exported.csv_path,
+    };
+    match output {
+        OutputMode::Text => print_export_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
+    let day = current_day_key();
+    let today = stats.daily_for(&day);
+    let session = stats.session();
+    let (_, selected_task_label) = stats.task_planner_state();
+    let goal_snapshot = DailyGoalSnapshot {
+        minutes: config.daily_goal.minutes,
+        pomodoros: config.daily_goal.pomodoros,
+    };
+    let active_sites_count = config
+        .blocklist_profiles
+        .iter()
+        .find(|profile| profile.name == config.selected_blocklist_profile)
+        .map(|profile| profile.sites.len())
+        .unwrap_or_default();
+
+    StatusOutput {
+        day,
+        selected_profile: profile_view(config.selected_profile, &config.effective_custom_profile()),
+        selected_task_label,
+        selected_blocklist_profile: config.selected_blocklist_profile.clone(),
+        blocked_sites_count: active_sites_count,
+        strict_mode: config.strict_mode,
+        goal: GoalOutput {
+            configured: goal_snapshot.has_any_target(),
+            minutes_target: goal_snapshot.minutes,
+            pomodoros_target: goal_snapshot.pomodoros,
+            met: goal_snapshot.is_met_by(today),
+        },
+        session: SessionOutput {
+            focused_minutes: session.focused_minutes(),
+            pomodoros_completed: session.pomodoros_completed,
+        },
+        today: TodayOutput {
+            focused_minutes: today.focused_minutes(),
+            pomodoros_completed: today.pomodoros_completed,
+        },
+    }
+}
+
+fn profile_view(profile: ProfileId, custom: &CustomProfileConfig) -> ProfileView {
+    let spec = resolve_profile_spec(profile, custom);
+    ProfileView {
+        id: profile_id(profile),
+        label: profile.label(),
+        focus_secs: spec.focus_secs,
+        short_break_secs: spec.short_break_secs,
+        long_break_secs: spec.long_break_secs,
+        long_break_interval: spec.long_break_interval,
+    }
+}
+
+fn resolve_profile_spec(profile: ProfileId, custom: &CustomProfileConfig) -> ProfileSpec {
+    match profile {
+        ProfileId::Classic => ProfileSpec {
+            focus_secs: DEFAULT_FOCUS_SECS,
+            short_break_secs: DEFAULT_SHORT_BREAK_SECS,
+            long_break_secs: DEFAULT_LONG_BREAK_SECS,
+            long_break_interval: DEFAULT_LONG_BREAK_INTERVAL,
+        },
+        ProfileId::DeepWork => ProfileSpec {
+            focus_secs: 50 * 60,
+            short_break_secs: 10 * 60,
+            long_break_secs: 30 * 60,
+            long_break_interval: 3,
+        },
+        ProfileId::Custom => {
+            let custom = custom.normalized();
+            ProfileSpec {
+                focus_secs: custom.focus_secs,
+                short_break_secs: custom.short_break_secs,
+                long_break_secs: custom.long_break_secs,
+                long_break_interval: custom.long_break_interval,
+            }
+        }
+    }
+}
+
+fn profile_id(profile: ProfileId) -> &'static str {
+    match profile {
+        ProfileId::Classic => "classic",
+        ProfileId::DeepWork => "deep-work",
+        ProfileId::Custom => "custom",
+    }
+}
+
+fn parse_profile_id(value: &str) -> Result<ProfileId, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "classic" => Ok(ProfileId::Classic),
+        "deep-work" | "deep_work" | "deepwork" => Ok(ProfileId::DeepWork),
+        "custom" => Ok(ProfileId::Custom),
+        _ => Err(invalid_usage(&format!(
+            "Invalid profile `{value}`. Use `classic`, `deep-work`, or `custom`."
+        ))),
+    }
+}
+
+fn set_primary_command(
+    primary: &mut Option<PrimaryCommand>,
+    next: PrimaryCommand,
+) -> Result<(), String> {
+    if let Some(existing) = primary {
+        return Err(invalid_usage(&format!(
+            "Multiple primary commands are not supported (`{}` and `{}`).",
+            primary_name(existing),
+            primary_name(&next)
+        )));
+    }
+    *primary = Some(next);
+    Ok(())
+}
+
+fn primary_name(command: &PrimaryCommand) -> &'static str {
+    match command {
+        PrimaryCommand::Start => "--start",
+        PrimaryCommand::Profile(_) => "--profile",
+        PrimaryCommand::Status => "--status",
+        PrimaryCommand::Export(_) => "--export",
+    }
+}
+
+fn print_profile_output(payload: &ProfileOutput) {
+    if payload.updated {
+        println!("Active profile updated.");
+    }
+    println!(
+        "Selected profile: {} ({})",
+        payload.selected.label, payload.selected.id
+    );
+    println!(
+        "Durations: focus {}, short break {}, long break {}, cadence every {} focus",
+        format_duration(payload.selected.focus_secs),
+        format_duration(payload.selected.short_break_secs),
+        format_duration(payload.selected.long_break_secs),
+        payload.selected.long_break_interval
+    );
+    println!("Available profiles:");
+    for profile in &payload.available {
+        println!(
+            "  - {} ({}): {}/{}/{} every {} focus",
+            profile.label,
+            profile.id,
+            format_duration(profile.focus_secs),
+            format_duration(profile.short_break_secs),
+            format_duration(profile.long_break_secs),
+            profile.long_break_interval
+        );
+    }
+}
+
+fn print_status_output(payload: &StatusOutput) {
+    println!("Date: {}", payload.day);
+    println!(
+        "Selected profile: {} ({})",
+        payload.selected_profile.label, payload.selected_profile.id
+    );
+    println!(
+        "Task label: {}",
+        payload.selected_task_label.as_deref().unwrap_or("none")
+    );
+    println!(
+        "Blocklist profile: {} ({} sites)",
+        payload.selected_blocklist_profile, payload.blocked_sites_count
+    );
+    println!(
+        "Strict mode: {}",
+        if payload.strict_mode { "on" } else { "off" }
+    );
+    println!(
+        "Today: {} focused minutes, {} pomodoros",
+        payload.today.focused_minutes, payload.today.pomodoros_completed
+    );
+    if payload.goal.configured {
+        println!(
+            "Goal: {} min, {} pomodoros ({})",
+            payload.goal.minutes_target,
+            payload.goal.pomodoros_target,
+            if payload.goal.met {
+                "met"
+            } else {
+                "in progress"
+            }
+        );
+    } else {
+        println!("Goal: off");
+    }
+    println!(
+        "Session: {} focused minutes, {} pomodoros",
+        payload.session.focused_minutes, payload.session.pomodoros_completed
+    );
+}
+
+fn print_export_output(payload: &ExportOutput) {
+    println!("Exported stats to {}", payload.export_dir.display());
+    println!("JSON: {}", payload.json_path.display());
+    println!("CSV: {}", payload.csv_path.display());
+}
+
+fn print_json<T: Serialize>(payload: &T) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(payload)
+        .map_err(|error| format!("Failed to encode JSON output: {error}"))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn format_duration(secs: u64) -> String {
+    let minutes = secs / 60;
+    let seconds = secs % 60;
+    match (minutes, seconds) {
+        (0, s) => format!("{s}s"),
+        (m, 0) => format!("{m}m"),
+        (m, s) => format!("{m}m {s}s"),
+    }
+}
+
+fn invalid_usage(message: &str) -> String {
+    format!("{message}\n\n{USAGE_TEXT}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(values: &[&str]) -> Result<CliAction, String> {
+        parse_args(values.iter().map(OsString::from))
+    }
+
+    #[test]
+    fn parse_without_arguments_runs_default_tui() {
+        let parsed = parse(&[]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunTui {
+                start_immediately: false
+            }
+        );
+    }
+
+    #[test]
+    fn parse_start_runs_tui_immediately() {
+        let parsed = parse(&["--start"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunTui {
+                start_immediately: true
+            }
+        );
+    }
+
+    #[test]
+    fn parse_status_supports_json_mode() {
+        let parsed = parse(&["--status", "--json"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Status,
+                output: OutputMode::Json
+            })
+        );
+    }
+
+    #[test]
+    fn parse_profile_without_value_reads_current_profile() {
+        let parsed = parse(&["--profile"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Profile { profile: None },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_profile_with_value_sets_profile() {
+        let parsed = parse(&["--profile", "deep-work"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Profile {
+                    profile: Some(ProfileId::DeepWork)
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_profile_with_equals_sets_profile() {
+        let parsed = parse(&["--profile=classic"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Profile {
+                    profile: Some(ProfileId::Classic)
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_export_accepts_optional_directory() {
+        let parsed = parse(&["--export", "reports"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Export {
+                    dir: Some(PathBuf::from("reports"))
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_help_returns_show_help_action() {
+        let parsed = parse(&["--help"]).unwrap();
+        assert_eq!(parsed, CliAction::ShowHelp);
+    }
+
+    #[test]
+    fn parse_rejects_multiple_primary_commands() {
+        let error = parse(&["--status", "--export"]).unwrap_err();
+        assert!(error.contains("Multiple primary commands"));
+    }
+
+    #[test]
+    fn parse_rejects_unknown_option() {
+        let error = parse(&["--unknown"]).unwrap_err();
+        assert!(error.contains("Unknown option"));
+    }
+
+    #[test]
+    fn parse_rejects_json_without_noninteractive_command() {
+        let error = parse(&["--json"]).unwrap_err();
+        assert!(error.contains("`--json` is only valid"));
+    }
+
+    #[test]
+    fn parse_rejects_json_with_start() {
+        let error = parse(&["--start", "--json"]).unwrap_err();
+        assert!(error.contains("not supported with `--start`"));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ use crate::timer::{
 const USAGE_TEXT: &str = r#"Usage:
   focustime
   focustime --start
-  focustime --profile [classic|deep-work|custom]
+  focustime --profile [classic|deep-work|custom] [--json]
   focustime --status [--json]
   focustime --export[=DIR] [--json]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,38 +126,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
             .checked_sub(last_tick.elapsed())
             .unwrap_or(Duration::ZERO);
 
-        if event::poll(timeout)? {
-            match event::read()? {
-                Event::Key(key) if should_handle_key(&key) => app.handle_key(key),
-                Event::Paste(text) => app.handle_paste(text),
-                _ => {}
-            }
-        }
-
-        if last_tick.elapsed() >= tick_rate {
-            let elapsed_ms = last_tick.elapsed().as_millis() as u64;
-            last_tick = Instant::now();
-
-            if app.is_running() {
-                tick_accumulator += elapsed_ms;
-                let mut elapsed_secs: u64 = 0;
-                while tick_accumulator >= 1000 {
-                    tick_accumulator -= 1000;
-                    elapsed_secs += 1;
-                }
-                let is_catchup = elapsed_secs > 1;
-                for _ in 0..elapsed_secs {
-                    app.on_tick(is_catchup);
-                }
-                // Advance WakaTime once per UI frame to avoid burst heartbeats
-                // after a suspend/resume catch-up.
-                if elapsed_secs > 0 {
-                    app.on_wakatime_elapsed(elapsed_secs);
-                }
-            } else {
-                tick_accumulator = 0;
-            }
-        }
+        handle_terminal_event(&mut app, timeout)?;
+        tick_timer_if_due(&mut app, &mut last_tick, &mut tick_accumulator, tick_rate);
 
         if app.should_quit {
             break;
@@ -165,4 +135,55 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
     }
 
     Ok(())
+}
+
+fn handle_terminal_event(app: &mut App, timeout: Duration) -> io::Result<()> {
+    if !event::poll(timeout)? {
+        return Ok(());
+    }
+
+    match event::read()? {
+        Event::Key(key) if should_handle_key(&key) => app.handle_key(key),
+        Event::Paste(text) => app.handle_paste(text),
+        _ => {}
+    }
+    Ok(())
+}
+
+fn tick_timer_if_due(
+    app: &mut App,
+    last_tick: &mut Instant,
+    tick_accumulator: &mut u64,
+    tick_rate: Duration,
+) {
+    if last_tick.elapsed() < tick_rate {
+        return;
+    }
+
+    let elapsed_ms = last_tick.elapsed().as_millis() as u64;
+    *last_tick = Instant::now();
+    if !app.is_running() {
+        *tick_accumulator = 0;
+        return;
+    }
+
+    advance_running_timer(app, tick_accumulator, elapsed_ms);
+}
+
+fn advance_running_timer(app: &mut App, tick_accumulator: &mut u64, elapsed_ms: u64) {
+    *tick_accumulator += elapsed_ms;
+    let mut elapsed_secs: u64 = 0;
+    while *tick_accumulator >= 1000 {
+        *tick_accumulator -= 1000;
+        elapsed_secs += 1;
+    }
+    let is_catchup = elapsed_secs > 1;
+    for _ in 0..elapsed_secs {
+        app.on_tick(is_catchup);
+    }
+    // Advance WakaTime once per UI frame to avoid burst heartbeats
+    // after a suspend/resume catch-up.
+    if elapsed_secs > 0 {
+        app.on_wakatime_elapsed(elapsed_secs);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod blocker;
+mod cli;
 mod config;
 mod notifications;
 mod stats;
@@ -9,7 +10,7 @@ mod ui;
 mod wakatime;
 
 use std::{
-    io,
+    io, process,
     time::{Duration, Instant},
 };
 
@@ -25,6 +26,7 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 
 use app::App;
 use app::should_handle_key;
+use cli::{CliAction, execute_command, parse_args, usage_text};
 
 /// RAII guard that restores the terminal on drop, ensuring cleanup on any exit path.
 struct TerminalGuard {
@@ -78,13 +80,41 @@ impl Drop for TerminalGuard {
 }
 
 fn main() -> io::Result<()> {
+    let cli_action = match parse_args(std::env::args_os().skip(1)) {
+        Ok(action) => action,
+        Err(error) => {
+            eprintln!("{error}");
+            process::exit(2);
+        }
+    };
+
+    let mut app = App::new();
+    match cli_action {
+        CliAction::ShowHelp => {
+            println!("{}", usage_text());
+            return Ok(());
+        }
+        CliAction::RunCommand(command) => {
+            if let Err(error) = execute_command(command) {
+                eprintln!("{error}");
+                process::exit(1);
+            }
+            return Ok(());
+        }
+        CliAction::RunTui { start_immediately } => {
+            if start_immediately && let Err(error) = app.start_focus_for_cli() {
+                eprintln!("{error}");
+                process::exit(1);
+            }
+        }
+    }
+
     let mut guard = TerminalGuard::new()?;
-    run_app(&mut guard.terminal)
+    run_app(&mut guard.terminal, app)
 }
 
-fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> io::Result<()> {
+fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) -> io::Result<()> {
     let tick_rate = Duration::from_millis(100);
-    let mut app = App::new();
     let mut last_tick = Instant::now();
     let mut tick_accumulator: u64 = 0; // milliseconds accumulated towards next second
 


### PR DESCRIPTION
## What

Add non-interactive CLI automation support for `--start`, `--profile`, `--status`, and `--export`, including JSON output mode for scripting. The startup flow now parses CLI args first and keeps the TUI as the default path when no automation command is provided.

## Why

Issue #115 requests command-driven automation surfaces without requiring interactive key input. This change enables scripting and CI-friendly usage while preserving existing TUI behavior.

Closes #115

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable) - N/A (no site blocking logic changes)
- [x] WakaTime integration behavior was verified for this change (if applicable) - N/A (no WakaTime logic changes)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) - N/A (no new dependencies)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR (none)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-interactive CLI to start focus, view/set the active profile, show persisted status, and export stats (optional target directory). Supports text or pretty JSON output and built-in help; invoking without CLI flags opens the interactive TUI.

* **Documentation**
  * README adds a “CLI automation commands” section documenting flags and behaviors (--start, --profile, --status, --export, --json).

* **Tests**
  * Unit tests added for CLI parsing, command behaviors, and non-interactive start validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->