### PR TITLE
Improve task planner label management and quick picks

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,13 @@ Profile selection and custom values are persisted in `config.toml`.
 Open the session planner from timer view with **`t`**.
 
 - `a`: add a new task label
+- `e`: rename highlighted task label
+- `d` or `Delete`: delete highlighted task label
+- `r` or `1-5`: quick-pick recent task labels
 - `↑/↓`: move selection
 - `Enter`: select highlighted task label
 - `t` or `Esc`: return to timer view
-- while adding a label, `Enter` saves and `Esc` cancels
+- while adding/renaming a label, `Enter` saves and `Esc` cancels
 
 Starting a focus session from idle now requires a selected task label. The timer
 view always shows the current task label (or a reminder to select one).

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     path::Path,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -66,6 +67,7 @@ const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 18;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
+const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
 const SCHEDULE_TIME_STEP_MINUTES: u16 = 15;
 const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
 const SCHEDULE_DAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -180,6 +182,12 @@ pub enum SiteInputMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlocklistProfileInputMode {
     Create,
+    Rename,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlannerInputMode {
+    Add,
     Rename,
 }
 
@@ -326,6 +334,7 @@ pub struct App {
     pub planner_selection_index: usize,
     pub planner_input: String,
     pub planner_input_active: bool,
+    pub planner_input_mode: Option<PlannerInputMode>,
     pub planner_feedback: Option<PlannerFeedback>,
     active_focus_task_label: Option<String>,
     active_focus_profile: Option<ProfileId>,
@@ -435,6 +444,7 @@ impl App {
             planner_selection_index,
             planner_input: String::new(),
             planner_input_active: false,
+            planner_input_mode: None,
             planner_feedback: None,
             active_focus_task_label: None,
             active_focus_profile: None,
@@ -677,6 +687,32 @@ impl App {
 
     pub fn selected_task_label_for_cli(&self) -> Option<String> {
         self.selected_task_label.clone()
+    }
+
+    pub fn planner_recent_labels(&self, limit: usize) -> Vec<String> {
+        if limit == 0 || self.task_labels.is_empty() {
+            return Vec::new();
+        }
+
+        let mut recent = Vec::new();
+        let mut seen = BTreeSet::new();
+        let source_limit = self.task_labels.len().max(limit);
+        for label in self.stats.recent_task_labels(source_limit) {
+            let Some(existing_index) = task_label_index(&self.task_labels, &label) else {
+                continue;
+            };
+            let canonical = self.task_labels[existing_index].clone();
+            let key = canonical.to_ascii_lowercase();
+            if !seen.insert(key) {
+                continue;
+            }
+            recent.push(canonical);
+            if recent.len() >= limit {
+                break;
+            }
+        }
+
+        recent
     }
 
     pub fn timer_state_for_cli(&self) -> (TimerPhase, TimerStatus, u64, u32) {
@@ -1537,6 +1573,13 @@ impl App {
                     (self.planner_selection_index + 1).min(self.task_labels.len() - 1);
             }
             KeyCode::Char('a') => self.start_planner_input(),
+            KeyCode::Char('e') => self.start_planner_rename_input(),
+            KeyCode::Char('d') | KeyCode::Delete => self.remove_planner_label(),
+            KeyCode::Char('r') => self.select_recent_planner_label(0),
+            KeyCode::Char(c @ '1'..='9') => {
+                let index = (c as usize).saturating_sub('1' as usize);
+                self.select_recent_planner_label(index);
+            }
             KeyCode::Enter => self.select_planner_label(),
             _ => {}
         }
@@ -1545,27 +1588,60 @@ impl App {
     fn start_planner_input(&mut self) {
         self.planner_input.clear();
         self.planner_input_active = true;
+        self.planner_input_mode = Some(PlannerInputMode::Add);
+        self.planner_feedback = None;
+    }
+
+    fn start_planner_rename_input(&mut self) {
+        if self.task_labels.is_empty() {
+            self.set_planner_feedback(PlannerFeedbackLevel::Warning, "No task labels available");
+            return;
+        }
+
+        self.clamp_planner_selection();
+        let Some(label) = self.task_labels.get(self.planner_selection_index).cloned() else {
+            self.set_planner_feedback(PlannerFeedbackLevel::Warning, "No task labels available");
+            return;
+        };
+
+        self.planner_input = label;
+        self.planner_input_active = true;
+        self.planner_input_mode = Some(PlannerInputMode::Rename);
         self.planner_feedback = None;
     }
 
     fn cancel_planner_input(&mut self) {
         self.planner_input.clear();
         self.planner_input_active = false;
+        self.planner_input_mode = None;
     }
 
     fn commit_planner_input(&mut self) {
+        let Some(mode) = self.planner_input_mode else {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                "Planner input mode unavailable",
+            );
+            return;
+        };
         let Some(label) = normalize_task_label(&self.planner_input) else {
             self.set_planner_feedback(PlannerFeedbackLevel::Warning, "Task label cannot be empty");
             return;
         };
-        self.planner_input_active = false;
-        self.planner_input.clear();
 
+        match mode {
+            PlannerInputMode::Add => self.commit_planner_add_input(label),
+            PlannerInputMode::Rename => self.commit_planner_rename_input(label),
+        }
+    }
+
+    fn commit_planner_add_input(&mut self, label: String) {
         if let Some(existing_index) = task_label_index(&self.task_labels, &label) {
             self.planner_selection_index = existing_index;
             self.selected_task_label = self.task_labels.get(existing_index).cloned();
             self.sync_task_planner_state();
             self.sync_recovery_snapshot();
+            self.cancel_planner_input();
             self.set_planner_feedback(
                 PlannerFeedbackLevel::Warning,
                 format!("`{label}` already exists, selected existing label"),
@@ -1579,9 +1655,142 @@ impl App {
         self.selected_task_label = Some(label.clone());
         self.sync_task_planner_state();
         self.sync_recovery_snapshot();
+        self.cancel_planner_input();
         self.set_planner_feedback(
             PlannerFeedbackLevel::Success,
             format!("Added and selected `{label}`"),
+        );
+    }
+
+    fn commit_planner_rename_input(&mut self, label: String) {
+        if self.task_labels.is_empty() {
+            self.set_planner_feedback(PlannerFeedbackLevel::Warning, "No task labels available");
+            return;
+        }
+
+        self.clamp_planner_selection();
+        let Some(current_label) = self.task_labels.get(self.planner_selection_index).cloned()
+        else {
+            self.set_planner_feedback(PlannerFeedbackLevel::Warning, "No task labels available");
+            return;
+        };
+
+        if current_label == label {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                format!("No change for `{current_label}`"),
+            );
+            return;
+        }
+
+        if let Some(existing_index) = task_label_index(&self.task_labels, &label)
+            && existing_index != self.planner_selection_index
+        {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                format!("`{label}` already exists"),
+            );
+            return;
+        }
+
+        if let Some(target) = self.task_labels.get_mut(self.planner_selection_index) {
+            *target = label.clone();
+        }
+        if self
+            .selected_task_label
+            .as_ref()
+            .is_some_and(|selected| selected.eq_ignore_ascii_case(&current_label))
+        {
+            self.selected_task_label = Some(label.clone());
+        }
+        if self
+            .active_focus_task_label
+            .as_ref()
+            .is_some_and(|active| active.eq_ignore_ascii_case(&current_label))
+        {
+            self.active_focus_task_label = Some(label.clone());
+        }
+
+        self.sync_task_planner_state();
+        self.sync_recovery_snapshot();
+        self.cancel_planner_input();
+        self.set_planner_feedback(
+            PlannerFeedbackLevel::Success,
+            format!("Renamed `{current_label}` -> `{label}`"),
+        );
+    }
+
+    fn remove_planner_label(&mut self) {
+        if self.task_labels.is_empty() {
+            self.set_planner_feedback(PlannerFeedbackLevel::Warning, "No task labels available");
+            return;
+        }
+
+        self.clamp_planner_selection();
+        let removed = self.task_labels.remove(self.planner_selection_index);
+        if self.planner_selection_index >= self.task_labels.len() && !self.task_labels.is_empty() {
+            self.planner_selection_index = self.task_labels.len().saturating_sub(1);
+        }
+        self.clamp_planner_selection();
+
+        let removed_was_selected = self
+            .selected_task_label
+            .as_ref()
+            .is_some_and(|selected| selected.eq_ignore_ascii_case(&removed));
+        let selected_label_missing = self
+            .selected_task_label
+            .as_ref()
+            .is_some_and(|selected| task_label_index(&self.task_labels, selected).is_none());
+        if removed_was_selected || selected_label_missing {
+            self.selected_task_label = self.task_labels.get(self.planner_selection_index).cloned();
+        }
+
+        self.sync_task_planner_state();
+        self.sync_recovery_snapshot();
+        let feedback = if removed_was_selected {
+            if let Some(selected) = self.selected_task_label.as_ref() {
+                format!("Deleted `{removed}` (selected `{selected}`)")
+            } else {
+                format!("Deleted `{removed}` (no selected label)")
+            }
+        } else {
+            format!("Deleted `{removed}`")
+        };
+        self.set_planner_feedback(PlannerFeedbackLevel::Success, feedback);
+    }
+
+    fn select_recent_planner_label(&mut self, index: usize) {
+        let recent = self.planner_recent_labels(PLANNER_RECENT_LABEL_LIMIT);
+        if recent.is_empty() {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                "No recent task labels available",
+            );
+            return;
+        }
+        if index >= recent.len() {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                format!("Recent quick-pick {} is unavailable", index + 1),
+            );
+            return;
+        }
+
+        let label = recent[index].clone();
+        let Some(existing_index) = task_label_index(&self.task_labels, &label) else {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                format!("Recent label `{label}` is no longer available"),
+            );
+            return;
+        };
+        self.planner_selection_index = existing_index;
+        self.selected_task_label = self.task_labels.get(existing_index).cloned();
+        self.sync_task_planner_state();
+        self.sync_recovery_snapshot();
+        self.set_planner_feedback(
+            PlannerFeedbackLevel::Success,
+            format!("Selected recent `{label}`"),
         );
     }
 
@@ -2353,6 +2562,7 @@ impl App {
         self.planner_feedback = None;
         self.planner_input.clear();
         self.planner_input_active = false;
+        self.planner_input_mode = None;
         if let Some(selected) = self.selected_task_label.as_ref()
             && let Some(index) = task_label_index(&self.task_labels, selected)
         {
@@ -5351,6 +5561,113 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char(' ')));
         assert_eq!(app.timer.status, TimerStatus::Running);
+    }
+
+    #[test]
+    fn session_planner_renames_highlighted_label_and_updates_selection() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string(), "Review".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+
+        app.handle_key(key(KeyCode::Char('t')));
+        app.handle_key(key(KeyCode::Char('e')));
+        assert!(app.planner_input_active);
+        assert_eq!(app.planner_input_mode, Some(PlannerInputMode::Rename));
+
+        app.planner_input = "Writing".to_string();
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(
+            app.task_labels,
+            vec!["Writing".to_string(), "Review".to_string()]
+        );
+        assert_eq!(app.selected_task_label.as_deref(), Some("Writing"));
+        assert!(!app.planner_input_active);
+        assert_eq!(app.planner_input_mode, None);
+        assert!(
+            app.planner_feedback
+                .as_ref()
+                .is_some_and(|feedback| feedback.message.contains("Renamed"))
+        );
+    }
+
+    #[test]
+    fn session_planner_delete_selected_label_selects_nearest_remaining() {
+        let mut app = App::default();
+        app.task_labels = vec![
+            "Docs".to_string(),
+            "Review".to_string(),
+            "Planning".to_string(),
+        ];
+        app.selected_task_label = Some("Review".to_string());
+
+        app.handle_key(key(KeyCode::Char('t')));
+        app.planner_selection_index = 1;
+        app.handle_key(key(KeyCode::Char('d')));
+
+        assert_eq!(
+            app.task_labels,
+            vec!["Docs".to_string(), "Planning".to_string()]
+        );
+        assert_eq!(app.selected_task_label.as_deref(), Some("Planning"));
+        assert_eq!(app.planner_selection_index, 1);
+    }
+
+    #[test]
+    fn session_planner_delete_last_label_clears_selection() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+
+        app.handle_key(key(KeyCode::Char('t')));
+        app.handle_key(key(KeyCode::Delete));
+
+        assert!(app.task_labels.is_empty());
+        assert!(app.selected_task_label.is_none());
+        assert_eq!(app.planner_selection_index, 0);
+    }
+
+    #[test]
+    fn session_planner_recent_quick_pick_selects_recent_labels() {
+        let mut app = App::default();
+        app.task_labels = vec![
+            "Docs".to_string(),
+            "Review".to_string(),
+            "Bugfix".to_string(),
+        ];
+        app.selected_task_label = Some("Docs".to_string());
+        let goal = DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        };
+        app.stats.record_completed_pomodoro_with_task(
+            "2026-04-07",
+            goal,
+            Some("Docs"),
+            25 * 60,
+            None,
+        );
+        app.stats.record_completed_pomodoro_with_task(
+            "2026-04-08",
+            goal,
+            Some("Review"),
+            25 * 60,
+            None,
+        );
+        app.stats.record_completed_pomodoro_with_task(
+            "2026-04-09",
+            goal,
+            Some("Bugfix"),
+            25 * 60,
+            None,
+        );
+
+        app.handle_key(key(KeyCode::Char('t')));
+        app.handle_key(key(KeyCode::Char('r')));
+        assert_eq!(app.selected_task_label.as_deref(), Some("Bugfix"));
+
+        app.handle_key(key(KeyCode::Char('2')));
+        assert_eq!(app.selected_task_label.as_deref(), Some("Review"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -68,7 +68,6 @@ const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
 pub(crate) const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
-const PLANNER_RECENT_LABEL_SOURCE_MULTIPLIER: usize = 3;
 const SCHEDULE_TIME_STEP_MINUTES: u16 = 15;
 const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
 const SCHEDULE_DAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -695,27 +694,38 @@ impl App {
             return Vec::new();
         }
 
-        let mut recent = Vec::new();
-        let mut seen = BTreeSet::new();
-        let source_limit = limit
-            .saturating_mul(PLANNER_RECENT_LABEL_SOURCE_MULTIPLIER)
-            .max(limit);
-        for label in self.stats.recent_task_labels(source_limit) {
-            let Some(existing_index) = task_label_index(&self.task_labels, &label) else {
-                continue;
-            };
-            let canonical = self.task_labels[existing_index].clone();
-            let key = canonical.to_ascii_lowercase();
-            if !seen.insert(key) {
-                continue;
-            }
-            recent.push(canonical);
-            if recent.len() >= limit {
-                break;
-            }
-        }
+        let mut source_limit = limit;
+        loop {
+            let source = self.stats.recent_task_labels(source_limit);
+            let exhausted = source.len() < source_limit;
+            let mut recent = Vec::new();
+            let mut seen = BTreeSet::new();
 
-        recent
+            for label in source {
+                let Some(existing_index) = task_label_index(&self.task_labels, &label) else {
+                    continue;
+                };
+                let canonical = self.task_labels[existing_index].clone();
+                let key = canonical.to_ascii_lowercase();
+                if !seen.insert(key) {
+                    continue;
+                }
+                recent.push(canonical);
+                if recent.len() >= limit {
+                    return recent;
+                }
+            }
+
+            if exhausted {
+                return recent;
+            }
+
+            let next_limit = source_limit.saturating_mul(2);
+            if next_limit == source_limit {
+                return recent;
+            }
+            source_limit = next_limit;
+        }
     }
 
     pub fn timer_state_for_cli(&self) -> (TimerPhase, TimerStatus, u64, u32) {
@@ -5668,6 +5678,44 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char('2')));
         assert_eq!(app.selected_task_label.as_deref(), Some("Review"));
+    }
+
+    #[test]
+    fn planner_recent_labels_finds_older_valid_labels_after_stale_entries() {
+        let mut app = App::default();
+        app.task_labels = vec!["Keep A".to_string(), "Keep B".to_string()];
+        let goal = DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        };
+
+        app.stats.record_completed_pomodoro_with_task(
+            "2026-04-01",
+            goal,
+            Some("Keep A"),
+            25 * 60,
+            None,
+        );
+        app.stats.record_completed_pomodoro_with_task(
+            "2026-04-02",
+            goal,
+            Some("Keep B"),
+            25 * 60,
+            None,
+        );
+        for i in 0..20 {
+            let label = format!("Stale {i}");
+            app.stats.record_completed_pomodoro_with_task(
+                "2026-04-10",
+                goal,
+                Some(&label),
+                25 * 60,
+                None,
+            );
+        }
+
+        let recent = app.planner_recent_labels(2);
+        assert_eq!(recent, vec!["Keep B".to_string(), "Keep A".to_string()]);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,7 +67,8 @@ const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 18;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
-const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
+pub(crate) const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
+const PLANNER_RECENT_LABEL_SOURCE_MULTIPLIER: usize = 3;
 const SCHEDULE_TIME_STEP_MINUTES: u16 = 15;
 const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
 const SCHEDULE_DAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -696,7 +697,9 @@ impl App {
 
         let mut recent = Vec::new();
         let mut seen = BTreeSet::new();
-        let source_limit = self.task_labels.len().max(limit);
+        let source_limit = limit
+            .saturating_mul(PLANNER_RECENT_LABEL_SOURCE_MULTIPLIER)
+            .max(limit);
         for label in self.stats.recent_task_labels(source_limit) {
             let Some(existing_index) = task_label_index(&self.task_labels, &label) else {
                 continue;
@@ -1728,9 +1731,6 @@ impl App {
 
         self.clamp_planner_selection();
         let removed = self.task_labels.remove(self.planner_selection_index);
-        if self.planner_selection_index >= self.task_labels.len() && !self.task_labels.is_empty() {
-            self.planner_selection_index = self.task_labels.len().saturating_sub(1);
-        }
         self.clamp_planner_selection();
 
         let removed_was_selected = self

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -471,6 +471,29 @@ impl FocusStats {
         true
     }
 
+    pub fn recent_task_labels(&self, limit: usize) -> Vec<String> {
+        if limit == 0 {
+            return Vec::new();
+        }
+
+        let mut recent = Vec::new();
+        let mut seen = BTreeSet::new();
+        for session in self.focus_sessions.iter().rev() {
+            let Some(task_label) = normalize_task_label(&session.task_label) else {
+                continue;
+            };
+            let key = task_label.to_ascii_lowercase();
+            if !seen.insert(key) {
+                continue;
+            }
+            recent.push(task_label);
+            if recent.len() >= limit {
+                break;
+            }
+        }
+        recent
+    }
+
     pub fn recent_daily(&self, limit: usize) -> Vec<(String, DailyStats)> {
         self.daily
             .iter()
@@ -1110,6 +1133,53 @@ mod tests {
         let (labels, selected) = stats.task_planner_state();
         assert_eq!(labels, vec!["Docs".to_string(), "Bugfix".to_string()]);
         assert_eq!(selected, Some("Docs".to_string()));
+    }
+
+    #[test]
+    fn recent_task_labels_returns_newest_first_unique_labels() {
+        let mut stats = FocusStats::default();
+        let goal = DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        };
+        stats.record_completed_pomodoro_with_task("2026-04-07", goal, Some("Docs"), 25 * 60, None);
+        stats.record_completed_pomodoro_with_task(
+            "2026-04-08",
+            goal,
+            Some("Bugfix"),
+            25 * 60,
+            None,
+        );
+        stats.record_completed_pomodoro_with_task("2026-04-09", goal, Some("docs"), 25 * 60, None);
+        stats.record_completed_pomodoro_with_task(
+            "2026-04-10",
+            goal,
+            Some("Planning"),
+            25 * 60,
+            None,
+        );
+
+        let recent = stats.recent_task_labels(3);
+        assert_eq!(
+            recent,
+            vec![
+                "Planning".to_string(),
+                "docs".to_string(),
+                "Bugfix".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn recent_task_labels_respects_zero_limit() {
+        let mut stats = FocusStats::default();
+        let goal = DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        };
+        stats.record_completed_pomodoro_with_task("2026-04-10", goal, Some("Docs"), 25 * 60, None);
+
+        assert!(stats.recent_task_labels(0).is_empty());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,8 +9,8 @@ use ratatui::{
 
 use crate::app::{
     App, AppMode, BlocklistProfileInputMode, DailyGoalProgress, HistoryFeedbackLevel,
-    PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, PlannerFeedbackLevel, SetupCheck, SetupCheckLevel,
-    SiteFeedbackLevel, SiteInputMode,
+    PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, PlannerFeedbackLevel, PlannerInputMode, SetupCheck,
+    SetupCheckLevel, SiteFeedbackLevel, SiteInputMode,
 };
 use crate::timer::{TimerPhase, TimerStatus};
 use crate::wakatime::WakatimeRuntimeState;
@@ -834,7 +834,7 @@ fn render_session_planner(frame: &mut Frame, app: &App) {
             Constraint::Min(5),    // task labels list
             Constraint::Length(3), // add input
             Constraint::Length(2), // feedback
-            Constraint::Length(3), // hints
+            Constraint::Length(4), // hints
         ])
         .split(outer);
 
@@ -922,14 +922,17 @@ fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {
 
 fn render_session_planner_input(frame: &mut Frame, app: &App, area: Rect) {
     let input_title = if app.planner_input_active {
-        " Add task label "
+        match app.planner_input_mode {
+            Some(PlannerInputMode::Rename) => " Rename task label ",
+            _ => " Add task label ",
+        }
     } else {
-        " Add task label ([a] to type) "
+        " Task label input ([a] add / [e] rename) "
     };
     let input_text = if app.planner_input_active {
         format!("{}|", app.planner_input)
     } else {
-        "Type a label, then press [Enter] to add and select".to_string()
+        "Use [a] add, [e] rename highlighted, [d/Del] delete highlighted".to_string()
     };
     frame.render_widget(
         Paragraph::new(input_text)
@@ -959,10 +962,31 @@ fn render_session_planner_feedback(frame: &mut Frame, app: &App, area: Rect) {
     }
 }
 
+fn planner_recent_quick_pick_text(app: &App) -> String {
+    let recent = app.planner_recent_labels(5);
+    if recent.is_empty() {
+        return "Recent: none yet".to_string();
+    }
+
+    let mut parts = Vec::new();
+    for (index, label) in recent.iter().enumerate() {
+        if index == 0 {
+            parts.push(format!("[r/1] {label}"));
+        } else {
+            parts.push(format!("[{}] {label}", index + 1));
+        }
+    }
+    format!("Recent: {}", parts.join("  "))
+}
+
 fn render_session_planner_hints(frame: &mut Frame, app: &App, area: Rect) {
     let hints = if app.planner_input_active {
+        let commit_line = match app.planner_input_mode {
+            Some(PlannerInputMode::Rename) => "Input: rename label, then [Enter]",
+            _ => "Input: type task label, then [Enter]",
+        };
         vec![
-            Line::from("Input: type task label, then [Enter]"),
+            Line::from(commit_line),
             Line::from("Input: [Esc] Cancel"),
             Line::from(if app.strict_mode_enforced_for_focus() {
                 "View: [q/Ctrl-C] Quit (Locked)"
@@ -972,8 +996,8 @@ fn render_session_planner_hints(frame: &mut Frame, app: &App, area: Rect) {
         ]
     } else {
         vec![
-            Line::from("Planner: [↑/↓] Move"),
-            Line::from("Planner: [Enter] Select  [a] Add label"),
+            Line::from("Planner: [↑/↓] Move  [Enter] Select  [a] Add  [e] Rename  [d/Del] Delete"),
+            Line::from(planner_recent_quick_pick_text(app)),
             Line::from(if app.strict_mode_enforced_for_focus() {
                 "View: [t/Esc] Back  [q/Ctrl-C] Quit (Locked)"
             } else {
@@ -1699,6 +1723,45 @@ mod tests {
 
         let text = terminal_text(&terminal, width, height);
         assert!(text.contains("Session Planner"));
+    }
+
+    #[test]
+    fn session_planner_view_renders_label_management_hints() {
+        let width = 120;
+        let height = 28;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.mode = AppMode::SessionPlanner;
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("Rename"));
+        assert!(text.contains("Delete"));
+        assert!(text.contains("Recent: none yet"));
+    }
+
+    #[test]
+    fn session_planner_view_renders_rename_input_title() {
+        let width = 120;
+        let height = 28;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.mode = AppMode::SessionPlanner;
+        app.planner_input_active = true;
+        app.planner_input_mode = Some(PlannerInputMode::Rename);
+        app.planner_input = "Docs".to_string();
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("Rename task label"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,8 +9,8 @@ use ratatui::{
 
 use crate::app::{
     App, AppMode, BlocklistProfileInputMode, DailyGoalProgress, HistoryFeedbackLevel,
-    PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, PlannerFeedbackLevel, PlannerInputMode, SetupCheck,
-    SetupCheckLevel, SiteFeedbackLevel, SiteInputMode,
+    PLANNER_RECENT_LABEL_LIMIT, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, PlannerFeedbackLevel,
+    PlannerInputMode, SetupCheck, SetupCheckLevel, SiteFeedbackLevel, SiteInputMode,
 };
 use crate::timer::{TimerPhase, TimerStatus};
 use crate::wakatime::WakatimeRuntimeState;
@@ -963,7 +963,7 @@ fn render_session_planner_feedback(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn planner_recent_quick_pick_text(app: &App) -> String {
-    let recent = app.planner_recent_labels(5);
+    let recent = app.planner_recent_labels(PLANNER_RECENT_LABEL_LIMIT);
     if recent.is_empty() {
         return "Recent: none yet".to_string();
     }


### PR DESCRIPTION
## Why
Task labels in the session planner could only be added and selected, which made long-term label maintenance cumbersome and slowed repeated task selection. This change adds full in-app label lifecycle management and a quick way to reuse recently used labels.

## What changed
- Added planner label management actions in-app:
  - Rename highlighted label (`e`)
  - Delete highlighted label (`d`/`Delete`)
  - Keep planner selection and selected task state consistent after mutations
- Added recent-label quick-pick flow:
  - `r` selects the most recent label
  - `1-5` selects indexed recent labels
  - Recent labels are derived from focus-session history, newest-first and deduplicated
- Added a new `FocusStats::recent_task_labels(limit)` API to support quick picks
- Updated planner UI and hints to reflect add/rename/delete/quick-pick behavior and input modes
- Updated README session planner keymap and interaction notes

Close #139 

## Notes for reviewers
- Historical focus-session records are intentionally preserved as recorded; rename/delete affects planner-managed labels and current selection behavior.
- Deleting the currently selected label now auto-selects the nearest remaining label, and clears selection only when no labels remain.
- This PR also adds test coverage for rename/delete consistency, recent quick-picks, recent label ordering, and planner UI hint rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rename task labels via the session planner using "e".
  * Delete task labels via "d" or "Delete".
  * Quick-pick recent labels with "r" or number keys (1–5).
  * Mode-aware input title/prompt and expanded hints including recent-label shortcuts.

* **Bug Fixes**
  * Selection and active/selected label update correctly after rename or delete.

* **Documentation**
  * README: clarified label entry flow — Enter saves, Esc cancels — and documented new keybindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->