### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+## [0.5.0] - 2026-04-22
+
+### Added
+
 - **CLI automation v2 commands (#137):** added non-interactive `--pause`, `--resume`, `--stop`, `--next`, and `--task` commands for scriptable timer/session control.
 
 ### Changed
@@ -115,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/utilForever/focustime/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/utilForever/focustime/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/utilForever/focustime/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/utilForever/focustime/compare/v0.3.2...v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -399,12 +399,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.4.2`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.5.0`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.4.2](https://github.com/utilForever/focustime/releases/tag/v0.4.2).
+The latest stable release is [v0.5.0](https://github.com/utilForever/focustime/releases/tag/v0.5.0).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the v0.5.0 release metadata by aligning the crate version and release-facing docs.

- Bump `focustime` version to `0.5.0` in `Cargo.toml` and `Cargo.lock`.
- Promote current `Unreleased` notes into `CHANGELOG.md` release section `0.5.0`.
- Update README release references from `v0.4.2` to `v0.5.0`.

## Why

Issue #152 requests the v0.5.0 release update. Keeping manifest and documentation version references in sync avoids release-note drift and makes the next tag/release flow consistent.

Closes #152

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable, N/A: release metadata/docs only)
- [x] Site blocking behavior was verified for this change (if applicable, N/A: release metadata/docs only)
- [x] WakaTime integration behavior was verified for this change (if applicable, N/A: release metadata/docs only)
- [x] I added or updated tests for changed behavior (if applicable, N/A: no behavior changes)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable, N/A)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR (N/A: none)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.5.0 and updated supporting documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->