### PR TITLE
CLI automation v2 commands and richer status JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CLI automation v2 commands (#137):** added non-interactive `--pause`, `--resume`, `--stop`, `--next`, and `--task` commands for scriptable timer/session control.
+
+### Changed
+
+- **Richer status JSON for automation (#137):** extended `--status --json` with live timer/session state fields from recovery-aware runtime context.
+
 ## [0.4.2] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,12 +82,22 @@ cargo run
 # Launch TUI with focus timer already started
 cargo run -- --start
 
+# Control timer flow without entering TUI
+cargo run -- --pause
+cargo run -- --resume
+cargo run -- --stop
+cargo run -- --next --json
+
+# Select task label (creates label if it does not exist yet)
+cargo run -- --task "Write docs"
+cargo run -- --task=Write-docs --json
+
 # Show or set the active profile
 cargo run -- --profile
 cargo run -- --profile deep-work
 cargo run -- --profile --json
 
-# Show persisted status (text or JSON)
+# Show status (text or JSON, including live timer/session fields in JSON)
 cargo run -- --status
 cargo run -- --status --json
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -597,6 +597,81 @@ impl App {
         Ok(())
     }
 
+    pub fn pause_for_cli(&mut self) -> Result<(), String> {
+        if self.timer.status != TimerStatus::Running {
+            return Err("Cannot pause: timer is not running.".to_string());
+        }
+        self.update_timer_and_sync(TimerState::toggle_pause);
+        Ok(())
+    }
+
+    pub fn resume_for_cli(&mut self) -> Result<(), String> {
+        if self.timer.status != TimerStatus::Paused {
+            return Err("Cannot resume: timer is not paused.".to_string());
+        }
+        self.update_timer_and_sync(TimerState::toggle_pause);
+        Ok(())
+    }
+
+    pub fn stop_for_cli(&mut self) -> Result<(), String> {
+        if self.strict_mode_enforced_for_focus() {
+            return Err("Cannot stop: strict mode is active during focus.".to_string());
+        }
+        if self.timer.status == TimerStatus::Idle {
+            return Err("Cannot stop: timer is already idle.".to_string());
+        }
+        self.update_timer_and_sync(TimerState::reset);
+        Ok(())
+    }
+
+    pub fn next_phase_for_cli(&mut self) -> Result<(), String> {
+        if self.strict_mode_enforced_for_focus() {
+            return Err(
+                "Cannot skip to next phase: strict mode is active during focus.".to_string(),
+            );
+        }
+        self.update_timer_and_sync(TimerState::next_phase);
+        Ok(())
+    }
+
+    pub fn select_task_label_for_cli(&mut self, label: &str) -> Result<bool, String> {
+        let Some(label) = normalize_task_label(label) else {
+            return Err("Cannot select task label: label cannot be empty.".to_string());
+        };
+
+        if let Some(existing_index) = task_label_index(&self.task_labels, &label) {
+            self.planner_selection_index = existing_index;
+            self.selected_task_label = self.task_labels.get(existing_index).cloned();
+            self.sync_task_planner_state();
+            self.sync_recovery_snapshot();
+            return Ok(false);
+        }
+
+        self.task_labels.push(label.clone());
+        self.planner_selection_index = self.task_labels.len().saturating_sub(1);
+        self.selected_task_label = Some(label);
+        self.sync_task_planner_state();
+        self.sync_recovery_snapshot();
+        Ok(true)
+    }
+
+    pub fn selected_profile_id(&self) -> ProfileId {
+        self.selected_profile
+    }
+
+    pub fn selected_task_label_for_cli(&self) -> Option<String> {
+        self.selected_task_label.clone()
+    }
+
+    pub fn timer_state_for_cli(&self) -> (TimerPhase, TimerStatus, u64, u32) {
+        (
+            self.timer.phase,
+            self.timer.status,
+            self.timer.remaining_secs,
+            self.timer.pomodoros_completed,
+        )
+    }
+
     pub fn selected_profile_name(&self) -> &'static str {
         self.selected_profile.label()
     }
@@ -4887,6 +4962,73 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(app.timer.status, TimerStatus::Running);
         assert_eq!(app.active_focus_task_label, Some("Docs".to_string()));
+    }
+
+    #[test]
+    fn cli_pause_and_resume_transitions_timer_state() {
+        let mut app = App::default();
+        app.selected_task_label = Some("Docs".to_string());
+        app.start_focus_for_cli().unwrap();
+
+        app.pause_for_cli().unwrap();
+        assert_eq!(app.timer.status, TimerStatus::Paused);
+
+        app.resume_for_cli().unwrap();
+        assert_eq!(app.timer.status, TimerStatus::Running);
+    }
+
+    #[test]
+    fn cli_pause_requires_running_timer() {
+        let mut app = App::default();
+
+        let error = app.pause_for_cli().unwrap_err();
+
+        assert_eq!(error, "Cannot pause: timer is not running.");
+    }
+
+    #[test]
+    fn cli_stop_respects_strict_mode_during_focus() {
+        let mut app = App::default();
+        app.strict_mode = true;
+        app.selected_task_label = Some("Docs".to_string());
+        app.start_focus_for_cli().unwrap();
+
+        let error = app.stop_for_cli().unwrap_err();
+
+        assert_eq!(error, "Cannot stop: strict mode is active during focus.");
+        assert_eq!(app.timer.status, TimerStatus::Running);
+    }
+
+    #[test]
+    fn cli_next_respects_strict_mode_during_focus() {
+        let mut app = App::default();
+        app.strict_mode = true;
+        app.selected_task_label = Some("Docs".to_string());
+        app.start_focus_for_cli().unwrap();
+
+        let error = app.next_phase_for_cli().unwrap_err();
+
+        assert_eq!(
+            error,
+            "Cannot skip to next phase: strict mode is active during focus."
+        );
+        assert_eq!(app.timer.phase, TimerPhase::Focus);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+    }
+
+    #[test]
+    fn cli_task_selection_auto_creates_and_reuses_labels() {
+        let mut app = App::default();
+
+        let created = app.select_task_label_for_cli("  Docs  ").unwrap();
+        assert!(created);
+        assert_eq!(app.task_labels, vec!["Docs".to_string()]);
+        assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
+
+        let created = app.select_task_label_for_cli("docs").unwrap();
+        assert!(!created);
+        assert_eq!(app.task_labels, vec!["Docs".to_string()]);
+        assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ Options:
   --next     Skip to the next phase
   --task     Select task label (auto-creates unknown labels)
   --profile  Show current profile, or set it when value is provided
-  --status   Print persisted status summary
+  --status   Print status summary (includes live timer/session fields)
   --export   Export stats to current directory or DIR
   --json     Emit machine-readable JSON output
   -h, --help Show this help"#;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1272,4 +1272,18 @@ mod tests {
         );
         assert_eq!(output.live.status, "idle");
     }
+
+    #[test]
+    fn cli_resume_requires_paused_timer() {
+        let mut app = App::default();
+        let error = app.resume_for_cli().unwrap_err();
+        assert_eq!(error, "Cannot resume: timer is not paused.");
+    }
+
+    #[test]
+    fn cli_stop_requires_non_idle_timer() {
+        let mut app = App::default();
+        let error = app.stop_for_cli().unwrap_err();
+        assert_eq!(error, "Cannot stop: timer is already idle.");
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -274,6 +274,11 @@ fn classify_task_arg(args: &[String], index: usize) -> Result<(ParsedToken, usiz
     if let Some(next) = args.get(index + 1)
         && !next.starts_with('-')
     {
+        if next.trim().is_empty() {
+            return Err(invalid_usage(
+                "`--task` requires a task label. Use `--task=LABEL` or `--task LABEL`.",
+            ));
+        }
         return Ok((ParsedToken::Task(next.clone()), 2));
     }
     Err(invalid_usage(
@@ -1178,6 +1183,12 @@ mod tests {
     #[test]
     fn parse_rejects_task_without_value() {
         let error = parse(&["--task"]).unwrap_err();
+        assert!(error.contains("`--task` requires a task label"));
+    }
+
+    #[test]
+    fn parse_rejects_task_with_blank_value() {
+        let error = parse(&["--task", "   "]).unwrap_err();
         assert!(error.contains("`--task` requires a task label"));
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,22 +2,34 @@ use std::{env, ffi::OsString, path::PathBuf};
 
 use serde::Serialize;
 
+use crate::app::App;
 use crate::config::{AppConfig, CustomProfileConfig, ProfileId};
+use crate::session_recovery;
 use crate::stats::{DailyGoalSnapshot, FocusStats, current_day_key};
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
-    DEFAULT_SHORT_BREAK_SECS,
+    DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerStatus,
 };
 
 const USAGE_TEXT: &str = r#"Usage:
   focustime
   focustime --start
+  focustime --pause [--json]
+  focustime --resume [--json]
+  focustime --stop [--json]
+  focustime --next [--json]
+  focustime --task=LABEL [--json]
   focustime --profile [classic|deep-work|custom] [--json]
   focustime --status [--json]
   focustime --export[=DIR] [--json]
 
 Options:
   --start    Launch TUI with focus timer already started
+  --pause    Pause a running timer
+  --resume   Resume a paused timer
+  --stop     Stop/reset the current phase
+  --next     Skip to the next phase
+  --task     Select task label (auto-creates unknown labels)
   --profile  Show current profile, or set it when value is provided
   --status   Print persisted status summary
   --export   Export stats to current directory or DIR
@@ -32,6 +44,11 @@ pub enum OutputMode {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommandKind {
+    Pause,
+    Resume,
+    Stop,
+    Next,
+    Task { label: String },
     Profile { profile: Option<ProfileId> },
     Status,
     Export { dir: Option<PathBuf> },
@@ -53,6 +70,11 @@ pub enum CliAction {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PrimaryCommand {
     Start,
+    Pause,
+    Resume,
+    Stop,
+    Next,
+    Task(String),
     Profile(Option<ProfileId>),
     Status,
     Export(Option<PathBuf>),
@@ -63,6 +85,11 @@ enum ParsedToken {
     Help,
     Json,
     Start,
+    Pause,
+    Resume,
+    Stop,
+    Next,
+    Task(String),
     Status,
     Profile(Option<ProfileId>),
     Export(Option<PathBuf>),
@@ -116,6 +143,20 @@ struct TodayOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct LiveStatusOutput {
+    state_source: &'static str,
+    recovery_error: Option<String>,
+    in_progress: bool,
+    phase: &'static str,
+    status: &'static str,
+    remaining_secs: u64,
+    pomodoros_completed: u32,
+    selected_profile: ProfileView,
+    selected_task_label: Option<String>,
+    strict_mode_enforced: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct StatusOutput {
     day: String,
     selected_profile: ProfileView,
@@ -126,6 +167,7 @@ struct StatusOutput {
     goal: GoalOutput,
     session: SessionOutput,
     today: TodayOutput,
+    live: LiveStatusOutput,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -133,6 +175,30 @@ struct ExportOutput {
     export_dir: PathBuf,
     json_path: PathBuf,
     csv_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TimerStateOutput {
+    phase: &'static str,
+    status: &'static str,
+    remaining_secs: u64,
+    pomodoros_completed: u32,
+    selected_profile: ProfileView,
+    selected_task_label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TimerCommandOutput {
+    action: &'static str,
+    timer: TimerStateOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TaskCommandOutput {
+    action: &'static str,
+    created: bool,
+    selected_task_label: String,
+    timer: TimerStateOutput,
 }
 
 pub fn usage_text() -> &'static str {
@@ -172,6 +238,9 @@ fn classify_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), S
     if let Some(token) = classify_simple_flag(arg) {
         return Ok((token, 1));
     }
+    if arg == "--task" {
+        return classify_task_arg(args, index);
+    }
     if arg == "--profile" {
         return classify_profile_arg(args, index);
     }
@@ -192,9 +261,24 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "-h" | "--help" => Some(ParsedToken::Help),
         "--json" => Some(ParsedToken::Json),
         "--start" => Some(ParsedToken::Start),
+        "--pause" => Some(ParsedToken::Pause),
+        "--resume" => Some(ParsedToken::Resume),
+        "--stop" => Some(ParsedToken::Stop),
+        "--next" => Some(ParsedToken::Next),
         "--status" => Some(ParsedToken::Status),
         _ => None,
     }
+}
+
+fn classify_task_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((ParsedToken::Task(next.clone()), 2));
+    }
+    Err(invalid_usage(
+        "`--task` requires a task label. Use `--task=LABEL` or `--task LABEL`.",
+    ))
 }
 
 fn classify_profile_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
@@ -217,6 +301,12 @@ fn classify_export_arg(args: &[String], index: usize) -> Result<(ParsedToken, us
 }
 
 fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--task=") {
+        if value.trim().is_empty() {
+            return Err(invalid_usage("`--task=` requires a task label."));
+        }
+        return Ok(Some(ParsedToken::Task(value.to_string())));
+    }
     if let Some(value) = arg.strip_prefix("--profile=") {
         if value.trim().is_empty() {
             return Err(invalid_usage("`--profile=` requires a profile value."));
@@ -254,6 +344,11 @@ fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), Str
                 )));
             }
             ParsedToken::Start
+            | ParsedToken::Pause
+            | ParsedToken::Resume
+            | ParsedToken::Stop
+            | ParsedToken::Next
+            | ParsedToken::Task(_)
             | ParsedToken::Status
             | ParsedToken::Profile(_)
             | ParsedToken::Export(_) => {}
@@ -267,6 +362,13 @@ fn parse_primary_command(tokens: &[ParsedToken]) -> Result<Option<PrimaryCommand
     for token in tokens {
         match token {
             ParsedToken::Start => set_primary_command(&mut primary, PrimaryCommand::Start)?,
+            ParsedToken::Pause => set_primary_command(&mut primary, PrimaryCommand::Pause)?,
+            ParsedToken::Resume => set_primary_command(&mut primary, PrimaryCommand::Resume)?,
+            ParsedToken::Stop => set_primary_command(&mut primary, PrimaryCommand::Stop)?,
+            ParsedToken::Next => set_primary_command(&mut primary, PrimaryCommand::Next)?,
+            ParsedToken::Task(label) => {
+                set_primary_command(&mut primary, PrimaryCommand::Task(label.clone()))?
+            }
             ParsedToken::Status => set_primary_command(&mut primary, PrimaryCommand::Status)?,
             ParsedToken::Profile(profile) => {
                 set_primary_command(&mut primary, PrimaryCommand::Profile(*profile))?
@@ -296,7 +398,7 @@ fn finalize_cli_action(
         None => {
             if output == OutputMode::Json {
                 return Err(invalid_usage(
-                    "`--json` is only valid with `--status`, `--profile`, or `--export`.",
+                    "`--json` is only valid with non-interactive commands.",
                 ));
             }
             Ok(CliAction::RunTui {
@@ -315,6 +417,26 @@ fn finalize_cli_action(
             kind: CommandKind::Profile { profile },
             output,
         })),
+        Some(PrimaryCommand::Pause) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Pause,
+            output,
+        })),
+        Some(PrimaryCommand::Resume) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Resume,
+            output,
+        })),
+        Some(PrimaryCommand::Stop) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Stop,
+            output,
+        })),
+        Some(PrimaryCommand::Next) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Next,
+            output,
+        })),
+        Some(PrimaryCommand::Task(label)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Task { label },
+            output,
+        })),
         Some(PrimaryCommand::Status) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Status,
             output,
@@ -328,10 +450,69 @@ fn finalize_cli_action(
 
 pub fn execute_command(command: CliCommand) -> Result<(), String> {
     match command.kind {
+        CommandKind::Pause => execute_pause_command(command.output),
+        CommandKind::Resume => execute_resume_command(command.output),
+        CommandKind::Stop => execute_stop_command(command.output),
+        CommandKind::Next => execute_next_command(command.output),
+        CommandKind::Task { label } => execute_task_command(label, command.output),
         CommandKind::Profile { profile } => execute_profile_command(profile, command.output),
         CommandKind::Status => execute_status_command(command.output),
         CommandKind::Export { dir } => execute_export_command(dir, command.output),
     }
+}
+
+fn execute_pause_command(output: OutputMode) -> Result<(), String> {
+    let mut app = App::new();
+    app.pause_for_cli()?;
+    emit_timer_command_output("pause", &app, output)
+}
+
+fn execute_resume_command(output: OutputMode) -> Result<(), String> {
+    let mut app = App::new();
+    app.resume_for_cli()?;
+    emit_timer_command_output("resume", &app, output)
+}
+
+fn execute_stop_command(output: OutputMode) -> Result<(), String> {
+    let mut app = App::new();
+    app.stop_for_cli()?;
+    emit_timer_command_output("stop", &app, output)
+}
+
+fn execute_next_command(output: OutputMode) -> Result<(), String> {
+    let mut app = App::new();
+    app.next_phase_for_cli()?;
+    emit_timer_command_output("next", &app, output)
+}
+
+fn execute_task_command(label: String, output: OutputMode) -> Result<(), String> {
+    let mut app = App::new();
+    let created = app.select_task_label_for_cli(&label)?;
+    let selected_task_label = app
+        .selected_task_label_for_cli()
+        .ok_or_else(|| "Task selection failed: no selected task label after update.".to_string())?;
+    let payload = TaskCommandOutput {
+        action: "task",
+        created,
+        selected_task_label,
+        timer: build_timer_state_output(&app),
+    };
+
+    match output {
+        OutputMode::Text => {
+            if payload.created {
+                println!(
+                    "Task label added and selected: {}",
+                    payload.selected_task_label
+                );
+            } else {
+                println!("Task label selected: {}", payload.selected_task_label);
+            }
+            print_timer_state_output(&payload.timer);
+        }
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
 }
 
 fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Result<(), String> {
@@ -399,6 +580,49 @@ fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
     Ok(())
 }
 
+fn emit_timer_command_output(
+    action: &'static str,
+    app: &App,
+    output: OutputMode,
+) -> Result<(), String> {
+    let payload = TimerCommandOutput {
+        action,
+        timer: build_timer_state_output(app),
+    };
+
+    match output {
+        OutputMode::Text => {
+            println!("Timer action applied: {}", payload.action);
+            print_timer_state_output(&payload.timer);
+        }
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn build_timer_state_output(app: &App) -> TimerStateOutput {
+    let (phase, status, remaining_secs, pomodoros_completed) = app.timer_state_for_cli();
+    let profile = app.selected_profile_id();
+    let (focus_secs, short_break_secs, long_break_secs, long_break_interval) =
+        app.profile_values(profile);
+
+    TimerStateOutput {
+        phase: timer_phase_id(phase),
+        status: timer_status_id(status),
+        remaining_secs,
+        pomodoros_completed,
+        selected_profile: ProfileView {
+            id: profile_id(profile),
+            label: profile.label(),
+            focus_secs,
+            short_break_secs,
+            long_break_secs,
+            long_break_interval,
+        },
+        selected_task_label: app.selected_task_label_for_cli(),
+    }
+}
+
 fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let day = current_day_key();
     let today = stats.daily_for(&day);
@@ -418,6 +642,7 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
         })
         .map(|profile| profile.sites.len())
         .unwrap_or_default();
+    let live = build_live_status_output(config, selected_task_label.clone());
 
     StatusOutput {
         day,
@@ -440,6 +665,64 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
             focused_minutes: today.focused_minutes(),
             pomodoros_completed: today.pomodoros_completed,
         },
+        live,
+    }
+}
+
+fn build_live_status_output(
+    config: &AppConfig,
+    fallback_task_label: Option<String>,
+) -> LiveStatusOutput {
+    let custom = config.effective_custom_profile();
+    match session_recovery::load() {
+        Ok(Some(snapshot)) => {
+            let phase = snapshot.phase();
+            let status = snapshot.status();
+            LiveStatusOutput {
+                state_source: "recovery",
+                recovery_error: None,
+                in_progress: true,
+                phase: timer_phase_id(phase),
+                status: timer_status_id(status),
+                remaining_secs: snapshot.remaining_secs,
+                pomodoros_completed: snapshot.pomodoros_completed,
+                selected_profile: profile_view(snapshot.selected_profile, &custom),
+                selected_task_label: snapshot.normalized_task_label(),
+                strict_mode_enforced: config.strict_mode
+                    && phase == TimerPhase::Focus
+                    && status != TimerStatus::Idle,
+            }
+        }
+        Ok(None) => {
+            let selected_profile = profile_view(config.selected_profile, &custom);
+            LiveStatusOutput {
+                state_source: "default",
+                recovery_error: None,
+                in_progress: false,
+                phase: timer_phase_id(TimerPhase::Focus),
+                status: timer_status_id(TimerStatus::Idle),
+                remaining_secs: selected_profile.focus_secs,
+                pomodoros_completed: 0,
+                selected_profile,
+                selected_task_label: fallback_task_label,
+                strict_mode_enforced: false,
+            }
+        }
+        Err(error) => {
+            let selected_profile = profile_view(config.selected_profile, &custom);
+            LiveStatusOutput {
+                state_source: "default",
+                recovery_error: Some(error),
+                in_progress: false,
+                phase: timer_phase_id(TimerPhase::Focus),
+                status: timer_status_id(TimerStatus::Idle),
+                remaining_secs: selected_profile.focus_secs,
+                pomodoros_completed: 0,
+                selected_profile,
+                selected_task_label: fallback_task_label,
+                strict_mode_enforced: false,
+            }
+        }
     }
 }
 
@@ -489,6 +772,22 @@ fn profile_id(profile: ProfileId) -> &'static str {
     }
 }
 
+fn timer_phase_id(phase: TimerPhase) -> &'static str {
+    match phase {
+        TimerPhase::Focus => "focus",
+        TimerPhase::ShortBreak => "short-break",
+        TimerPhase::LongBreak => "long-break",
+    }
+}
+
+fn timer_status_id(status: TimerStatus) -> &'static str {
+    match status {
+        TimerStatus::Idle => "idle",
+        TimerStatus::Running => "running",
+        TimerStatus::Paused => "paused",
+    }
+}
+
 fn parse_profile_id(value: &str) -> Result<ProfileId, String> {
     match value.trim().to_ascii_lowercase().as_str() {
         "classic" => Ok(ProfileId::Classic),
@@ -518,6 +817,11 @@ fn set_primary_command(
 fn primary_name(command: &PrimaryCommand) -> &'static str {
     match command {
         PrimaryCommand::Start => "--start",
+        PrimaryCommand::Pause => "--pause",
+        PrimaryCommand::Resume => "--resume",
+        PrimaryCommand::Stop => "--stop",
+        PrimaryCommand::Next => "--next",
+        PrimaryCommand::Task(_) => "--task",
         PrimaryCommand::Profile(_) => "--profile",
         PrimaryCommand::Status => "--status",
         PrimaryCommand::Export(_) => "--export",
@@ -593,6 +897,34 @@ fn print_status_output(payload: &StatusOutput) {
         "Session: {} focused minutes, {} pomodoros",
         payload.session.focused_minutes, payload.session.pomodoros_completed
     );
+    println!(
+        "Live timer: {} {} ({} remaining, source: {})",
+        payload.live.phase,
+        payload.live.status,
+        format_duration(payload.live.remaining_secs),
+        payload.live.state_source
+    );
+    if let Some(error) = payload.live.recovery_error.as_deref() {
+        println!("Live timer warning: {error}");
+    }
+}
+
+fn print_timer_state_output(timer: &TimerStateOutput) {
+    println!(
+        "Timer: {} {} ({} remaining)",
+        timer.phase,
+        timer.status,
+        format_duration(timer.remaining_secs)
+    );
+    println!("Pomodoros completed: {}", timer.pomodoros_completed);
+    println!(
+        "Task label: {}",
+        timer.selected_task_label.as_deref().unwrap_or("none")
+    );
+    println!(
+        "Profile: {} ({})",
+        timer.selected_profile.label, timer.selected_profile.id
+    );
 }
 
 fn print_export_output(payload: &ExportOutput) {
@@ -625,6 +957,9 @@ fn invalid_usage(message: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session_recovery::{
+        self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
+    };
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
 
@@ -662,6 +997,46 @@ mod tests {
             CliAction::RunCommand(CliCommand {
                 kind: CommandKind::Status,
                 output: OutputMode::Json
+            })
+        );
+    }
+
+    #[test]
+    fn parse_pause_supports_json_mode() {
+        let parsed = parse(&["--pause", "--json"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Pause,
+                output: OutputMode::Json
+            })
+        );
+    }
+
+    #[test]
+    fn parse_task_with_equals_sets_label() {
+        let parsed = parse(&["--task=Docs"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Task {
+                    label: "Docs".to_string()
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_task_with_value_sets_label() {
+        let parsed = parse(&["--task", "Docs"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Task {
+                    label: "Docs".to_string()
+                },
+                output: OutputMode::Text
             })
         );
     }
@@ -756,6 +1131,18 @@ mod tests {
     }
 
     #[test]
+    fn classify_key_value_arg_accepts_task_equals_value() {
+        let parsed = classify_key_value_arg("--task=Docs").unwrap();
+        assert_eq!(parsed, Some(ParsedToken::Task("Docs".to_string())));
+    }
+
+    #[test]
+    fn classify_key_value_arg_rejects_empty_task_equals_value() {
+        let error = classify_key_value_arg("--task=").unwrap_err();
+        assert!(error.contains("`--task=` requires a task label."));
+    }
+
+    #[test]
     fn classify_key_value_arg_rejects_empty_profile_equals_value() {
         let error = classify_key_value_arg("--profile=").unwrap_err();
         assert!(error.contains("`--profile=` requires a profile value."));
@@ -786,6 +1173,12 @@ mod tests {
     fn parse_help_short_circuits_unknown_arguments() {
         let parsed = parse(&["--help", "--unknown"]).unwrap();
         assert_eq!(parsed, CliAction::ShowHelp);
+    }
+
+    #[test]
+    fn parse_rejects_task_without_value() {
+        let error = parse(&["--task"]).unwrap_err();
+        assert!(error.contains("`--task` requires a task label"));
     }
 
     #[test]
@@ -835,5 +1228,48 @@ mod tests {
         let output = build_status_output(&config, &stats);
 
         assert_eq!(output.blocked_sites_count, 2);
+    }
+
+    #[test]
+    fn build_status_output_uses_recovery_snapshot_for_live_state() {
+        session_recovery::set_test_load_snapshot(Some(InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Running,
+            remaining_secs: 42,
+            pomodoros_completed: 3,
+            selected_task_label: Some("Docs".to_string()),
+            selected_profile: ProfileId::DeepWork,
+        }));
+        let config = AppConfig::default();
+        let stats = FocusStats::default();
+
+        let output = build_status_output(&config, &stats);
+
+        assert!(output.live.in_progress);
+        assert_eq!(output.live.state_source, "recovery");
+        assert_eq!(output.live.phase, "focus");
+        assert_eq!(output.live.status, "running");
+        assert_eq!(output.live.remaining_secs, 42);
+        assert_eq!(output.live.pomodoros_completed, 3);
+        assert_eq!(output.live.selected_task_label.as_deref(), Some("Docs"));
+        assert_eq!(output.live.selected_profile.id, "deep-work");
+        assert!(output.live.recovery_error.is_none());
+    }
+
+    #[test]
+    fn build_status_output_reports_recovery_error_without_failing() {
+        session_recovery::set_test_load_error("simulated load failure");
+        let config = AppConfig::default();
+        let stats = FocusStats::default();
+
+        let output = build_status_output(&config, &stats);
+
+        assert!(!output.live.in_progress);
+        assert_eq!(output.live.state_source, "default");
+        assert_eq!(
+            output.live.recovery_error.as_deref(),
+            Some("simulated load failure")
+        );
+        assert_eq!(output.live.status, "idle");
     }
 }


### PR DESCRIPTION
## What

- Add non-interactive CLI automation v2 commands: `--pause`, `--resume`, `--stop`, `--next`, and `--task` (with auto-create behavior for unknown labels).
- Add CLI-safe timer/task control APIs in `App` so command execution reuses existing strict-mode, recovery sync, and planner persistence logic.
- Extend `--status --json` with a recovery-aware `live` object containing timer/session state used by orchestration scripts.
- Update user docs and changelog, and expand unit tests for parser behavior, command behavior, and richer status output.

## Why

Automation workflows need to control timer state and read live status without entering the TUI. This change expands scriptable control while preserving backward compatibility for existing CLI flags and commands.

Closes #137

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable, N/A: behavior not changed)
- [x] WakaTime integration behavior was verified for this change (if applicable, N/A: behavior not changed)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable, N/A: none added)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR (N/A: no breaking change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-interactive CLI commands to control timer flow: --pause, --resume, --stop, --next
  * --task to select or create task labels (supports --task LABEL and --task=LABEL); CLI errors if label omitted
  * These commands can emit JSON or text confirmations with current timer state

* **Changed**
  * --status --json now includes richer live timer/session fields (live state, remaining time, profile/task, strict-mode); recovery-load errors surfaced in output

* **Documentation**
  * README and changelog updated to document new commands and JSON behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->