### PR TITLE
Add blocking dry-run preview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ cargo run -- --schedule --json
 cargo run -- --diagnostics
 cargo run -- --diagnostics --json
 
+# Preview focustime-managed hosts-file changes without writing
+cargo run -- --blocking-preview
+cargo run -- --blocking-preview --json
+
 # Show status (text or JSON, including live timer/session fields in JSON)
 cargo run -- --status
 cargo run -- --status --json
@@ -320,6 +324,7 @@ The diagnostics screen reports:
 
 - blocking permissions
 - hosts file write capability
+- blocking preview summary and focustime-managed hosts section
 - remediation guidance when hosts permissions are insufficient
 - WakaTime config status (`~/.wakatime.cfg` and `api_key` availability)
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,8 @@ use chrono::{DateTime, Local, NaiveDate};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use crate::blocker::{
-    BulkAddResult, EditSiteResult, HostsFileDiagnostics, InvalidSiteInput, SiteBlocker,
+    BlockingIntent, BlockingPreview, BlockingPreviewAction, BulkAddResult, EditSiteResult,
+    HostsFileDiagnostics, InvalidSiteInput, SiteBlocker,
 };
 use crate::config::{
     AppConfig, AutoStartConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
@@ -343,6 +344,27 @@ impl SetupDiagnostics {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockingPreviewSnapshot {
+    pub action: BlockingPreviewAction,
+    pub would_change: bool,
+    pub effective_blocked_sites_count: usize,
+    pub section: Option<String>,
+    pub error: Option<String>,
+}
+
+impl Default for BlockingPreviewSnapshot {
+    fn default() -> Self {
+        Self {
+            action: BlockingPreviewAction::NoChange,
+            would_change: false,
+            effective_blocked_sites_count: 0,
+            section: None,
+            error: None,
+        }
+    }
+}
+
 pub struct App {
     pub timer: TimerState,
     pub should_quit: bool,
@@ -376,6 +398,7 @@ pub struct App {
     /// Last error from a block/unblock operation (e.g. permission denied).
     pub block_error: Option<String>,
     pub setup_diagnostics: SetupDiagnostics,
+    pub blocking_preview: BlockingPreviewSnapshot,
     /// Last error from persisting timer/site configuration.
     pub config_error: Option<String>,
     /// Last error from persisting focus stats.
@@ -488,6 +511,7 @@ impl App {
             selected_site: 0,
             block_error: None,
             setup_diagnostics,
+            blocking_preview: BlockingPreviewSnapshot::default(),
             config_error: None,
             stats_error,
             history_feedback: None,
@@ -528,6 +552,7 @@ impl App {
         app.restore_in_progress_session();
         app.sync_recovery_snapshot();
         app.apply_blocking_for_phase();
+        app.refresh_setup_diagnostics();
         app
     }
 
@@ -705,6 +730,11 @@ impl App {
         }
         self.update_timer_and_sync(TimerState::next_phase);
         Ok(())
+    }
+
+    pub fn blocking_preview_for_cli(&self) -> Result<BlockingPreview, String> {
+        self.compute_blocking_preview()
+            .map_err(|error| format!("Failed to generate blocking preview: {error}"))
     }
 
     pub fn select_task_label_for_cli(&mut self, label: &str) -> Result<bool, String> {
@@ -3184,6 +3214,32 @@ impl App {
 
     fn refresh_setup_diagnostics(&mut self) {
         self.setup_diagnostics = SetupDiagnostics::collect(&self.blocker);
+        self.refresh_blocking_preview();
+    }
+
+    fn refresh_blocking_preview(&mut self) {
+        self.blocking_preview = match self.compute_blocking_preview() {
+            Ok(preview) => BlockingPreviewSnapshot {
+                action: preview.action,
+                would_change: preview.would_change,
+                effective_blocked_sites_count: preview.effective_blocked_sites.len(),
+                section: preview.section_for_display().map(ToString::to_string),
+                error: None,
+            },
+            Err(error) => BlockingPreviewSnapshot {
+                error: Some(error.to_string()),
+                ..BlockingPreviewSnapshot::default()
+            },
+        };
+    }
+
+    fn compute_blocking_preview(&self) -> std::io::Result<BlockingPreview> {
+        let intent = if self.should_block_for_current_state() {
+            BlockingIntent::Block
+        } else {
+            BlockingIntent::Unblock
+        };
+        self.blocker.preview_hosts_update(intent)
     }
 
     fn rebuild_notifier(&mut self) {

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -97,6 +97,37 @@ pub enum EditSiteResult {
     MissingSelection,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockingIntent {
+    Block,
+    Unblock,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockingPreviewAction {
+    Block,
+    Unblock,
+    NoChange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockingPreview {
+    pub hosts_file_path: String,
+    pub action: BlockingPreviewAction,
+    pub effective_blocked_sites: Vec<String>,
+    pub would_change: bool,
+    pub current_section: Option<String>,
+    pub next_section: Option<String>,
+}
+
+impl BlockingPreview {
+    pub fn section_for_display(&self) -> Option<&str> {
+        self.next_section
+            .as_deref()
+            .or(self.current_section.as_deref())
+    }
+}
+
 impl SiteBlocker {
     pub fn new() -> Self {
         Self {
@@ -277,6 +308,11 @@ impl SiteBlocker {
         hosts_file_diagnostics_for(Path::new(HOSTS_FILE))
     }
 
+    pub fn preview_hosts_update(&self, intent: BlockingIntent) -> io::Result<BlockingPreview> {
+        let original = fs::read_to_string(HOSTS_FILE)?;
+        Ok(self.preview_from_content(HOSTS_FILE, &original, intent))
+    }
+
     /// Activate blocking by writing entries into the hosts file.
     /// Returns an error if the file is not writable (e.g. needs sudo).
     pub fn block(&mut self) -> io::Result<()> {
@@ -313,24 +349,7 @@ impl SiteBlocker {
 
     fn apply_hosts_block(&self) -> io::Result<()> {
         let original = fs::read_to_string(HOSTS_FILE)?;
-        // Detect the original line ending style so we don't convert CRLF → LF
-        // on Windows hosts files.
-        let nl = line_ending_for(&original);
-        let mut content = Self::strip_block_section(&original);
-
-        // Only insert a separator newline when the content doesn't already end
-        // with one, so repeated focus/break cycles don't accumulate blank lines.
-        if !content.ends_with(nl) && !content.is_empty() {
-            content.push_str(nl);
-        }
-        content.push_str(BLOCK_MARKER_START);
-        content.push_str(nl);
-        for site in &self.sites {
-            append_site_entries(&mut content, site, nl);
-        }
-        content.push_str(BLOCK_MARKER_END);
-        content.push_str(nl);
-
+        let content = self.build_blocked_hosts_content(&original);
         atomic_write_hosts(&content)?;
         flush_dns_cache();
         Ok(())
@@ -389,6 +408,105 @@ impl SiteBlocker {
         }
 
         result
+    }
+
+    fn preview_from_content(
+        &self,
+        hosts_file_path: &str,
+        original: &str,
+        intent: BlockingIntent,
+    ) -> BlockingPreview {
+        let nl = line_ending_for(original);
+        let current_section = Self::extract_block_section(original);
+        let next_section = match intent {
+            BlockingIntent::Block if !self.sites.is_empty() => Some(self.render_block_section(nl)),
+            BlockingIntent::Block | BlockingIntent::Unblock => None,
+        };
+        let next_content = match next_section.as_deref() {
+            Some(section) => Self::build_hosts_content_with_section(original, section, nl),
+            None => Self::strip_block_section(original),
+        };
+        let would_change = next_content != original;
+        let action = if !would_change {
+            BlockingPreviewAction::NoChange
+        } else if next_section.is_some() {
+            BlockingPreviewAction::Block
+        } else {
+            BlockingPreviewAction::Unblock
+        };
+        let effective_blocked_sites = if next_section.is_some() {
+            self.sites.clone()
+        } else {
+            Vec::new()
+        };
+
+        BlockingPreview {
+            hosts_file_path: hosts_file_path.to_string(),
+            action,
+            effective_blocked_sites,
+            would_change,
+            current_section,
+            next_section,
+        }
+    }
+
+    fn build_blocked_hosts_content(&self, original: &str) -> String {
+        let nl = line_ending_for(original);
+        let section = self.render_block_section(nl);
+        Self::build_hosts_content_with_section(original, &section, nl)
+    }
+
+    fn build_hosts_content_with_section(original: &str, section: &str, nl: &str) -> String {
+        let mut content = Self::strip_block_section(original);
+
+        // Only insert a separator newline when the content doesn't already end
+        // with one, so repeated focus/break cycles don't accumulate blank lines.
+        if !content.ends_with(nl) && !content.is_empty() {
+            content.push_str(nl);
+        }
+        content.push_str(section);
+        content
+    }
+
+    fn render_block_section(&self, nl: &str) -> String {
+        let mut section = String::new();
+        section.push_str(BLOCK_MARKER_START);
+        section.push_str(nl);
+        for site in &self.sites {
+            append_site_entries(&mut section, site, nl);
+        }
+        section.push_str(BLOCK_MARKER_END);
+        section.push_str(nl);
+        section
+    }
+
+    fn extract_block_section(content: &str) -> Option<String> {
+        let nl = line_ending_for(content);
+        let mut in_block = false;
+        let mut section = String::new();
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if !in_block {
+                if trimmed == BLOCK_MARKER_START {
+                    in_block = true;
+                    section.push_str(BLOCK_MARKER_START);
+                    section.push_str(nl);
+                }
+                continue;
+            }
+
+            if trimmed == BLOCK_MARKER_END {
+                section.push_str(BLOCK_MARKER_END);
+                section.push_str(nl);
+                return Some(section);
+            }
+
+            section.push_str(line);
+            section.push_str(nl);
+        }
+
+        None
     }
 }
 
@@ -768,5 +886,60 @@ mod tests {
             assert!(diagnostics.can_write());
             assert!(diagnostics.write_error.is_none());
         }
+    }
+
+    #[test]
+    fn preview_block_reports_next_section_and_change() {
+        let mut blocker = SiteBlocker::new();
+        blocker.add_site("example.com".to_string());
+        let original = "127.0.0.1 localhost\n";
+
+        let preview = blocker.preview_from_content("hosts", original, BlockingIntent::Block);
+
+        assert_eq!(preview.action, BlockingPreviewAction::Block);
+        assert!(preview.would_change);
+        assert_eq!(preview.current_section, None);
+        assert_eq!(preview.effective_blocked_sites, vec!["example.com"]);
+        let section = preview
+            .next_section
+            .as_deref()
+            .expect("block preview should include next section");
+        assert!(section.contains("# focustime-block-start"));
+        assert!(section.contains("127.0.0.1 example.com"));
+        assert!(section.contains("::1 www.example.com"));
+        assert_eq!(preview.section_for_display(), Some(section));
+    }
+
+    #[test]
+    fn preview_unblock_reports_current_section_and_change() {
+        let blocker = SiteBlocker::new();
+        let original = "127.0.0.1 localhost\n# focustime-block-start\n127.0.0.1 example.com\n# focustime-block-end\n";
+
+        let preview = blocker.preview_from_content("hosts", original, BlockingIntent::Unblock);
+
+        assert_eq!(preview.action, BlockingPreviewAction::Unblock);
+        assert!(preview.would_change);
+        assert!(preview.next_section.is_none());
+        let section = preview
+            .current_section
+            .as_deref()
+            .expect("unblock preview should include current section");
+        assert!(section.contains("# focustime-block-start"));
+        assert!(section.contains("# focustime-block-end"));
+        assert_eq!(preview.section_for_display(), Some(section));
+    }
+
+    #[test]
+    fn preview_block_no_change_when_hosts_already_match() {
+        let mut blocker = SiteBlocker::new();
+        blocker.add_site("example.com".to_string());
+        let original = blocker.build_blocked_hosts_content("127.0.0.1 localhost\n");
+
+        let preview = blocker.preview_from_content("hosts", &original, BlockingIntent::Block);
+
+        assert_eq!(preview.action, BlockingPreviewAction::NoChange);
+        assert!(!preview.would_change);
+        assert!(preview.next_section.is_some());
+        assert!(preview.current_section.is_some());
     }
 }

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -417,7 +417,7 @@ impl SiteBlocker {
         intent: BlockingIntent,
     ) -> BlockingPreview {
         let nl = line_ending_for(original);
-        let current_section = Self::extract_block_section(original);
+        let current_section = Self::extract_block_sections(original);
         let next_section = match intent {
             BlockingIntent::Block if !self.sites.is_empty() => Some(self.render_block_section(nl)),
             BlockingIntent::Block | BlockingIntent::Unblock => None,
@@ -480,16 +480,18 @@ impl SiteBlocker {
         section
     }
 
-    fn extract_block_section(content: &str) -> Option<String> {
+    fn extract_block_sections(content: &str) -> Option<String> {
         let nl = line_ending_for(content);
         let mut in_block = false;
         let mut section = String::new();
+        let mut sections = Vec::new();
 
         for line in content.lines() {
             let trimmed = line.trim();
             if !in_block {
                 if trimmed == BLOCK_MARKER_START {
                     in_block = true;
+                    section.clear();
                     section.push_str(BLOCK_MARKER_START);
                     section.push_str(nl);
                 }
@@ -499,14 +501,20 @@ impl SiteBlocker {
             if trimmed == BLOCK_MARKER_END {
                 section.push_str(BLOCK_MARKER_END);
                 section.push_str(nl);
-                return Some(section);
+                sections.push(std::mem::take(&mut section));
+                in_block = false;
+                continue;
             }
 
             section.push_str(line);
             section.push_str(nl);
         }
 
-        None
+        if sections.is_empty() {
+            None
+        } else {
+            Some(sections.concat())
+        }
     }
 }
 
@@ -927,6 +935,30 @@ mod tests {
         assert!(section.contains("# focustime-block-start"));
         assert!(section.contains("# focustime-block-end"));
         assert_eq!(preview.section_for_display(), Some(section));
+    }
+
+    #[test]
+    fn preview_unblock_reports_all_existing_sections() {
+        let blocker = SiteBlocker::new();
+        let original = concat!(
+            "127.0.0.1 localhost\n",
+            "# focustime-block-start\n",
+            "127.0.0.1 example.com\n",
+            "# focustime-block-end\n",
+            "# focustime-block-start\n",
+            "127.0.0.1 github.com\n",
+            "# focustime-block-end\n",
+        );
+
+        let preview = blocker.preview_from_content("hosts", original, BlockingIntent::Unblock);
+        let section = preview
+            .current_section
+            .as_deref()
+            .expect("unblock preview should include all current sections");
+
+        assert_eq!(section.matches("# focustime-block-start").count(), 2);
+        assert!(section.contains("127.0.0.1 example.com"));
+        assert!(section.contains("127.0.0.1 github.com"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ use chrono::NaiveDate;
 use serde::Serialize;
 
 use crate::app::{App, SetupCheck, SetupCheckLevel, SetupDiagnostics};
-use crate::blocker::{EditSiteResult, InvalidSiteInput, SiteBlocker};
+use crate::blocker::{BlockingPreviewAction, EditSiteResult, InvalidSiteInput, SiteBlocker};
 use crate::config::{
     AppConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig, ProfileId,
     RecurringFocusWindowConfig, RecurringScheduleConfig,
@@ -52,6 +52,7 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --blocklist-site-delete=HOSTNAME [--json]
   focustime --allowlist-site-delete=HOSTNAME [--json]
   focustime --diagnostics [--json]
+  focustime --blocking-preview [--json]
   focustime --status [--watch[=SECONDS]] [--json]
   focustime --export[=DIR] [--json]
 
@@ -80,6 +81,7 @@ Options:
   --blocklist-site-delete     Delete blocklist hostname in active profile
   --allowlist-site-delete     Delete allowlist hostname in active profile
   --diagnostics   Show setup diagnostics checks
+  --blocking-preview  Preview focustime hosts-section changes without writing
   --status        Print status summary (includes live timer/session fields)
   --watch         Stream periodic status updates (status command only; default 1s)
   --export        Export stats to current directory or DIR
@@ -154,6 +156,7 @@ pub enum CommandKind {
         schedule: Option<RecurringScheduleConfig>,
     },
     Diagnostics,
+    BlockingPreview,
     Status {
         watch_interval_secs: Option<u64>,
     },
@@ -196,6 +199,7 @@ enum PrimaryCommand {
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
     Diagnostics,
+    BlockingPreview,
     Status,
     Export(Option<PathBuf>),
     BlocklistProfile(Option<String>),
@@ -230,6 +234,7 @@ enum ParsedToken {
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
     Diagnostics,
+    BlockingPreview,
     Export(Option<PathBuf>),
     BlocklistProfile(Option<String>),
     BlocklistProfileCreate(String),
@@ -430,6 +435,16 @@ struct DiagnosticsCommandOutput {
     blocking_permissions: SetupCheckOutput,
     hosts_write_capability: SetupCheckOutput,
     wakatime_config: SetupCheckOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct BlockingPreviewCommandOutput {
+    hosts_file_path: String,
+    action: &'static str,
+    would_change: bool,
+    effective_blocked_sites_count: usize,
+    effective_blocked_sites: Vec<String>,
+    section: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -670,6 +685,7 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "--status" => Some(ParsedToken::Status),
         "--schedule" => Some(ParsedToken::Schedule),
         "--diagnostics" => Some(ParsedToken::Diagnostics),
+        "--blocking-preview" => Some(ParsedToken::BlockingPreview),
         "--blocklist-profile-delete" => Some(ParsedToken::BlocklistProfileDelete),
         "--blocklist-sites" => Some(ParsedToken::BlocklistSites),
         "--allowlist-sites" => Some(ParsedToken::AllowlistSites),
@@ -1128,6 +1144,7 @@ fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), Str
             | ParsedToken::Schedule
             | ParsedToken::ScheduleSet(_)
             | ParsedToken::Diagnostics
+            | ParsedToken::BlockingPreview
             | ParsedToken::Export(_)
             | ParsedToken::BlocklistProfile(_)
             | ParsedToken::BlocklistProfileCreate(_)
@@ -1175,6 +1192,9 @@ fn parse_primary_command(tokens: &[ParsedToken]) -> Result<Option<PrimaryCommand
             }
             ParsedToken::Diagnostics => {
                 set_primary_command(&mut primary, PrimaryCommand::Diagnostics)?
+            }
+            ParsedToken::BlockingPreview => {
+                set_primary_command(&mut primary, PrimaryCommand::BlockingPreview)?
             }
             ParsedToken::Export(dir) => {
                 set_primary_command(&mut primary, PrimaryCommand::Export(dir.clone()))?
@@ -1290,6 +1310,10 @@ fn finalize_cli_action(
         })),
         Some(PrimaryCommand::Diagnostics) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Diagnostics,
+            output,
+        })),
+        Some(PrimaryCommand::BlockingPreview) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::BlockingPreview,
             output,
         })),
         Some(PrimaryCommand::Pause) => Ok(CliAction::RunCommand(CliCommand {
@@ -1423,6 +1447,7 @@ pub fn execute_command(cli_command: CliCommand) -> Result<(), String> {
             execute_schedule_command(schedule, cli_command.output)
         }
         CommandKind::Diagnostics => execute_diagnostics_command(cli_command.output),
+        CommandKind::BlockingPreview => execute_blocking_preview_command(cli_command.output),
         CommandKind::Status {
             watch_interval_secs,
         } => execute_status_command(cli_command.output, watch_interval_secs),
@@ -2049,6 +2074,18 @@ fn execute_diagnostics_command(output: OutputMode) -> Result<(), String> {
     Ok(())
 }
 
+fn execute_blocking_preview_command(output: OutputMode) -> Result<(), String> {
+    let app = App::new();
+    let preview = app.blocking_preview_for_cli()?;
+    let payload = build_blocking_preview_command_output(&preview);
+
+    match output {
+        OutputMode::Text => print_blocking_preview_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
 fn execute_status_command(
     output: OutputMode,
     watch_interval_secs: Option<u64>,
@@ -2554,6 +2591,7 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Schedule => "--schedule",
         PrimaryCommand::ScheduleSet(_) => "--schedule-set",
         PrimaryCommand::Diagnostics => "--diagnostics",
+        PrimaryCommand::BlockingPreview => "--blocking-preview",
         PrimaryCommand::Status => "--status",
         PrimaryCommand::Export(_) => "--export",
         PrimaryCommand::BlocklistProfile(_) => "--blocklist-profile",
@@ -2894,6 +2932,46 @@ fn build_diagnostics_command_output(diagnostics: &SetupDiagnostics) -> Diagnosti
         blocking_permissions: setup_check_output(&diagnostics.blocking_permissions),
         hosts_write_capability: setup_check_output(&diagnostics.hosts_write_capability),
         wakatime_config: setup_check_output(&diagnostics.wakatime_config),
+    }
+}
+
+fn print_blocking_preview_command_output(payload: &BlockingPreviewCommandOutput) {
+    println!("Hosts file: {}", payload.hosts_file_path);
+    println!(
+        "Preview action: {} (changes: {})",
+        payload.action,
+        if payload.would_change { "yes" } else { "no" }
+    );
+    println!(
+        "Effective blocked sites: {}",
+        payload.effective_blocked_sites_count
+    );
+    if !payload.effective_blocked_sites.is_empty() {
+        println!("Sites: {}", payload.effective_blocked_sites.join(", "));
+    }
+    if let Some(section) = payload.section.as_deref() {
+        println!("Section preview:");
+        print!("{section}");
+    } else {
+        println!("Section preview: none");
+    }
+}
+
+fn build_blocking_preview_command_output(
+    preview: &crate::blocker::BlockingPreview,
+) -> BlockingPreviewCommandOutput {
+    let action = match preview.action {
+        BlockingPreviewAction::Block => "block",
+        BlockingPreviewAction::Unblock => "unblock",
+        BlockingPreviewAction::NoChange => "no_change",
+    };
+    BlockingPreviewCommandOutput {
+        hosts_file_path: preview.hosts_file_path.clone(),
+        action,
+        would_change: preview.would_change,
+        effective_blocked_sites_count: preview.effective_blocked_sites.len(),
+        effective_blocked_sites: preview.effective_blocked_sites.clone(),
+        section: preview.section_for_display().map(ToString::to_string),
     }
 }
 
@@ -3295,6 +3373,18 @@ mod tests {
             parsed,
             CliAction::RunCommand(CliCommand {
                 kind: CommandKind::Diagnostics,
+                output: OutputMode::Json
+            })
+        );
+    }
+
+    #[test]
+    fn parse_blocking_preview_supports_json_mode() {
+        let parsed = parse(&["--blocking-preview", "--json"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::BlockingPreview,
                 output: OutputMode::Json
             })
         );

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -12,6 +12,7 @@ use crate::app::{
     PLANNER_RECENT_LABEL_LIMIT, PROFILE_EDIT_FIELD_LABELS, PROFILE_IDS, PlannerFeedbackLevel,
     PlannerInputMode, SetupCheck, SetupCheckLevel, SiteFeedbackLevel, SiteInputMode, SiteListMode,
 };
+use crate::blocker::BlockingPreviewAction;
 use crate::timer::{TimerPhase, TimerStatus};
 use crate::wakatime::WakatimeRuntimeState;
 
@@ -1375,7 +1376,8 @@ fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             Constraint::Length(2), // blocking permissions
             Constraint::Length(2), // hosts write capability
             Constraint::Length(2), // wakatime config status
-            Constraint::Min(0),    // spacer
+            Constraint::Length(1), // preview summary
+            Constraint::Min(0),    // preview section
             Constraint::Length(2), // key hints
         ])
         .split(outer);
@@ -1406,8 +1408,59 @@ fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         &app.setup_diagnostics.wakatime_config,
     );
 
+    let (preview_summary, preview_style) = if let Some(error) = app.blocking_preview.error.as_ref()
+    {
+        (
+            format!("Preview unavailable: {error}"),
+            Style::default().fg(Color::Yellow),
+        )
+    } else {
+        let action = match app.blocking_preview.action {
+            BlockingPreviewAction::Block => "block",
+            BlockingPreviewAction::Unblock => "unblock",
+            BlockingPreviewAction::NoChange => "no-change",
+        };
+        (
+            format!(
+                "Preview action: {action} · changes: {} · effective blocked sites: {}",
+                if app.blocking_preview.would_change {
+                    "yes"
+                } else {
+                    "no"
+                },
+                app.blocking_preview.effective_blocked_sites_count
+            ),
+            Style::default().fg(Color::DarkGray),
+        )
+    };
+    frame.render_widget(
+        Paragraph::new(preview_summary)
+            .alignment(Alignment::Left)
+            .style(preview_style),
+        inner[5],
+    );
+
+    let preview_section_text = if app.blocking_preview.error.is_some() {
+        "Preview section unavailable due to hosts-file access error.".to_string()
+    } else if let Some(section) = app.blocking_preview.section.as_ref() {
+        section.clone()
+    } else {
+        "No focustime block section changes are required for the current state.".to_string()
+    };
+    frame.render_widget(
+        Paragraph::new(preview_section_text)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Blocking preview (focustime section) "),
+            )
+            .style(Style::default().fg(Color::Gray))
+            .wrap(Wrap { trim: false }),
+        inner[6],
+    );
+
     let hints = Paragraph::new(vec![
-        Line::from("Diagnostics: [r] Refresh"),
+        Line::from("Diagnostics: [r] Refresh checks + preview"),
         Line::from(if app.strict_mode_enforced_for_focus() {
             "View: [d/Esc] Back  [q/Ctrl-C] Quit (Locked)"
         } else {
@@ -1416,7 +1469,7 @@ fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
     ])
     .alignment(Alignment::Center)
     .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(hints, inner[6]);
+    frame.render_widget(hints, inner[7]);
 }
 
 fn render_setup_check(frame: &mut Frame, area: Rect, label: &str, check: &SetupCheck) {
@@ -1708,6 +1761,33 @@ mod tests {
 
         let text = terminal_text(&terminal, width, height);
         assert!(text.contains("WRAP-END"));
+    }
+
+    #[test]
+    fn setup_diagnostics_view_renders_blocking_preview_section() {
+        let width = 100;
+        let height = 40;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.mode = AppMode::SetupDiagnostics;
+        app.blocking_preview.action = BlockingPreviewAction::Block;
+        app.blocking_preview.would_change = true;
+        app.blocking_preview.effective_blocked_sites_count = 2;
+        app.blocking_preview.section = Some(
+            "# focustime-block-start\n127.0.0.1 example.com\n# focustime-block-end\n".to_string(),
+        );
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("Preview action: block"));
+        assert!(
+            text.contains("# focustime-block-start"),
+            "rendered diagnostics text:\n{text}"
+        );
     }
 
     #[test]

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -180,3 +180,20 @@ fn text_parse_errors_still_use_stderr() {
     assert!(stdout_text(&output).trim().is_empty());
     assert!(stderr_text(&output).contains("Unknown option"));
 }
+
+#[test]
+fn blocking_preview_json_emits_payload_on_stdout() {
+    let env = TestEnv::new("blocking-preview-json");
+    let output = env.run(&["--blocking-preview", "--json"]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert!(payload.get("hosts_file_path").is_some());
+    assert!(payload.get("action").is_some());
+    assert!(payload.get("would_change").is_some());
+    assert!(payload.get("effective_blocked_sites_count").is_some());
+    assert!(payload.get("effective_blocked_sites").is_some());
+    assert!(payload.get("section").is_some());
+}


### PR DESCRIPTION
## What

Add a non-destructive blocking preview flow that computes focustime hosts-file changes without writing them, and surface that preview in CLI and TUI diagnostics.

## Why

Users need a safe way to inspect what blocking updates will do before focustime modifies the hosts file. This adds preview-first visibility while keeping existing blocking behavior unchanged.

Closes #180.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--blocking-preview` CLI command to preview hosts-file changes without writing
  * Optional `--json` output format for the preview
  * Diagnostics UI now shows a blocking-preview summary and displays the relevant hosts-file section snippet or an error

* **Documentation**
  * README updated to document the new CLI flag and diagnostic preview output

* **Tests**
  * New contract test validating `--blocking-preview --json` output and exit behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->