### PR TITLE
Add one-time ad-hoc schedule windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **One-time ad-hoc schedule windows (#181):** added date-specific one-time schedule windows across config/CLI/TUI/runtime flows while preserving recurring schedule defaults and compatibility.
+
 ## [0.6.1] - 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ cargo run -- --allowlist-site-add "reddit.com"
 cargo run -- --blocklist-site-edit "youtube.com=news.ycombinator.com"
 cargo run -- --allowlist-site-delete reddit.com
 
-# Show recurring schedule or replace it atomically from JSON
+# Show schedule or replace recurring + one-time windows atomically from JSON
 cargo run -- --schedule
-cargo run -- --schedule-set='{"windows":[{"days":["mon","tue"],"start":"09:00","end":"11:00"}],"exception_dates":["2026-12-25"]}'
+cargo run -- --schedule-set='{"windows":[{"days":["mon","tue"],"start":"09:00","end":"11:00"}],"exception_dates":["2026-12-25"],"one_time_windows":[{"date":"2026-05-02","start":"14:00","end":"16:00"}]}'
 cargo run -- --schedule --json
 
 # Show setup diagnostics checks (including hosts and WakaTime readiness)
@@ -273,6 +273,10 @@ exception_dates = ["2026-12-25", "2027-01-01"]
 days = ["mon", "tue", "wed", "thu", "fri"]
 start = "09:00"
 end = "11:00"
+[[recurring_schedule.one_time_windows]]
+date = "2026-05-02"
+start = "14:00"
+end = "16:00"
 
 [daily_goal]
 minutes = 120
@@ -353,8 +357,10 @@ Recurring schedule windows can also trigger focus behavior at wall-clock times:
 - `recurring_schedule.windows[].days` accepts day tokens (`mon`..`sun`, case-insensitive)
 - `recurring_schedule.windows[].start` / `end` use 24-hour `HH:MM` local time (`start < end`)
 - `recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
+- `recurring_schedule.one_time_windows[]` accepts one-time date windows with `date` (`YYYY-MM-DD`) plus `start`/`end` (`HH:MM`)
 - when a window begins, focus auto-starts if possible; otherwise schedule mode arms and shows a reminder until you manually start focus
-- if multiple windows overlap, the most recently started active window takes precedence; windows with the same start time are resolved by config order
+- recurring exception dates only skip recurring windows; one-time windows still apply on their configured date
+- if multiple windows overlap, the most recently started active window takes precedence; windows with the same start time are resolved deterministically
 - the timer session overview shows the current/next scheduled window
 
 You can configure notification and auto-start settings directly from the TUI:
@@ -372,6 +378,10 @@ You can configure notification and auto-start settings directly from the TUI:
   - **Schedule exception**: `←/→` changes which exception date is selected
   - **Exception date**: `←/→` moves selected exception date backward/forward by 1 day
   - **Exception add/remove**: `→` adds a date (starting from today), `←` removes selected date
+  - **One-time window**: `←/→` changes which one-time window is selected
+  - **One-time date**: `←/→` moves selected one-time window date backward/forward by 1 day
+  - **One-time start/end**: adjust one-time window times in 15-minute steps
+  - **One-time add/remove**: `→` adds a one-time window (starting from today), `←` removes selected window
 
 ## Session recovery
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,13 +13,15 @@ use crate::blocker::{
 };
 use crate::config::{
     AppConfig, AutoStartConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
-    NotificationConfig, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig,
-    WakatimeMetadataConfig,
+    NotificationConfig, OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig,
+    RecurringScheduleConfig, WakatimeMetadataConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
-    RecurringWindow, WindowOccurrence, active_occurrence, compile_exception_dates, compile_windows,
-    next_occurrence_after, occurrence_key,
+    OneTimeWindow, RecurringWindow, WindowOccurrence, active_occurrence,
+    active_one_time_occurrence, compile_exception_dates, compile_one_time_windows, compile_windows,
+    next_occurrence_after, next_one_time_occurrence_after, occurrence_key, pick_active_occurrence,
+    pick_next_occurrence,
 };
 use crate::session_recovery::{self, InProgressSessionSnapshot};
 use crate::stats::{
@@ -37,7 +39,7 @@ use crate::wakatime::{WakatimeConfigStatus, WakatimeHeartbeatMetadata, WakatimeT
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
-pub const PROFILE_EDIT_FIELD_LABELS: [&str; 22] = [
+pub const PROFILE_EDIT_FIELD_LABELS: [&str; 27] = [
     "Focus",
     "Short Break",
     "Long Break",
@@ -60,6 +62,11 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 22] = [
     "Schedule exception",
     "Exception date",
     "Exception add/remove",
+    "One-time window",
+    "One-time date",
+    "One-time start",
+    "One-time end",
+    "One-time add/remove",
 ];
 const PROFILE_EDIT_WAKATIME_PROJECT_INDEX: usize = 11;
 const PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX: usize = 12;
@@ -72,6 +79,11 @@ const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 18;
 const PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX: usize = 19;
 const PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX: usize = 20;
 const PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX: usize = 21;
+const PROFILE_EDIT_ONE_TIME_WINDOW_INDEX: usize = 22;
+const PROFILE_EDIT_ONE_TIME_DATE_INDEX: usize = 23;
+const PROFILE_EDIT_ONE_TIME_START_INDEX: usize = 24;
+const PROFILE_EDIT_ONE_TIME_END_INDEX: usize = 25;
+const PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX: usize = 26;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
@@ -414,12 +426,14 @@ pub struct App {
     profile_edit_schedule_window: usize,
     profile_edit_schedule_day: usize,
     profile_edit_schedule_exception: usize,
+    profile_edit_one_time_window: usize,
     profile_edit_snapshot: Option<ProfileEditSnapshot>,
     notification_settings: NotificationConfig,
     auto_start: AutoStartConfig,
     recurring_schedule: RecurringScheduleConfig,
     recurring_windows: Vec<RecurringWindow>,
     recurring_exception_dates: HashSet<NaiveDate>,
+    one_time_windows: Vec<OneTimeWindow>,
     schedule_armed_occurrence_key: Option<String>,
     last_schedule_occurrence_key: Option<String>,
     current_frame_now: DateTime<Local>,
@@ -457,6 +471,7 @@ impl App {
         let recurring_windows = compile_windows(&recurring_schedule.windows);
         let recurring_exception_dates =
             compile_exception_dates(&recurring_schedule.exception_dates);
+        let one_time_windows = compile_one_time_windows(&recurring_schedule.one_time_windows);
         let strict_mode = config.strict_mode;
         let break_glass_duration_secs = config.break_glass_duration_secs;
         let daily_goal = config.daily_goal;
@@ -528,12 +543,14 @@ impl App {
             profile_edit_schedule_window: 0,
             profile_edit_schedule_day: 0,
             profile_edit_schedule_exception: 0,
+            profile_edit_one_time_window: 0,
             profile_edit_snapshot: None,
             notification_settings,
             auto_start,
             recurring_schedule,
             recurring_windows,
             recurring_exception_dates,
+            one_time_windows,
             schedule_armed_occurrence_key: None,
             last_schedule_occurrence_key: None,
             current_frame_now: Local::now(),
@@ -832,19 +849,29 @@ impl App {
 
     fn schedule_display_state_at(&self, now: DateTime<Local>) -> ScheduleDisplayState {
         let today = now.date_naive();
+        let recurring_active = active_occurrence(
+            now,
+            &self.recurring_windows,
+            &self.recurring_exception_dates,
+        );
+        let one_time_active = active_one_time_occurrence(now, &self.one_time_windows);
+        let recurring_next = next_occurrence_after(
+            now,
+            &self.recurring_windows,
+            &self.recurring_exception_dates,
+        );
+        let one_time_next = next_one_time_occurrence_after(now, &self.one_time_windows);
+        let has_one_time_window_today = self
+            .one_time_windows
+            .iter()
+            .any(|window| window.date == today);
         ScheduleDisplayState {
-            has_schedule_windows: !self.recurring_windows.is_empty(),
-            active_window: active_occurrence(
-                now,
-                &self.recurring_windows,
-                &self.recurring_exception_dates,
-            ),
-            next_window: next_occurrence_after(
-                now,
-                &self.recurring_windows,
-                &self.recurring_exception_dates,
-            ),
-            is_exception_today: self.recurring_exception_dates.contains(&today),
+            has_schedule_windows: !(self.recurring_windows.is_empty()
+                && self.one_time_windows.is_empty()),
+            active_window: pick_active_occurrence(recurring_active, one_time_active),
+            next_window: pick_next_occurrence(recurring_next, one_time_next),
+            is_exception_today: self.recurring_exception_dates.contains(&today)
+                && !has_one_time_window_today,
             is_armed: self.schedule_armed_occurrence_key.is_some(),
             has_selected_task: self.selected_task_label.is_some(),
             timer_phase: self.timer.phase,
@@ -970,7 +997,7 @@ impl App {
     }
 
     pub fn profile_edit_field_value(&self, field_index: usize) -> String {
-        if (PROFILE_EDIT_SCHEDULE_WINDOW_INDEX..=PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX)
+        if (PROFILE_EDIT_SCHEDULE_WINDOW_INDEX..=PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX)
             .contains(&field_index)
         {
             return self.profile_edit_schedule_field_value(field_index);
@@ -1022,6 +1049,20 @@ impl App {
             PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX => {
                 self.schedule_exception_collection_value()
             }
+            PROFILE_EDIT_ONE_TIME_WINDOW_INDEX => self.one_time_window_selector_value(),
+            PROFILE_EDIT_ONE_TIME_DATE_INDEX => self
+                .selected_one_time_window()
+                .map(|window| window.date.clone())
+                .unwrap_or_else(|| "n/a".to_string()),
+            PROFILE_EDIT_ONE_TIME_START_INDEX => self
+                .selected_one_time_window()
+                .map(|window| window.start.clone())
+                .unwrap_or_else(|| "n/a".to_string()),
+            PROFILE_EDIT_ONE_TIME_END_INDEX => self
+                .selected_one_time_window()
+                .map(|window| window.end.clone())
+                .unwrap_or_else(|| "n/a".to_string()),
+            PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX => self.one_time_window_collection_value(),
             _ => String::new(),
         }
     }
@@ -1076,6 +1117,26 @@ impl App {
         }
     }
 
+    fn one_time_window_selector_value(&self) -> String {
+        if self.recurring_schedule.one_time_windows.is_empty() {
+            "none".to_string()
+        } else {
+            format!(
+                "{}/{}",
+                self.profile_edit_one_time_window.saturating_add(1),
+                self.recurring_schedule.one_time_windows.len()
+            )
+        }
+    }
+
+    fn one_time_window_collection_value(&self) -> String {
+        if self.recurring_schedule.one_time_windows.is_empty() {
+            "→ Add window".to_string()
+        } else {
+            "← Remove · → Add".to_string()
+        }
+    }
+
     fn selected_schedule_window(&self) -> Option<&RecurringFocusWindowConfig> {
         self.recurring_schedule
             .windows
@@ -1092,6 +1153,18 @@ impl App {
         self.recurring_schedule
             .exception_dates
             .get(self.profile_edit_schedule_exception)
+    }
+
+    fn selected_one_time_window(&self) -> Option<&OneTimeFocusWindowConfig> {
+        self.recurring_schedule
+            .one_time_windows
+            .get(self.profile_edit_one_time_window)
+    }
+
+    fn selected_one_time_window_mut(&mut self) -> Option<&mut OneTimeFocusWindowConfig> {
+        self.recurring_schedule
+            .one_time_windows
+            .get_mut(self.profile_edit_one_time_window)
     }
 
     fn selected_schedule_day_token(&self) -> &'static str {
@@ -1137,6 +1210,16 @@ impl App {
                     .saturating_sub(1),
             );
         }
+        if self.recurring_schedule.one_time_windows.is_empty() {
+            self.profile_edit_one_time_window = 0;
+        } else {
+            self.profile_edit_one_time_window = self.profile_edit_one_time_window.min(
+                self.recurring_schedule
+                    .one_time_windows
+                    .len()
+                    .saturating_sub(1),
+            );
+        }
     }
 
     fn cycle_schedule_window(&mut self, increase: bool) {
@@ -1177,6 +1260,20 @@ impl App {
         } else {
             self.profile_edit_schedule_exception =
                 self.profile_edit_schedule_exception.saturating_sub(1);
+        }
+    }
+
+    fn cycle_one_time_window(&mut self, increase: bool) {
+        if self.recurring_schedule.one_time_windows.is_empty() {
+            return;
+        }
+        let total = self.recurring_schedule.one_time_windows.len();
+        if increase {
+            self.profile_edit_one_time_window = (self.profile_edit_one_time_window + 1) % total;
+        } else if self.profile_edit_one_time_window == 0 {
+            self.profile_edit_one_time_window = total - 1;
+        } else {
+            self.profile_edit_one_time_window = self.profile_edit_one_time_window.saturating_sub(1);
         }
     }
 
@@ -1274,6 +1371,99 @@ impl App {
         }
     }
 
+    fn adjust_selected_one_time_date(&mut self, increase: bool) {
+        let Some(current_window) = self.selected_one_time_window().cloned() else {
+            return;
+        };
+        let Some(current_date) = parse_schedule_exception_date(&current_window.date) else {
+            return;
+        };
+        let next_date = if increase {
+            current_date.succ_opt().unwrap_or(current_date)
+        } else {
+            current_date.pred_opt().unwrap_or(current_date)
+        };
+        let updated = OneTimeFocusWindowConfig {
+            date: next_date.format("%Y-%m-%d").to_string(),
+            start: current_window.start,
+            end: current_window.end,
+        };
+        if let Some(target) = self
+            .recurring_schedule
+            .one_time_windows
+            .get_mut(self.profile_edit_one_time_window)
+        {
+            *target = updated.clone();
+        }
+        sort_one_time_windows(&mut self.recurring_schedule.one_time_windows);
+        if let Some(position) =
+            self.recurring_schedule
+                .one_time_windows
+                .iter()
+                .position(|candidate| {
+                    candidate.date == updated.date
+                        && candidate.start == updated.start
+                        && candidate.end == updated.end
+                })
+        {
+            self.profile_edit_one_time_window = position;
+        }
+    }
+
+    fn adjust_selected_one_time_time(&mut self, is_start: bool, increase: bool) {
+        let updated = {
+            let Some(window) = self.selected_one_time_window_mut() else {
+                return;
+            };
+
+            let mut start = parse_hhmm_minutes(&window.start).unwrap_or(9 * 60);
+            let mut end = parse_hhmm_minutes(&window.end).unwrap_or(10 * 60);
+            if end <= start {
+                end = start.saturating_add(1).min(23 * 60 + 59);
+            }
+
+            if is_start {
+                if increase {
+                    start = start
+                        .saturating_add(SCHEDULE_TIME_STEP_MINUTES)
+                        .min(end.saturating_sub(1));
+                } else {
+                    start = start.saturating_sub(SCHEDULE_TIME_STEP_MINUTES);
+                }
+            } else if increase {
+                end = end
+                    .saturating_add(SCHEDULE_TIME_STEP_MINUTES)
+                    .min(23 * 60 + 59)
+                    .max(start.saturating_add(1));
+            } else {
+                end = end
+                    .saturating_sub(SCHEDULE_TIME_STEP_MINUTES)
+                    .max(start.saturating_add(1));
+            }
+
+            let updated = OneTimeFocusWindowConfig {
+                date: window.date.clone(),
+                start: format_hhmm(start),
+                end: format_hhmm(end),
+            };
+            *window = updated.clone();
+            updated
+        };
+        sort_one_time_windows(&mut self.recurring_schedule.one_time_windows);
+        if let Some(position) =
+            self.recurring_schedule
+                .one_time_windows
+                .iter()
+                .position(|candidate| {
+                    candidate.date == updated.date
+                        && candidate.start == updated.start
+                        && candidate.end == updated.end
+                })
+        {
+            self.profile_edit_one_time_window = position;
+        }
+    }
+
     fn adjust_schedule_windows_collection(&mut self, increase: bool) {
         if increase {
             self.recurring_schedule
@@ -1327,6 +1517,60 @@ impl App {
         self.recurring_schedule
             .exception_dates
             .remove(self.profile_edit_schedule_exception);
+        self.clamp_profile_edit_schedule_selection();
+    }
+
+    fn adjust_one_time_windows_collection(&mut self, increase: bool) {
+        if increase {
+            let default_window = OneTimeFocusWindowConfig::default();
+            let mut candidate_date = self.current_frame_now.date_naive();
+            let mut added = OneTimeFocusWindowConfig {
+                date: candidate_date.format("%Y-%m-%d").to_string(),
+                start: default_window.start.clone(),
+                end: default_window.end.clone(),
+            };
+            while self
+                .recurring_schedule
+                .one_time_windows
+                .iter()
+                .any(|candidate| {
+                    candidate.date == added.date
+                        && candidate.start == added.start
+                        && candidate.end == added.end
+                })
+            {
+                let Some(next_date) = candidate_date.succ_opt() else {
+                    return;
+                };
+                candidate_date = next_date;
+                added.date = candidate_date.format("%Y-%m-%d").to_string();
+            }
+            self.recurring_schedule.one_time_windows.push(added.clone());
+            sort_one_time_windows(&mut self.recurring_schedule.one_time_windows);
+            self.profile_edit_one_time_window = self
+                .recurring_schedule
+                .one_time_windows
+                .iter()
+                .position(|candidate| {
+                    candidate.date == added.date
+                        && candidate.start == added.start
+                        && candidate.end == added.end
+                })
+                .unwrap_or_else(|| {
+                    self.recurring_schedule
+                        .one_time_windows
+                        .len()
+                        .saturating_sub(1)
+                });
+            return;
+        }
+
+        if self.recurring_schedule.one_time_windows.is_empty() {
+            return;
+        }
+        self.recurring_schedule
+            .one_time_windows
+            .remove(self.profile_edit_one_time_window);
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -2143,6 +2387,7 @@ impl App {
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
         self.profile_edit_schedule_exception = 0;
+        self.profile_edit_one_time_window = 0;
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -2164,6 +2409,7 @@ impl App {
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
         self.profile_edit_schedule_exception = 0;
+        self.profile_edit_one_time_window = 0;
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -2211,6 +2457,7 @@ impl App {
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
         self.profile_edit_schedule_exception = 0;
+        self.profile_edit_one_time_window = 0;
         self.clamp_profile_edit_schedule_selection();
         self.profile_edit_snapshot = None;
     }
@@ -2283,6 +2530,21 @@ impl App {
             PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX => {
                 self.adjust_schedule_exceptions_collection(increase);
             }
+            PROFILE_EDIT_ONE_TIME_WINDOW_INDEX => {
+                self.cycle_one_time_window(increase);
+            }
+            PROFILE_EDIT_ONE_TIME_DATE_INDEX => {
+                self.adjust_selected_one_time_date(increase);
+            }
+            PROFILE_EDIT_ONE_TIME_START_INDEX => {
+                self.adjust_selected_one_time_time(true, increase);
+            }
+            PROFILE_EDIT_ONE_TIME_END_INDEX => {
+                self.adjust_selected_one_time_time(false, increase);
+            }
+            PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX => {
+                self.adjust_one_time_windows_collection(increase);
+            }
             PROFILE_EDIT_WAKATIME_PROJECT_INDEX | PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX => {}
             _ => {}
         }
@@ -2300,6 +2562,7 @@ impl App {
         self.recurring_windows = compile_windows(&self.recurring_schedule.windows);
         self.recurring_exception_dates =
             compile_exception_dates(&self.recurring_schedule.exception_dates);
+        self.one_time_windows = compile_one_time_windows(&self.recurring_schedule.one_time_windows);
     }
 
     fn apply_profile(&mut self, profile: ProfileId) -> bool {
@@ -2948,6 +3211,7 @@ impl App {
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
         self.profile_edit_schedule_exception = 0;
+        self.profile_edit_one_time_window = 0;
         self.profile_edit_snapshot = None;
         self.profile_selection_index = profile_index(self.selected_profile);
         self.clamp_profile_selection();
@@ -3343,21 +3607,19 @@ impl App {
     }
 
     fn sync_recurring_schedule(&mut self, now: DateTime<Local>) {
-        if self.recurring_windows.is_empty() {
+        if self.recurring_windows.is_empty() && self.one_time_windows.is_empty() {
             self.schedule_armed_occurrence_key = None;
             return;
         }
 
-        if self.recurring_exception_dates.contains(&now.date_naive()) {
-            self.schedule_armed_occurrence_key = None;
-            return;
-        }
-
-        let Some(active_window) = active_occurrence(
+        let recurring_active = active_occurrence(
             now,
             &self.recurring_windows,
             &self.recurring_exception_dates,
-        ) else {
+        );
+        let one_time_active = active_one_time_occurrence(now, &self.one_time_windows);
+
+        let Some(active_window) = pick_active_occurrence(recurring_active, one_time_active) else {
             self.schedule_armed_occurrence_key = None;
             return;
         };
@@ -3525,6 +3787,15 @@ fn sort_schedule_exception_dates(dates: &mut Vec<String>) {
     *dates = sorted.into_iter().collect();
 }
 
+fn sort_one_time_windows(windows: &mut [OneTimeFocusWindowConfig]) {
+    windows.sort_by(|left, right| {
+        left.date
+            .cmp(&right.date)
+            .then(left.start.cmp(&right.start))
+            .then(left.end.cmp(&right.end))
+    });
+}
+
 fn format_schedule_days_for_display(days: &[String]) -> String {
     let mut labels = Vec::new();
     for (index, token) in SCHEDULE_DAY_TOKENS.iter().enumerate() {
@@ -3576,16 +3847,16 @@ fn schedule_status_text_from_state(state: &ScheduleDisplayState) -> String {
         return "⚙  Schedule status: off".to_string();
     }
 
-    if state.is_exception_today {
-        return "⚙  Schedule status: skipped today (exception date)".to_string();
-    }
-
     if state.active_window.is_some() {
         return schedule_active_window_status_text(state);
     }
 
     if state.is_armed {
         return schedule_armed_status_text(state.has_selected_task);
+    }
+
+    if state.is_exception_today {
+        return "⚙  Schedule status: skipped today (exception date)".to_string();
     }
 
     "⚙  Schedule status: ready for next window".to_string()
@@ -4347,6 +4618,35 @@ mod tests {
         assert_eq!(
             persisted.recurring_schedule.exception_dates,
             vec![expected_date]
+        );
+    }
+
+    #[test]
+    fn editing_one_time_schedule_fields_updates_and_persists_settings() {
+        let mut app = App::default();
+        app.current_frame_now = local_datetime_today(10, 15);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        app.profile_edit_field = PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX;
+        app.handle_key(key(KeyCode::Right)); // add one-time window for today
+        app.profile_edit_field = PROFILE_EDIT_ONE_TIME_DATE_INDEX;
+        app.handle_key(key(KeyCode::Right)); // move to tomorrow
+        app.profile_edit_field = PROFILE_EDIT_ONE_TIME_START_INDEX;
+        app.handle_key(key(KeyCode::Right)); // 09:00 -> 09:15
+        app.profile_edit_field = PROFILE_EDIT_ONE_TIME_END_INDEX;
+        app.handle_key(key(KeyCode::Right)); // 10:00 -> 10:15
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(app.recurring_schedule.one_time_windows.len(), 1);
+        let window = &app.recurring_schedule.one_time_windows[0];
+        assert_eq!(window.start, "09:15");
+        assert_eq!(window.end, "10:15");
+
+        let persisted = app.persisted_config();
+        assert_eq!(
+            persisted.recurring_schedule.one_time_windows,
+            app.recurring_schedule.one_time_windows
         );
     }
 
@@ -5220,6 +5520,32 @@ mod tests {
     }
 
     #[test]
+    fn one_time_schedule_next_window_text_shows_upcoming_window_for_today() {
+        let now = local_datetime_today(10, 15);
+        let config = AppConfig {
+            recurring_schedule: RecurringScheduleConfig {
+                one_time_windows: vec![OneTimeFocusWindowConfig {
+                    date: now.date_naive().format("%Y-%m-%d").to_string(),
+                    start: "11:00".to_string(),
+                    end: "12:00".to_string(),
+                }],
+                ..RecurringScheduleConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let app = App::from_config(config);
+
+        assert_eq!(
+            app.recurring_schedule_texts_at(now).0,
+            "🗓  Next schedule: today 11:00-12:00"
+        );
+        assert_eq!(
+            app.recurring_schedule_texts_at(now).1,
+            "⚙  Schedule status: ready for next window"
+        );
+    }
+
+    #[test]
     fn recurring_schedule_next_window_text_shows_active_window_then_next_window() {
         let now = local_datetime_today(10, 15);
         let config = AppConfig {
@@ -5415,6 +5741,7 @@ mod tests {
                     },
                 ],
                 exception_dates: vec![today.format("%Y-%m-%d").to_string()],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -5442,6 +5769,7 @@ mod tests {
                     end: "11:00".to_string(),
                 }],
                 exception_dates: vec![today.format("%Y-%m-%d").to_string()],
+                ..RecurringScheduleConfig::default()
             },
             ..AppConfig::default()
         };
@@ -5455,6 +5783,40 @@ mod tests {
         assert_eq!(app.timer.status, TimerStatus::Idle);
         assert!(app.schedule_armed_occurrence_key.is_none());
         assert!(app.phase_notification.is_none());
+    }
+
+    #[test]
+    fn one_time_schedule_triggers_on_recurring_exception_date() {
+        let now = local_datetime_today(10, 15);
+        let today = now.date_naive();
+        let config = AppConfig {
+            recurring_schedule: RecurringScheduleConfig {
+                windows: vec![crate::config::RecurringFocusWindowConfig {
+                    days: vec![weekday_token(today.weekday()).to_string()],
+                    start: "10:00".to_string(),
+                    end: "11:00".to_string(),
+                }],
+                exception_dates: vec![today.format("%Y-%m-%d").to_string()],
+                one_time_windows: vec![OneTimeFocusWindowConfig {
+                    date: today.format("%Y-%m-%d").to_string(),
+                    start: "10:00".to_string(),
+                    end: "11:00".to_string(),
+                }],
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        app.task_labels = vec!["Coding".to_string()];
+        app.selected_task_label = Some("Coding".to_string());
+
+        app.sync_recurring_schedule(now);
+
+        assert_eq!(app.timer.phase, TimerPhase::Focus);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+        assert_eq!(
+            app.phase_notification.as_deref(),
+            Some("Scheduled window started. Focus auto-started.")
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,8 +14,8 @@ use serde::Serialize;
 use crate::app::{App, SetupCheck, SetupCheckLevel, SetupDiagnostics};
 use crate::blocker::{BlockingPreviewAction, EditSiteResult, InvalidSiteInput, SiteBlocker};
 use crate::config::{
-    AppConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig,
+    AppConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
+    OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig,
 };
 use crate::session_recovery;
 use crate::stats::{DailyGoalSnapshot, FocusStats, current_day_key};
@@ -67,7 +67,7 @@ Options:
   --goal          Show current daily goal, or set minutes/pomodoros targets
   --strict        Show strict mode, or set on/off
   --schedule      Show recurring schedule
-  --schedule-set  Replace recurring schedule from JSON payload
+  --schedule-set  Replace schedule (recurring + one-time) from JSON payload
   --blocklist-profile         Show active blocklist profile, or set active profile
   --blocklist-profile-create  Create a blocklist profile and select it
   --blocklist-profile-rename  Rename the active blocklist profile
@@ -2462,7 +2462,7 @@ fn parse_site_edit_value(value: &str) -> Result<SiteEditValue, String> {
 fn parse_schedule_value(value: &str) -> Result<RecurringScheduleConfig, String> {
     let schedule = serde_json::from_str::<RecurringScheduleConfig>(value).map_err(|error| {
         invalid_usage(&format!(
-            "Invalid schedule JSON payload: {error}. Use `--schedule-set='{{\"windows\":[...],\"exception_dates\":[...]}}'`."
+            "Invalid schedule JSON payload: {error}. Use `--schedule-set='{{\"windows\":[...],\"exception_dates\":[...],\"one_time_windows\":[...]}}'`."
         ))
     })?;
     validate_schedule_value(&schedule)?;
@@ -2475,6 +2475,9 @@ fn validate_schedule_value(schedule: &RecurringScheduleConfig) -> Result<(), Str
     }
     for (index, date) in schedule.exception_dates.iter().enumerate() {
         validate_schedule_exception_date(date, index)?;
+    }
+    for (index, window) in schedule.one_time_windows.iter().enumerate() {
+        validate_one_time_schedule_window(window, index)?;
     }
     Ok(())
 }
@@ -2523,6 +2526,39 @@ fn validate_schedule_exception_date(value: &str, index: usize) -> Result<(), Str
             "Invalid exception date at index {index}: `{value}` must be YYYY-MM-DD."
         ))
     })?;
+    Ok(())
+}
+
+fn validate_one_time_schedule_window(
+    window: &OneTimeFocusWindowConfig,
+    index: usize,
+) -> Result<(), String> {
+    NaiveDate::parse_from_str(window.date.trim(), "%Y-%m-%d").map_err(|_| {
+        invalid_usage(&format!(
+            "Invalid one-time window at index {index}: date `{}` must be YYYY-MM-DD.",
+            window.date
+        ))
+    })?;
+
+    let start_minutes = parse_schedule_minutes(&window.start).ok_or_else(|| {
+        invalid_usage(&format!(
+            "Invalid one-time window at index {index}: start `{}` must be HH:MM in 24-hour format.",
+            window.start
+        ))
+    })?;
+    let end_minutes = parse_schedule_minutes(&window.end).ok_or_else(|| {
+        invalid_usage(&format!(
+            "Invalid one-time window at index {index}: end `{}` must be HH:MM in 24-hour format.",
+            window.end
+        ))
+    })?;
+
+    if start_minutes >= end_minutes {
+        return Err(invalid_usage(&format!(
+            "Invalid one-time window at index {index}: start must be earlier than end."
+        )));
+    }
+
     Ok(())
 }
 
@@ -2890,12 +2926,12 @@ fn print_strict_command_output(payload: &StrictCommandOutput) {
 
 fn print_schedule_command_output(payload: &ScheduleCommandOutput) {
     if payload.updated {
-        println!("Recurring schedule updated.");
+        println!("Schedule updated.");
     }
     if payload.schedule.windows.is_empty() {
-        println!("Schedule windows: none");
+        println!("Recurring windows: none");
     } else {
-        println!("Schedule windows:");
+        println!("Recurring windows:");
         for window in &payload.schedule.windows {
             println!(
                 "  - [{}] {}-{}",
@@ -2912,6 +2948,14 @@ fn print_schedule_command_output(payload: &ScheduleCommandOutput) {
             "Exception dates: {}",
             payload.schedule.exception_dates.join(", ")
         );
+    }
+    if payload.schedule.one_time_windows.is_empty() {
+        println!("One-time windows: none");
+    } else {
+        println!("One-time windows:");
+        for window in &payload.schedule.one_time_windows {
+            println!("  - {} {}-{}", window.date, window.start, window.end);
+        }
     }
 }
 
@@ -3359,6 +3403,31 @@ mod tests {
                             end: "11:00".to_string(),
                         }],
                         exception_dates: vec!["2026-12-25".to_string()],
+                        one_time_windows: Vec::new(),
+                    }),
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_schedule_set_accepts_one_time_windows_payload() {
+        let payload = r#"{"windows":[],"exception_dates":[],"one_time_windows":[{"date":"2026-05-02","start":"14:00","end":"15:30"}]}"#;
+        let parsed =
+            parse_args([OsString::from("--schedule-set"), OsString::from(payload)]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::Schedule {
+                    schedule: Some(RecurringScheduleConfig {
+                        windows: Vec::new(),
+                        exception_dates: Vec::new(),
+                        one_time_windows: vec![OneTimeFocusWindowConfig {
+                            date: "2026-05-02".to_string(),
+                            start: "14:00".to_string(),
+                            end: "15:30".to_string(),
+                        }],
                     }),
                 },
                 output: OutputMode::Text
@@ -3599,6 +3668,7 @@ mod tests {
                     end: "11:00".to_string(),
                 }],
                 exception_dates: Vec::new(),
+                one_time_windows: Vec::new(),
             }))
         );
     }
@@ -3695,6 +3765,14 @@ mod tests {
         let error =
             parse_args([OsString::from("--schedule-set"), OsString::from(payload)]).unwrap_err();
         assert!(error.contains("must be YYYY-MM-DD"));
+    }
+
+    #[test]
+    fn parse_rejects_schedule_set_with_invalid_one_time_date() {
+        let payload = r#"{"windows":[],"exception_dates":[],"one_time_windows":[{"date":"2026-99-99","start":"09:00","end":"10:00"}]}"#;
+        let error =
+            parse_args([OsString::from("--schedule-set"), OsString::from(payload)]).unwrap_err();
+        assert!(error.contains("Invalid one-time window"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
-use chrono::NaiveDate;
+use chrono::{Local, NaiveDate};
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Persistent application configuration stored as TOML.
@@ -122,6 +122,8 @@ pub struct RecurringScheduleConfig {
     pub windows: Vec<RecurringFocusWindowConfig>,
     #[serde(default)]
     pub exception_dates: Vec<String>,
+    #[serde(default)]
+    pub one_time_windows: Vec<OneTimeFocusWindowConfig>,
 }
 
 impl RecurringScheduleConfig {
@@ -141,9 +143,27 @@ impl RecurringScheduleConfig {
             })
             .collect();
         let exception_dates = normalize_schedule_exception_dates(&self.exception_dates);
+        let one_time_windows = self
+            .one_time_windows
+            .iter()
+            .map(OneTimeFocusWindowConfig::normalized)
+            .filter(|window| {
+                if parse_schedule_exception_date(&window.date).is_none() {
+                    return false;
+                }
+                let Some(start_minutes) = parse_schedule_time_minutes(&window.start) else {
+                    return false;
+                };
+                let Some(end_minutes) = parse_schedule_time_minutes(&window.end) else {
+                    return false;
+                };
+                start_minutes < end_minutes
+            })
+            .collect();
         Self {
             windows,
             exception_dates,
+            one_time_windows,
         }
     }
 }
@@ -172,6 +192,36 @@ impl Default for RecurringFocusWindowConfig {
     fn default() -> Self {
         Self {
             days: default_schedule_window_days(),
+            start: default_schedule_window_start(),
+            end: default_schedule_window_end(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OneTimeFocusWindowConfig {
+    #[serde(default = "default_one_time_schedule_date")]
+    pub date: String,
+    #[serde(default = "default_schedule_window_start")]
+    pub start: String,
+    #[serde(default = "default_schedule_window_end")]
+    pub end: String,
+}
+
+impl OneTimeFocusWindowConfig {
+    pub fn normalized(&self) -> Self {
+        Self {
+            date: self.date.trim().to_string(),
+            start: normalize_schedule_time_or_default(&self.start, default_schedule_window_start),
+            end: normalize_schedule_time_or_default(&self.end, default_schedule_window_end),
+        }
+    }
+}
+
+impl Default for OneTimeFocusWindowConfig {
+    fn default() -> Self {
+        Self {
+            date: default_one_time_schedule_date(),
             start: default_schedule_window_start(),
             end: default_schedule_window_end(),
         }
@@ -257,6 +307,10 @@ fn default_schedule_window_start() -> String {
 
 fn default_schedule_window_end() -> String {
     "10:00".to_string()
+}
+
+fn default_one_time_schedule_date() -> String {
+    Local::now().date_naive().format("%Y-%m-%d").to_string()
 }
 
 fn default_blocklist_profile_name() -> String {
@@ -787,6 +841,11 @@ mod tests {
                     end: "11:00".to_string(),
                 }],
                 exception_dates: vec!["2026-04-27".to_string(), "2026-05-05".to_string()],
+                one_time_windows: vec![OneTimeFocusWindowConfig {
+                    date: "2026-05-10".to_string(),
+                    start: "14:00".to_string(),
+                    end: "15:00".to_string(),
+                }],
             },
             strict_mode: true,
             break_glass_duration_secs: 7 * 60,
@@ -890,6 +949,23 @@ start = "08:30"
         assert_eq!(window.end, default_schedule_window_end());
         assert_eq!(window.days, default_schedule_window_days());
         assert!(cfg.recurring_schedule.exception_dates.is_empty());
+        assert!(cfg.recurring_schedule.one_time_windows.is_empty());
+    }
+
+    #[test]
+    fn partial_one_time_schedule_window_uses_defaults_for_missing_fields() {
+        let partial = r#"
+[recurring_schedule]
+[[recurring_schedule.one_time_windows]]
+date = "2026-04-27"
+"#;
+        let cfg: AppConfig = toml::from_str(partial).unwrap();
+
+        assert_eq!(cfg.recurring_schedule.one_time_windows.len(), 1);
+        let window = &cfg.recurring_schedule.one_time_windows[0];
+        assert_eq!(window.date, "2026-04-27");
+        assert_eq!(window.start, default_schedule_window_start());
+        assert_eq!(window.end, default_schedule_window_end());
     }
 
     #[test]
@@ -909,6 +985,7 @@ start = "08:30"
                     },
                 ],
                 exception_dates: Vec::new(),
+                one_time_windows: Vec::new(),
             },
             ..AppConfig::default()
         }
@@ -931,6 +1008,7 @@ start = "08:30"
                     "2026-12-25".to_string(),
                     "not-a-date".to_string(),
                 ],
+                one_time_windows: Vec::new(),
             },
             ..AppConfig::default()
         }
@@ -940,6 +1018,43 @@ start = "08:30"
             cfg.recurring_schedule.exception_dates,
             vec!["2026-01-01".to_string(), "2026-12-25".to_string()]
         );
+    }
+
+    #[test]
+    fn normalize_drops_one_time_windows_with_invalid_entries() {
+        let cfg = AppConfig {
+            recurring_schedule: RecurringScheduleConfig {
+                windows: Vec::new(),
+                exception_dates: Vec::new(),
+                one_time_windows: vec![
+                    OneTimeFocusWindowConfig {
+                        date: "2026-04-27".to_string(),
+                        start: "10:00".to_string(),
+                        end: "11:00".to_string(),
+                    },
+                    OneTimeFocusWindowConfig {
+                        date: "not-a-date".to_string(),
+                        start: "10:00".to_string(),
+                        end: "11:00".to_string(),
+                    },
+                    OneTimeFocusWindowConfig {
+                        date: "2026-04-28".to_string(),
+                        start: "12:00".to_string(),
+                        end: "11:00".to_string(),
+                    },
+                ],
+            },
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        assert_eq!(cfg.recurring_schedule.one_time_windows.len(), 1);
+        assert_eq!(
+            cfg.recurring_schedule.one_time_windows[0].date,
+            "2026-04-27"
+        );
+        assert_eq!(cfg.recurring_schedule.one_time_windows[0].start, "10:00");
+        assert_eq!(cfg.recurring_schedule.one_time_windows[0].end, "11:00");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,7 +200,7 @@ impl Default for RecurringFocusWindowConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OneTimeFocusWindowConfig {
-    #[serde(default = "default_one_time_schedule_date")]
+    #[serde(default)]
     pub date: String,
     #[serde(default = "default_schedule_window_start")]
     pub start: String,
@@ -212,8 +212,8 @@ impl OneTimeFocusWindowConfig {
     pub fn normalized(&self) -> Self {
         Self {
             date: self.date.trim().to_string(),
-            start: normalize_schedule_time_or_default(&self.start, default_schedule_window_start),
-            end: normalize_schedule_time_or_default(&self.end, default_schedule_window_end),
+            start: self.start.trim().to_string(),
+            end: self.end.trim().to_string(),
         }
     }
 }
@@ -969,6 +969,20 @@ date = "2026-04-27"
     }
 
     #[test]
+    fn normalize_drops_one_time_window_without_date_in_config() {
+        let partial = r#"
+[recurring_schedule]
+[[recurring_schedule.one_time_windows]]
+start = "09:00"
+end = "10:00"
+"#;
+        let cfg: AppConfig = toml::from_str(partial).unwrap();
+        let normalized = cfg.normalize();
+
+        assert!(normalized.recurring_schedule.one_time_windows.is_empty());
+    }
+
+    #[test]
     fn normalize_drops_recurring_windows_with_invalid_time_ranges() {
         let cfg = AppConfig {
             recurring_schedule: RecurringScheduleConfig {
@@ -1041,6 +1055,16 @@ date = "2026-04-27"
                         date: "2026-04-28".to_string(),
                         start: "12:00".to_string(),
                         end: "11:00".to_string(),
+                    },
+                    OneTimeFocusWindowConfig {
+                        date: "2026-04-29".to_string(),
+                        start: "25:00".to_string(),
+                        end: "26:00".to_string(),
+                    },
+                    OneTimeFocusWindowConfig {
+                        date: String::new(),
+                        start: "09:00".to_string(),
+                        end: "10:00".to_string(),
                     },
                 ],
             },

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -4,7 +4,7 @@ use chrono::{
     DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, TimeZone, Timelike, Weekday,
 };
 
-use crate::config::RecurringFocusWindowConfig;
+use crate::config::{OneTimeFocusWindowConfig, RecurringFocusWindowConfig};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecurringWindow {
@@ -14,7 +14,21 @@ pub struct RecurringWindow {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OneTimeWindow {
+    pub date: NaiveDate,
+    start_minutes: u16,
+    end_minutes: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowOccurrenceKind {
+    Recurring,
+    OneTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WindowOccurrence {
+    pub kind: WindowOccurrenceKind,
     pub window_index: usize,
     pub start: DateTime<Local>,
     pub end: DateTime<Local>,
@@ -27,6 +41,13 @@ pub fn compile_windows(config_windows: &[RecurringFocusWindowConfig]) -> Vec<Rec
         .collect()
 }
 
+pub fn compile_one_time_windows(config_windows: &[OneTimeFocusWindowConfig]) -> Vec<OneTimeWindow> {
+    config_windows
+        .iter()
+        .filter_map(OneTimeWindow::from_config)
+        .collect()
+}
+
 pub fn compile_exception_dates(config_dates: &[String]) -> HashSet<NaiveDate> {
     config_dates
         .iter()
@@ -35,8 +56,12 @@ pub fn compile_exception_dates(config_dates: &[String]) -> HashSet<NaiveDate> {
 }
 
 pub fn occurrence_key(occurrence: &WindowOccurrence) -> String {
+    let kind_key = match occurrence.kind {
+        WindowOccurrenceKind::Recurring => "r",
+        WindowOccurrenceKind::OneTime => "o",
+    };
     format!(
-        "{}-{}",
+        "{kind_key}-{}-{}",
         occurrence.window_index,
         occurrence.start.timestamp()
     )
@@ -72,13 +97,14 @@ pub fn active_occurrence(
         }
 
         let candidate = WindowOccurrence {
+            kind: WindowOccurrenceKind::Recurring,
             window_index,
             start,
             end,
         };
         let should_replace = selected
             .as_ref()
-            .is_none_or(|existing| active_candidate_is_higher_priority(&candidate, existing));
+            .is_none_or(|existing| active_occurrence_is_higher_priority(&candidate, existing));
         if should_replace {
             selected = Some(candidate);
         }
@@ -119,13 +145,14 @@ pub fn next_occurrence_after(
                 continue;
             };
             let candidate = WindowOccurrence {
+                kind: WindowOccurrenceKind::Recurring,
                 window_index,
                 start,
                 end,
             };
             let should_replace = selected
                 .as_ref()
-                .is_none_or(|existing| next_candidate_is_higher_priority(&candidate, existing));
+                .is_none_or(|existing| next_occurrence_is_higher_priority(&candidate, existing));
             if should_replace {
                 selected = Some(candidate);
             }
@@ -133,6 +160,117 @@ pub fn next_occurrence_after(
     }
 
     selected
+}
+
+pub fn active_one_time_occurrence(
+    now: DateTime<Local>,
+    windows: &[OneTimeWindow],
+) -> Option<WindowOccurrence> {
+    let now_minutes = now.hour() as u16 * 60 + now.minute() as u16;
+    let today = now.date_naive();
+    let mut selected: Option<WindowOccurrence> = None;
+
+    for (window_index, window) in windows.iter().enumerate() {
+        if window.date != today {
+            continue;
+        }
+        if now_minutes < window.start_minutes || now_minutes >= window.end_minutes {
+            continue;
+        }
+        let Some(start) = local_datetime_on(today, window.start_minutes) else {
+            continue;
+        };
+        let Some(end) = local_datetime_on(today, window.end_minutes) else {
+            continue;
+        };
+        if now < start || now >= end {
+            continue;
+        }
+
+        let candidate = WindowOccurrence {
+            kind: WindowOccurrenceKind::OneTime,
+            window_index,
+            start,
+            end,
+        };
+        let should_replace = selected
+            .as_ref()
+            .is_none_or(|existing| active_occurrence_is_higher_priority(&candidate, existing));
+        if should_replace {
+            selected = Some(candidate);
+        }
+    }
+
+    selected
+}
+
+pub fn next_one_time_occurrence_after(
+    now: DateTime<Local>,
+    windows: &[OneTimeWindow],
+) -> Option<WindowOccurrence> {
+    let mut selected: Option<WindowOccurrence> = None;
+
+    for (window_index, window) in windows.iter().enumerate() {
+        let Some(start) = local_datetime_on(window.date, window.start_minutes) else {
+            continue;
+        };
+        if start <= now {
+            continue;
+        }
+        let Some(end) = local_datetime_on(window.date, window.end_minutes) else {
+            continue;
+        };
+        let candidate = WindowOccurrence {
+            kind: WindowOccurrenceKind::OneTime,
+            window_index,
+            start,
+            end,
+        };
+        let should_replace = selected
+            .as_ref()
+            .is_none_or(|existing| next_occurrence_is_higher_priority(&candidate, existing));
+        if should_replace {
+            selected = Some(candidate);
+        }
+    }
+
+    selected
+}
+
+pub fn pick_active_occurrence(
+    first: Option<WindowOccurrence>,
+    second: Option<WindowOccurrence>,
+) -> Option<WindowOccurrence> {
+    match (first, second) {
+        (Some(first), Some(second)) => {
+            if active_occurrence_is_higher_priority(&first, &second) {
+                Some(first)
+            } else {
+                Some(second)
+            }
+        }
+        (Some(first), None) => Some(first),
+        (None, Some(second)) => Some(second),
+        (None, None) => None,
+    }
+}
+
+pub fn pick_next_occurrence(
+    first: Option<WindowOccurrence>,
+    second: Option<WindowOccurrence>,
+) -> Option<WindowOccurrence> {
+    match (first, second) {
+        (Some(first), Some(second)) => {
+            if next_occurrence_is_higher_priority(&first, &second) {
+                Some(first)
+            } else {
+                Some(second)
+            }
+        }
+        (Some(first), None) => Some(first),
+        (None, Some(second)) => Some(second),
+        (None, None) => None,
+    }
 }
 
 impl RecurringWindow {
@@ -148,6 +286,22 @@ impl RecurringWindow {
         }
         Some(Self {
             days,
+            start_minutes,
+            end_minutes,
+        })
+    }
+}
+
+impl OneTimeWindow {
+    fn from_config(config: &OneTimeFocusWindowConfig) -> Option<Self> {
+        let date = parse_exception_date(&config.date)?;
+        let start_minutes = parse_time_minutes(&config.start)?;
+        let end_minutes = parse_time_minutes(&config.end)?;
+        if start_minutes >= end_minutes {
+            return None;
+        }
+        Some(Self {
+            date,
             start_minutes,
             end_minutes,
         })
@@ -198,20 +352,27 @@ fn parse_exception_date(raw: &str) -> Option<NaiveDate> {
     NaiveDate::parse_from_str(raw.trim(), "%Y-%m-%d").ok()
 }
 
-fn active_candidate_is_higher_priority(
+fn active_occurrence_is_higher_priority(
     candidate: &WindowOccurrence,
     existing: &WindowOccurrence,
 ) -> bool {
     candidate.start > existing.start
-        || (candidate.start == existing.start && candidate.window_index < existing.window_index)
+        || (candidate.start == existing.start && occurrence_tie_break(candidate, existing))
 }
 
-fn next_candidate_is_higher_priority(
+fn next_occurrence_is_higher_priority(
     candidate: &WindowOccurrence,
     existing: &WindowOccurrence,
 ) -> bool {
     candidate.start < existing.start
-        || (candidate.start == existing.start && candidate.window_index < existing.window_index)
+        || (candidate.start == existing.start && occurrence_tie_break(candidate, existing))
+}
+
+fn occurrence_tie_break(candidate: &WindowOccurrence, existing: &WindowOccurrence) -> bool {
+    if candidate.kind != existing.kind {
+        return candidate.kind == WindowOccurrenceKind::OneTime;
+    }
+    candidate.window_index < existing.window_index
 }
 
 fn local_datetime_on(date: NaiveDate, total_minutes: u16) -> Option<DateTime<Local>> {
@@ -262,6 +423,35 @@ mod tests {
     }
 
     #[test]
+    fn compile_one_time_windows_ignores_invalid_entries() {
+        let windows = vec![
+            OneTimeFocusWindowConfig {
+                date: "2026-04-27".to_string(),
+                start: "10:00".to_string(),
+                end: "11:00".to_string(),
+            },
+            OneTimeFocusWindowConfig {
+                date: "not-a-date".to_string(),
+                start: "10:00".to_string(),
+                end: "11:00".to_string(),
+            },
+            OneTimeFocusWindowConfig {
+                date: "2026-04-27".to_string(),
+                start: "12:00".to_string(),
+                end: "11:00".to_string(),
+            },
+        ];
+
+        let compiled = compile_one_time_windows(&windows);
+
+        assert_eq!(compiled.len(), 1);
+        assert_eq!(
+            compiled[0].date,
+            NaiveDate::from_ymd_opt(2026, 4, 27).expect("valid date literal")
+        );
+    }
+
+    #[test]
     fn compile_exception_dates_ignores_invalid_and_deduplicates() {
         let dates = compile_exception_dates(&[
             " 2026-12-25 ".to_string(),
@@ -289,6 +479,25 @@ mod tests {
         let active =
             active_occurrence(now, &windows, &HashSet::new()).expect("window should be active");
 
+        assert_eq!(active.kind, WindowOccurrenceKind::Recurring);
+        assert_eq!(active.start, local_datetime(date, 10, 0));
+        assert_eq!(active.end, local_datetime(date, 11, 0));
+    }
+
+    #[test]
+    fn active_one_time_occurrence_returns_window_when_inside_range() {
+        let date = Local::now().date_naive();
+        let now = local_datetime(date, 10, 15);
+        let windows = compile_one_time_windows(&[OneTimeFocusWindowConfig {
+            date: date.format("%Y-%m-%d").to_string(),
+            start: "10:00".to_string(),
+            end: "11:00".to_string(),
+        }]);
+
+        let active =
+            active_one_time_occurrence(now, &windows).expect("one-time window should be active");
+
+        assert_eq!(active.kind, WindowOccurrenceKind::OneTime);
         assert_eq!(active.start, local_datetime(date, 10, 0));
         assert_eq!(active.end, local_datetime(date, 11, 0));
     }
@@ -437,5 +646,49 @@ mod tests {
 
         assert_eq!(next.start, local_datetime(following_week, 11, 0));
         assert_eq!(next.end, local_datetime(following_week, 12, 0));
+    }
+
+    #[test]
+    fn pick_active_occurrence_prefers_one_time_on_equal_start() {
+        let date = Local::now().date_naive();
+        let recurring = WindowOccurrence {
+            kind: WindowOccurrenceKind::Recurring,
+            window_index: 0,
+            start: local_datetime(date, 10, 0),
+            end: local_datetime(date, 11, 0),
+        };
+        let one_time = WindowOccurrence {
+            kind: WindowOccurrenceKind::OneTime,
+            window_index: 0,
+            start: local_datetime(date, 10, 0),
+            end: local_datetime(date, 10, 30),
+        };
+
+        let selected = pick_active_occurrence(Some(recurring), Some(one_time))
+            .expect("one occurrence should be selected");
+
+        assert_eq!(selected.kind, WindowOccurrenceKind::OneTime);
+    }
+
+    #[test]
+    fn pick_next_occurrence_prefers_earlier_start() {
+        let date = Local::now().date_naive();
+        let recurring = WindowOccurrence {
+            kind: WindowOccurrenceKind::Recurring,
+            window_index: 0,
+            start: local_datetime(date, 11, 0),
+            end: local_datetime(date, 12, 0),
+        };
+        let one_time = WindowOccurrence {
+            kind: WindowOccurrenceKind::OneTime,
+            window_index: 0,
+            start: local_datetime(date, 10, 0),
+            end: local_datetime(date, 10, 30),
+        };
+
+        let selected = pick_next_occurrence(Some(recurring), Some(one_time))
+            .expect("one occurrence should be selected");
+
+        assert_eq!(selected.kind, WindowOccurrenceKind::OneTime);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,7 +20,8 @@ const PROFILE_EDIT_GROUP_TIMER: [usize; 4] = [0, 1, 2, 3];
 const PROFILE_EDIT_GROUP_AUTOMATION: [usize; 5] = [4, 5, 6, 7, 8];
 const PROFILE_EDIT_GROUP_GOALS: [usize; 2] = [9, 10];
 const PROFILE_EDIT_GROUP_WAKATIME: [usize; 2] = [11, 12];
-const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 9] = [13, 14, 15, 16, 17, 18, 19, 20, 21];
+const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 14] =
+    [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26];
 const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 5] = [
     ("Timer", &PROFILE_EDIT_GROUP_TIMER),
     ("Automation", &PROFILE_EDIT_GROUP_AUTOMATION),
@@ -806,7 +807,7 @@ fn profile_manager_hints(app: &App) -> Vec<Line<'static>> {
         vec![
             Line::from("Sections: Timer · Automation · Goals · WakaTime · Schedule"),
             Line::from(
-                "Edit: [↑/↓] Field  [←/→] Change value (schedule window/day/time/exception)",
+                "Edit: [↑/↓] Field  [←/→] Change value (schedule recurring + one-time windows)",
             ),
             Line::from("Text input: [Type/Backspace] WakaTime project/language"),
             Line::from(if app.strict_mode_enforced_for_focus() {
@@ -855,6 +856,11 @@ fn profile_edit_field_display_label(field_index: usize) -> &'static str {
         19 => "Exception selector",
         20 => "Exception date",
         21 => "Exception add/remove",
+        22 => "One-time selector",
+        23 => "One-time date",
+        24 => "One-time start",
+        25 => "One-time end",
+        26 => "One-time add/remove",
         _ => "",
     }
 }
@@ -1931,7 +1937,7 @@ mod tests {
     #[test]
     fn profile_editor_renders_schedule_fields() {
         let width = 120;
-        let height = 60;
+        let height = 80;
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
         let mut app = App::default();
@@ -1952,6 +1958,11 @@ mod tests {
         assert!(text.contains("Exception selector"));
         assert!(text.contains("Exception date"));
         assert!(text.contains("Exception add/remove"));
+        assert!(text.contains("One-time selector"));
+        assert!(text.contains("One-time date"));
+        assert!(text.contains("One-time start"));
+        assert!(text.contains("One-time end"));
+        assert!(text.contains("One-time add/remove"));
     }
 
     #[test]


### PR DESCRIPTION
## What

- Added date-specific one-time schedule windows via `recurring_schedule.one_time_windows` (`date`, `start`, `end`) in config normalization and runtime compilation.
- Updated schedule evaluation to resolve recurring and one-time windows together for active/next occurrence and trigger behavior, with deterministic overlap handling.
- Extended the profile editor schedule section to manage one-time windows (selector/date/start/end/add-remove) and updated timer schedule status messaging.
- Extended CLI schedule payload handling so `--schedule` / `--schedule-set` can validate, persist, and print one-time windows.
- Updated README and changelog, and added/updated schedule-related tests across config, runtime, app, UI, and CLI paths.

## Why

Issue #181 requires one-time ad-hoc schedule windows without changing existing recurring defaults. This adds a backward-compatible one-time window path so users can schedule specific dates while keeping recurring workflows intact.

Closes #181

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-time, date-specific ad-hoc schedule windows across config, CLI, interactive editor, and runtime; recurring schedules remain supported.
  * Deterministic overlap rules: when windows start simultaneously, one-time windows take precedence; exception dates now skip only recurring windows.

* **Documentation**
  * README and CHANGELOG updated with examples, CLI usage, and editor controls for managing one-time windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->