### PR TITLE
Recover in-progress timer sessions after restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,15 @@ You can configure notification and auto-start settings directly from the TUI:
   - **Schedule day** + **Schedule day enabled**: choose day cursor and toggle it `Off/On`
   - **Schedule start/end**: adjust times in 15-minute steps
 
+## Session recovery
+
+`focustime` persists in-progress timer sessions so restart/crash recovery can resume where you left off.
+
+- while a focus/break phase is running or paused, the app saves phase, remaining time, selected task label, and active profile
+- on startup, valid in-progress state is restored and shown in the timer notice line
+- stale or invalid saved recovery state is ignored safely with a warning notice
+- recovery state is cleared when an in-progress phase ends naturally or when you reset/skip out of the active session
+
 ## Strict focus mode
 
 `focustime` provides an optional strict mode (`strict_mode = false` by default).

--- a/src/app.rs
+++ b/src/app.rs
@@ -1113,9 +1113,17 @@ impl App {
     }
 
     fn sync_recovery_snapshot(&mut self) {
+        let recovery_task_label = if self.focus_session_active_for_current_state() {
+            self.active_focus_task_label
+                .clone()
+                .or_else(|| self.selected_task_label.clone())
+        } else {
+            self.selected_task_label.clone()
+        };
+
         let snapshot = InProgressSessionSnapshot::from_timer_state(
             &self.timer,
-            self.selected_task_label.clone(),
+            recovery_task_label,
             self.selected_profile,
         );
 
@@ -4976,6 +4984,22 @@ mod tests {
         app.handle_key(key(KeyCode::Char('s')));
         assert_eq!(app.timer.status, TimerStatus::Idle);
         assert!(session_recovery::test_saved_snapshot().is_none());
+    }
+
+    #[test]
+    fn recovery_snapshot_prefers_active_focus_label_over_selected_label() {
+        let mut app = App::default();
+        app.task_labels = vec!["Task A".to_string(), "Task B".to_string()];
+        app.selected_task_label = Some("Task A".to_string());
+
+        app.handle_key(key(KeyCode::Char(' ')));
+        assert_eq!(app.active_focus_task_label.as_deref(), Some("Task A"));
+
+        app.selected_task_label = Some("Task B".to_string());
+        app.sync_recovery_snapshot();
+
+        let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
+        assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task A"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1489,6 +1489,7 @@ impl App {
             self.planner_selection_index = existing_index;
             self.selected_task_label = self.task_labels.get(existing_index).cloned();
             self.sync_task_planner_state();
+            self.sync_recovery_snapshot();
             self.set_planner_feedback(
                 PlannerFeedbackLevel::Warning,
                 format!("`{label}` already exists, selected existing label"),
@@ -1501,6 +1502,7 @@ impl App {
         self.planner_selection_index = self.task_labels.len().saturating_sub(1);
         self.selected_task_label = Some(label.clone());
         self.sync_task_planner_state();
+        self.sync_recovery_snapshot();
         self.set_planner_feedback(
             PlannerFeedbackLevel::Success,
             format!("Added and selected `{label}`"),
@@ -1517,6 +1519,7 @@ impl App {
         if let Some(label) = self.task_labels.get(self.planner_selection_index).cloned() {
             self.selected_task_label = Some(label.clone());
             self.sync_task_planner_state();
+            self.sync_recovery_snapshot();
             self.set_planner_feedback(PlannerFeedbackLevel::Success, format!("Selected `{label}`"));
         }
     }
@@ -5000,6 +5003,29 @@ mod tests {
 
         let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
         assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task A"));
+    }
+
+    #[test]
+    fn planner_label_change_during_running_break_updates_recovery_snapshot() {
+        let mut app = App::default();
+        app.task_labels = vec!["Task A".to_string(), "Task B".to_string()];
+        app.selected_task_label = Some("Task A".to_string());
+        app.sync_task_planner_state();
+
+        app.handle_key(key(KeyCode::Char(' '))); // focus running
+        app.handle_key(key(KeyCode::Char('n'))); // short break idle
+        app.handle_key(key(KeyCode::Char(' '))); // short break running
+        assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+
+        app.open_session_planner();
+        app.planner_selection_index = 1;
+        app.select_planner_label();
+
+        let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
+        assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task B"));
+        assert_eq!(snapshot.phase, RecoveryTimerPhase::ShortBreak);
+        assert_eq!(snapshot.status, RecoveryTimerStatus::Running);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1032,11 +1032,6 @@ impl App {
             Err(error) => {
                 self.phase_notification =
                     Some(format!("Ignored saved in-progress session: {error}."));
-                if let Err(clear_error) = session_recovery::clear() {
-                    self.config_error = Some(format!(
-                        "session recovery cleanup failed after load error: {clear_error}"
-                    ));
-                }
                 return;
             }
         };
@@ -1076,6 +1071,7 @@ impl App {
         recovered_timer.phase = snapshot.phase();
         recovered_timer.status = snapshot.status();
         recovered_timer.remaining_secs = snapshot.remaining_secs;
+        recovered_timer.pomodoros_completed = snapshot.pomodoros_completed;
         snapshot.validate_for_timer(&recovered_timer)?;
 
         let task_label = snapshot
@@ -2968,6 +2964,7 @@ mod tests {
             phase: RecoveryTimerPhase::from_timer_phase(phase),
             status: RecoveryTimerStatus::from_timer_status(status),
             remaining_secs,
+            pomodoros_completed: 0,
             selected_task_label: task_label.map(str::to_string),
             selected_profile,
         }
@@ -4937,6 +4934,25 @@ mod tests {
                 .as_deref()
                 .is_some_and(|message| message.contains("Recovered in-progress Focus session"))
         );
+    }
+
+    #[test]
+    fn startup_restores_pomodoro_count_for_phase_cadence() {
+        session_recovery::set_test_load_snapshot(Some(InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Running,
+            remaining_secs: 1,
+            pomodoros_completed: 3,
+            selected_task_label: Some("Docs".to_string()),
+            selected_profile: ProfileId::Classic,
+        }));
+
+        let mut app = App::from_config(AppConfig::default());
+        assert_eq!(app.timer.pomodoros_completed, 3);
+
+        app.on_tick(false);
+
+        assert_eq!(app.timer.phase, TimerPhase::LongBreak);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,7 @@ use crate::notifications::PhaseNotifier;
 use crate::schedule::{
     RecurringWindow, active_occurrence, compile_windows, next_occurrence_after, occurrence_key,
 };
+use crate::session_recovery::{self, InProgressSessionSnapshot};
 use crate::stats::{
     BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles, FocusStats,
     GoalStreak, MonthlyHeatmap, MonthlyStats, ProfileTotals, SessionStats, WeeklyStats,
@@ -402,7 +403,7 @@ impl App {
             blocker.add_site(site.clone());
         }
         let setup_diagnostics = SetupDiagnostics::collect(&blocker);
-        Self {
+        let mut app = Self {
             timer,
             should_quit: false,
             mode: AppMode::Timer,
@@ -459,7 +460,10 @@ impl App {
             stats,
             stats_dirty: false,
             stats_has_unsaved_elapsed: false,
-        }
+        };
+        app.restore_in_progress_session();
+        app.sync_recovery_snapshot();
+        app
     }
 
     pub fn on_tick(&mut self, is_catchup: bool) {
@@ -473,6 +477,7 @@ impl App {
         if phase_changed {
             self.handle_phase_change(completed_phase, completed_focus_secs, is_catchup);
         }
+        self.sync_recovery_snapshot();
         self.flush_stats_if_dirty(false);
     }
 
@@ -1019,6 +1024,113 @@ impl App {
 
     pub fn blocklist_profile_count(&self) -> usize {
         self.blocklist_profiles.len()
+    }
+
+    fn restore_in_progress_session(&mut self) {
+        let loaded_snapshot = match session_recovery::load() {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                self.phase_notification =
+                    Some(format!("Ignored saved in-progress session: {error}."));
+                if let Err(clear_error) = session_recovery::clear() {
+                    self.config_error = Some(format!(
+                        "session recovery cleanup failed after load error: {clear_error}"
+                    ));
+                }
+                return;
+            }
+        };
+
+        let Some(snapshot) = loaded_snapshot else {
+            return;
+        };
+
+        if let Err(reason) = self.try_apply_recovery_snapshot(snapshot.clone()) {
+            self.phase_notification = Some(format!("Ignored saved in-progress session: {reason}."));
+            if let Err(clear_error) = session_recovery::clear() {
+                self.config_error = Some(format!(
+                    "session recovery cleanup failed after invalid state: {clear_error}"
+                ));
+            }
+            return;
+        }
+
+        self.phase_notification = Some(format!(
+            "Recovered in-progress {} session ({} remaining).",
+            snapshot.phase().label(),
+            format_duration_label(snapshot.remaining_secs)
+        ));
+    }
+
+    fn try_apply_recovery_snapshot(
+        &mut self,
+        snapshot: InProgressSessionSnapshot,
+    ) -> Result<(), String> {
+        let profile_spec = profile_spec_for(snapshot.selected_profile, &self.custom_profile);
+        let mut recovered_timer = TimerState::with_profile(
+            profile_spec.focus_secs,
+            profile_spec.short_break_secs,
+            profile_spec.long_break_secs,
+            profile_spec.long_break_interval,
+        );
+        recovered_timer.phase = snapshot.phase();
+        recovered_timer.status = snapshot.status();
+        recovered_timer.remaining_secs = snapshot.remaining_secs;
+        snapshot.validate_for_timer(&recovered_timer)?;
+
+        let task_label = snapshot
+            .normalized_task_label()
+            .ok_or_else(|| "saved task label is missing or invalid".to_string())?;
+        let selected_task_label =
+            if let Some(existing_index) = task_label_index(&self.task_labels, &task_label) {
+                self.task_labels[existing_index].clone()
+            } else {
+                self.task_labels.push(task_label.clone());
+                task_label
+            };
+
+        self.selected_profile = snapshot.selected_profile;
+        self.profile_selection_index = profile_index(snapshot.selected_profile);
+        self.timer = recovered_timer;
+        self.selected_task_label = Some(selected_task_label);
+        self.pending_timer_action = None;
+        self.break_glass_expires_at = None;
+        self.schedule_armed_occurrence_key = None;
+        self.last_schedule_occurrence_key = None;
+        self.active_focus_task_label = if self.timer.phase == TimerPhase::Focus {
+            self.selected_task_label.clone()
+        } else {
+            None
+        };
+        self.active_focus_profile = if self.timer.phase == TimerPhase::Focus {
+            Some(self.selected_profile)
+        } else {
+            None
+        };
+        self.apply_blocking_for_phase();
+        self.sync_task_planner_state();
+        Ok(())
+    }
+
+    fn sync_recovery_snapshot(&mut self) {
+        let snapshot = InProgressSessionSnapshot::from_timer_state(
+            &self.timer,
+            self.selected_task_label.clone(),
+            self.selected_profile,
+        );
+
+        match snapshot {
+            Some(snapshot) => {
+                if let Err(error) = session_recovery::save(&snapshot) {
+                    self.config_error = Some(format!("session recovery save failed: {error}"));
+                }
+            }
+            None => {
+                if let Err(error) = session_recovery::clear() {
+                    self.config_error = Some(format!("session recovery clear failed: {error}"));
+                }
+            }
+        }
     }
 
     /// Persist the current blocked-sites list and timer preferences to disk.
@@ -1580,6 +1692,7 @@ impl App {
         self.pending_timer_action = None;
         self.save_config();
         self.apply_blocking_for_phase();
+        self.sync_recovery_snapshot();
         true
     }
 
@@ -2122,6 +2235,7 @@ impl App {
             self.break_glass_expires_at = None;
         }
         self.apply_blocking_for_phase();
+        self.sync_recovery_snapshot();
     }
 
     fn open_site_manager(&mut self) {
@@ -2794,6 +2908,9 @@ pub(crate) fn should_handle_key(key: &KeyEvent) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session_recovery::{
+        self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
+    };
     use chrono::{Datelike, Local, LocalResult, TimeZone, Weekday};
     use std::{
         fs,
@@ -2826,6 +2943,22 @@ mod tests {
             Weekday::Fri => "fri",
             Weekday::Sat => "sat",
             Weekday::Sun => "sun",
+        }
+    }
+
+    fn snapshot_for_tests(
+        phase: TimerPhase,
+        status: TimerStatus,
+        remaining_secs: u64,
+        task_label: Option<&str>,
+        selected_profile: ProfileId,
+    ) -> InProgressSessionSnapshot {
+        InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::from_timer_phase(phase),
+            status: RecoveryTimerStatus::from_timer_status(status),
+            remaining_secs,
+            selected_task_label: task_label.map(str::to_string),
+            selected_profile,
         }
     }
 
@@ -4769,6 +4902,80 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char(' ')));
         assert_eq!(app.timer.status, TimerStatus::Running);
+    }
+
+    #[test]
+    fn startup_restores_valid_in_progress_snapshot() {
+        session_recovery::set_test_load_snapshot(Some(snapshot_for_tests(
+            TimerPhase::Focus,
+            TimerStatus::Running,
+            42,
+            Some("Docs"),
+            ProfileId::DeepWork,
+        )));
+
+        let app = App::from_config(AppConfig::default());
+
+        assert_eq!(app.timer.phase, TimerPhase::Focus);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+        assert_eq!(app.timer.remaining_secs, 42);
+        assert_eq!(app.selected_profile, ProfileId::DeepWork);
+        assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
+        assert!(
+            app.phase_notification
+                .as_deref()
+                .is_some_and(|message| message.contains("Recovered in-progress Focus session"))
+        );
+    }
+
+    #[test]
+    fn startup_ignores_invalid_snapshot_and_starts_fresh() {
+        session_recovery::set_test_load_snapshot(Some(snapshot_for_tests(
+            TimerPhase::Focus,
+            TimerStatus::Idle,
+            60,
+            Some("Docs"),
+            ProfileId::Classic,
+        )));
+
+        let app = App::from_config(AppConfig::default());
+
+        assert_eq!(app.timer.phase, TimerPhase::Focus);
+        assert_eq!(app.timer.status, TimerStatus::Idle);
+        assert_eq!(app.timer.remaining_secs, DEFAULT_FOCUS_SECS);
+        assert!(
+            app.phase_notification
+                .as_deref()
+                .is_some_and(|message| message.contains("Ignored saved in-progress session"))
+        );
+        assert!(session_recovery::test_saved_snapshot().is_none());
+    }
+
+    #[test]
+    fn startup_reports_recovery_load_error() {
+        session_recovery::set_test_load_error("simulated read failure");
+
+        let app = App::from_config(AppConfig::default());
+
+        assert!(
+            app.phase_notification
+                .as_deref()
+                .is_some_and(|message| message.contains("Ignored saved in-progress session"))
+        );
+    }
+
+    #[test]
+    fn reset_clears_saved_recovery_snapshot() {
+        let mut app = App::default();
+        app.selected_task_label = Some("Docs".to_string());
+
+        app.handle_key(key(KeyCode::Char(' ')));
+        assert_eq!(app.timer.status, TimerStatus::Running);
+        assert!(session_recovery::test_saved_snapshot().is_some());
+
+        app.handle_key(key(KeyCode::Char('s')));
+        assert_eq!(app.timer.status, TimerStatus::Idle);
+        assert!(session_recovery::test_saved_snapshot().is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod cli;
 mod config;
 mod notifications;
 mod schedule;
+mod session_recovery;
 mod stats;
 mod task_labels;
 mod timer;

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -1,0 +1,349 @@
+use std::io;
+
+#[cfg(not(test))]
+use std::{fs, path::Path};
+
+#[cfg(test)]
+use std::cell::RefCell;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::ProfileId,
+    task_labels::normalize_task_label,
+    timer::{TimerPhase, TimerState, TimerStatus},
+};
+
+#[cfg(not(test))]
+use crate::config::app_data_path;
+
+#[cfg(not(test))]
+const RECOVERY_FILE_NAME: &str = "session-recovery.toml";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RecoveryTimerPhase {
+    Focus,
+    ShortBreak,
+    LongBreak,
+}
+
+impl RecoveryTimerPhase {
+    pub fn from_timer_phase(phase: TimerPhase) -> Self {
+        match phase {
+            TimerPhase::Focus => Self::Focus,
+            TimerPhase::ShortBreak => Self::ShortBreak,
+            TimerPhase::LongBreak => Self::LongBreak,
+        }
+    }
+
+    pub fn to_timer_phase(self) -> TimerPhase {
+        match self {
+            Self::Focus => TimerPhase::Focus,
+            Self::ShortBreak => TimerPhase::ShortBreak,
+            Self::LongBreak => TimerPhase::LongBreak,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RecoveryTimerStatus {
+    Idle,
+    Running,
+    Paused,
+}
+
+impl RecoveryTimerStatus {
+    pub fn from_timer_status(status: TimerStatus) -> Self {
+        match status {
+            TimerStatus::Idle => Self::Idle,
+            TimerStatus::Running => Self::Running,
+            TimerStatus::Paused => Self::Paused,
+        }
+    }
+
+    pub fn to_timer_status(self) -> TimerStatus {
+        match self {
+            Self::Idle => TimerStatus::Idle,
+            Self::Running => TimerStatus::Running,
+            Self::Paused => TimerStatus::Paused,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InProgressSessionSnapshot {
+    pub phase: RecoveryTimerPhase,
+    pub status: RecoveryTimerStatus,
+    pub remaining_secs: u64,
+    pub selected_task_label: Option<String>,
+    pub selected_profile: ProfileId,
+}
+
+impl InProgressSessionSnapshot {
+    pub fn from_timer_state(
+        timer: &TimerState,
+        selected_task_label: Option<String>,
+        selected_profile: ProfileId,
+    ) -> Option<Self> {
+        if timer.status == TimerStatus::Idle {
+            return None;
+        }
+
+        let selected_task_label = selected_task_label
+            .as_deref()
+            .and_then(normalize_task_label)?;
+
+        Some(Self {
+            phase: RecoveryTimerPhase::from_timer_phase(timer.phase),
+            status: RecoveryTimerStatus::from_timer_status(timer.status),
+            remaining_secs: timer.remaining_secs,
+            selected_task_label: Some(selected_task_label),
+            selected_profile,
+        })
+    }
+
+    pub fn phase(&self) -> TimerPhase {
+        self.phase.to_timer_phase()
+    }
+
+    pub fn status(&self) -> TimerStatus {
+        self.status.to_timer_status()
+    }
+
+    pub fn normalized_task_label(&self) -> Option<String> {
+        self.selected_task_label
+            .as_deref()
+            .and_then(normalize_task_label)
+    }
+
+    pub fn validate_for_timer(&self, timer: &TimerState) -> Result<(), String> {
+        if !matches!(
+            self.status,
+            RecoveryTimerStatus::Running | RecoveryTimerStatus::Paused
+        ) {
+            return Err("saved status is not in-progress".to_string());
+        }
+
+        if self.normalized_task_label().is_none() {
+            return Err("saved task label is missing or invalid".to_string());
+        }
+
+        let phase_duration_secs = phase_duration_secs(timer, self.phase());
+        if self.remaining_secs == 0 || self.remaining_secs > phase_duration_secs {
+            return Err(format!(
+                "saved remaining time {}s is out of range for {} phase",
+                self.remaining_secs,
+                self.phase().label()
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(not(test))]
+pub fn load() -> Result<Option<InProgressSessionSnapshot>, String> {
+    let path = recovery_path().map_err(|e| format!("session recovery path failed: {e}"))?;
+    match fs::read_to_string(path) {
+        Ok(content) => toml::from_str(&content)
+            .map(Some)
+            .map_err(|e| format!("session recovery parse failed: {e}")),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("session recovery read failed: {e}")),
+    }
+}
+
+#[cfg(not(test))]
+pub fn save(snapshot: &InProgressSessionSnapshot) -> io::Result<()> {
+    let path = recovery_path()?;
+    let content = toml::to_string_pretty(snapshot)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    write_atomic_text(&path, &content)
+}
+
+#[cfg(not(test))]
+pub fn clear() -> io::Result<()> {
+    let path = recovery_path()?;
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_LOAD_OVERRIDE: RefCell<Option<Result<Option<InProgressSessionSnapshot>, String>>> = const { RefCell::new(None) };
+    static TEST_SAVED_SNAPSHOT: RefCell<Option<InProgressSessionSnapshot>> = const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub fn load() -> Result<Option<InProgressSessionSnapshot>, String> {
+    TEST_LOAD_OVERRIDE.with(|slot| slot.borrow_mut().take().unwrap_or(Ok(None)))
+}
+
+#[cfg(test)]
+pub fn save(snapshot: &InProgressSessionSnapshot) -> io::Result<()> {
+    TEST_SAVED_SNAPSHOT.with(|slot| {
+        *slot.borrow_mut() = Some(snapshot.clone());
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+pub fn clear() -> io::Result<()> {
+    TEST_SAVED_SNAPSHOT.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_load_snapshot(snapshot: Option<InProgressSessionSnapshot>) {
+    TEST_LOAD_OVERRIDE.with(|slot| {
+        *slot.borrow_mut() = Some(Ok(snapshot));
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_load_error(error: impl Into<String>) {
+    TEST_LOAD_OVERRIDE.with(|slot| {
+        *slot.borrow_mut() = Some(Err(error.into()));
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_saved_snapshot() -> Option<InProgressSessionSnapshot> {
+    TEST_SAVED_SNAPSHOT.with(|slot| slot.borrow().clone())
+}
+
+#[cfg(not(test))]
+fn recovery_path() -> io::Result<std::path::PathBuf> {
+    app_data_path(RECOVERY_FILE_NAME).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "cannot determine session recovery directory",
+        )
+    })
+}
+
+#[cfg(not(test))]
+fn write_atomic_text(path: &Path, content: &str) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let tmp_path = path.with_extension("toml.tmp");
+    fs::write(&tmp_path, content)?;
+
+    #[cfg(target_os = "windows")]
+    {
+        match fs::rename(&tmp_path, path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                fs::remove_file(path)?;
+                fs::rename(&tmp_path, path)
+            }
+            Err(e) => {
+                let _ = fs::remove_file(&tmp_path);
+                Err(e)
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        match fs::rename(&tmp_path, path) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let _ = fs::remove_file(&tmp_path);
+                Err(e)
+            }
+        }
+    }
+}
+
+fn phase_duration_secs(timer: &TimerState, phase: TimerPhase) -> u64 {
+    match phase {
+        TimerPhase::Focus => timer.focus_secs,
+        TimerPhase::ShortBreak => timer.short_break_secs,
+        TimerPhase::LongBreak => timer.long_break_secs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_validation_rejects_idle_status() {
+        let timer = TimerState::new();
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Idle,
+            remaining_secs: 10,
+            selected_task_label: Some("Docs".to_string()),
+            selected_profile: ProfileId::Classic,
+        };
+
+        assert!(snapshot.validate_for_timer(&timer).is_err());
+    }
+
+    #[test]
+    fn snapshot_validation_rejects_zero_remaining_time() {
+        let timer = TimerState::new();
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Running,
+            remaining_secs: 0,
+            selected_task_label: Some("Docs".to_string()),
+            selected_profile: ProfileId::Classic,
+        };
+
+        assert!(snapshot.validate_for_timer(&timer).is_err());
+    }
+
+    #[test]
+    fn snapshot_validation_rejects_out_of_range_remaining_time() {
+        let timer = TimerState::with_profile(60, 30, 90, 4);
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::ShortBreak,
+            status: RecoveryTimerStatus::Paused,
+            remaining_secs: 31,
+            selected_task_label: Some("Docs".to_string()),
+            selected_profile: ProfileId::Classic,
+        };
+
+        assert!(snapshot.validate_for_timer(&timer).is_err());
+    }
+
+    #[test]
+    fn snapshot_validation_rejects_missing_task_label() {
+        let timer = TimerState::new();
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Running,
+            remaining_secs: 50,
+            selected_task_label: None,
+            selected_profile: ProfileId::Classic,
+        };
+
+        assert!(snapshot.validate_for_timer(&timer).is_err());
+    }
+
+    #[test]
+    fn snapshot_validation_accepts_running_state() {
+        let timer = TimerState::with_profile(60, 30, 90, 4);
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::LongBreak,
+            status: RecoveryTimerStatus::Paused,
+            remaining_secs: 90,
+            selected_task_label: Some("Docs".to_string()),
+            selected_profile: ProfileId::DeepWork,
+        };
+
+        assert!(snapshot.validate_for_timer(&timer).is_ok());
+    }
+}

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -77,6 +77,8 @@ pub struct InProgressSessionSnapshot {
     pub phase: RecoveryTimerPhase,
     pub status: RecoveryTimerStatus,
     pub remaining_secs: u64,
+    #[serde(default)]
+    pub pomodoros_completed: u32,
     pub selected_task_label: Option<String>,
     pub selected_profile: ProfileId,
 }
@@ -99,6 +101,7 @@ impl InProgressSessionSnapshot {
             phase: RecoveryTimerPhase::from_timer_phase(timer.phase),
             status: RecoveryTimerStatus::from_timer_status(timer.status),
             remaining_secs: timer.remaining_secs,
+            pomodoros_completed: timer.pomodoros_completed,
             selected_task_label: Some(selected_task_label),
             selected_profile,
         })
@@ -284,6 +287,7 @@ mod tests {
             phase: RecoveryTimerPhase::Focus,
             status: RecoveryTimerStatus::Idle,
             remaining_secs: 10,
+            pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
         };
@@ -298,6 +302,7 @@ mod tests {
             phase: RecoveryTimerPhase::Focus,
             status: RecoveryTimerStatus::Running,
             remaining_secs: 0,
+            pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
         };
@@ -312,6 +317,7 @@ mod tests {
             phase: RecoveryTimerPhase::ShortBreak,
             status: RecoveryTimerStatus::Paused,
             remaining_secs: 31,
+            pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
         };
@@ -326,6 +332,7 @@ mod tests {
             phase: RecoveryTimerPhase::Focus,
             status: RecoveryTimerStatus::Running,
             remaining_secs: 50,
+            pomodoros_completed: 0,
             selected_task_label: None,
             selected_profile: ProfileId::Classic,
         };
@@ -340,6 +347,7 @@ mod tests {
             phase: RecoveryTimerPhase::LongBreak,
             status: RecoveryTimerStatus::Paused,
             remaining_secs: 90,
+            pomodoros_completed: 2,
             selected_task_label: Some("Docs".to_string()),
             selected_profile: ProfileId::DeepWork,
         };


### PR DESCRIPTION
## What

Add in-progress session recovery for the TUI timer lifecycle.

- Introduce `src/session_recovery.rs` to persist and load a typed snapshot (`phase`, `status`, `remaining_secs`, selected task label, selected profile).
- Restore valid running/paused focus or break state on app startup and surface a recovery notice in the timer view.
- Ignore and clear invalid or stale recovery snapshots with explicit user-facing warning text.
- Keep recovery state synchronized during timer transitions and clear it when the session is no longer recoverable.
- Add recovery-focused tests in `app.rs` and in the new recovery module.
- Document the feature in `README.md`.

## Why

Closes #136.

Restarting during an active session currently loses in-progress timer context. This change keeps focus/break progress and session context recoverable after restart/crash while failing safely for bad persisted state. Recovery resumes from the last saved remaining time (no downtime subtraction), which matches the issue decision for predictable behavior.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timer state is persisted during running/paused focus or break phases and automatically restored on app restart/crash (phase, remaining time, task label, profile). Persistence is kept up-to-date during runtime and when planner/label/profile changes occur.

* **Bug Fixes**
  * Invalid or stale recovery data is ignored with a warning; recovery data is cleared when a phase ends or the user resets/skips. Startup load errors surface a clear notification.

* **Documentation**
  * Added "Session recovery" docs explaining behavior and visible notifications.

* **Tests**
  * Added unit tests for restore, invalid-snapshot handling, runtime save/clear, and label-change behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->