### PR TITLE
Promote session metadata v2 fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **CLI v3 core management commands (#172):** added `--goal`, `--strict`, `--schedule`, `--schedule-set`, and `--diagnostics` commands with text/JSON output for automation workflows.
+- **Session metadata v2 persistence (#174):** promoted `focus_intention` and `task_note` to first-class persisted session metadata across recovery, stats storage, and CLI JSON surfaces (defaulting to `task_label` when no dedicated metadata input is provided).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ You can configure notification and auto-start settings directly from the TUI:
 
 `focustime` persists in-progress timer sessions so restart/crash recovery can resume where you left off.
 
-- while a focus/break phase is running or paused, the app saves phase, remaining time, selected task label, and active profile
+- while a focus/break phase is running or paused, the app saves phase, remaining time, task metadata (`task_label`, `focus_intention`, `task_note`), and active profile
 - on startup, valid in-progress state is restored and shown in the timer notice line
 - stale or invalid saved recovery state is ignored safely with a warning notice
 - recovery state is cleared when an in-progress phase ends naturally or when you reset/skip out of the active session
@@ -410,8 +410,9 @@ From timer view:
 
 Exports include daily/weekly aggregates, weekly consistency, profile
 effectiveness, task summaries/trends, and labeled focus-session records where
-task labels were attached. Focus-session rows also include `focus_intention`
-and `task_note` fields (mirroring `task_label`) for downstream consumers.
+task labels were attached. Focus-session rows persist and export first-class
+`focus_intention` and `task_note` fields; when dedicated metadata input is not
+provided, both fields default to the selected `task_label`.
 
 ## The way the system works
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,9 +22,10 @@ use crate::schedule::{
 };
 use crate::session_recovery::{self, InProgressSessionSnapshot};
 use crate::stats::{
-    BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles, FocusStats,
-    GoalStreak, MonthlyHeatmap, MonthlyStats, ProfileEffectiveness, ProfileTotals, SessionStats,
-    TaskTotals, TaskTrend, WeeklyConsistency, WeeklyStats, current_day_key,
+    BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles,
+    FocusSessionMetadata, FocusStats, GoalStreak, MonthlyHeatmap, MonthlyStats,
+    ProfileEffectiveness, ProfileTotals, SessionStats, TaskTotals, TaskTrend, WeeklyConsistency,
+    WeeklyStats, current_day_key,
 };
 use crate::task_labels::{normalize_task_label, task_label_index};
 use crate::timer::{
@@ -366,6 +367,8 @@ pub struct App {
     pub planner_input_mode: Option<PlannerInputMode>,
     pub planner_feedback: Option<PlannerFeedback>,
     active_focus_task_label: Option<String>,
+    active_focus_intention: Option<String>,
+    active_focus_task_note: Option<String>,
     active_focus_profile: Option<ProfileId>,
     site_list_mode: SiteListMode,
     /// Index of the highlighted site in the SiteManager list.
@@ -478,6 +481,8 @@ impl App {
             planner_input_mode: None,
             planner_feedback: None,
             active_focus_task_label: None,
+            active_focus_intention: None,
+            active_focus_task_note: None,
             active_focus_profile: None,
             site_list_mode: SiteListMode::Blocklist,
             selected_site: 0,
@@ -566,6 +571,8 @@ impl App {
         if self.should_record_completed_focus_session(completed_phase, is_catchup) {
             self.record_completed_focus_session(completed_focus_secs);
             self.active_focus_task_label = None;
+            self.active_focus_intention = None;
+            self.active_focus_task_note = None;
             self.active_focus_profile = None;
         }
 
@@ -579,6 +586,8 @@ impl App {
 
         if self.timer.phase != TimerPhase::Focus {
             self.active_focus_task_label = None;
+            self.active_focus_intention = None;
+            self.active_focus_task_note = None;
             self.active_focus_profile = None;
             self.break_glass_expires_at = None;
         }
@@ -601,6 +610,8 @@ impl App {
         self.timer.status = TimerStatus::Running;
         if self.timer.phase == TimerPhase::Focus {
             self.active_focus_task_label = self.selected_task_label.clone();
+            self.active_focus_intention = self.selected_task_label.clone();
+            self.active_focus_task_note = self.selected_task_label.clone();
             self.active_focus_profile = Some(self.selected_profile);
         }
         false
@@ -1457,6 +1468,16 @@ impl App {
         } else {
             None
         };
+        self.active_focus_intention = if self.timer.phase == TimerPhase::Focus {
+            snapshot.normalized_focus_intention()
+        } else {
+            None
+        };
+        self.active_focus_task_note = if self.timer.phase == TimerPhase::Focus {
+            snapshot.normalized_task_note()
+        } else {
+            None
+        };
         self.active_focus_profile = if self.timer.phase == TimerPhase::Focus {
             Some(self.selected_profile)
         } else {
@@ -1475,10 +1496,26 @@ impl App {
         } else {
             self.selected_task_label.clone()
         };
+        let recovery_focus_intention = if self.focus_session_active_for_current_state() {
+            self.active_focus_intention
+                .clone()
+                .or_else(|| recovery_task_label.clone())
+        } else {
+            recovery_task_label.clone()
+        };
+        let recovery_task_note = if self.focus_session_active_for_current_state() {
+            self.active_focus_task_note
+                .clone()
+                .or_else(|| recovery_task_label.clone())
+        } else {
+            recovery_task_label.clone()
+        };
 
-        let snapshot = InProgressSessionSnapshot::from_timer_state(
+        let snapshot = InProgressSessionSnapshot::from_timer_state_with_metadata(
             &self.timer,
             recovery_task_label,
+            recovery_focus_intention,
+            recovery_task_note,
             self.selected_profile,
         );
 
@@ -1957,6 +1994,8 @@ impl App {
             .is_some_and(|active| active.eq_ignore_ascii_case(&current_label))
         {
             self.active_focus_task_label = Some(label.clone());
+            self.active_focus_intention = Some(label.clone());
+            self.active_focus_task_note = Some(label.clone());
         }
 
         self.sync_task_planner_state();
@@ -2243,6 +2282,8 @@ impl App {
             profile_spec.long_break_interval,
         );
         self.active_focus_task_label = None;
+        self.active_focus_intention = None;
+        self.active_focus_task_note = None;
         self.active_focus_profile = None;
         self.selected_profile = profile;
         self.profile_selection_index = profile_index(profile);
@@ -2840,10 +2881,14 @@ impl App {
         let is_focus_active = self.focus_session_active_for_current_state();
         if !was_focus_active && is_focus_active {
             self.active_focus_task_label = self.selected_task_label.clone();
+            self.active_focus_intention = self.selected_task_label.clone();
+            self.active_focus_task_note = self.selected_task_label.clone();
             self.active_focus_profile = Some(self.selected_profile);
             self.schedule_armed_occurrence_key = None;
         } else if was_focus_active && !is_focus_active {
             self.active_focus_task_label = None;
+            self.active_focus_intention = None;
+            self.active_focus_task_note = None;
             self.active_focus_profile = None;
             self.break_glass_expires_at = None;
         }
@@ -3001,11 +3046,23 @@ impl App {
     fn record_completed_focus_session(&mut self, focused_seconds: u64) {
         let day_key = current_day_key();
         let goal = self.current_goal_snapshot();
-        if self.active_focus_task_label.is_some() {
-            self.stats.record_completed_pomodoro_with_task(
+        if let Some(active_task_label) = self.active_focus_task_label.clone() {
+            let focus_intention = self
+                .active_focus_intention
+                .clone()
+                .unwrap_or_else(|| active_task_label.clone());
+            let task_note = self
+                .active_focus_task_note
+                .clone()
+                .unwrap_or_else(|| active_task_label.clone());
+            self.stats.record_completed_pomodoro_with_metadata(
                 &day_key,
                 goal,
-                self.active_focus_task_label.as_deref(),
+                FocusSessionMetadata {
+                    task_label: Some(active_task_label.as_str()),
+                    focus_intention: Some(focus_intention.as_str()),
+                    task_note: Some(task_note.as_str()),
+                },
                 focused_seconds,
                 self.active_focus_profile,
             );
@@ -3730,12 +3787,15 @@ mod tests {
         task_label: Option<&str>,
         selected_profile: ProfileId,
     ) -> InProgressSessionSnapshot {
+        let metadata_value = task_label.map(str::to_string);
         InProgressSessionSnapshot {
             phase: RecoveryTimerPhase::from_timer_phase(phase),
             status: RecoveryTimerStatus::from_timer_status(status),
             remaining_secs,
             pomodoros_completed: 0,
-            selected_task_label: task_label.map(str::to_string),
+            selected_task_label: metadata_value.clone(),
+            focus_intention: metadata_value.clone(),
+            task_note: metadata_value,
             selected_profile,
         }
     }
@@ -6329,6 +6389,8 @@ mod tests {
             remaining_secs: 1,
             pomodoros_completed: 3,
             selected_task_label: Some("Docs".to_string()),
+            focus_intention: Some("Docs".to_string()),
+            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
         }));
 
@@ -6404,6 +6466,8 @@ mod tests {
 
         let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
         assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task A"));
+        assert_eq!(snapshot.focus_intention.as_deref(), Some("Task A"));
+        assert_eq!(snapshot.task_note.as_deref(), Some("Task A"));
     }
 
     #[test]
@@ -6425,6 +6489,8 @@ mod tests {
 
         let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
         assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task B"));
+        assert_eq!(snapshot.focus_intention.as_deref(), Some("Task B"));
+        assert_eq!(snapshot.task_note.as_deref(), Some("Task B"));
         assert_eq!(snapshot.phase, RecoveryTimerPhase::ShortBreak);
         assert_eq!(snapshot.status, RecoveryTimerStatus::Running);
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -236,6 +236,8 @@ struct LiveStatusOutput {
     pomodoros_completed: u32,
     selected_profile: ProfileView,
     selected_task_label: Option<String>,
+    focus_intention: Option<String>,
+    task_note: Option<String>,
     strict_mode_enforced: bool,
 }
 
@@ -244,6 +246,8 @@ struct StatusOutput {
     day: String,
     selected_profile: ProfileView,
     selected_task_label: Option<String>,
+    focus_intention: Option<String>,
+    task_note: Option<String>,
     selected_blocklist_profile: String,
     blocked_sites_count: usize,
     strict_mode: bool,
@@ -268,6 +272,8 @@ struct TimerStateOutput {
     pomodoros_completed: u32,
     selected_profile: ProfileView,
     selected_task_label: Option<String>,
+    focus_intention: Option<String>,
+    task_note: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -1016,6 +1022,8 @@ fn build_timer_state_output(app: &App) -> TimerStateOutput {
     let profile = app.selected_profile_id();
     let (focus_secs, short_break_secs, long_break_secs, long_break_interval) =
         app.profile_values(profile);
+    let (selected_task_label, focus_intention, task_note) =
+        mirror_metadata_from_task_label(app.selected_task_label_for_cli());
 
     TimerStateOutput {
         phase: timer_phase_id(phase),
@@ -1030,7 +1038,9 @@ fn build_timer_state_output(app: &App) -> TimerStateOutput {
             long_break_secs,
             long_break_interval,
         },
-        selected_task_label: app.selected_task_label_for_cli(),
+        selected_task_label,
+        focus_intention,
+        task_note,
     }
 }
 
@@ -1039,6 +1049,8 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let today = stats.daily_for(&day);
     let session = stats.session();
     let (_, selected_task_label) = stats.task_planner_state();
+    let (selected_task_label, focus_intention, task_note) =
+        mirror_metadata_from_task_label(selected_task_label);
     let goal_snapshot = DailyGoalSnapshot {
         minutes: config.daily_goal.minutes,
         pomodoros: config.daily_goal.pomodoros,
@@ -1070,6 +1082,8 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
         day,
         selected_profile: profile_view(config.selected_profile, &config.effective_custom_profile()),
         selected_task_label,
+        focus_intention,
+        task_note,
         selected_blocklist_profile: config.selected_blocklist_profile.clone(),
         blocked_sites_count: active_sites_count,
         strict_mode: config.strict_mode,
@@ -1096,6 +1110,8 @@ fn build_live_status_output(
     fallback_task_label: Option<String>,
 ) -> LiveStatusOutput {
     let custom = config.effective_custom_profile();
+    let (fallback_task_label, fallback_focus_intention, fallback_task_note) =
+        mirror_metadata_from_task_label(fallback_task_label);
     match session_recovery::load() {
         Ok(Some(snapshot)) => {
             let phase = snapshot.phase();
@@ -1110,6 +1126,8 @@ fn build_live_status_output(
                 pomodoros_completed: snapshot.pomodoros_completed,
                 selected_profile: profile_view(snapshot.selected_profile, &custom),
                 selected_task_label: snapshot.normalized_task_label(),
+                focus_intention: snapshot.normalized_focus_intention(),
+                task_note: snapshot.normalized_task_note(),
                 strict_mode_enforced: config.strict_mode
                     && phase == TimerPhase::Focus
                     && status != TimerStatus::Idle,
@@ -1126,7 +1144,9 @@ fn build_live_status_output(
                 remaining_secs: selected_profile.focus_secs,
                 pomodoros_completed: 0,
                 selected_profile,
-                selected_task_label: fallback_task_label,
+                selected_task_label: fallback_task_label.clone(),
+                focus_intention: fallback_focus_intention.clone(),
+                task_note: fallback_task_note.clone(),
                 strict_mode_enforced: false,
             }
         }
@@ -1142,10 +1162,23 @@ fn build_live_status_output(
                 pomodoros_completed: 0,
                 selected_profile,
                 selected_task_label: fallback_task_label,
+                focus_intention: fallback_focus_intention,
+                task_note: fallback_task_note,
                 strict_mode_enforced: false,
             }
         }
     }
+}
+
+fn mirror_metadata_from_task_label(
+    task_label: Option<String>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let task_label = task_label
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let focus_intention = task_label.clone();
+    let task_note = task_label.clone();
+    (task_label, focus_intention, task_note)
 }
 
 fn profile_view(profile: ProfileId, custom: &CustomProfileConfig) -> ProfileView {
@@ -1428,6 +1461,14 @@ fn print_status_output(payload: &StatusOutput) {
         payload.selected_task_label.as_deref().unwrap_or("none")
     );
     println!(
+        "Focus intention: {}",
+        payload.focus_intention.as_deref().unwrap_or("none")
+    );
+    println!(
+        "Task note: {}",
+        payload.task_note.as_deref().unwrap_or("none")
+    );
+    println!(
         "Blocklist profile: {} ({} sites)",
         payload.selected_blocklist_profile, payload.blocked_sites_count
     );
@@ -1464,6 +1505,14 @@ fn print_status_output(payload: &StatusOutput) {
         format_duration(payload.live.remaining_secs),
         payload.live.state_source
     );
+    println!(
+        "Live focus intention: {}",
+        payload.live.focus_intention.as_deref().unwrap_or("none")
+    );
+    println!(
+        "Live task note: {}",
+        payload.live.task_note.as_deref().unwrap_or("none")
+    );
     if let Some(error) = payload.live.recovery_error.as_deref() {
         println!("Live timer warning: {error}");
     }
@@ -1480,6 +1529,14 @@ fn print_timer_state_output(timer: &TimerStateOutput) {
     println!(
         "Task label: {}",
         timer.selected_task_label.as_deref().unwrap_or("none")
+    );
+    println!(
+        "Focus intention: {}",
+        timer.focus_intention.as_deref().unwrap_or("none")
+    );
+    println!(
+        "Task note: {}",
+        timer.task_note.as_deref().unwrap_or("none")
     );
     println!(
         "Profile: {} ({})",
@@ -2140,6 +2197,8 @@ mod tests {
             remaining_secs: 42,
             pomodoros_completed: 3,
             selected_task_label: Some("Docs".to_string()),
+            focus_intention: Some("Write docs".to_string()),
+            task_note: Some("API section".to_string()),
             selected_profile: ProfileId::DeepWork,
         }));
         let config = AppConfig::default();
@@ -2154,6 +2213,8 @@ mod tests {
         assert_eq!(output.live.remaining_secs, 42);
         assert_eq!(output.live.pomodoros_completed, 3);
         assert_eq!(output.live.selected_task_label.as_deref(), Some("Docs"));
+        assert_eq!(output.live.focus_intention.as_deref(), Some("Write docs"));
+        assert_eq!(output.live.task_note.as_deref(), Some("API section"));
         assert_eq!(output.live.selected_profile.id, "deep-work");
         assert!(output.live.recovery_error.is_none());
     }

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -80,13 +80,19 @@ pub struct InProgressSessionSnapshot {
     #[serde(default)]
     pub pomodoros_completed: u32,
     pub selected_task_label: Option<String>,
+    #[serde(default)]
+    pub focus_intention: Option<String>,
+    #[serde(default)]
+    pub task_note: Option<String>,
     pub selected_profile: ProfileId,
 }
 
 impl InProgressSessionSnapshot {
-    pub fn from_timer_state(
+    pub fn from_timer_state_with_metadata(
         timer: &TimerState,
         selected_task_label: Option<String>,
+        focus_intention: Option<String>,
+        task_note: Option<String>,
         selected_profile: ProfileId,
     ) -> Option<Self> {
         if timer.status == TimerStatus::Idle {
@@ -96,6 +102,14 @@ impl InProgressSessionSnapshot {
         let selected_task_label = selected_task_label
             .as_deref()
             .and_then(normalize_task_label)?;
+        let focus_intention = focus_intention
+            .as_deref()
+            .and_then(normalize_metadata_text)
+            .unwrap_or_else(|| selected_task_label.clone());
+        let task_note = task_note
+            .as_deref()
+            .and_then(normalize_metadata_text)
+            .unwrap_or_else(|| selected_task_label.clone());
 
         Some(Self {
             phase: RecoveryTimerPhase::from_timer_phase(timer.phase),
@@ -103,6 +117,8 @@ impl InProgressSessionSnapshot {
             remaining_secs: timer.remaining_secs,
             pomodoros_completed: timer.pomodoros_completed,
             selected_task_label: Some(selected_task_label),
+            focus_intention: Some(focus_intention),
+            task_note: Some(task_note),
             selected_profile,
         })
     }
@@ -121,6 +137,20 @@ impl InProgressSessionSnapshot {
             .and_then(normalize_task_label)
     }
 
+    pub fn normalized_focus_intention(&self) -> Option<String> {
+        self.focus_intention
+            .as_deref()
+            .and_then(normalize_metadata_text)
+            .or_else(|| self.normalized_task_label())
+    }
+
+    pub fn normalized_task_note(&self) -> Option<String> {
+        self.task_note
+            .as_deref()
+            .and_then(normalize_metadata_text)
+            .or_else(|| self.normalized_task_label())
+    }
+
     pub fn validate_for_timer(&self, timer: &TimerState) -> Result<(), String> {
         if !matches!(
             self.status,
@@ -131,6 +161,12 @@ impl InProgressSessionSnapshot {
 
         if self.normalized_task_label().is_none() {
             return Err("saved task label is missing or invalid".to_string());
+        }
+        if self.normalized_focus_intention().is_none() {
+            return Err("saved focus intention is missing or invalid".to_string());
+        }
+        if self.normalized_task_note().is_none() {
+            return Err("saved task note is missing or invalid".to_string());
         }
 
         let phase_duration_secs = phase_duration_secs(timer, self.phase());
@@ -276,6 +312,11 @@ fn phase_duration_secs(timer: &TimerState, phase: TimerPhase) -> u64 {
     }
 }
 
+fn normalize_metadata_text(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,6 +330,8 @@ mod tests {
             remaining_secs: 10,
             pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
+            focus_intention: Some("Docs".to_string()),
+            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
         };
 
@@ -304,6 +347,8 @@ mod tests {
             remaining_secs: 0,
             pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
+            focus_intention: Some("Docs".to_string()),
+            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
         };
 
@@ -319,6 +364,8 @@ mod tests {
             remaining_secs: 31,
             pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
+            focus_intention: Some("Docs".to_string()),
+            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
         };
 
@@ -334,6 +381,8 @@ mod tests {
             remaining_secs: 50,
             pomodoros_completed: 0,
             selected_task_label: None,
+            focus_intention: Some("Docs".to_string()),
+            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
         };
 
@@ -349,9 +398,33 @@ mod tests {
             remaining_secs: 90,
             pomodoros_completed: 2,
             selected_task_label: Some("Docs".to_string()),
+            focus_intention: Some("Docs".to_string()),
+            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::DeepWork,
         };
 
+        assert!(snapshot.validate_for_timer(&timer).is_ok());
+    }
+
+    #[test]
+    fn metadata_defaults_to_task_label_for_legacy_snapshots() {
+        let timer = TimerState::with_profile(60, 30, 90, 4);
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Running,
+            remaining_secs: 60,
+            pomodoros_completed: 1,
+            selected_task_label: Some("Docs".to_string()),
+            focus_intention: None,
+            task_note: None,
+            selected_profile: ProfileId::Classic,
+        };
+
+        assert_eq!(
+            snapshot.normalized_focus_intention().as_deref(),
+            Some("Docs")
+        );
+        assert_eq!(snapshot.normalized_task_note().as_deref(), Some("Docs"));
         assert!(snapshot.validate_for_timer(&timer).is_ok());
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -144,9 +144,20 @@ pub struct ExportedStatsFiles {
 pub struct FocusSessionRecord {
     pub date: String,
     pub task_label: String,
+    #[serde(default)]
+    pub focus_intention: String,
+    #[serde(default)]
+    pub task_note: String,
     pub focused_seconds: u64,
     #[serde(default)]
     pub profile: Option<ProfileId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FocusSessionMetadata<'a> {
+    pub task_label: Option<&'a str>,
+    pub focus_intention: Option<&'a str>,
+    pub task_note: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -470,9 +481,15 @@ impl FocusStats {
         let mut focus_sessions = Vec::new();
         for session in persisted.focus_sessions {
             if let Some(task_label) = normalize_task_label(&session.task_label) {
+                let focus_intention = normalize_session_metadata_text(&session.focus_intention)
+                    .unwrap_or_else(|| task_label.clone());
+                let task_note = normalize_session_metadata_text(&session.task_note)
+                    .unwrap_or_else(|| task_label.clone());
                 focus_sessions.push(FocusSessionRecord {
                     date: session.date.trim().to_string(),
                     task_label,
+                    focus_intention,
+                    task_note,
                     focused_seconds: session.focused_seconds,
                     profile: session.profile,
                 });
@@ -551,19 +568,50 @@ impl FocusStats {
         focused_seconds: u64,
         profile: Option<ProfileId>,
     ) {
+        self.record_completed_pomodoro_with_metadata(
+            day_key,
+            goal,
+            FocusSessionMetadata {
+                task_label,
+                focus_intention: task_label,
+                task_note: task_label,
+            },
+            focused_seconds,
+            profile,
+        );
+    }
+
+    pub fn record_completed_pomodoro_with_metadata(
+        &mut self,
+        day_key: &str,
+        goal: DailyGoalSnapshot,
+        metadata: FocusSessionMetadata<'_>,
+        focused_seconds: u64,
+        profile: Option<ProfileId>,
+    ) {
         self.session.pomodoros_completed = self.session.pomodoros_completed.saturating_add(1);
         let daily = self.daily.entry(day_key.to_string()).or_default();
         daily.pomodoros_completed = daily.pomodoros_completed.saturating_add(1);
         daily.goal = Some(goal);
 
-        if let Some(task_label) = task_label.and_then(normalize_task_label) {
+        if let Some(task_label) = metadata.task_label.and_then(normalize_task_label) {
             if task_label_index(&self.task_labels, &task_label).is_none() {
                 self.task_labels.push(task_label.clone());
             }
             self.selected_task_label = Some(task_label.clone());
+            let focus_intention = metadata
+                .focus_intention
+                .and_then(normalize_session_metadata_text)
+                .unwrap_or_else(|| task_label.clone());
+            let task_note = metadata
+                .task_note
+                .and_then(normalize_session_metadata_text)
+                .unwrap_or_else(|| task_label.clone());
             self.focus_sessions.push(FocusSessionRecord {
                 date: day_key.to_string(),
                 task_label,
+                focus_intention,
+                task_note,
                 focused_seconds,
                 profile,
             });
@@ -1463,6 +1511,11 @@ fn normalize_task_planner_state(
     (normalized_labels, normalized_selected)
 }
 
+fn normalize_session_metadata_text(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 pub fn current_day_key() -> String {
     chrono::Local::now()
         .date_naive()
@@ -2093,6 +2146,23 @@ mod tests {
         assert_eq!(profile_totals[0].profile, ProfileBucket::DeepWork);
         assert_eq!(profile_totals[0].pomodoros_completed, 1);
         assert_eq!(profile_totals[0].focused_minutes(), 25);
+    }
+
+    #[test]
+    fn legacy_focus_sessions_default_metadata_from_task_label() {
+        let legacy_toml = r#"
+            [[focus_sessions]]
+            date = "2026-04-09"
+            task_label = "Project A"
+            focused_seconds = 1500
+        "#;
+        let restored = FocusStats::try_from_toml(legacy_toml).unwrap();
+
+        let export = restored.export_data();
+        assert_eq!(export.sessions.len(), 1);
+        assert_eq!(export.sessions[0].task_label, "Project A");
+        assert_eq!(export.sessions[0].focus_intention, "Project A");
+        assert_eq!(export.sessions[0].task_note, "Project A");
     }
 
     #[test]

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -72,7 +72,11 @@ fn status_json_success_emits_payload_on_stdout() {
 
     let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
     assert!(payload.get("day").is_some());
+    assert!(payload.get("focus_intention").is_some());
+    assert!(payload.get("task_note").is_some());
     assert!(payload.get("live").is_some());
+    assert!(payload["live"].get("focus_intention").is_some());
+    assert!(payload["live"].get("task_note").is_some());
 }
 
 #[test]


### PR DESCRIPTION
## What

Promotes `focus_intention` and `task_note` from export-only mirrors to first-class persisted session metadata across runtime, session recovery, stats persistence/export, and CLI status/timer outputs.

It also keeps legacy compatibility by defaulting missing metadata to `task_label` when loading older recovery or stats data.

## Why

Issue #174 requests session metadata v2 so these fields are preserved through the primary data path instead of being derived only at export time.

Closes #174

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Focus intention and task note are now persisted as first-class session metadata in recovery, stats storage, and CLI outputs.
  * When no dedicated metadata inputs are provided, these fields fall back to the task label.

* **Documentation**
  * Updated session recovery and export documentation to reflect the new metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->