### PR TITLE
Harden recurring schedule reliability determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CLI JSON/error contract and exit-code consistency (#173):** centralized CLI error handling, added machine-readable JSON error envelopes for `--json` failures, and standardized exit-code mapping (`0` success, `1` runtime failure, `2` usage failure).
 - **Export schema v3 compatibility (#175):** bumped stats export schema to `v3`, exported focus-session `focus_intention`/`task_note` from persisted metadata, and preserved backward compatibility for legacy stats entries by defaulting missing metadata to `task_label`.
+- **Schedule reliability hardening (#176):** made overlapping recurring-window activation deterministic (most recently started active window wins, stable same-start tie handling), tightened next-occurrence scanning around exception-date edge cases, and added regression coverage for schedule trigger consistency.
 
 ## [0.5.2] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Recurring schedule windows can also trigger focus behavior at wall-clock times:
 - `recurring_schedule.windows[].start` / `end` use 24-hour `HH:MM` local time (`start < end`)
 - `recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
 - when a window begins, focus auto-starts if possible; otherwise schedule mode arms and shows a reminder until you manually start focus
+- if multiple windows overlap, the most recently started active window takes precedence; windows with the same start time are resolved by config order
 - the timer session overview shows the current/next scheduled window
 
 You can configure notification and auto-start settings directly from the TUI:

--- a/src/app.rs
+++ b/src/app.rs
@@ -5513,6 +5513,85 @@ mod tests {
     }
 
     #[test]
+    fn recurring_schedule_triggers_overlapping_window_when_new_window_starts() {
+        let first_tick = local_datetime_today(10, 15);
+        let overlap_window_tick = local_datetime_today(10, 35);
+        let config = AppConfig {
+            recurring_schedule: RecurringScheduleConfig {
+                windows: vec![
+                    crate::config::RecurringFocusWindowConfig {
+                        days: vec![weekday_token(first_tick.weekday()).to_string()],
+                        start: "10:00".to_string(),
+                        end: "11:00".to_string(),
+                    },
+                    crate::config::RecurringFocusWindowConfig {
+                        days: vec![weekday_token(first_tick.weekday()).to_string()],
+                        start: "10:30".to_string(),
+                        end: "11:30".to_string(),
+                    },
+                ],
+                ..RecurringScheduleConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.task_labels = vec!["Coding".to_string()];
+        app.selected_task_label = Some("Coding".to_string());
+
+        app.sync_recurring_schedule(first_tick);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+
+        app.timer.status = TimerStatus::Idle;
+        app.sync_recurring_schedule(overlap_window_tick);
+
+        assert_eq!(app.timer.phase, TimerPhase::Focus);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+        assert_eq!(
+            app.phase_notification.as_deref(),
+            Some("Scheduled window started. Focus auto-started.")
+        );
+    }
+
+    #[test]
+    fn recurring_schedule_does_not_retrigger_within_same_overlapping_occurrence() {
+        let first_tick = local_datetime_today(10, 15);
+        let overlap_window_tick = local_datetime_today(10, 35);
+        let same_overlap_occurrence_tick = local_datetime_today(10, 40);
+        let config = AppConfig {
+            recurring_schedule: RecurringScheduleConfig {
+                windows: vec![
+                    crate::config::RecurringFocusWindowConfig {
+                        days: vec![weekday_token(first_tick.weekday()).to_string()],
+                        start: "10:00".to_string(),
+                        end: "11:00".to_string(),
+                    },
+                    crate::config::RecurringFocusWindowConfig {
+                        days: vec![weekday_token(first_tick.weekday()).to_string()],
+                        start: "10:30".to_string(),
+                        end: "11:30".to_string(),
+                    },
+                ],
+                ..RecurringScheduleConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.task_labels = vec!["Coding".to_string()];
+        app.selected_task_label = Some("Coding".to_string());
+
+        app.sync_recurring_schedule(first_tick);
+        app.timer.status = TimerStatus::Idle;
+        app.sync_recurring_schedule(overlap_window_tick);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+
+        app.timer.status = TimerStatus::Idle;
+        app.sync_recurring_schedule(same_overlap_occurrence_tick);
+
+        assert_eq!(app.timer.phase, TimerPhase::Focus);
+        assert_eq!(app.timer.status, TimerStatus::Idle);
+    }
+
+    #[test]
     fn strict_mode_blocks_skip_during_active_focus() {
         let config = AppConfig {
             strict_mode: true,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -78,7 +78,7 @@ pub fn active_occurrence(
         };
         let should_replace = selected
             .as_ref()
-            .is_none_or(|existing| candidate.start < existing.start);
+            .is_none_or(|existing| active_candidate_is_higher_priority(&candidate, existing));
         if should_replace {
             selected = Some(candidate);
         }
@@ -94,7 +94,11 @@ pub fn next_occurrence_after(
 ) -> Option<WindowOccurrence> {
     let mut selected: Option<WindowOccurrence> = None;
     let today = now.date_naive();
-    let search_days = 7_i64.saturating_mul(exception_dates.len() as i64 + 1);
+    let future_exception_count = exception_dates
+        .iter()
+        .filter(|date| **date >= today)
+        .count();
+    let search_days = 7_i64.saturating_mul((future_exception_count as i64).saturating_add(1));
 
     for day_offset in 0..=search_days {
         let date = today + Duration::days(day_offset);
@@ -121,7 +125,7 @@ pub fn next_occurrence_after(
             };
             let should_replace = selected
                 .as_ref()
-                .is_none_or(|existing| candidate.start < existing.start);
+                .is_none_or(|existing| next_candidate_is_higher_priority(&candidate, existing));
             if should_replace {
                 selected = Some(candidate);
             }
@@ -192,6 +196,22 @@ fn parse_time_minutes(raw: &str) -> Option<u16> {
 
 fn parse_exception_date(raw: &str) -> Option<NaiveDate> {
     NaiveDate::parse_from_str(raw.trim(), "%Y-%m-%d").ok()
+}
+
+fn active_candidate_is_higher_priority(
+    candidate: &WindowOccurrence,
+    existing: &WindowOccurrence,
+) -> bool {
+    candidate.start > existing.start
+        || (candidate.start == existing.start && candidate.window_index < existing.window_index)
+}
+
+fn next_candidate_is_higher_priority(
+    candidate: &WindowOccurrence,
+    existing: &WindowOccurrence,
+) -> bool {
+    candidate.start < existing.start
+        || (candidate.start == existing.start && candidate.window_index < existing.window_index)
 }
 
 fn local_datetime_on(date: NaiveDate, total_minutes: u16) -> Option<DateTime<Local>> {
@@ -322,6 +342,81 @@ mod tests {
             .expect("next window should skip exception date");
         assert_eq!(next.start, local_datetime(tomorrow, 9, 0));
         assert_eq!(next.end, local_datetime(tomorrow, 10, 0));
+    }
+
+    #[test]
+    fn active_occurrence_prefers_most_recent_overlap_start() {
+        let date = Local::now().date_naive();
+        let now = local_datetime(date, 10, 45);
+        let windows = compile_windows(&[
+            RecurringFocusWindowConfig {
+                days: vec![date.weekday().to_string()],
+                start: "10:00".to_string(),
+                end: "11:30".to_string(),
+            },
+            RecurringFocusWindowConfig {
+                days: vec![date.weekday().to_string()],
+                start: "10:30".to_string(),
+                end: "12:00".to_string(),
+            },
+        ]);
+
+        let active =
+            active_occurrence(now, &windows, &HashSet::new()).expect("window should be active");
+
+        assert_eq!(active.window_index, 1);
+        assert_eq!(active.start, local_datetime(date, 10, 30));
+        assert_eq!(active.end, local_datetime(date, 12, 0));
+    }
+
+    #[test]
+    fn active_occurrence_tie_on_start_prefers_first_window_index() {
+        let date = Local::now().date_naive();
+        let now = local_datetime(date, 10, 15);
+        let windows = compile_windows(&[
+            RecurringFocusWindowConfig {
+                days: vec![date.weekday().to_string()],
+                start: "10:00".to_string(),
+                end: "11:00".to_string(),
+            },
+            RecurringFocusWindowConfig {
+                days: vec![date.weekday().to_string()],
+                start: "10:00".to_string(),
+                end: "10:30".to_string(),
+            },
+        ]);
+
+        let active =
+            active_occurrence(now, &windows, &HashSet::new()).expect("window should be active");
+
+        assert_eq!(active.window_index, 0);
+        assert_eq!(active.start, local_datetime(date, 10, 0));
+        assert_eq!(active.end, local_datetime(date, 11, 0));
+    }
+
+    #[test]
+    fn next_occurrence_after_tie_on_start_prefers_first_window_index() {
+        let date = Local::now().date_naive();
+        let now = local_datetime(date, 9, 45);
+        let windows = compile_windows(&[
+            RecurringFocusWindowConfig {
+                days: vec![date.weekday().to_string()],
+                start: "10:00".to_string(),
+                end: "11:00".to_string(),
+            },
+            RecurringFocusWindowConfig {
+                days: vec![date.weekday().to_string()],
+                start: "10:00".to_string(),
+                end: "10:30".to_string(),
+            },
+        ]);
+
+        let next = next_occurrence_after(now, &windows, &HashSet::new())
+            .expect("next window should exist for tied start");
+
+        assert_eq!(next.window_index, 0);
+        assert_eq!(next.start, local_datetime(date, 10, 0));
+        assert_eq!(next.end, local_datetime(date, 11, 0));
     }
 
     #[test]


### PR DESCRIPTION
## What

- Harden recurring schedule occurrence resolution for deterministic overlap behavior.
- Prefer the most recently started active window when overlaps occur, with stable same-start tie handling by config order.
- Tighten next-occurrence scanning to bound lookups using only future exception dates.
- Add regression tests in scheduler/app paths for overlap precedence and trigger-once behavior.
- Update README schedule semantics and add an Unreleased changelog note.

## Why

Recurring schedule behavior needed deterministic outcomes for overlapping windows and edge-case exception-date sets so automation and timer guidance remain predictable. This addresses ambiguity in schedule resolution and hardens reliability for issue-driven behavior expectations.

Closes #176

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable) (N/A)
- [ ] WakaTime integration behavior was verified for this change (if applicable) (N/A)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR (N/A: no known breaking behavior changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deterministic behavior for overlapping recurring schedule windows; overlapping windows now use consistent tie-breaking rules.
  * Fixed edge case handling for exception dates in schedule calculations.

* **Documentation**
  * Updated README with details on how overlapping schedule windows are resolved.
  * Added changelog entry documenting schedule reliability improvements.

* **Tests**
  * Added regression tests to ensure schedule trigger consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->