### PR TITLE
Prepare v0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.5.1] - 2026-04-22
+
+### Changed
+
+- **v0.5.1 release metadata/docs refresh (#156):** bumped crate version to `0.5.1`, updated the README latest-stable-release reference, and advanced changelog comparison links.
+
 ## [0.5.0] - 2026-04-22
 
 ### Added
@@ -121,7 +127,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/utilForever/focustime/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/utilForever/focustime/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/utilForever/focustime/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/utilForever/focustime/compare/v0.4.0...v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.5.0](https://github.com/utilForever/focustime/releases/tag/v0.5.0).
+The latest stable release is [v0.5.1](https://github.com/utilForever/focustime/releases/tag/v0.5.1).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the v0.5.1 release metadata and documentation updates requested in #156.

- Bump crate version to `0.5.1` in `Cargo.toml` (and `Cargo.lock`).
- Update the README latest-stable-release link to `v0.5.1`.
- Add a `0.5.1` changelog entry and advance comparison links.

## Why

These updates keep release/version references aligned for the v0.5.1 patch release and ensure changelog comparison links point at the correct tags.

Closes #156

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

Note: In this environment, `cargo test --all` repeatedly timed out/hung after starting the test run, both before and after this metadata/docs-only change.

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable) - N/A
- [x] Site blocking behavior was verified for this change (if applicable) - N/A
- [x] WakaTime integration behavior was verified for this change (if applicable) - N/A
- [x] I added or updated tests for changed behavior (if applicable) - N/A

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) - N/A
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) - N/A
- [x] Breaking behavior changes are clearly described in this PR - N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.5.1
  * Updated release documentation and stable release references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->