### PR TITLE
Harden startup blocking and recovery reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ You can configure notification and auto-start settings directly from the TUI:
 
 - while a focus/break phase is running or paused, the app saves phase, remaining time, task metadata (`task_label`, `focus_intention`, `task_note`), and active profile
 - on startup, valid in-progress state is restored and shown in the timer notice line
+- on startup, blocking is reconciled with recovered timer state: recovered active focus re-applies blocking, while non-recovered startup attempts to remove stale crash-era block entries
 - stale or invalid saved recovery state is ignored safely with a warning notice
 - recovery state is cleared when an in-progress phase ends naturally or when you reset/skip out of the active session
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -527,6 +527,7 @@ impl App {
         app.recompute_blocker_sites_from_active_profile();
         app.restore_in_progress_session();
         app.sync_recovery_snapshot();
+        app.apply_blocking_for_phase();
         app
     }
 
@@ -1402,6 +1403,11 @@ impl App {
             Err(error) => {
                 self.phase_notification =
                     Some(format!("Ignored saved in-progress session: {error}."));
+                if let Err(clear_error) = session_recovery::clear() {
+                    self.config_error = Some(format!(
+                        "session recovery cleanup failed after load error: {clear_error}"
+                    ));
+                }
                 return;
             }
         };
@@ -1483,7 +1489,6 @@ impl App {
         } else {
             None
         };
-        self.apply_blocking_for_phase();
         self.sync_task_planner_state();
         Ok(())
     }
@@ -3742,6 +3747,7 @@ pub(crate) fn should_handle_key(key: &KeyEvent) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::blocker;
     use crate::session_recovery::{
         self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
     };
@@ -6438,6 +6444,7 @@ mod tests {
 
     #[test]
     fn startup_restores_valid_in_progress_snapshot() {
+        let _ = blocker::take_test_blocking_action();
         session_recovery::set_test_load_snapshot(Some(snapshot_for_tests(
             TimerPhase::Focus,
             TimerStatus::Running,
@@ -6453,6 +6460,7 @@ mod tests {
         assert_eq!(app.timer.remaining_secs, 42);
         assert_eq!(app.selected_profile, ProfileId::DeepWork);
         assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
+        assert_eq!(blocker::take_test_blocking_action(), Some("block"));
         assert!(
             app.phase_notification
                 .as_deref()
@@ -6506,10 +6514,12 @@ mod tests {
 
     #[test]
     fn startup_reports_recovery_load_error() {
+        let _ = blocker::take_test_blocking_action();
         session_recovery::set_test_load_error("simulated read failure");
 
         let app = App::from_config(AppConfig::default());
 
+        assert_eq!(blocker::take_test_blocking_action(), Some("unblock"));
         assert!(
             app.phase_notification
                 .as_deref()

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::cell::RefCell;
 use std::collections::HashSet;
 use std::fs::{self, OpenOptions};
 use std::io;
@@ -10,6 +12,23 @@ const HOSTS_FILE: &str = r"C:\Windows\System32\drivers\etc\hosts";
 const HOSTS_FILE: &str = "/etc/hosts";
 const BLOCK_MARKER_START: &str = "# focustime-block-start";
 const BLOCK_MARKER_END: &str = "# focustime-block-end";
+
+#[cfg(test)]
+thread_local! {
+    static TEST_LAST_BLOCKING_ACTION: RefCell<Option<&'static str>> = const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn record_test_blocking_action(action: &'static str) {
+    TEST_LAST_BLOCKING_ACTION.with(|slot| {
+        *slot.borrow_mut() = Some(action);
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn take_test_blocking_action() -> Option<&'static str> {
+    TEST_LAST_BLOCKING_ACTION.with(|slot| slot.borrow_mut().take())
+}
 
 pub struct SiteBlocker {
     pub sites: Vec<String>,
@@ -261,6 +280,9 @@ impl SiteBlocker {
     /// Activate blocking by writing entries into the hosts file.
     /// Returns an error if the file is not writable (e.g. needs sudo).
     pub fn block(&mut self) -> io::Result<()> {
+        #[cfg(test)]
+        record_test_blocking_action("block");
+
         if self.sites.is_empty() {
             self.is_blocking = false;
             // Best-effort: strip any stale block section left by a prior run.
@@ -276,6 +298,9 @@ impl SiteBlocker {
     /// Always attempts to strip any existing block section, even after a crash
     /// left entries behind with is_blocking == false.
     pub fn unblock(&mut self) -> io::Result<()> {
+        #[cfg(test)]
+        record_test_blocking_action("unblock");
+
         self.remove_hosts_block()?;
         self.is_blocking = false;
         Ok(())


### PR DESCRIPTION
## What

Harden startup reconciliation between session recovery and hosts-file blocking.

This centralizes startup blocking sync, adds recovery-load cleanup on failure, and adds regression coverage for startup recovery paths.

## Why

Crash/restart flows should always converge to a reliable blocking state that matches the effective timer state. This change makes startup behavior explicit and consistent: recovered active focus re-applies blocking, while non-recovered startup attempts to clear stale crash-era block entries.

Closes #177.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable) - N/A (no WakaTime logic changed)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable) - N/A
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR - N/A (no breaking behavior changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blocking state recovery during app startup to ensure active focus blocks are properly re-applied after unexpected shutdowns
  * Enhanced cleanup of stale block entries left behind from crashes

* **Documentation**
  * Updated session recovery documentation to detail blocking state reconciliation behavior during startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->