### PR TITLE
Allowlist exceptions and blocking remediation UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,12 @@ break_glass_duration_secs = 300
 [[blocklist_profiles]]
 name = "Work"
 sites = ["youtube.com", "reddit.com"]
+allowlist_sites = ["reddit.com"]
 
 [[blocklist_profiles]]
 name = "Study"
 sites = ["x.com", "news.ycombinator.com"]
+allowlist_sites = []
 
 [custom_profile]
 focus_secs = 1800
@@ -223,6 +225,7 @@ Open the site manager from timer view with **`b`**.
 - `a`: add/import hostnames
 - `e`: edit the selected hostname
 - `d` or `Delete`: remove the selected hostname
+- `m`: toggle between editing blocklist sites and allowlist exceptions
 - `[` / `]`: switch active blocklist profile
 - `n`: create a blocklist profile
 - `r`: rename the active blocklist profile
@@ -240,6 +243,8 @@ Add/import input supports:
 
 Invalid and duplicate entries are reported inline so you can fix them without leaving the view.
 
+Allowlist entries act as explicit exceptions: effective focus blocking is computed as **blocklist sites minus allowlist sites** for the active profile.
+
 ## Setup diagnostics
 
 Open the setup diagnostics screen from timer view with **`d`**.
@@ -251,6 +256,7 @@ The diagnostics screen reports:
 
 - blocking permissions
 - hosts file write capability
+- remediation guidance when hosts permissions are insufficient
 - WakaTime config status (`~/.wakatime.cfg` and `api_key` availability)
 
 ## Phase notifications

--- a/src/app.rs
+++ b/src/app.rs
@@ -187,6 +187,28 @@ pub enum SiteInputMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiteListMode {
+    Blocklist,
+    Allowlist,
+}
+
+impl SiteListMode {
+    fn toggle(self) -> Self {
+        match self {
+            Self::Blocklist => Self::Allowlist,
+            Self::Allowlist => Self::Blocklist,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Blocklist => "Blocklist",
+            Self::Allowlist => "Allowlist",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlocklistProfileInputMode {
     Create,
     Rename,
@@ -345,6 +367,7 @@ pub struct App {
     pub planner_feedback: Option<PlannerFeedback>,
     active_focus_task_label: Option<String>,
     active_focus_profile: Option<ProfileId>,
+    site_list_mode: SiteListMode,
     /// Index of the highlighted site in the SiteManager list.
     pub selected_site: usize,
     /// Last error from a block/unblock operation (e.g. permission denied).
@@ -431,10 +454,7 @@ impl App {
             profile_spec.long_break_secs,
             profile_spec.long_break_interval,
         );
-        let mut blocker = SiteBlocker::new();
-        for site in &blocklist_profiles[active_blocklist_profile].sites {
-            blocker.add_site(site.clone());
-        }
+        let blocker = SiteBlocker::new();
         let setup_diagnostics = SetupDiagnostics::collect(&blocker);
         let mut app = Self {
             timer,
@@ -459,6 +479,7 @@ impl App {
             planner_feedback: None,
             active_focus_task_label: None,
             active_focus_profile: None,
+            site_list_mode: SiteListMode::Blocklist,
             selected_site: 0,
             block_error: None,
             setup_diagnostics,
@@ -498,6 +519,7 @@ impl App {
             stats_dirty: false,
             stats_has_unsaved_elapsed: false,
         };
+        app.recompute_blocker_sites_from_active_profile();
         app.restore_in_progress_session();
         app.sync_recovery_snapshot();
         app
@@ -1314,6 +1336,22 @@ impl App {
         }
     }
 
+    pub fn site_list_mode(&self) -> SiteListMode {
+        self.site_list_mode
+    }
+
+    pub fn active_policy_sites(&self) -> &[String] {
+        self.active_profile_sites_for_mode(self.site_list_mode)
+    }
+
+    pub fn active_policy_site_count(&self) -> usize {
+        self.active_policy_sites().len()
+    }
+
+    pub fn effective_blocked_site_count(&self) -> usize {
+        self.blocker.sites.len()
+    }
+
     pub fn blocklist_profile_input_mode(&self) -> Option<BlocklistProfileInputMode> {
         self.blocklist_profile_input_mode
     }
@@ -1450,19 +1488,24 @@ impl App {
         let custom_profile = self.custom_profile.normalized();
         let mut blocklist_profiles = self.blocklist_profiles.clone();
         if blocklist_profiles.is_empty() {
-            blocklist_profiles.push(BlocklistProfileConfig::default());
+            blocklist_profiles.push(BlocklistProfileConfig {
+                name: DEFAULT_BLOCKLIST_PROFILE_NAME.to_string(),
+                sites: self.blocker.sites.clone(),
+                allowlist_sites: Vec::new(),
+            });
         }
         let active_index = self
             .active_blocklist_profile
             .min(blocklist_profiles.len().saturating_sub(1));
-        if let Some(active_profile) = blocklist_profiles.get_mut(active_index) {
-            active_profile.sites = self.blocker.sites.clone();
-        }
         let selected_blocklist_profile = blocklist_profiles
             .get(active_index)
             .or_else(|| blocklist_profiles.first())
             .map(|profile| profile.name.clone())
             .unwrap_or_else(|| DEFAULT_BLOCKLIST_PROFILE_NAME.to_string());
+        let blocked_sites = blocklist_profiles
+            .get(active_index)
+            .map(effective_blocked_sites_for_profile)
+            .unwrap_or_default();
         AppConfig {
             // Keep legacy fields aligned with the editable custom profile so
             // older releases retain user-configured values.
@@ -1470,7 +1513,7 @@ impl App {
             short_break_secs: custom_profile.short_break_secs,
             long_break_secs: custom_profile.long_break_secs,
             long_break_interval: custom_profile.long_break_interval,
-            blocked_sites: self.blocker.sites.clone(),
+            blocked_sites,
             blocklist_profiles,
             selected_blocklist_profile,
             selected_profile: self.selected_profile,
@@ -2196,6 +2239,15 @@ impl App {
         true
     }
 
+    fn toggle_site_list_mode(&mut self) {
+        self.site_list_mode = self.site_list_mode.toggle();
+        self.clamp_selection();
+        self.set_site_feedback(
+            SiteFeedbackLevel::Success,
+            format!("Switched to {} entries", self.site_list_mode.label()),
+        );
+    }
+
     fn handle_key_site_manager(&mut self, key: KeyEvent) {
         if self.blocklist_profile_input_active {
             match key.code {
@@ -2245,12 +2297,17 @@ impl App {
                 self.mode = AppMode::Timer;
             }
             // Navigate down
-            KeyCode::Down | KeyCode::Char('j') if !self.blocker.sites.is_empty() => {
-                self.selected_site = (self.selected_site + 1).min(self.blocker.sites.len() - 1);
+            KeyCode::Down | KeyCode::Char('j') if !self.active_policy_sites().is_empty() => {
+                self.selected_site =
+                    (self.selected_site + 1).min(self.active_policy_sites().len() - 1);
             }
             // Navigate up
             KeyCode::Up | KeyCode::Char('k') => {
                 self.selected_site = self.selected_site.saturating_sub(1);
+            }
+            // Toggle between blocklist and allowlist entries
+            KeyCode::Char('m') => {
+                self.toggle_site_list_mode();
             }
             // Start adding a site
             KeyCode::Char('a') => {
@@ -2298,14 +2355,18 @@ impl App {
                 self.site_input.clear();
             }
             SiteInputMode::Edit => {
-                if self.blocker.sites.is_empty() {
+                if self.active_policy_sites().is_empty() {
                     self.site_input_active = false;
                     self.set_site_feedback(SiteFeedbackLevel::Warning, "No site selected to edit");
                     return;
                 }
                 self.clamp_selection();
                 self.site_edit_index = Some(self.selected_site);
-                self.site_input = self.blocker.sites[self.selected_site].clone();
+                self.site_input = self
+                    .active_policy_sites()
+                    .get(self.selected_site)
+                    .cloned()
+                    .unwrap_or_default();
             }
         }
     }
@@ -2339,12 +2400,23 @@ impl App {
 
     fn commit_site_input(&mut self) {
         let input = self.site_input.clone();
+        let mode = self.site_list_mode;
+        let mut working = SiteBlocker::new();
+        for site in self.active_profile_sites_for_mode(mode).iter().cloned() {
+            working.add_site(site);
+        }
 
         let committed = if let Some(index) = self.site_edit_index {
-            let edit_result = self.blocker.edit_site_from_input(index, &input);
+            let edit_result = working.edit_site_from_input(index, &input);
+            if let Some(target_sites) = self.active_profile_sites_for_mode_mut(mode) {
+                *target_sites = working.sites.clone();
+            }
             self.apply_edit_site_result(edit_result)
         } else {
-            let add_result = self.blocker.add_sites_from_input(&input);
+            let add_result = working.add_sites_from_input(&input);
+            if let Some(target_sites) = self.active_profile_sites_for_mode_mut(mode) {
+                *target_sites = working.sites.clone();
+            }
             self.apply_bulk_add_result(add_result)
         };
 
@@ -2383,13 +2455,13 @@ impl App {
 
         match mode {
             BlocklistProfileInputMode::Create => {
-                self.sync_active_profile_sites_from_blocker();
                 self.blocklist_profiles.push(BlocklistProfileConfig {
                     name: name.clone(),
                     sites: Vec::new(),
+                    allowlist_sites: Vec::new(),
                 });
                 self.active_blocklist_profile = self.blocklist_profiles.len().saturating_sub(1);
-                self.load_active_profile_sites_into_blocker();
+                self.recompute_blocker_sites_from_active_profile();
                 self.clamp_selection();
                 self.cancel_blocklist_profile_input();
                 self.save_config();
@@ -2427,7 +2499,7 @@ impl App {
     fn apply_bulk_add_result(&mut self, result: BulkAddResult) -> bool {
         let committed = !result.added.is_empty();
         if committed {
-            self.selected_site = self.blocker.sites.len().saturating_sub(1);
+            self.selected_site = self.active_policy_site_count().saturating_sub(1);
             self.finalize_site_mutation();
         }
 
@@ -2490,7 +2562,10 @@ impl App {
             EditSiteResult::Duplicate { hostname } => {
                 self.set_site_feedback(
                     SiteFeedbackLevel::Warning,
-                    format!("`{hostname}` is already in the blocklist"),
+                    format!(
+                        "`{hostname}` is already in the {}",
+                        self.site_list_mode.label().to_ascii_lowercase()
+                    ),
                 );
                 false
             }
@@ -2513,16 +2588,28 @@ impl App {
     }
 
     fn remove_selected_site(&mut self) {
-        if self.blocker.sites.is_empty() {
+        if self.active_policy_sites().is_empty() {
             self.set_site_feedback(SiteFeedbackLevel::Warning, "No site selected to delete");
             return;
         }
 
-        if let Some(removed) = self.blocker.remove_site(self.selected_site) {
+        let mode = self.site_list_mode;
+        let selected_site = self.selected_site;
+        let list_name = mode.label().to_ascii_lowercase();
+        let mut working = SiteBlocker::new();
+        for site in self.active_profile_sites_for_mode(mode).iter().cloned() {
+            working.add_site(site);
+        }
+        let removed = working.remove_site(selected_site);
+        if let Some(target_sites) = self.active_profile_sites_for_mode_mut(mode) {
+            *target_sites = working.sites.clone();
+        }
+
+        if let Some(removed) = removed {
             self.finalize_site_mutation();
             self.set_site_feedback(
                 SiteFeedbackLevel::Success,
-                format!("Removed `{removed}` from blocklist"),
+                format!("Removed `{removed}` from {list_name}"),
             );
         } else {
             self.set_site_feedback(SiteFeedbackLevel::Warning, "No site selected to delete");
@@ -2556,9 +2643,8 @@ impl App {
             return;
         }
 
-        self.sync_active_profile_sites_from_blocker();
         self.active_blocklist_profile = next_index;
-        self.load_active_profile_sites_into_blocker();
+        self.recompute_blocker_sites_from_active_profile();
         self.clamp_selection();
         self.save_config();
         self.sync_blocking_after_site_mutation();
@@ -2580,14 +2666,13 @@ impl App {
             return;
         }
 
-        self.sync_active_profile_sites_from_blocker();
         let removed = self
             .blocklist_profiles
             .remove(self.active_blocklist_profile);
         if self.active_blocklist_profile >= self.blocklist_profiles.len() {
             self.active_blocklist_profile = self.blocklist_profiles.len().saturating_sub(1);
         }
-        self.load_active_profile_sites_into_blocker();
+        self.recompute_blocker_sites_from_active_profile();
         self.clamp_selection();
         self.save_config();
         self.sync_blocking_after_site_mutation();
@@ -2622,10 +2707,10 @@ impl App {
     }
 
     fn clamp_selection(&mut self) {
-        if self.blocker.sites.is_empty() {
+        if self.active_policy_sites().is_empty() {
             self.selected_site = 0;
         } else {
-            self.selected_site = self.selected_site.min(self.blocker.sites.len() - 1);
+            self.selected_site = self.selected_site.min(self.active_policy_sites().len() - 1);
         }
     }
 
@@ -2641,22 +2726,36 @@ impl App {
             .min(self.blocklist_profiles.len().saturating_sub(1));
     }
 
-    fn sync_active_profile_sites_from_blocker(&mut self) {
-        self.clamp_blocklist_profile_selection();
-        if let Some(active_profile) = self
-            .blocklist_profiles
-            .get_mut(self.active_blocklist_profile)
-        {
-            active_profile.sites = self.blocker.sites.clone();
-        }
+    fn active_profile_sites_for_mode(&self, mode: SiteListMode) -> &[String] {
+        self.blocklist_profiles
+            .get(self.active_blocklist_profile)
+            .map(|profile| match mode {
+                SiteListMode::Blocklist => &profile.sites,
+                SiteListMode::Allowlist => &profile.allowlist_sites,
+            })
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
     }
 
-    fn load_active_profile_sites_into_blocker(&mut self) {
+    fn active_profile_sites_for_mode_mut(
+        &mut self,
+        mode: SiteListMode,
+    ) -> Option<&mut Vec<String>> {
+        self.clamp_blocklist_profile_selection();
+        self.blocklist_profiles
+            .get_mut(self.active_blocklist_profile)
+            .map(|profile| match mode {
+                SiteListMode::Blocklist => &mut profile.sites,
+                SiteListMode::Allowlist => &mut profile.allowlist_sites,
+            })
+    }
+
+    fn recompute_blocker_sites_from_active_profile(&mut self) {
         self.clamp_blocklist_profile_selection();
         self.blocker.sites.clear();
         if let Some(active_profile) = self.blocklist_profiles.get(self.active_blocklist_profile) {
-            for site in &active_profile.sites {
-                self.blocker.add_site(site.clone());
+            for site in effective_blocked_sites_for_profile(active_profile) {
+                self.blocker.add_site(site);
             }
         }
     }
@@ -2741,6 +2840,7 @@ impl App {
     fn open_site_manager(&mut self) {
         self.pending_timer_action = None;
         self.mode = AppMode::SiteManager;
+        self.site_list_mode = SiteListMode::Blocklist;
         self.cancel_site_input();
         self.cancel_blocklist_profile_input();
         self.clamp_blocklist_profile_selection();
@@ -2792,8 +2892,8 @@ impl App {
     }
 
     fn finalize_site_mutation(&mut self) {
+        self.recompute_blocker_sites_from_active_profile();
         self.clamp_selection();
-        self.sync_active_profile_sites_from_blocker();
         self.save_config();
         self.sync_blocking_after_site_mutation();
     }
@@ -3022,7 +3122,7 @@ impl App {
         }
         if self.blocker.sites.is_empty() {
             self.phase_notification = Some(
-                "Break-glass override unavailable: active blocklist profile has no sites."
+                "Break-glass override unavailable: active profile has no effective blocked sites."
                     .to_string(),
             );
             return;
@@ -3051,7 +3151,7 @@ impl App {
         }
         if self.blocker.sites.is_empty() {
             self.phase_notification = Some(
-                "Break-glass override unavailable: active blocklist profile has no sites."
+                "Break-glass override unavailable: active profile has no effective blocked sites."
                     .to_string(),
             );
             return;
@@ -3477,6 +3577,28 @@ fn display_input_value(input: &str) -> String {
     }
 }
 
+fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+    let allowlist: HashSet<String> = profile
+        .allowlist_sites
+        .iter()
+        .map(|site| site.to_ascii_lowercase())
+        .collect();
+    profile
+        .sites
+        .iter()
+        .filter(|site| !allowlist.contains(&site.to_ascii_lowercase()))
+        .cloned()
+        .collect()
+}
+
+fn permission_remediation_guidance() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "Run focustime from an Administrator terminal, then open [d] Setup and press [r] Refresh."
+    } else {
+        "Run focustime with elevated privileges (e.g. sudo), verify hosts-file permissions, then press [r] Refresh."
+    }
+}
+
 fn current_epoch_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -3500,7 +3622,10 @@ fn blocking_permissions_check(hosts_diagnostics: &HostsFileDiagnostics) -> Setup
             .write_error
             .as_deref()
             .unwrap_or("unknown write error");
-        SetupCheck::warning(format!("Blocked: write permission unavailable ({reason})"))
+        SetupCheck::warning(format!(
+            "Blocked: write permission unavailable ({reason}). {}",
+            permission_remediation_guidance()
+        ))
     }
 }
 
@@ -3514,16 +3639,22 @@ fn hosts_write_capability_check(hosts_diagnostics: &HostsFileDiagnostics) -> Set
         hosts_diagnostics.write_error.as_deref(),
     ) {
         (true, true, _, _) => SetupCheck::ok("Ready: hosts file is readable and writable"),
-        (false, true, Some(read_error), _) => {
-            SetupCheck::warning(format!("Blocked: cannot read hosts file ({read_error})"))
-        }
-        (true, false, _, Some(write_error)) => {
-            SetupCheck::warning(format!("Blocked: cannot write hosts file ({write_error})"))
-        }
-        (false, false, Some(read_error), Some(write_error)) => SetupCheck::warning(format!(
-            "Blocked: read error ({read_error}); write error ({write_error})"
+        (false, true, Some(read_error), _) => SetupCheck::warning(format!(
+            "Blocked: cannot read hosts file ({read_error}). {}",
+            permission_remediation_guidance()
         )),
-        _ => SetupCheck::warning("Blocked: hosts access diagnostics unavailable"),
+        (true, false, _, Some(write_error)) => SetupCheck::warning(format!(
+            "Blocked: cannot write hosts file ({write_error}). {}",
+            permission_remediation_guidance()
+        )),
+        (false, false, Some(read_error), Some(write_error)) => SetupCheck::warning(format!(
+            "Blocked: read error ({read_error}); write error ({write_error}). {}",
+            permission_remediation_guidance()
+        )),
+        _ => SetupCheck::warning(format!(
+            "Blocked: hosts access diagnostics unavailable. {}",
+            permission_remediation_guidance()
+        )),
     }
 }
 
@@ -4679,10 +4810,12 @@ mod tests {
                 BlocklistProfileConfig {
                     name: "Work".to_string(),
                     sites: vec!["a.com".to_string()],
+                    allowlist_sites: Vec::new(),
                 },
                 BlocklistProfileConfig {
                     name: "Study".to_string(),
                     sites: vec!["b.com".to_string(), "c.com".to_string()],
+                    allowlist_sites: Vec::new(),
                 },
             ],
             selected_blocklist_profile: "Work".to_string(),
@@ -4700,6 +4833,90 @@ mod tests {
         assert_eq!(
             app.blocker.sites,
             vec!["b.com".to_string(), "c.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn site_manager_allowlist_mode_clamps_selection_on_profile_switch() {
+        let config = AppConfig {
+            blocklist_profiles: vec![
+                BlocklistProfileConfig {
+                    name: "Study".to_string(),
+                    sites: vec!["study.com".to_string()],
+                    allowlist_sites: vec!["allow-a.com".to_string(), "allow-b.com".to_string()],
+                },
+                BlocklistProfileConfig {
+                    name: "Work".to_string(),
+                    sites: vec!["work.com".to_string(), "news.com".to_string()],
+                    allowlist_sites: vec!["news.com".to_string()],
+                },
+            ],
+            selected_blocklist_profile: "Study".to_string(),
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.handle_key(key(KeyCode::Char('b')));
+        app.handle_key(key(KeyCode::Char('m')));
+        app.handle_key(key(KeyCode::Down));
+
+        assert_eq!(app.site_list_mode(), SiteListMode::Allowlist);
+        assert_eq!(app.selected_site, 1);
+
+        app.handle_key(key(KeyCode::Char(']')));
+
+        assert_eq!(app.active_blocklist_profile_name(), "Work");
+        assert_eq!(app.site_list_mode(), SiteListMode::Allowlist);
+        assert_eq!(app.active_policy_sites(), vec!["news.com".to_string()]);
+        assert_eq!(app.selected_site, 0);
+        assert_eq!(app.blocker.sites, vec!["work.com".to_string()]);
+    }
+
+    #[test]
+    fn allowlist_excludes_sites_from_effective_blocking() {
+        let config = AppConfig {
+            blocklist_profiles: vec![BlocklistProfileConfig {
+                name: "Work".to_string(),
+                sites: vec!["a.com".to_string(), "b.com".to_string()],
+                allowlist_sites: vec!["b.com".to_string()],
+            }],
+            selected_blocklist_profile: "Work".to_string(),
+            ..AppConfig::default()
+        };
+        let app = App::from_config(config);
+
+        assert_eq!(app.blocker.sites, vec!["a.com".to_string()]);
+    }
+
+    #[test]
+    fn site_manager_allowlist_mode_updates_effective_blocked_sites() {
+        let config = AppConfig {
+            blocklist_profiles: vec![BlocklistProfileConfig {
+                name: "Default".to_string(),
+                sites: vec!["a.com".to_string(), "b.com".to_string()],
+                allowlist_sites: vec!["b.com".to_string()],
+            }],
+            selected_blocklist_profile: "Default".to_string(),
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.handle_key(key(KeyCode::Char('b')));
+        app.handle_key(key(KeyCode::Char('m'))); // switch to allowlist view
+        app.handle_key(key(KeyCode::Char('a')));
+        for c in "a.com".chars() {
+            app.handle_key(key(KeyCode::Char(c)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(
+            app.active_policy_sites(),
+            vec!["b.com".to_string(), "a.com".to_string()]
+        );
+        assert!(app.blocker.sites.is_empty());
+        let persisted = app.persisted_config();
+        assert_eq!(persisted.blocked_sites, Vec::<String>::new());
+        assert_eq!(
+            persisted.blocklist_profiles[0].allowlist_sites,
+            vec!["b.com".to_string(), "a.com".to_string()]
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{env, ffi::OsString, path::PathBuf};
+use std::{collections::HashSet, env, ffi::OsString, path::PathBuf};
 
 use serde::Serialize;
 
@@ -645,7 +645,18 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
                 .name
                 .eq_ignore_ascii_case(&config.selected_blocklist_profile)
         })
-        .map(|profile| profile.sites.len())
+        .map(|profile| {
+            let allowlist: HashSet<String> = profile
+                .allowlist_sites
+                .iter()
+                .map(|site| site.to_ascii_lowercase())
+                .collect();
+            profile
+                .sites
+                .iter()
+                .filter(|site| !allowlist.contains(&site.to_ascii_lowercase()))
+                .count()
+        })
         .unwrap_or_default();
     let live = build_live_status_output(config, selected_task_label.clone());
 
@@ -1230,6 +1241,7 @@ mod tests {
             blocklist_profiles: vec![crate::config::BlocklistProfileConfig {
                 name: "Work".to_string(),
                 sites: vec!["youtube.com".to_string(), "reddit.com".to_string()],
+                allowlist_sites: Vec::new(),
             }],
             selected_blocklist_profile: "work".to_string(),
             ..AppConfig::default()
@@ -1239,6 +1251,24 @@ mod tests {
         let output = build_status_output(&config, &stats);
 
         assert_eq!(output.blocked_sites_count, 2);
+    }
+
+    #[test]
+    fn build_status_output_excludes_allowlist_from_blocked_sites_count() {
+        let config = AppConfig {
+            blocklist_profiles: vec![crate::config::BlocklistProfileConfig {
+                name: "Work".to_string(),
+                sites: vec!["youtube.com".to_string(), "reddit.com".to_string()],
+                allowlist_sites: vec!["reddit.com".to_string()],
+            }],
+            selected_blocklist_profile: "Work".to_string(),
+            ..AppConfig::default()
+        };
+        let stats = FocusStats::default();
+
+        let output = build_status_output(&config, &stats);
+
+        assert_eq!(output.blocked_sites_count, 1);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,11 @@ pub struct BlocklistProfileConfig {
     pub name: String,
     #[serde(default)]
     pub sites: Vec<String>,
+    /// Sites that are explicitly excluded from blocking.
+    ///
+    /// Effective focus blocking is computed as `sites - allowlist_sites`.
+    #[serde(default)]
+    pub allowlist_sites: Vec<String>,
 }
 
 impl Default for BlocklistProfileConfig {
@@ -90,6 +95,7 @@ impl Default for BlocklistProfileConfig {
         Self {
             name: default_blocklist_profile_name(),
             sites: Vec::new(),
+            allowlist_sites: Vec::new(),
         }
     }
 }
@@ -484,7 +490,7 @@ impl AppConfig {
             .blocklist_profiles
             .iter()
             .find(|profile| profile.name == self.selected_blocklist_profile)
-            .map(|profile| profile.sites.clone())
+            .map(effective_blocked_sites_for_profile)
             .unwrap_or_default();
         self.wakatime = self.wakatime.normalized();
         self
@@ -635,6 +641,7 @@ fn normalize_blocklist_profiles(
         normalized.push(BlocklistProfileConfig {
             name,
             sites: profile.sites.clone(),
+            allowlist_sites: profile.allowlist_sites.clone(),
         });
     }
 
@@ -642,6 +649,7 @@ fn normalize_blocklist_profiles(
         return vec![BlocklistProfileConfig {
             name: default_blocklist_profile_name(),
             sites: legacy_blocked_sites.to_vec(),
+            allowlist_sites: Vec::new(),
         }];
     }
 
@@ -686,6 +694,20 @@ fn make_unique_profile_name(base_name: &str, seen_names: &mut HashSet<String>) -
         }
         suffix += 1;
     }
+}
+
+fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+    let allowlist: HashSet<String> = profile
+        .allowlist_sites
+        .iter()
+        .map(|site| site.to_ascii_lowercase())
+        .collect();
+    profile
+        .sites
+        .iter()
+        .filter(|site| !allowlist.contains(&site.to_ascii_lowercase()))
+        .cloned()
+        .collect()
 }
 
 #[cfg(test)]
@@ -734,10 +756,12 @@ mod tests {
                 BlocklistProfileConfig {
                     name: "Work".to_string(),
                     sites: vec!["example.com".to_string(), "reddit.com".to_string()],
+                    allowlist_sites: vec!["reddit.com".to_string()],
                 },
                 BlocklistProfileConfig {
                     name: "Study".to_string(),
                     sites: vec!["x.com".to_string()],
+                    allowlist_sites: Vec::new(),
                 },
             ],
             selected_blocklist_profile: "Study".to_string(),
@@ -1129,6 +1153,7 @@ language = ""
         );
         assert_eq!(cfg.selected_blocklist_profile, "Default");
         assert_eq!(cfg.blocked_sites, cfg.blocklist_profiles[0].sites);
+        assert!(cfg.blocklist_profiles[0].allowlist_sites.is_empty());
     }
 
     #[test]
@@ -1138,10 +1163,12 @@ language = ""
                 BlocklistProfileConfig {
                     name: "Work".to_string(),
                     sites: vec!["a.com".to_string()],
+                    allowlist_sites: vec!["b.com".to_string()],
                 },
                 BlocklistProfileConfig {
                     name: "work".to_string(),
                     sites: vec!["b.com".to_string()],
+                    allowlist_sites: Vec::new(),
                 },
             ],
             selected_blocklist_profile: "missing".to_string(),
@@ -1152,6 +1179,22 @@ language = ""
         assert_eq!(cfg.blocklist_profiles[0].name, "Work");
         assert_eq!(cfg.blocklist_profiles[1].name, "work (2)");
         assert_eq!(cfg.selected_blocklist_profile, "Work");
+        assert_eq!(cfg.blocked_sites, vec!["a.com".to_string()]);
+    }
+
+    #[test]
+    fn normalize_derives_legacy_blocked_sites_from_effective_blocked_set() {
+        let cfg = AppConfig {
+            blocklist_profiles: vec![BlocklistProfileConfig {
+                name: "Work".to_string(),
+                sites: vec!["a.com".to_string(), "b.com".to_string()],
+                allowlist_sites: vec!["b.com".to_string()],
+            }],
+            selected_blocklist_profile: "Work".to_string(),
+            ..AppConfig::default()
+        }
+        .normalize();
+
         assert_eq!(cfg.blocked_sites, vec!["a.com".to_string()]);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
 use crate::app::{
     App, AppMode, BlocklistProfileInputMode, DailyGoalProgress, HistoryFeedbackLevel,
     PLANNER_RECENT_LABEL_LIMIT, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, PlannerFeedbackLevel,
-    PlannerInputMode, SetupCheck, SetupCheckLevel, SiteFeedbackLevel, SiteInputMode,
+    PlannerInputMode, SetupCheck, SetupCheckLevel, SiteFeedbackLevel, SiteInputMode, SiteListMode,
 };
 use crate::timer::{TimerPhase, TimerStatus};
 use crate::wakatime::WakatimeRuntimeState;
@@ -416,8 +416,8 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         ])
         .split(outer);
 
-    // Blocking status — derive the message from both the blocker flag and the
-    // current timer phase/status so the copy is accurate in all states.
+    // Blocking status — derive the message from blocker state, timer state, and
+    // known failure/empty-effective-set causes so the copy is explicit.
     let focus_session_active =
         app.timer.phase == TimerPhase::Focus && app.timer.status != TimerStatus::Idle;
     let status_text = if app.blocker.is_blocking {
@@ -435,12 +435,22 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
             Style::default().fg(Color::Yellow),
         )
     } else if focus_session_active {
-        // Focus session is running/paused but blocking is not active
-        // (empty site list or a permission error prevented it).
-        Span::styled(
-            "Focus session active — blocking inactive (no sites or permission error)",
-            Style::default().fg(Color::Yellow),
-        )
+        if app.block_error.is_some() {
+            Span::styled(
+                "Focus session active — blocking unavailable (permission/setup issue; open [d] Setup)",
+                Style::default().fg(Color::Yellow),
+            )
+        } else if app.effective_blocked_site_count() == 0 {
+            Span::styled(
+                "Focus session active — blocking inactive (effective blocked set is empty)",
+                Style::default().fg(Color::Yellow),
+            )
+        } else {
+            Span::styled(
+                "Focus session active — blocking unavailable (open [d] Setup)",
+                Style::default().fg(Color::Yellow),
+            )
+        }
     } else {
         Span::styled(
             "Blocking will activate when a focus session starts",
@@ -452,11 +462,14 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         inner[0],
     );
 
+    let site_list_mode = app.site_list_mode();
     let profile_text = format!(
-        "Profile: {} ({}/{})",
+        "Profile: {} ({}/{}) · List: {} · Effective blocks: {}",
         app.active_blocklist_profile_name(),
         app.active_blocklist_profile_position(),
-        app.blocklist_profile_count()
+        app.blocklist_profile_count(),
+        site_list_mode.label(),
+        app.effective_blocked_site_count()
     );
     frame.render_widget(
         Paragraph::new(profile_text)
@@ -474,27 +487,38 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
 
     let input_mode = app.site_input_mode();
     let profile_input_mode = app.blocklist_profile_input_mode();
+    let (list_title_label, empty_text, idle_input_text) = match site_list_mode {
+        SiteListMode::Blocklist => (
+            "Blocklist Sites",
+            "  No blocked sites yet. Press [a] to add one.",
+            "Press [a] to add/import blocked sites or [e] to edit selected",
+        ),
+        SiteListMode::Allowlist => (
+            "Allowlist Exceptions",
+            "  No allowlist exceptions yet. Press [a] to add one.",
+            "Press [a] to add/import allowlist exceptions or [e] to edit selected",
+        ),
+    };
 
     // Site list
     let list_title = format!(
-        " Blocked Sites · {} ({}) ",
+        " {list_title_label} · {} ({}) ",
         app.active_blocklist_profile_name(),
-        app.blocker.sites.len()
+        app.active_policy_site_count()
     );
     let list_block = Block::default()
         .borders(Borders::ALL)
         .title(list_title)
         .style(Style::default().fg(Color::Gray));
 
-    if app.blocker.sites.is_empty() {
-        let empty = Paragraph::new("  No sites blocked yet. Press [a] to add one.")
+    if app.active_policy_sites().is_empty() {
+        let empty = Paragraph::new(empty_text)
             .style(Style::default().fg(Color::DarkGray))
             .block(list_block);
         frame.render_widget(empty, inner[4]);
     } else {
         let items: Vec<ListItem> = app
-            .blocker
-            .sites
+            .active_policy_sites()
             .iter()
             .map(|s| ListItem::new(format!("  {s}")))
             .collect();
@@ -516,8 +540,14 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
 
     // Input area
     let input_title = match input_mode {
-        SiteInputMode::Add => " Add / Import Sites ",
-        SiteInputMode::Edit => " Edit Site ",
+        SiteInputMode::Add => match site_list_mode {
+            SiteListMode::Blocklist => " Add / Import Blocklist Sites ",
+            SiteListMode::Allowlist => " Add / Import Allowlist Sites ",
+        },
+        SiteInputMode::Edit => match site_list_mode {
+            SiteListMode::Blocklist => " Edit Blocklist Site ",
+            SiteListMode::Allowlist => " Edit Allowlist Site ",
+        },
     };
     let input_block = Block::default()
         .borders(Borders::ALL)
@@ -531,7 +561,7 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
     let input_text = if app.site_input_active {
         format!("{}_", app.site_input)
     } else {
-        "Press [a] to add/import (comma/newline) or [e] to edit selected".to_string()
+        idle_input_text.to_string()
     };
     let input_widget =
         Paragraph::new(input_text)
@@ -559,7 +589,8 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
     let profile_input_text = if app.blocklist_profile_input_active {
         format!("{}_", app.blocklist_profile_input)
     } else {
-        "Use [n] to create, [r] to rename, [x] to delete, [[ ] to switch".to_string()
+        "Use [m] to toggle blocklist/allowlist, [n] create, [r] rename, [x] delete, [[ ] switch"
+            .to_string()
     };
     frame.render_widget(
         Paragraph::new(profile_input_text)
@@ -579,7 +610,11 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         } else {
             " (try running with elevated privileges)"
         };
-        render_centered_error(frame, inner[8], format!("⚠  {err}{privilege_hint}"));
+        render_centered_error(
+            frame,
+            inner[8],
+            format!("⚠  {err}{privilege_hint} · open [d] Setup for remediation"),
+        );
     } else if let Some(err) = app.config_error.as_ref() {
         render_centered_error(frame, inner[8], format!("⚠  {err}"));
     } else if let Some(feedback) = app.site_feedback.as_ref() {
@@ -612,14 +647,20 @@ fn render_site_manager(frame: &mut Frame, app: &App) {
         ]
     } else if app.strict_mode_enforced_for_focus() {
         vec![
-            Line::from("Sites: [a] Add  [e] Edit  [d/Del] Remove  [↑/↓] Move"),
+            Line::from(format!(
+                "Mode: [m] Toggle ({})  Sites: [a] Add  [e] Edit  [d/Del] Remove  [↑/↓] Move",
+                site_list_mode.label()
+            )),
             Line::from(
                 "Profiles: [[ ] Switch  [n] New  [r] Rename  [x] Delete  [b/Esc] Back  [q] Quit (Locked)",
             ),
         ]
     } else {
         vec![
-            Line::from("Sites: [a] Add  [e] Edit  [d/Del] Remove  [↑/↓] Move"),
+            Line::from(format!(
+                "Mode: [m] Toggle ({})  Sites: [a] Add  [e] Edit  [d/Del] Remove  [↑/↓] Move",
+                site_list_mode.label()
+            )),
             Line::from("Profiles: [[ ] Switch  [n] New  [r] Rename  [x] Delete  [b/Esc] Back"),
         ]
     };
@@ -1652,6 +1693,51 @@ mod tests {
 
         let text = terminal_text(&terminal, width, height);
         assert!(text.contains("WRAP-END"));
+    }
+
+    #[test]
+    fn site_manager_status_surfaces_permission_remediation_context() {
+        let width = 120;
+        let height = 30;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.mode = AppMode::SiteManager;
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.block_error = Some("permission denied".to_string());
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("blocking unavailable (permission/setup issue"));
+    }
+
+    #[test]
+    fn site_manager_renders_allowlist_mode_labels() {
+        let width = 120;
+        let height = 30;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('b'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('m'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("Allowlist Exceptions"));
+        assert!(text.contains("Mode: [m] Toggle (Allowlist)"));
     }
 
     #[test]


### PR DESCRIPTION
## What

- Add allowlist exception support to blocklist profiles and compute effective blocked sites as `sites - allowlist_sites`.
- Extend Site Manager with `[m]` mode toggling so users can edit blocklist entries and allowlist exceptions in one flow.
- Keep runtime blocking and persisted config aligned with the effective blocked set, including legacy `blocked_sites` compatibility fields.
- Improve setup and runtime status messaging when blocking is unavailable due to permissions or setup issues, with explicit remediation guidance.
- Update CLI status blocked-site counting and README docs, and add regression tests for allowlist and status behavior.

## Why

Issue #142 requests policy and UX upgrades so users can keep explicit exceptions in focus mode while still blocking distracting sites. It also asks for clearer degraded-state messaging and actionable remediation steps when system permissions prevent hosts-file blocking.

Closes #142

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added allowlist mode to Site Manager—toggle between blocklist and allowlist editing with the `m` key
  * Site blocking now automatically accounts for allowlisted exceptions when calculating effective blocked sites
  * Enhanced UI displays current editing mode and effective blocked count

* **Bug Fixes**
  * Fixed blocked site count calculation to exclude allowlisted sites

* **Documentation**
  * Added allowlist configuration examples and OS-specific remediation guidance for setup issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->