### PR TITLE
Add schedule exception dates and skip-day UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ focus_to_break = false
 break_to_focus = false
 
 [recurring_schedule]
+exception_dates = ["2026-12-25", "2027-01-01"]
 [[recurring_schedule.windows]]
 days = ["mon", "tue", "wed", "thu", "fri"]
 start = "09:00"
@@ -276,6 +277,7 @@ Recurring schedule windows can also trigger focus behavior at wall-clock times:
 
 - `recurring_schedule.windows[].days` accepts day tokens (`mon`..`sun`, case-insensitive)
 - `recurring_schedule.windows[].start` / `end` use 24-hour `HH:MM` local time (`start < end`)
+- `recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
 - when a window begins, focus auto-starts if possible; otherwise schedule mode arms and shows a reminder until you manually start focus
 - the timer session overview shows the current/next scheduled window
 
@@ -291,6 +293,9 @@ You can configure notification and auto-start settings directly from the TUI:
   - **Schedule window**: `←/→` changes which window is selected
   - **Schedule day** + **Schedule day enabled**: choose day cursor and toggle it `Off/On`
   - **Schedule start/end**: adjust times in 15-minute steps
+  - **Schedule exception**: `←/→` changes which exception date is selected
+  - **Exception date**: `←/→` moves selected exception date backward/forward by 1 day
+  - **Exception add/remove**: `→` adds a date (starting from today), `←` removes selected date
 
 ## Session recovery
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -921,26 +921,8 @@ impl App {
 
     fn profile_edit_schedule_field_value(&self, field_index: usize) -> String {
         match field_index {
-            PROFILE_EDIT_SCHEDULE_WINDOW_INDEX => {
-                if self.recurring_schedule.windows.is_empty() {
-                    "none".to_string()
-                } else {
-                    format!(
-                        "{}/{}",
-                        self.profile_edit_schedule_window.saturating_add(1),
-                        self.recurring_schedule.windows.len()
-                    )
-                }
-            }
-            PROFILE_EDIT_SCHEDULE_DAY_INDEX => {
-                if let Some(window) = self.selected_schedule_window() {
-                    let day_label = self.selected_schedule_day_label();
-                    let days = format_schedule_days_for_display(&window.days);
-                    format!("{day_label} ({days})")
-                } else {
-                    "n/a".to_string()
-                }
-            }
+            PROFILE_EDIT_SCHEDULE_WINDOW_INDEX => self.schedule_window_selector_value(),
+            PROFILE_EDIT_SCHEDULE_DAY_INDEX => self.schedule_day_selector_value(),
             PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX => self
                 .selected_schedule_day_enabled()
                 .map(|enabled| bool_label(enabled).to_string())
@@ -953,36 +935,66 @@ impl App {
                 .selected_schedule_window()
                 .map(|window| window.end.clone())
                 .unwrap_or_else(|| "n/a".to_string()),
-            PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX => {
-                if self.recurring_schedule.windows.is_empty() {
-                    "→ Add window".to_string()
-                } else {
-                    "← Remove · → Add".to_string()
-                }
-            }
-            PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX => {
-                if self.recurring_schedule.exception_dates.is_empty() {
-                    "none".to_string()
-                } else {
-                    format!(
-                        "{}/{}",
-                        self.profile_edit_schedule_exception.saturating_add(1),
-                        self.recurring_schedule.exception_dates.len()
-                    )
-                }
-            }
+            PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX => self.schedule_window_collection_value(),
+            PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX => self.schedule_exception_selector_value(),
             PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX => self
                 .selected_schedule_exception_date()
                 .cloned()
                 .unwrap_or_else(|| "n/a".to_string()),
             PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX => {
-                if self.recurring_schedule.exception_dates.is_empty() {
-                    "→ Add date".to_string()
-                } else {
-                    "← Remove · → Add".to_string()
-                }
+                self.schedule_exception_collection_value()
             }
             _ => String::new(),
+        }
+    }
+
+    fn schedule_window_selector_value(&self) -> String {
+        if self.recurring_schedule.windows.is_empty() {
+            "none".to_string()
+        } else {
+            format!(
+                "{}/{}",
+                self.profile_edit_schedule_window.saturating_add(1),
+                self.recurring_schedule.windows.len()
+            )
+        }
+    }
+
+    fn schedule_day_selector_value(&self) -> String {
+        if let Some(window) = self.selected_schedule_window() {
+            let day_label = self.selected_schedule_day_label();
+            let days = format_schedule_days_for_display(&window.days);
+            format!("{day_label} ({days})")
+        } else {
+            "n/a".to_string()
+        }
+    }
+
+    fn schedule_window_collection_value(&self) -> String {
+        if self.recurring_schedule.windows.is_empty() {
+            "→ Add window".to_string()
+        } else {
+            "← Remove · → Add".to_string()
+        }
+    }
+
+    fn schedule_exception_selector_value(&self) -> String {
+        if self.recurring_schedule.exception_dates.is_empty() {
+            "none".to_string()
+        } else {
+            format!(
+                "{}/{}",
+                self.profile_edit_schedule_exception.saturating_add(1),
+                self.recurring_schedule.exception_dates.len()
+            )
+        }
+    }
+
+    fn schedule_exception_collection_value(&self) -> String {
+        if self.recurring_schedule.exception_dates.is_empty() {
+            "→ Add date".to_string()
+        } else {
+            "← Remove · → Add".to_string()
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1217,15 +1217,19 @@ impl App {
     fn adjust_schedule_exceptions_collection(&mut self, increase: bool) {
         if increase {
             let mut candidate = self.current_frame_now.date_naive();
+            let mut candidate_value = candidate.format("%Y-%m-%d").to_string();
             while self
                 .recurring_schedule
                 .exception_dates
                 .iter()
-                .any(|value| value == &candidate.format("%Y-%m-%d").to_string())
+                .any(|value| value == &candidate_value)
             {
-                candidate = candidate.succ_opt().unwrap_or(candidate);
+                let Some(next_candidate) = candidate.succ_opt() else {
+                    return;
+                };
+                candidate = next_candidate;
+                candidate_value = candidate.format("%Y-%m-%d").to_string();
             }
-            let candidate_value = candidate.format("%Y-%m-%d").to_string();
             self.recurring_schedule
                 .exception_dates
                 .push(candidate_value.clone());

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,10 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashSet},
     path::Path,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, NaiveDate};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use crate::blocker::{
@@ -17,8 +17,8 @@ use crate::config::{
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
-    RecurringWindow, WindowOccurrence, active_occurrence, compile_windows, next_occurrence_after,
-    occurrence_key,
+    RecurringWindow, WindowOccurrence, active_occurrence, compile_exception_dates, compile_windows,
+    next_occurrence_after, occurrence_key,
 };
 use crate::session_recovery::{self, InProgressSessionSnapshot};
 use crate::stats::{
@@ -35,7 +35,7 @@ use crate::wakatime::{WakatimeConfigStatus, WakatimeHeartbeatMetadata, WakatimeT
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
-pub const PROFILE_EDIT_FIELD_LABELS: [&str; 19] = [
+pub const PROFILE_EDIT_FIELD_LABELS: [&str; 22] = [
     "Focus",
     "Short Break",
     "Long Break",
@@ -55,6 +55,9 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 19] = [
     "Schedule start",
     "Schedule end",
     "Schedule add/remove",
+    "Schedule exception",
+    "Exception date",
+    "Exception add/remove",
 ];
 const PROFILE_EDIT_WAKATIME_PROJECT_INDEX: usize = 11;
 const PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX: usize = 12;
@@ -64,6 +67,9 @@ const PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX: usize = 15;
 const PROFILE_EDIT_SCHEDULE_START_INDEX: usize = 16;
 const PROFILE_EDIT_SCHEDULE_END_INDEX: usize = 17;
 const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 18;
+const PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX: usize = 19;
+const PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX: usize = 20;
+const PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX: usize = 21;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
@@ -167,6 +173,7 @@ struct ScheduleDisplayState {
     has_schedule_windows: bool,
     active_window: Option<WindowOccurrence>,
     next_window: Option<WindowOccurrence>,
+    is_exception_today: bool,
     is_armed: bool,
     has_selected_task: bool,
     timer_phase: TimerPhase,
@@ -357,11 +364,13 @@ pub struct App {
     pub profile_edit_field: usize,
     profile_edit_schedule_window: usize,
     profile_edit_schedule_day: usize,
+    profile_edit_schedule_exception: usize,
     profile_edit_snapshot: Option<ProfileEditSnapshot>,
     notification_settings: NotificationConfig,
     auto_start: AutoStartConfig,
     recurring_schedule: RecurringScheduleConfig,
     recurring_windows: Vec<RecurringWindow>,
+    recurring_exception_dates: HashSet<NaiveDate>,
     schedule_armed_occurrence_key: Option<String>,
     last_schedule_occurrence_key: Option<String>,
     current_frame_now: DateTime<Local>,
@@ -397,6 +406,8 @@ impl App {
         let auto_start = config.auto_start;
         let recurring_schedule = config.recurring_schedule.clone();
         let recurring_windows = compile_windows(&recurring_schedule.windows);
+        let recurring_exception_dates =
+            compile_exception_dates(&recurring_schedule.exception_dates);
         let strict_mode = config.strict_mode;
         let break_glass_duration_secs = config.break_glass_duration_secs;
         let daily_goal = config.daily_goal;
@@ -466,11 +477,13 @@ impl App {
             profile_edit_field: 0,
             profile_edit_schedule_window: 0,
             profile_edit_schedule_day: 0,
+            profile_edit_schedule_exception: 0,
             profile_edit_snapshot: None,
             notification_settings,
             auto_start,
             recurring_schedule,
             recurring_windows,
+            recurring_exception_dates,
             schedule_armed_occurrence_key: None,
             last_schedule_occurrence_key: None,
             current_frame_now: Local::now(),
@@ -754,10 +767,20 @@ impl App {
     }
 
     fn schedule_display_state_at(&self, now: DateTime<Local>) -> ScheduleDisplayState {
+        let today = now.date_naive();
         ScheduleDisplayState {
             has_schedule_windows: !self.recurring_windows.is_empty(),
-            active_window: active_occurrence(now, &self.recurring_windows),
-            next_window: next_occurrence_after(now, &self.recurring_windows),
+            active_window: active_occurrence(
+                now,
+                &self.recurring_windows,
+                &self.recurring_exception_dates,
+            ),
+            next_window: next_occurrence_after(
+                now,
+                &self.recurring_windows,
+                &self.recurring_exception_dates,
+            ),
+            is_exception_today: self.recurring_exception_dates.contains(&today),
             is_armed: self.schedule_armed_occurrence_key.is_some(),
             has_selected_task: self.selected_task_label.is_some(),
             timer_phase: self.timer.phase,
@@ -925,6 +948,28 @@ impl App {
                     "← Remove · → Add".to_string()
                 }
             }
+            PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX => {
+                if self.recurring_schedule.exception_dates.is_empty() {
+                    "none".to_string()
+                } else {
+                    format!(
+                        "{}/{}",
+                        self.profile_edit_schedule_exception.saturating_add(1),
+                        self.recurring_schedule.exception_dates.len()
+                    )
+                }
+            }
+            PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX => self
+                .selected_schedule_exception_date()
+                .cloned()
+                .unwrap_or_else(|| "n/a".to_string()),
+            PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX => {
+                if self.recurring_schedule.exception_dates.is_empty() {
+                    "→ Add date".to_string()
+                } else {
+                    "← Remove · → Add".to_string()
+                }
+            }
             _ => String::new(),
         }
     }
@@ -939,6 +984,12 @@ impl App {
         self.recurring_schedule
             .windows
             .get_mut(self.profile_edit_schedule_window)
+    }
+
+    fn selected_schedule_exception_date(&self) -> Option<&String> {
+        self.recurring_schedule
+            .exception_dates
+            .get(self.profile_edit_schedule_exception)
     }
 
     fn selected_schedule_day_token(&self) -> &'static str {
@@ -974,6 +1025,16 @@ impl App {
         self.profile_edit_schedule_day = self
             .profile_edit_schedule_day
             .min(SCHEDULE_DAY_TOKENS.len().saturating_sub(1));
+        if self.recurring_schedule.exception_dates.is_empty() {
+            self.profile_edit_schedule_exception = 0;
+        } else {
+            self.profile_edit_schedule_exception = self.profile_edit_schedule_exception.min(
+                self.recurring_schedule
+                    .exception_dates
+                    .len()
+                    .saturating_sub(1),
+            );
+        }
     }
 
     fn cycle_schedule_window(&mut self, increase: bool) {
@@ -998,6 +1059,22 @@ impl App {
             self.profile_edit_schedule_day = total - 1;
         } else {
             self.profile_edit_schedule_day = self.profile_edit_schedule_day.saturating_sub(1);
+        }
+    }
+
+    fn cycle_schedule_exception(&mut self, increase: bool) {
+        if self.recurring_schedule.exception_dates.is_empty() {
+            return;
+        }
+        let total = self.recurring_schedule.exception_dates.len();
+        if increase {
+            self.profile_edit_schedule_exception =
+                (self.profile_edit_schedule_exception + 1) % total;
+        } else if self.profile_edit_schedule_exception == 0 {
+            self.profile_edit_schedule_exception = total - 1;
+        } else {
+            self.profile_edit_schedule_exception =
+                self.profile_edit_schedule_exception.saturating_sub(1);
         }
     }
 
@@ -1064,6 +1141,37 @@ impl App {
         window.end = format_hhmm(end);
     }
 
+    fn adjust_selected_schedule_exception_date(&mut self, increase: bool) {
+        let Some(current_value) = self.selected_schedule_exception_date().cloned() else {
+            return;
+        };
+        let Some(current_date) = parse_schedule_exception_date(&current_value) else {
+            return;
+        };
+        let next_date = if increase {
+            current_date.succ_opt().unwrap_or(current_date)
+        } else {
+            current_date.pred_opt().unwrap_or(current_date)
+        };
+        let next_value = next_date.format("%Y-%m-%d").to_string();
+        if let Some(target) = self
+            .recurring_schedule
+            .exception_dates
+            .get_mut(self.profile_edit_schedule_exception)
+        {
+            *target = next_value.clone();
+        }
+        sort_schedule_exception_dates(&mut self.recurring_schedule.exception_dates);
+        if let Some(position) = self
+            .recurring_schedule
+            .exception_dates
+            .iter()
+            .position(|value| value == &next_value)
+        {
+            self.profile_edit_schedule_exception = position;
+        }
+    }
+
     fn adjust_schedule_windows_collection(&mut self, increase: bool) {
         if increase {
             self.recurring_schedule
@@ -1079,6 +1187,40 @@ impl App {
         self.recurring_schedule
             .windows
             .remove(self.profile_edit_schedule_window);
+        self.clamp_profile_edit_schedule_selection();
+    }
+
+    fn adjust_schedule_exceptions_collection(&mut self, increase: bool) {
+        if increase {
+            let mut candidate = self.current_frame_now.date_naive();
+            while self
+                .recurring_schedule
+                .exception_dates
+                .iter()
+                .any(|value| value == &candidate.format("%Y-%m-%d").to_string())
+            {
+                candidate = candidate.succ_opt().unwrap_or(candidate);
+            }
+            let candidate_value = candidate.format("%Y-%m-%d").to_string();
+            self.recurring_schedule
+                .exception_dates
+                .push(candidate_value.clone());
+            sort_schedule_exception_dates(&mut self.recurring_schedule.exception_dates);
+            self.profile_edit_schedule_exception = self
+                .recurring_schedule
+                .exception_dates
+                .iter()
+                .position(|value| value == &candidate_value)
+                .unwrap_or(0);
+            return;
+        }
+
+        if self.recurring_schedule.exception_dates.is_empty() {
+            return;
+        }
+        self.recurring_schedule
+            .exception_dates
+            .remove(self.profile_edit_schedule_exception);
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -1841,6 +1983,7 @@ impl App {
         self.profile_edit_field = 0;
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
+        self.profile_edit_schedule_exception = 0;
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -1855,12 +1998,13 @@ impl App {
             self.wakatime_metadata = snapshot.wakatime_metadata;
             self.sync_wakatime_metadata_to_tracker();
             self.rebuild_notifier();
-            self.rebuild_recurring_windows();
+            self.rebuild_recurring_schedule_runtime();
         }
         self.profile_edit_active = false;
         self.profile_edit_field = 0;
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
+        self.profile_edit_schedule_exception = 0;
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -1892,7 +2036,7 @@ impl App {
         }
         self.sync_wakatime_metadata_to_tracker();
         self.rebuild_notifier();
-        self.rebuild_recurring_windows();
+        self.rebuild_recurring_schedule_runtime();
         if schedule_changed {
             self.schedule_armed_occurrence_key = None;
             self.last_schedule_occurrence_key = None;
@@ -1907,6 +2051,7 @@ impl App {
         self.profile_edit_field = 0;
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
+        self.profile_edit_schedule_exception = 0;
         self.clamp_profile_edit_schedule_selection();
         self.profile_edit_snapshot = None;
     }
@@ -1970,6 +2115,15 @@ impl App {
             PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX => {
                 self.adjust_schedule_windows_collection(increase);
             }
+            PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX => {
+                self.cycle_schedule_exception(increase);
+            }
+            PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX => {
+                self.adjust_selected_schedule_exception_date(increase);
+            }
+            PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX => {
+                self.adjust_schedule_exceptions_collection(increase);
+            }
             PROFILE_EDIT_WAKATIME_PROJECT_INDEX | PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX => {}
             _ => {}
         }
@@ -1983,8 +2137,10 @@ impl App {
             });
     }
 
-    fn rebuild_recurring_windows(&mut self) {
+    fn rebuild_recurring_schedule_runtime(&mut self) {
         self.recurring_windows = compile_windows(&self.recurring_schedule.windows);
+        self.recurring_exception_dates =
+            compile_exception_dates(&self.recurring_schedule.exception_dates);
     }
 
     fn apply_profile(&mut self, profile: ProfileId) -> bool {
@@ -2569,6 +2725,7 @@ impl App {
         self.profile_edit_field = 0;
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
+        self.profile_edit_schedule_exception = 0;
         self.profile_edit_snapshot = None;
         self.profile_selection_index = profile_index(self.selected_profile);
         self.clamp_profile_selection();
@@ -2931,7 +3088,16 @@ impl App {
             return;
         }
 
-        let Some(active_window) = active_occurrence(now, &self.recurring_windows) else {
+        if self.recurring_exception_dates.contains(&now.date_naive()) {
+            self.schedule_armed_occurrence_key = None;
+            return;
+        }
+
+        let Some(active_window) = active_occurrence(
+            now,
+            &self.recurring_windows,
+            &self.recurring_exception_dates,
+        ) else {
             self.schedule_armed_occurrence_key = None;
             return;
         };
@@ -3065,6 +3231,10 @@ fn parse_hhmm_minutes(value: &str) -> Option<u16> {
     Some(hour * 60 + minute)
 }
 
+fn parse_schedule_exception_date(value: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").ok()
+}
+
 fn format_hhmm(total_minutes: u16) -> String {
     let hours = total_minutes / 60;
     let minutes = total_minutes % 60;
@@ -3082,6 +3252,17 @@ fn sort_schedule_days(days: &mut Vec<String>) {
         sorted.push(SCHEDULE_DAY_TOKENS[0].to_string());
     }
     *days = sorted;
+}
+
+fn sort_schedule_exception_dates(dates: &mut Vec<String>) {
+    let mut sorted = BTreeSet::new();
+    for value in dates.iter() {
+        let Some(date) = parse_schedule_exception_date(value) else {
+            continue;
+        };
+        sorted.insert(date.format("%Y-%m-%d").to_string());
+    }
+    *dates = sorted.into_iter().collect();
 }
 
 fn format_schedule_days_for_display(days: &[String]) -> String {
@@ -3133,6 +3314,10 @@ fn schedule_next_window_text_from_state(
 fn schedule_status_text_from_state(state: &ScheduleDisplayState) -> String {
     if !state.has_schedule_windows {
         return "⚙  Schedule status: off".to_string();
+    }
+
+    if state.is_exception_today {
+        return "⚙  Schedule status: skipped today (exception date)".to_string();
     }
 
     if state.active_window.is_some() {
@@ -3840,6 +4025,37 @@ mod tests {
     }
 
     #[test]
+    fn editing_schedule_exception_fields_updates_and_persists_settings() {
+        let mut app = App::default();
+        let base_date = local_datetime_today(10, 15).date_naive();
+        app.current_frame_now = local_datetime_today(10, 15);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        app.profile_edit_field = PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX;
+        app.handle_key(key(KeyCode::Right)); // add exception on base date
+        app.profile_edit_field = PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX;
+        app.handle_key(key(KeyCode::Right)); // shift to next day
+        app.handle_key(key(KeyCode::Enter));
+
+        let expected_date = base_date
+            .succ_opt()
+            .expect("next day should be representable")
+            .format("%Y-%m-%d")
+            .to_string();
+        assert_eq!(
+            app.recurring_schedule.exception_dates,
+            vec![expected_date.clone()]
+        );
+
+        let persisted = app.persisted_config();
+        assert_eq!(
+            persisted.recurring_schedule.exception_dates,
+            vec![expected_date]
+        );
+    }
+
+    #[test]
     fn editing_daily_goal_fields_updates_and_persists_settings() {
         let mut app = App::default();
 
@@ -3870,6 +4086,7 @@ mod tests {
                 start: "13:00".to_string(),
                 end: "14:30".to_string(),
             }],
+            ..RecurringScheduleConfig::default()
         };
         let config = AppConfig {
             recurring_schedule: original_schedule.clone(),
@@ -4609,6 +4826,7 @@ mod tests {
                     start: "11:00".to_string(),
                     end: "12:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4637,6 +4855,7 @@ mod tests {
                         end: "15:00".to_string(),
                     },
                 ],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4658,6 +4877,7 @@ mod tests {
                     start: "10:00".to_string(),
                     end: "11:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4685,6 +4905,7 @@ mod tests {
                     start: "10:00".to_string(),
                     end: "11:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4707,6 +4928,7 @@ mod tests {
                     start: "10:00".to_string(),
                     end: "11:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4730,6 +4952,7 @@ mod tests {
                     start: "10:00".to_string(),
                     end: "11:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4755,6 +4978,7 @@ mod tests {
                     start: "10:00".to_string(),
                     end: "11:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4778,6 +5002,7 @@ mod tests {
                     start: "11:00".to_string(),
                     end: "12:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4790,6 +5015,68 @@ mod tests {
     }
 
     #[test]
+    fn recurring_schedule_status_text_shows_exception_skip_for_today() {
+        let now = local_datetime_today(10, 15);
+        let today = now.date_naive();
+        let tomorrow = today.succ_opt().expect("tomorrow should be representable");
+        let config = AppConfig {
+            recurring_schedule: RecurringScheduleConfig {
+                windows: vec![
+                    crate::config::RecurringFocusWindowConfig {
+                        days: vec![weekday_token(today.weekday()).to_string()],
+                        start: "10:00".to_string(),
+                        end: "11:00".to_string(),
+                    },
+                    crate::config::RecurringFocusWindowConfig {
+                        days: vec![weekday_token(tomorrow.weekday()).to_string()],
+                        start: "09:00".to_string(),
+                        end: "10:00".to_string(),
+                    },
+                ],
+                exception_dates: vec![today.format("%Y-%m-%d").to_string()],
+            },
+            ..AppConfig::default()
+        };
+        let app = App::from_config(config);
+
+        assert_eq!(
+            app.recurring_schedule_texts_at(now).0,
+            "🗓  Next schedule: tomorrow 09:00-10:00"
+        );
+        assert_eq!(
+            app.recurring_schedule_texts_at(now).1,
+            "⚙  Schedule status: skipped today (exception date)"
+        );
+    }
+
+    #[test]
+    fn recurring_schedule_does_not_trigger_on_exception_date() {
+        let now = local_datetime_today(10, 15);
+        let today = now.date_naive();
+        let config = AppConfig {
+            recurring_schedule: RecurringScheduleConfig {
+                windows: vec![crate::config::RecurringFocusWindowConfig {
+                    days: vec![weekday_token(today.weekday()).to_string()],
+                    start: "10:00".to_string(),
+                    end: "11:00".to_string(),
+                }],
+                exception_dates: vec![today.format("%Y-%m-%d").to_string()],
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.task_labels = vec!["Coding".to_string()];
+        app.selected_task_label = Some("Coding".to_string());
+
+        app.sync_recurring_schedule(now);
+
+        assert_eq!(app.timer.phase, TimerPhase::Focus);
+        assert_eq!(app.timer.status, TimerStatus::Idle);
+        assert!(app.schedule_armed_occurrence_key.is_none());
+        assert!(app.phase_notification.is_none());
+    }
+
+    #[test]
     fn recurring_schedule_auto_starts_focus_when_window_begins_and_task_is_selected() {
         let now = local_datetime_today(10, 15);
         let config = AppConfig {
@@ -4799,6 +5086,7 @@ mod tests {
                     start: "10:00".to_string(),
                     end: "11:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4827,6 +5115,7 @@ mod tests {
                     start: "10:00".to_string(),
                     end: "11:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4855,6 +5144,7 @@ mod tests {
                     start: "10:00".to_string(),
                     end: "11:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -4886,6 +5176,7 @@ mod tests {
                     start: "10:00".to_string(),
                     end: "11:00".to_string(),
                 }],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };

--- a/src/app.rs
+++ b/src/app.rs
@@ -892,6 +892,12 @@ impl App {
     }
 
     pub fn profile_edit_field_value(&self, field_index: usize) -> String {
+        if (PROFILE_EDIT_SCHEDULE_WINDOW_INDEX..=PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX)
+            .contains(&field_index)
+        {
+            return self.profile_edit_schedule_field_value(field_index);
+        }
+
         match field_index {
             0 => format_duration_label(self.custom_profile.focus_secs),
             1 => format_duration_label(self.custom_profile.short_break_secs),
@@ -909,6 +915,12 @@ impl App {
             10 => format_daily_goal_pomodoros_label(self.daily_goal.pomodoros),
             PROFILE_EDIT_WAKATIME_PROJECT_INDEX => self.wakatime_metadata.project.clone(),
             PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX => self.wakatime_metadata.language.clone(),
+            _ => String::new(),
+        }
+    }
+
+    fn profile_edit_schedule_field_value(&self, field_index: usize) -> String {
+        match field_index {
             PROFILE_EDIT_SCHEDULE_WINDOW_INDEX => {
                 if self.recurring_schedule.windows.is_empty() {
                     "none".to_string()

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
+use chrono::NaiveDate;
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Persistent application configuration stored as TOML.
@@ -113,6 +114,8 @@ pub struct AutoStartConfig {
 pub struct RecurringScheduleConfig {
     #[serde(default)]
     pub windows: Vec<RecurringFocusWindowConfig>,
+    #[serde(default)]
+    pub exception_dates: Vec<String>,
 }
 
 impl RecurringScheduleConfig {
@@ -131,7 +134,11 @@ impl RecurringScheduleConfig {
                 start_minutes < end_minutes
             })
             .collect();
-        Self { windows }
+        let exception_dates = normalize_schedule_exception_dates(&self.exception_dates);
+        Self {
+            windows,
+            exception_dates,
+        }
     }
 }
 
@@ -594,6 +601,26 @@ fn parse_schedule_time_minutes(value: &str) -> Option<u16> {
     Some(hour * 60 + minute)
 }
 
+fn normalize_schedule_exception_dates(dates: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    let mut seen = HashSet::new();
+    for date in dates {
+        let Some(parsed) = parse_schedule_exception_date(date) else {
+            continue;
+        };
+        let canonical = parsed.format("%Y-%m-%d").to_string();
+        if seen.insert(canonical.clone()) {
+            normalized.push(canonical);
+        }
+    }
+    normalized.sort();
+    normalized
+}
+
+fn parse_schedule_exception_date(value: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").ok()
+}
+
 fn normalize_blocklist_profiles(
     profiles: &[BlocklistProfileConfig],
     legacy_blocked_sites: &[String],
@@ -735,6 +762,7 @@ mod tests {
                     start: "09:15".to_string(),
                     end: "11:00".to_string(),
                 }],
+                exception_dates: vec!["2026-04-27".to_string(), "2026-05-05".to_string()],
             },
             strict_mode: true,
             break_glass_duration_secs: 7 * 60,
@@ -837,6 +865,7 @@ start = "08:30"
         assert_eq!(window.start, "08:30");
         assert_eq!(window.end, default_schedule_window_end());
         assert_eq!(window.days, default_schedule_window_days());
+        assert!(cfg.recurring_schedule.exception_dates.is_empty());
     }
 
     #[test]
@@ -855,6 +884,7 @@ start = "08:30"
                         end: "09:00".to_string(),
                     },
                 ],
+                exception_dates: Vec::new(),
             },
             ..AppConfig::default()
         }
@@ -863,6 +893,29 @@ start = "08:30"
         assert_eq!(cfg.recurring_schedule.windows.len(), 1);
         assert_eq!(cfg.recurring_schedule.windows[0].start, "09:00");
         assert_eq!(cfg.recurring_schedule.windows[0].end, "11:00");
+    }
+
+    #[test]
+    fn normalize_recurring_schedule_exception_dates_dedupes_and_drops_invalid_entries() {
+        let cfg = AppConfig {
+            recurring_schedule: RecurringScheduleConfig {
+                windows: Vec::new(),
+                exception_dates: vec![
+                    " 2026-12-25 ".to_string(),
+                    "2026-02-30".to_string(),
+                    "2026-01-01".to_string(),
+                    "2026-12-25".to_string(),
+                    "not-a-date".to_string(),
+                ],
+            },
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        assert_eq!(
+            cfg.recurring_schedule.exception_dates,
+            vec!["2026-01-01".to_string(), "2026-12-25".to_string()]
+        );
     }
 
     #[test]

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -94,8 +94,9 @@ pub fn next_occurrence_after(
 ) -> Option<WindowOccurrence> {
     let mut selected: Option<WindowOccurrence> = None;
     let today = now.date_naive();
+    let search_days = 7_i64.saturating_mul(exception_dates.len() as i64 + 1);
 
-    for day_offset in 0..=7 {
+    for day_offset in 0..=search_days {
         let date = today + Duration::days(day_offset);
         if exception_dates.contains(&date) {
             continue;
@@ -306,5 +307,25 @@ mod tests {
             .expect("next window should skip exception date");
         assert_eq!(next.start, local_datetime(tomorrow, 9, 0));
         assert_eq!(next.end, local_datetime(tomorrow, 10, 0));
+    }
+
+    #[test]
+    fn next_occurrence_after_skips_weekly_exception_and_returns_following_week() {
+        let date = Local::now().date_naive();
+        let now = local_datetime(date, 12, 15);
+        let next_week = date + Duration::days(7);
+        let following_week = date + Duration::days(14);
+        let windows = compile_windows(&[RecurringFocusWindowConfig {
+            days: vec![date.weekday().to_string()],
+            start: "11:00".to_string(),
+            end: "12:00".to_string(),
+        }]);
+        let exception_dates = compile_exception_dates(&[next_week.format("%Y-%m-%d").to_string()]);
+
+        let next = next_occurrence_after(now, &windows, &exception_dates)
+            .expect("next window should skip the excepted weekly occurrence");
+
+        assert_eq!(next.start, local_datetime(following_week, 11, 0));
+        assert_eq!(next.end, local_datetime(following_week, 12, 0));
     }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use chrono::{
     DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, TimeZone, Timelike, Weekday,
 };
@@ -25,6 +27,13 @@ pub fn compile_windows(config_windows: &[RecurringFocusWindowConfig]) -> Vec<Rec
         .collect()
 }
 
+pub fn compile_exception_dates(config_dates: &[String]) -> HashSet<NaiveDate> {
+    config_dates
+        .iter()
+        .filter_map(|value| parse_exception_date(value))
+        .collect()
+}
+
 pub fn occurrence_key(occurrence: &WindowOccurrence) -> String {
     format!(
         "{}-{}",
@@ -36,9 +45,13 @@ pub fn occurrence_key(occurrence: &WindowOccurrence) -> String {
 pub fn active_occurrence(
     now: DateTime<Local>,
     windows: &[RecurringWindow],
+    exception_dates: &HashSet<NaiveDate>,
 ) -> Option<WindowOccurrence> {
     let now_minutes = now.hour() as u16 * 60 + now.minute() as u16;
     let today = now.date_naive();
+    if exception_dates.contains(&today) {
+        return None;
+    }
     let mut selected: Option<WindowOccurrence> = None;
 
     for (window_index, window) in windows.iter().enumerate() {
@@ -77,12 +90,16 @@ pub fn active_occurrence(
 pub fn next_occurrence_after(
     now: DateTime<Local>,
     windows: &[RecurringWindow],
+    exception_dates: &HashSet<NaiveDate>,
 ) -> Option<WindowOccurrence> {
     let mut selected: Option<WindowOccurrence> = None;
     let today = now.date_naive();
 
     for day_offset in 0..=7 {
         let date = today + Duration::days(day_offset);
+        if exception_dates.contains(&date) {
+            continue;
+        }
         for (window_index, window) in windows.iter().enumerate() {
             if !window.days.contains(&date.weekday()) {
                 continue;
@@ -172,6 +189,10 @@ fn parse_time_minutes(raw: &str) -> Option<u16> {
     Some(hour * 60 + minute)
 }
 
+fn parse_exception_date(raw: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(raw.trim(), "%Y-%m-%d").ok()
+}
+
 fn local_datetime_on(date: NaiveDate, total_minutes: u16) -> Option<DateTime<Local>> {
     let hour = u32::from(total_minutes / 60);
     let minute = u32::from(total_minutes % 60);
@@ -229,7 +250,8 @@ mod tests {
             end: "11:00".to_string(),
         }]);
 
-        let active = active_occurrence(now, &windows).expect("window should be active");
+        let active =
+            active_occurrence(now, &windows, &HashSet::new()).expect("window should be active");
 
         assert_eq!(active.start, local_datetime(date, 10, 0));
         assert_eq!(active.end, local_datetime(date, 11, 0));
@@ -252,9 +274,37 @@ mod tests {
             },
         ]);
 
-        let next = next_occurrence_after(now, &windows).expect("next window should exist");
+        let next = next_occurrence_after(now, &windows, &HashSet::new())
+            .expect("next window should exist");
 
         assert_eq!(next.start, local_datetime(date, 11, 0));
         assert_eq!(next.end, local_datetime(date, 12, 0));
+    }
+
+    #[test]
+    fn active_and_next_occurrences_skip_exception_dates() {
+        let date = Local::now().date_naive();
+        let now = local_datetime(date, 10, 15);
+        let tomorrow = date.succ_opt().expect("tomorrow should be representable");
+        let windows = compile_windows(&[
+            RecurringFocusWindowConfig {
+                days: vec![date.weekday().to_string()],
+                start: "10:00".to_string(),
+                end: "11:00".to_string(),
+            },
+            RecurringFocusWindowConfig {
+                days: vec![tomorrow.weekday().to_string()],
+                start: "09:00".to_string(),
+                end: "10:00".to_string(),
+            },
+        ]);
+        let exception_dates = compile_exception_dates(&[date.format("%Y-%m-%d").to_string()]);
+
+        assert!(active_occurrence(now, &windows, &exception_dates).is_none());
+
+        let next = next_occurrence_after(now, &windows, &exception_dates)
+            .expect("next window should skip exception date");
+        assert_eq!(next.start, local_datetime(tomorrow, 9, 0));
+        assert_eq!(next.end, local_datetime(tomorrow, 10, 0));
     }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -242,6 +242,21 @@ mod tests {
     }
 
     #[test]
+    fn compile_exception_dates_ignores_invalid_and_deduplicates() {
+        let dates = compile_exception_dates(&[
+            " 2026-12-25 ".to_string(),
+            "2026-12-25".to_string(),
+            "not-a-date".to_string(),
+            "".to_string(),
+        ]);
+
+        assert_eq!(dates.len(), 1);
+        assert!(
+            dates.contains(&NaiveDate::from_ymd_opt(2026, 12, 25).expect("valid date literal"))
+        );
+    }
+
+    #[test]
     fn active_occurrence_returns_window_when_inside_range() {
         let date = Local::now().date_naive();
         let now = local_datetime(date, 10, 15);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -19,7 +19,7 @@ const PROFILE_EDIT_GROUP_TIMER: [usize; 4] = [0, 1, 2, 3];
 const PROFILE_EDIT_GROUP_AUTOMATION: [usize; 5] = [4, 5, 6, 7, 8];
 const PROFILE_EDIT_GROUP_GOALS: [usize; 2] = [9, 10];
 const PROFILE_EDIT_GROUP_WAKATIME: [usize; 2] = [11, 12];
-const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 6] = [13, 14, 15, 16, 17, 18];
+const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 9] = [13, 14, 15, 16, 17, 18, 19, 20, 21];
 const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 5] = [
     ("Timer", &PROFILE_EDIT_GROUP_TIMER),
     ("Automation", &PROFILE_EDIT_GROUP_AUTOMATION),
@@ -764,7 +764,7 @@ fn profile_manager_hints(app: &App) -> Vec<Line<'static>> {
         vec![
             Line::from("Sections: Timer · Automation · Goals · WakaTime · Schedule"),
             Line::from(
-                "Edit: [↑/↓] Field  [←/→] Change value (schedule window/day/time/add/remove)",
+                "Edit: [↑/↓] Field  [←/→] Change value (schedule window/day/time/exception)",
             ),
             Line::from("Text input: [Type/Backspace] WakaTime project/language"),
             Line::from(if app.strict_mode_enforced_for_focus() {
@@ -810,6 +810,9 @@ fn profile_edit_field_display_label(field_index: usize) -> &'static str {
         16 => "Start time",
         17 => "End time",
         18 => "Add/remove",
+        19 => "Exception selector",
+        20 => "Exception date",
+        21 => "Exception add/remove",
         _ => "",
     }
 }
@@ -1763,6 +1766,9 @@ mod tests {
         assert!(text.contains("Start time"));
         assert!(text.contains("End time"));
         assert!(text.contains("Add/remove"));
+        assert!(text.contains("Exception selector"));
+        assert!(text.contains("Exception date"));
+        assert!(text.contains("Exception add/remove"));
     }
 
     #[test]


### PR DESCRIPTION
## What

- Add `recurring_schedule.exception_dates` to config with normalization and validation (`YYYY-MM-DD`, deduped, sorted, invalid entries dropped).
- Update schedule evaluation and app runtime so recurring windows are skipped on exception dates for both active-window and next-window logic.
- Extend the profile schedule editor with exception controls (selector, date adjust, add/remove) and show explicit skip-day status in timer schedule text.
- Add and update tests in `config`, `schedule`, `app`, and `ui`, and update README schedule docs and config examples.

## Why

Recurring weekly windows need a practical way to handle holidays and one-off unavailable days without deleting baseline schedule rules. This adds a clear exception overlay so recurring behavior remains the default while specific dates can be skipped safely and visibly in the UI. Closes #141.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable) (N/A)
- [ ] WakaTime integration behavior was verified for this change (if applicable) (N/A)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exception dates for recurring schedules: specify local YYYY‑MM‑DD dates to suppress automatic arming/triggers; today’s schedule can show as “skipped today (exception date)”.
  * Profile editor updated to view/manage exception dates: select an exception, shift it by ±1 day, add or remove entries; next-window calculations honor exceptions.

* **Documentation**
  * README extended with an example exception_dates setting and TUI instructions for managing exception dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->