### PR TITLE
Prepare v0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-04-20
+
+### Added
+
+- **CLI automation commands (#133):** added non-interactive `--start`, `--profile`, `--status`, and `--export` commands for scripting and automation workflows.
+- **Recurring focus schedule automation (#134):** added recurring schedule windows, schedule-mode reminders, and in-app schedule editing controls.
+
+### Changed
+
+- **Schedule UX and messaging polish:** clarified schedule UI text and break interruption guidance for more predictable timer behavior.
+
 ## [0.4.1] - 2026-04-20
 
 ### Added
@@ -96,7 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/utilForever/focustime/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/utilForever/focustime/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/utilForever/focustime/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/utilForever/focustime/compare/v0.3.1...v0.3.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -380,12 +380,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.4.1`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.4.2`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.4.1](https://github.com/utilForever/focustime/releases/tag/v0.4.1).
+The latest stable release is [v0.4.2](https://github.com/utilForever/focustime/releases/tag/v0.4.2).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the v0.4.2 release metadata across package and documentation files.

## Why

Issue #126 requests the release update so the crate version, release docs, and changelog are aligned before tagging/publishing. This keeps release automation and public references consistent.

Closes #126

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable) (N/A: no runtime timer logic changes)
- [x] Site blocking behavior was verified for this change (if applicable) (N/A: no blocker logic changes)
- [x] WakaTime integration behavior was verified for this change (if applicable) (N/A: no WakaTime logic changes)
- [x] I added or updated tests for changed behavior (if applicable) (N/A: release metadata/docs only)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A: no new deps/config)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) (N/A: no codepath/security model changes)
- [x] Breaking behavior changes are clearly described in this PR (N/A: no breaking behavior changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added non-interactive CLI automation commands for starting sessions, managing profiles, checking status, and exporting data.
  * Introduced recurring focus schedule automation with schedule-mode reminders and in-app schedule editing controls.

* **Changed**
  * Enhanced schedule UI text clarity and break interruption guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->