### PR TITLE
Standardize CLI JSON error contract and exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CLI JSON/error contract and exit-code consistency (#173):** centralized CLI error handling, added machine-readable JSON error envelopes for `--json` failures, and standardized exit-code mapping (`0` success, `1` runtime failure, `2` usage failure).
+
 ## [0.5.2] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cargo run -- --export
 cargo run -- --export=./reports --json
 ```
 
-#### CLI JSON/error contract
+### CLI JSON/error contract
 
 - `--json` success responses are emitted to `stdout` as JSON and exit with code `0`.
 - `--json` failures are emitted to `stdout` as JSON (no mixed human text) and exit with a non-zero code.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,31 @@ cargo run -- --export
 cargo run -- --export=./reports --json
 ```
 
+#### CLI JSON/error contract
+
+- `--json` success responses are emitted to `stdout` as JSON and exit with code `0`.
+- `--json` failures are emitted to `stdout` as JSON (no mixed human text) and exit with a non-zero code.
+- Text-mode failures are emitted to `stderr` for interactive readability.
+
+Exit codes:
+
+- `0`: success
+- `1`: runtime/command failure
+- `2`: argument/usage failure
+
+JSON failure shape:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "kind": "usage",
+    "exit_code": 2,
+    "message": "Unknown option `--unknown`.\n\nUsage:\n..."
+  }
+}
+```
+
 When no CLI command is provided, `focustime` keeps the default interactive TUI mode.
 
 > Site blocking updates your OS hosts file and may require elevated privileges

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,45 @@ pub enum OutputMode {
     Json,
 }
 
+const EXIT_CODE_RUNTIME_ERROR: i32 = 1;
+const EXIT_CODE_USAGE_ERROR: i32 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliErrorKind {
+    Usage,
+    Runtime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliError {
+    kind: CliErrorKind,
+    output: OutputMode,
+    message: String,
+}
+
+impl CliError {
+    pub fn exit_code(&self) -> i32 {
+        match self.kind {
+            CliErrorKind::Usage => EXIT_CODE_USAGE_ERROR,
+            CliErrorKind::Runtime => EXIT_CODE_RUNTIME_ERROR,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct CliErrorEnvelope {
+    ok: bool,
+    error: CliErrorPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct CliErrorPayload {
+    kind: CliErrorKind,
+    exit_code: i32,
+    message: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommandKind {
     Pause,
@@ -283,21 +322,82 @@ pub fn usage_text() -> &'static str {
     USAGE_TEXT
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn parse_args<I>(args: I) -> Result<CliAction, String>
 where
     I: IntoIterator<Item = OsString>,
 {
-    let args: Vec<String> = args
+    parse_args_with_contract(args).map_err(|error| error.message)
+}
+
+pub fn parse_args_with_contract<I>(args: I) -> Result<CliAction, CliError>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let raw_args: Vec<OsString> = args.into_iter().collect();
+    let output_hint = infer_output_mode_from_os_args(&raw_args);
+    let args: Vec<String> = raw_args
         .into_iter()
         .map(|arg| {
-            arg.into_string()
-                .map_err(|_| invalid_usage("Arguments must be valid UTF-8."))
+            arg.into_string().map_err(|_| {
+                usage_error(output_hint, invalid_usage("Arguments must be valid UTF-8."))
+            })
         })
         .collect::<Result<_, _>>()?;
-    let tokens = classify_args(&args)?;
-    let (show_help, output) = parse_global_tokens(&tokens)?;
-    let primary = parse_primary_command(&tokens)?;
-    finalize_cli_action(show_help, output, primary)
+    let tokens = classify_args(&args).map_err(|message| usage_error(output_hint, message))?;
+    let (show_help, output) =
+        parse_global_tokens(&tokens).map_err(|message| usage_error(output_hint, message))?;
+    let primary = parse_primary_command(&tokens).map_err(|message| usage_error(output, message))?;
+    finalize_cli_action(show_help, output, primary).map_err(|message| usage_error(output, message))
+}
+
+pub fn runtime_error(output: OutputMode, message: String) -> CliError {
+    CliError {
+        kind: CliErrorKind::Runtime,
+        output,
+        message,
+    }
+}
+
+pub fn emit_cli_error(error: &CliError) -> Result<(), String> {
+    match error.output {
+        OutputMode::Text => {
+            eprintln!("{}", error.message);
+            Ok(())
+        }
+        OutputMode::Json => print_json(&CliErrorEnvelope {
+            ok: false,
+            error: CliErrorPayload {
+                kind: error.kind,
+                exit_code: error.exit_code(),
+                message: error.message.clone(),
+            },
+        }),
+    }
+}
+
+fn usage_error(output: OutputMode, message: String) -> CliError {
+    CliError {
+        kind: CliErrorKind::Usage,
+        output,
+        message,
+    }
+}
+
+fn infer_output_mode_from_os_args(args: &[OsString]) -> OutputMode {
+    let parsed_args: Vec<String> = args
+        .iter()
+        .filter_map(|arg| arg.to_str().map(ToString::to_string))
+        .collect();
+    infer_output_mode_from_args(&parsed_args)
+}
+
+fn infer_output_mode_from_args(args: &[String]) -> OutputMode {
+    if args.iter().any(|arg| arg == "--json") {
+        OutputMode::Json
+    } else {
+        OutputMode::Text
+    }
 }
 
 fn classify_args(args: &[String]) -> Result<Vec<ParsedToken>, String> {
@@ -1512,6 +1612,10 @@ mod tests {
         parse_args(values.iter().map(OsString::from))
     }
 
+    fn parse_with_contract(values: &[&str]) -> Result<CliAction, CliError> {
+        parse_args_with_contract(values.iter().map(OsString::from))
+    }
+
     #[test]
     fn parse_without_arguments_runs_default_tui() {
         let parsed = parse(&[]).unwrap();
@@ -1960,6 +2064,28 @@ mod tests {
     fn parse_rejects_json_with_start() {
         let error = parse(&["--start", "--json"]).unwrap_err();
         assert!(error.contains("not supported with `--start`"));
+    }
+
+    #[test]
+    fn parse_with_contract_marks_json_usage_errors() {
+        let error = parse_with_contract(&["--status", "--unknown", "--json"]).unwrap_err();
+        assert_eq!(error.kind, CliErrorKind::Usage);
+        assert_eq!(error.output, OutputMode::Json);
+        assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+        assert!(error.message.contains("Unknown option"));
+    }
+
+    #[test]
+    fn parse_with_contract_detects_json_on_early_parse_failures() {
+        let error = parse_with_contract(&["--schedule-set", "--json"]).unwrap_err();
+        assert_eq!(error.kind, CliErrorKind::Usage);
+        assert_eq!(error.output, OutputMode::Json);
+        assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+        assert!(
+            error
+                .message
+                .contains("`--schedule-set` requires a JSON payload")
+        );
     }
 
     #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,10 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 
 use app::App;
 use app::should_handle_key;
-use cli::{CliAction, execute_command, parse_args, usage_text};
+use cli::{
+    CliAction, OutputMode, emit_cli_error, execute_command, parse_args_with_contract,
+    runtime_error, usage_text,
+};
 
 /// RAII guard that restores the terminal on drop, ensuring cleanup on any exit path.
 struct TerminalGuard {
@@ -82,11 +85,13 @@ impl Drop for TerminalGuard {
 }
 
 fn main() -> io::Result<()> {
-    let cli_action = match parse_args(std::env::args_os().skip(1)) {
+    let cli_action = match parse_args_with_contract(std::env::args_os().skip(1)) {
         Ok(action) => action,
         Err(error) => {
-            eprintln!("{error}");
-            process::exit(2);
+            if let Err(render_error) = emit_cli_error(&error) {
+                eprintln!("{render_error}");
+            }
+            process::exit(error.exit_code());
         }
     };
 
@@ -97,16 +102,23 @@ fn main() -> io::Result<()> {
             return Ok(());
         }
         CliAction::RunCommand(command) => {
+            let output_mode = command.output;
             if let Err(error) = execute_command(command) {
-                eprintln!("{error}");
-                process::exit(1);
+                let cli_error = runtime_error(output_mode, error);
+                if let Err(render_error) = emit_cli_error(&cli_error) {
+                    eprintln!("{render_error}");
+                }
+                process::exit(cli_error.exit_code());
             }
             return Ok(());
         }
         CliAction::RunTui { start_immediately } => {
             if start_immediately && let Err(error) = app.start_focus_for_cli() {
-                eprintln!("{error}");
-                process::exit(1);
+                let cli_error = runtime_error(OutputMode::Text, error);
+                if let Err(render_error) = emit_cli_error(&cli_error) {
+                    eprintln!("{render_error}");
+                }
+                process::exit(cli_error.exit_code());
             }
         }
     }

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -1,0 +1,126 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output},
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde_json::Value;
+
+static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+struct TestEnv {
+    root: PathBuf,
+}
+
+impl TestEnv {
+    fn new(label: &str) -> Self {
+        let unique = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "focustime-cli-contract-{label}-{}-{now}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("failed to create temp test directory");
+        Self { root }
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        let mut command = Command::new(focustime_bin_path());
+        command.args(args);
+        command.current_dir(&self.root);
+        command.env("APPDATA", &self.root);
+        command.env("XDG_CONFIG_HOME", &self.root);
+        command.env("HOME", &self.root);
+        command
+            .output()
+            .expect("failed to run focustime integration command")
+    }
+}
+
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn focustime_bin_path() -> PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_focustime")
+        .map(PathBuf::from)
+        .expect("CARGO_BIN_EXE_focustime not set")
+}
+
+fn stdout_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stderr_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+#[test]
+fn status_json_success_emits_payload_on_stdout() {
+    let env = TestEnv::new("status-json-success");
+    let output = env.run(&["--status", "--json"]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert!(payload.get("day").is_some());
+    assert!(payload.get("live").is_some());
+}
+
+#[test]
+fn parse_errors_in_json_mode_emit_usage_envelope() {
+    let env = TestEnv::new("json-parse-error");
+    let output = env.run(&["--status", "--unknown", "--json"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"]["kind"], "usage");
+    assert_eq!(payload["error"]["exit_code"], 2);
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .expect("error message should be a string")
+            .contains("Unknown option")
+    );
+}
+
+#[test]
+fn runtime_errors_in_json_mode_emit_runtime_envelope() {
+    let env = TestEnv::new("json-runtime-error");
+    let output = env.run(&["--resume", "--json"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"]["kind"], "runtime");
+    assert_eq!(payload["error"]["exit_code"], 1);
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .expect("error message should be a string")
+            .contains("Cannot resume")
+    );
+}
+
+#[test]
+fn text_parse_errors_still_use_stderr() {
+    let env = TestEnv::new("text-parse-error");
+    let output = env.run(&["--unknown"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stdout_text(&output).trim().is_empty());
+    assert!(stderr_text(&output).contains("Unknown option"));
+}


### PR DESCRIPTION
## What

Standardize CLI contract behavior by centralizing error classification and exit-code mapping, and emit machine-readable JSON error envelopes whenever `--json` is requested.

## Why

Automation consumers need predictable JSON output and deterministic exit semantics across parse and runtime failure paths. Previously, success paths were JSON-capable, but failures could still fall back to text stderr output depending on where the error occurred.

Closes #173.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

No intentional breaking behavior changes were introduced. Existing success JSON payload shapes remain unchanged; this PR standardizes failure output in JSON mode and centralizes `0/1/2` exit-code behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now emits structured JSON error responses when `--json` is used; failures return a machine-readable envelope with `ok:false`, `error.kind`, `error.exit_code`, and `message`.
  * Standardized exit codes: `0` success, `1` runtime failures, `2` usage/argument failures.

* **Documentation**
  * README and changelog updated with the deterministic `--json` contract, output destinations, and example error envelope.

* **Tests**
  * Added contract tests validating JSON/non-JSON outputs and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->