### PR TITLE
Add schedule conflict inspector for UI and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ cargo run -- --allowlist-site-add "reddit.com"
 cargo run -- --blocklist-site-edit "youtube.com=news.ycombinator.com"
 cargo run -- --allowlist-site-delete reddit.com
 
-# Show schedule or replace recurring + one-time windows atomically from JSON
+# Show schedule (including overlap/conflict inspection) or replace recurring + one-time windows atomically from JSON
 cargo run -- --schedule
 cargo run -- --schedule-set='{"windows":[{"days":["mon","tue"],"start":"09:00","end":"11:00"}],"exception_dates":["2026-12-25"],"one_time_windows":[{"date":"2026-05-02","start":"14:00","end":"16:00"}]}'
 cargo run -- --schedule --json
@@ -362,6 +362,7 @@ Recurring schedule windows can also trigger focus behavior at wall-clock times:
 - while a schedule window is active and focus is not already running, press `z` to delay the scheduled start by 10 minutes
 - recurring exception dates only skip recurring windows; one-time windows still apply on their configured date
 - if multiple windows overlap, the most recently started active window takes precedence; windows with the same start time are resolved deterministically
+- `--schedule` (text and JSON) reports detected schedule conflicts/overlaps without rejecting the schedule
 - the timer session overview shows the current/next scheduled window
 
 You can configure notification and auto-start settings directly from the TUI:
@@ -383,6 +384,7 @@ You can configure notification and auto-start settings directly from the TUI:
   - **One-time date**: `←/→` moves selected one-time window date backward/forward by 1 day
   - **One-time start/end**: adjust one-time window times in 15-minute steps
   - **One-time add/remove**: `→` adds a one-time window (starting from today), `←` removes selected window
+  - **Conflict inspector**: read-only summary of detected schedule overlaps/conflicts
 
 ## Session recovery
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,8 +20,8 @@ use crate::notifications::PhaseNotifier;
 use crate::schedule::{
     OneTimeWindow, RecurringWindow, WindowOccurrence, active_occurrence,
     active_one_time_occurrence, compile_exception_dates, compile_one_time_windows, compile_windows,
-    next_occurrence_after, next_one_time_occurrence_after, occurrence_key, pick_active_occurrence,
-    pick_next_occurrence,
+    format_schedule_conflict, inspect_schedule_conflicts_from_config, next_occurrence_after,
+    next_one_time_occurrence_after, occurrence_key, pick_active_occurrence, pick_next_occurrence,
 };
 use crate::session_recovery::{self, InProgressSessionSnapshot};
 use crate::stats::{
@@ -39,7 +39,7 @@ use crate::wakatime::{WakatimeConfigStatus, WakatimeHeartbeatMetadata, WakatimeT
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
-pub const PROFILE_EDIT_FIELD_LABELS: [&str; 27] = [
+pub const PROFILE_EDIT_FIELD_LABELS: [&str; 28] = [
     "Focus",
     "Short Break",
     "Long Break",
@@ -67,6 +67,7 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 27] = [
     "One-time start",
     "One-time end",
     "One-time add/remove",
+    "Schedule conflicts",
 ];
 const PROFILE_EDIT_WAKATIME_PROJECT_INDEX: usize = 11;
 const PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX: usize = 12;
@@ -84,6 +85,7 @@ const PROFILE_EDIT_ONE_TIME_DATE_INDEX: usize = 23;
 const PROFILE_EDIT_ONE_TIME_START_INDEX: usize = 24;
 const PROFILE_EDIT_ONE_TIME_END_INDEX: usize = 25;
 const PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX: usize = 26;
+const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 27;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
@@ -1012,7 +1014,7 @@ impl App {
     }
 
     pub fn profile_edit_field_value(&self, field_index: usize) -> String {
-        if (PROFILE_EDIT_SCHEDULE_WINDOW_INDEX..=PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX)
+        if (PROFILE_EDIT_SCHEDULE_WINDOW_INDEX..=PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX)
             .contains(&field_index)
         {
             return self.profile_edit_schedule_field_value(field_index);
@@ -1078,8 +1080,25 @@ impl App {
                 .map(|window| window.end.clone())
                 .unwrap_or_else(|| "n/a".to_string()),
             PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX => self.one_time_window_collection_value(),
+            PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX => self.schedule_conflict_summary_value(),
             _ => String::new(),
         }
+    }
+
+    fn schedule_conflict_messages(&self) -> Vec<String> {
+        inspect_schedule_conflicts_from_config(&self.recurring_schedule)
+            .into_iter()
+            .map(|conflict| format_schedule_conflict(&conflict))
+            .collect()
+    }
+
+    fn schedule_conflict_summary_value(&self) -> String {
+        let conflicts = self.schedule_conflict_messages();
+        if conflicts.is_empty() {
+            return "none detected".to_string();
+        }
+
+        format!("{} detected · {}", conflicts.len(), conflicts[0])
     }
 
     fn schedule_window_selector_value(&self) -> String {
@@ -5837,6 +5856,34 @@ mod tests {
             app.recurring_schedule_texts_at(now).1,
             "⚙  Schedule status: ready for next window"
         );
+    }
+
+    #[test]
+    fn profile_edit_schedule_conflict_summary_reports_overlap() {
+        let now = local_datetime_today(10, 15);
+        let config = AppConfig {
+            recurring_schedule: RecurringScheduleConfig {
+                windows: vec![
+                    crate::config::RecurringFocusWindowConfig {
+                        days: vec![weekday_token(now.weekday()).to_string()],
+                        start: "09:00".to_string(),
+                        end: "11:00".to_string(),
+                    },
+                    crate::config::RecurringFocusWindowConfig {
+                        days: vec![weekday_token(now.weekday()).to_string()],
+                        start: "10:30".to_string(),
+                        end: "12:00".to_string(),
+                    },
+                ],
+                ..RecurringScheduleConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let app = App::from_config(config);
+
+        let summary = app.profile_edit_field_value(PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX);
+        assert!(summary.contains("1 detected"));
+        assert!(summary.contains("recurring #1 overlaps recurring #2"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,7 @@ use crate::config::{
     AppConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
     OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig,
 };
+use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
 use crate::stats::{DailyGoalSnapshot, FocusStats, current_day_key};
 use crate::timer::{
@@ -66,7 +67,7 @@ Options:
   --profile       Show current profile, or set it when value is provided
   --goal          Show current daily goal, or set minutes/pomodoros targets
   --strict        Show strict mode, or set on/off
-  --schedule      Show recurring schedule
+  --schedule      Show recurring schedule with overlap/conflict inspection
   --schedule-set  Replace schedule (recurring + one-time) from JSON payload
   --blocklist-profile         Show active blocklist profile, or set active profile
   --blocklist-profile-create  Create a blocklist profile and select it
@@ -421,6 +422,13 @@ struct StrictCommandOutput {
 struct ScheduleCommandOutput {
     updated: bool,
     schedule: RecurringScheduleConfig,
+    inspection: ScheduleInspectionOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ScheduleInspectionOutput {
+    conflict_count: usize,
+    conflicts: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -2051,9 +2059,11 @@ fn execute_schedule_command(
         updated = true;
     }
 
+    let inspection = build_schedule_inspection_output(&config.recurring_schedule);
     let payload = ScheduleCommandOutput {
         updated,
         schedule: config.recurring_schedule,
+        inspection,
     };
 
     match output {
@@ -2957,6 +2967,30 @@ fn print_schedule_command_output(payload: &ScheduleCommandOutput) {
             println!("  - {} {}-{}", window.date, window.start, window.end);
         }
     }
+    if payload.inspection.conflicts.is_empty() {
+        println!("Schedule conflicts: none");
+    } else {
+        println!(
+            "Schedule conflicts: {} detected",
+            payload.inspection.conflict_count
+        );
+        for conflict in &payload.inspection.conflicts {
+            println!("  - {conflict}");
+        }
+    }
+}
+
+fn build_schedule_inspection_output(
+    schedule: &RecurringScheduleConfig,
+) -> ScheduleInspectionOutput {
+    let conflicts = inspect_schedule_conflicts_from_config(schedule)
+        .into_iter()
+        .map(|conflict| format_schedule_conflict(&conflict))
+        .collect::<Vec<_>>();
+    ScheduleInspectionOutput {
+        conflict_count: conflicts.len(),
+        conflicts,
+    }
 }
 
 fn print_diagnostics_command_output(payload: &DiagnosticsCommandOutput) {
@@ -3433,6 +3467,48 @@ mod tests {
                 output: OutputMode::Text
             })
         );
+    }
+
+    #[test]
+    fn schedule_inspection_output_reports_detected_conflicts() {
+        let schedule = RecurringScheduleConfig {
+            windows: vec![
+                RecurringFocusWindowConfig {
+                    days: vec!["mon".to_string()],
+                    start: "09:00".to_string(),
+                    end: "11:00".to_string(),
+                },
+                RecurringFocusWindowConfig {
+                    days: vec!["mon".to_string()],
+                    start: "10:30".to_string(),
+                    end: "12:00".to_string(),
+                },
+            ],
+            ..RecurringScheduleConfig::default()
+        };
+
+        let output = build_schedule_inspection_output(&schedule);
+
+        assert_eq!(output.conflict_count, 1);
+        assert_eq!(output.conflicts.len(), 1);
+        assert!(output.conflicts[0].contains("recurring #1 overlaps recurring #2"));
+    }
+
+    #[test]
+    fn schedule_inspection_output_reports_no_conflicts() {
+        let schedule = RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec!["mon".to_string()],
+                start: "09:00".to_string(),
+                end: "10:00".to_string(),
+            }],
+            ..RecurringScheduleConfig::default()
+        };
+
+        let output = build_schedule_inspection_output(&schedule);
+
+        assert_eq!(output.conflict_count, 0);
+        assert!(output.conflicts.is_empty());
     }
 
     #[test]

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -93,86 +93,13 @@ pub fn inspect_schedule_conflicts(
     recurring_exception_dates: &HashSet<NaiveDate>,
 ) -> Vec<ScheduleConflict> {
     let mut conflicts = Vec::new();
-
-    for (first_index, first) in recurring_windows.iter().enumerate() {
-        for (second_index, second) in recurring_windows.iter().enumerate().skip(first_index + 1) {
-            let Some((overlap_start, overlap_end)) = overlap_minutes(
-                first.start_minutes,
-                first.end_minutes,
-                second.start_minutes,
-                second.end_minutes,
-            ) else {
-                continue;
-            };
-            for day in shared_weekdays(first, second) {
-                conflicts.push(ScheduleConflict {
-                    first_kind: WindowOccurrenceKind::Recurring,
-                    first_window_index: first_index,
-                    second_kind: WindowOccurrenceKind::Recurring,
-                    second_window_index: second_index,
-                    context: ScheduleConflictContext::Weekday(day),
-                    overlap_start_minutes: overlap_start,
-                    overlap_end_minutes: overlap_end,
-                });
-            }
-        }
-    }
-
-    for (first_index, first) in one_time_windows.iter().enumerate() {
-        for (second_index, second) in one_time_windows.iter().enumerate().skip(first_index + 1) {
-            if first.date != second.date {
-                continue;
-            }
-            let Some((overlap_start, overlap_end)) = overlap_minutes(
-                first.start_minutes,
-                first.end_minutes,
-                second.start_minutes,
-                second.end_minutes,
-            ) else {
-                continue;
-            };
-            conflicts.push(ScheduleConflict {
-                first_kind: WindowOccurrenceKind::OneTime,
-                first_window_index: first_index,
-                second_kind: WindowOccurrenceKind::OneTime,
-                second_window_index: second_index,
-                context: ScheduleConflictContext::Date(first.date),
-                overlap_start_minutes: overlap_start,
-                overlap_end_minutes: overlap_end,
-            });
-        }
-    }
-
-    for (recurring_index, recurring_window) in recurring_windows.iter().enumerate() {
-        for (one_time_index, one_time_window) in one_time_windows.iter().enumerate() {
-            if recurring_exception_dates.contains(&one_time_window.date) {
-                continue;
-            }
-            if !recurring_window
-                .days
-                .contains(&one_time_window.date.weekday())
-            {
-                continue;
-            }
-            let Some((overlap_start, overlap_end)) = overlap_minutes(
-                recurring_window.start_minutes,
-                recurring_window.end_minutes,
-                one_time_window.start_minutes,
-                one_time_window.end_minutes,
-            ) else {
-                continue;
-            };
-            conflicts.push(ScheduleConflict {
-                first_kind: WindowOccurrenceKind::Recurring,
-                first_window_index: recurring_index,
-                second_kind: WindowOccurrenceKind::OneTime,
-                second_window_index: one_time_index,
-                context: ScheduleConflictContext::Date(one_time_window.date),
-                overlap_start_minutes: overlap_start,
-                overlap_end_minutes: overlap_end,
-            });
-        }
-    }
+    conflicts.extend(find_recurring_conflicts(recurring_windows));
+    conflicts.extend(find_one_time_conflicts(one_time_windows));
+    conflicts.extend(find_recurring_one_time_conflicts(
+        recurring_windows,
+        one_time_windows,
+        recurring_exception_dates,
+    ));
 
     conflicts.sort_by_key(conflict_sort_key);
     conflicts
@@ -599,6 +526,102 @@ fn format_minutes(total_minutes: u16) -> String {
     format!("{hours:02}:{minutes:02}")
 }
 
+fn find_recurring_conflicts(recurring_windows: &[RecurringWindow]) -> Vec<ScheduleConflict> {
+    let mut conflicts = Vec::new();
+    for (first_index, first) in recurring_windows.iter().enumerate() {
+        for (second_index, second) in recurring_windows.iter().enumerate().skip(first_index + 1) {
+            let Some((overlap_start, overlap_end)) = overlap_minutes(
+                first.start_minutes,
+                first.end_minutes,
+                second.start_minutes,
+                second.end_minutes,
+            ) else {
+                continue;
+            };
+            for day in shared_weekdays(first, second) {
+                conflicts.push(ScheduleConflict {
+                    first_kind: WindowOccurrenceKind::Recurring,
+                    first_window_index: first_index,
+                    second_kind: WindowOccurrenceKind::Recurring,
+                    second_window_index: second_index,
+                    context: ScheduleConflictContext::Weekday(day),
+                    overlap_start_minutes: overlap_start,
+                    overlap_end_minutes: overlap_end,
+                });
+            }
+        }
+    }
+    conflicts
+}
+
+fn find_one_time_conflicts(one_time_windows: &[OneTimeWindow]) -> Vec<ScheduleConflict> {
+    let mut conflicts = Vec::new();
+    for (first_index, first) in one_time_windows.iter().enumerate() {
+        for (second_index, second) in one_time_windows.iter().enumerate().skip(first_index + 1) {
+            if first.date != second.date {
+                continue;
+            }
+            let Some((overlap_start, overlap_end)) = overlap_minutes(
+                first.start_minutes,
+                first.end_minutes,
+                second.start_minutes,
+                second.end_minutes,
+            ) else {
+                continue;
+            };
+            conflicts.push(ScheduleConflict {
+                first_kind: WindowOccurrenceKind::OneTime,
+                first_window_index: first_index,
+                second_kind: WindowOccurrenceKind::OneTime,
+                second_window_index: second_index,
+                context: ScheduleConflictContext::Date(first.date),
+                overlap_start_minutes: overlap_start,
+                overlap_end_minutes: overlap_end,
+            });
+        }
+    }
+    conflicts
+}
+
+fn find_recurring_one_time_conflicts(
+    recurring_windows: &[RecurringWindow],
+    one_time_windows: &[OneTimeWindow],
+    recurring_exception_dates: &HashSet<NaiveDate>,
+) -> Vec<ScheduleConflict> {
+    let mut conflicts = Vec::new();
+    for (recurring_index, recurring_window) in recurring_windows.iter().enumerate() {
+        for (one_time_index, one_time_window) in one_time_windows.iter().enumerate() {
+            if recurring_exception_dates.contains(&one_time_window.date) {
+                continue;
+            }
+            if !recurring_window
+                .days
+                .contains(&one_time_window.date.weekday())
+            {
+                continue;
+            }
+            let Some((overlap_start, overlap_end)) = overlap_minutes(
+                recurring_window.start_minutes,
+                recurring_window.end_minutes,
+                one_time_window.start_minutes,
+                one_time_window.end_minutes,
+            ) else {
+                continue;
+            };
+            conflicts.push(ScheduleConflict {
+                first_kind: WindowOccurrenceKind::Recurring,
+                first_window_index: recurring_index,
+                second_kind: WindowOccurrenceKind::OneTime,
+                second_window_index: one_time_index,
+                context: ScheduleConflictContext::Date(one_time_window.date),
+                overlap_start_minutes: overlap_start,
+                overlap_end_minutes: overlap_end,
+            });
+        }
+    }
+    conflicts
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -932,6 +955,34 @@ mod tests {
         assert_eq!(conflicts[0].second_kind, WindowOccurrenceKind::Recurring);
         assert_eq!(conflicts[0].overlap_start_minutes, 10 * 60 + 30);
         assert_eq!(conflicts[0].overlap_end_minutes, 11 * 60);
+    }
+
+    #[test]
+    fn inspect_schedule_conflicts_detects_one_time_overlap_on_same_date() {
+        let date = Local::now().date_naive();
+        let schedule = RecurringScheduleConfig {
+            one_time_windows: vec![
+                OneTimeFocusWindowConfig {
+                    date: date.format("%Y-%m-%d").to_string(),
+                    start: "14:00".to_string(),
+                    end: "16:00".to_string(),
+                },
+                OneTimeFocusWindowConfig {
+                    date: date.format("%Y-%m-%d").to_string(),
+                    start: "15:30".to_string(),
+                    end: "17:00".to_string(),
+                },
+            ],
+            ..RecurringScheduleConfig::default()
+        };
+
+        let conflicts = inspect_schedule_conflicts_from_config(&schedule);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].first_kind, WindowOccurrenceKind::OneTime);
+        assert_eq!(conflicts[0].second_kind, WindowOccurrenceKind::OneTime);
+        assert_eq!(conflicts[0].overlap_start_minutes, 15 * 60 + 30);
+        assert_eq!(conflicts[0].overlap_end_minutes, 16 * 60);
     }
 
     #[test]

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -4,7 +4,9 @@ use chrono::{
     DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, TimeZone, Timelike, Weekday,
 };
 
-use crate::config::{OneTimeFocusWindowConfig, RecurringFocusWindowConfig};
+use crate::config::{
+    OneTimeFocusWindowConfig, RecurringFocusWindowConfig, RecurringScheduleConfig,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecurringWindow {
@@ -34,6 +36,23 @@ pub struct WindowOccurrence {
     pub end: DateTime<Local>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScheduleConflictContext {
+    Weekday(Weekday),
+    Date(NaiveDate),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScheduleConflict {
+    pub first_kind: WindowOccurrenceKind,
+    pub first_window_index: usize,
+    pub second_kind: WindowOccurrenceKind,
+    pub second_window_index: usize,
+    pub context: ScheduleConflictContext,
+    pub overlap_start_minutes: u16,
+    pub overlap_end_minutes: u16,
+}
+
 pub fn compile_windows(config_windows: &[RecurringFocusWindowConfig]) -> Vec<RecurringWindow> {
     config_windows
         .iter()
@@ -53,6 +72,126 @@ pub fn compile_exception_dates(config_dates: &[String]) -> HashSet<NaiveDate> {
         .iter()
         .filter_map(|value| parse_exception_date(value))
         .collect()
+}
+
+pub fn inspect_schedule_conflicts_from_config(
+    schedule: &RecurringScheduleConfig,
+) -> Vec<ScheduleConflict> {
+    let recurring_windows = compile_windows(&schedule.windows);
+    let one_time_windows = compile_one_time_windows(&schedule.one_time_windows);
+    let recurring_exception_dates = compile_exception_dates(&schedule.exception_dates);
+    inspect_schedule_conflicts(
+        &recurring_windows,
+        &one_time_windows,
+        &recurring_exception_dates,
+    )
+}
+
+pub fn inspect_schedule_conflicts(
+    recurring_windows: &[RecurringWindow],
+    one_time_windows: &[OneTimeWindow],
+    recurring_exception_dates: &HashSet<NaiveDate>,
+) -> Vec<ScheduleConflict> {
+    let mut conflicts = Vec::new();
+
+    for (first_index, first) in recurring_windows.iter().enumerate() {
+        for (second_index, second) in recurring_windows.iter().enumerate().skip(first_index + 1) {
+            let Some((overlap_start, overlap_end)) = overlap_minutes(
+                first.start_minutes,
+                first.end_minutes,
+                second.start_minutes,
+                second.end_minutes,
+            ) else {
+                continue;
+            };
+            for day in shared_weekdays(first, second) {
+                conflicts.push(ScheduleConflict {
+                    first_kind: WindowOccurrenceKind::Recurring,
+                    first_window_index: first_index,
+                    second_kind: WindowOccurrenceKind::Recurring,
+                    second_window_index: second_index,
+                    context: ScheduleConflictContext::Weekday(day),
+                    overlap_start_minutes: overlap_start,
+                    overlap_end_minutes: overlap_end,
+                });
+            }
+        }
+    }
+
+    for (first_index, first) in one_time_windows.iter().enumerate() {
+        for (second_index, second) in one_time_windows.iter().enumerate().skip(first_index + 1) {
+            if first.date != second.date {
+                continue;
+            }
+            let Some((overlap_start, overlap_end)) = overlap_minutes(
+                first.start_minutes,
+                first.end_minutes,
+                second.start_minutes,
+                second.end_minutes,
+            ) else {
+                continue;
+            };
+            conflicts.push(ScheduleConflict {
+                first_kind: WindowOccurrenceKind::OneTime,
+                first_window_index: first_index,
+                second_kind: WindowOccurrenceKind::OneTime,
+                second_window_index: second_index,
+                context: ScheduleConflictContext::Date(first.date),
+                overlap_start_minutes: overlap_start,
+                overlap_end_minutes: overlap_end,
+            });
+        }
+    }
+
+    for (recurring_index, recurring_window) in recurring_windows.iter().enumerate() {
+        for (one_time_index, one_time_window) in one_time_windows.iter().enumerate() {
+            if recurring_exception_dates.contains(&one_time_window.date) {
+                continue;
+            }
+            if !recurring_window
+                .days
+                .contains(&one_time_window.date.weekday())
+            {
+                continue;
+            }
+            let Some((overlap_start, overlap_end)) = overlap_minutes(
+                recurring_window.start_minutes,
+                recurring_window.end_minutes,
+                one_time_window.start_minutes,
+                one_time_window.end_minutes,
+            ) else {
+                continue;
+            };
+            conflicts.push(ScheduleConflict {
+                first_kind: WindowOccurrenceKind::Recurring,
+                first_window_index: recurring_index,
+                second_kind: WindowOccurrenceKind::OneTime,
+                second_window_index: one_time_index,
+                context: ScheduleConflictContext::Date(one_time_window.date),
+                overlap_start_minutes: overlap_start,
+                overlap_end_minutes: overlap_end,
+            });
+        }
+    }
+
+    conflicts.sort_by_key(conflict_sort_key);
+    conflicts
+}
+
+pub fn format_schedule_conflict(conflict: &ScheduleConflict) -> String {
+    let context = match conflict.context {
+        ScheduleConflictContext::Weekday(day) => day_token(day).to_uppercase(),
+        ScheduleConflictContext::Date(date) => date.format("%Y-%m-%d").to_string(),
+    };
+    format!(
+        "{context}: {} #{} overlaps {} #{} at {}-{}",
+        conflict_kind_label(conflict.first_kind),
+        conflict.first_window_index + 1,
+        conflict_kind_label(conflict.second_kind),
+        conflict.second_window_index + 1,
+        format_minutes(conflict.overlap_start_minutes),
+        format_minutes(conflict.overlap_end_minutes)
+    )
 }
 
 pub fn occurrence_key(occurrence: &WindowOccurrence) -> String {
@@ -385,6 +524,81 @@ fn local_datetime_on(date: NaiveDate, total_minutes: u16) -> Option<DateTime<Loc
     }
 }
 
+fn shared_weekdays(first: &RecurringWindow, second: &RecurringWindow) -> Vec<Weekday> {
+    let mut shared = Vec::new();
+    for day in &first.days {
+        if second.days.contains(day) {
+            shared.push(*day);
+        }
+    }
+    shared.sort_by_key(|day| day.num_days_from_monday());
+    shared
+}
+
+fn overlap_minutes(
+    first_start_minutes: u16,
+    first_end_minutes: u16,
+    second_start_minutes: u16,
+    second_end_minutes: u16,
+) -> Option<(u16, u16)> {
+    let overlap_start = first_start_minutes.max(second_start_minutes);
+    let overlap_end = first_end_minutes.min(second_end_minutes);
+    if overlap_start < overlap_end {
+        Some((overlap_start, overlap_end))
+    } else {
+        None
+    }
+}
+
+fn conflict_sort_key(conflict: &ScheduleConflict) -> (u8, i32, u16, u16, u8, usize, u8, usize) {
+    let context_key = match conflict.context {
+        ScheduleConflictContext::Weekday(day) => (0_u8, day.num_days_from_monday() as i32),
+        ScheduleConflictContext::Date(date) => (1_u8, date.num_days_from_ce()),
+    };
+    (
+        context_key.0,
+        context_key.1,
+        conflict.overlap_start_minutes,
+        conflict.overlap_end_minutes,
+        conflict_kind_rank(conflict.first_kind),
+        conflict.first_window_index,
+        conflict_kind_rank(conflict.second_kind),
+        conflict.second_window_index,
+    )
+}
+
+fn conflict_kind_rank(kind: WindowOccurrenceKind) -> u8 {
+    match kind {
+        WindowOccurrenceKind::Recurring => 0,
+        WindowOccurrenceKind::OneTime => 1,
+    }
+}
+
+fn conflict_kind_label(kind: WindowOccurrenceKind) -> &'static str {
+    match kind {
+        WindowOccurrenceKind::Recurring => "recurring",
+        WindowOccurrenceKind::OneTime => "one-time",
+    }
+}
+
+fn day_token(day: Weekday) -> &'static str {
+    match day {
+        Weekday::Mon => "mon",
+        Weekday::Tue => "tue",
+        Weekday::Wed => "wed",
+        Weekday::Thu => "thu",
+        Weekday::Fri => "fri",
+        Weekday::Sat => "sat",
+        Weekday::Sun => "sun",
+    }
+}
+
+fn format_minutes(total_minutes: u16) -> String {
+    let hours = total_minutes / 60;
+    let minutes = total_minutes % 60;
+    format!("{hours:02}:{minutes:02}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -690,5 +904,100 @@ mod tests {
             .expect("one occurrence should be selected");
 
         assert_eq!(selected.kind, WindowOccurrenceKind::OneTime);
+    }
+
+    #[test]
+    fn inspect_schedule_conflicts_detects_recurring_overlap_on_shared_weekday() {
+        let date = Local::now().date_naive();
+        let schedule = RecurringScheduleConfig {
+            windows: vec![
+                RecurringFocusWindowConfig {
+                    days: vec![date.weekday().to_string()],
+                    start: "09:00".to_string(),
+                    end: "11:00".to_string(),
+                },
+                RecurringFocusWindowConfig {
+                    days: vec![date.weekday().to_string()],
+                    start: "10:30".to_string(),
+                    end: "12:00".to_string(),
+                },
+            ],
+            ..RecurringScheduleConfig::default()
+        };
+
+        let conflicts = inspect_schedule_conflicts_from_config(&schedule);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].first_kind, WindowOccurrenceKind::Recurring);
+        assert_eq!(conflicts[0].second_kind, WindowOccurrenceKind::Recurring);
+        assert_eq!(conflicts[0].overlap_start_minutes, 10 * 60 + 30);
+        assert_eq!(conflicts[0].overlap_end_minutes, 11 * 60);
+    }
+
+    #[test]
+    fn inspect_schedule_conflicts_detects_one_time_and_recurring_overlap() {
+        let date = Local::now().date_naive();
+        let schedule = RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec![date.weekday().to_string()],
+                start: "09:00".to_string(),
+                end: "11:00".to_string(),
+            }],
+            one_time_windows: vec![OneTimeFocusWindowConfig {
+                date: date.format("%Y-%m-%d").to_string(),
+                start: "10:45".to_string(),
+                end: "11:30".to_string(),
+            }],
+            ..RecurringScheduleConfig::default()
+        };
+
+        let conflicts = inspect_schedule_conflicts_from_config(&schedule);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].first_kind, WindowOccurrenceKind::Recurring);
+        assert_eq!(conflicts[0].second_kind, WindowOccurrenceKind::OneTime);
+        assert_eq!(conflicts[0].overlap_start_minutes, 10 * 60 + 45);
+        assert_eq!(conflicts[0].overlap_end_minutes, 11 * 60);
+    }
+
+    #[test]
+    fn inspect_schedule_conflicts_skips_recurring_vs_one_time_on_exception_date() {
+        let date = Local::now().date_naive();
+        let schedule = RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec![date.weekday().to_string()],
+                start: "09:00".to_string(),
+                end: "11:00".to_string(),
+            }],
+            exception_dates: vec![date.format("%Y-%m-%d").to_string()],
+            one_time_windows: vec![OneTimeFocusWindowConfig {
+                date: date.format("%Y-%m-%d").to_string(),
+                start: "10:45".to_string(),
+                end: "11:30".to_string(),
+            }],
+        };
+
+        let conflicts = inspect_schedule_conflicts_from_config(&schedule);
+
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn format_schedule_conflict_includes_context_and_overlap_window() {
+        let date = NaiveDate::from_ymd_opt(2026, 5, 2).expect("date literal should be valid");
+        let conflict = ScheduleConflict {
+            first_kind: WindowOccurrenceKind::Recurring,
+            first_window_index: 0,
+            second_kind: WindowOccurrenceKind::OneTime,
+            second_window_index: 1,
+            context: ScheduleConflictContext::Date(date),
+            overlap_start_minutes: 14 * 60,
+            overlap_end_minutes: 15 * 60,
+        };
+
+        assert_eq!(
+            format_schedule_conflict(&conflict),
+            "2026-05-02: recurring #1 overlaps one-time #2 at 14:00-15:00"
+        );
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,8 +20,8 @@ const PROFILE_EDIT_GROUP_TIMER: [usize; 4] = [0, 1, 2, 3];
 const PROFILE_EDIT_GROUP_AUTOMATION: [usize; 5] = [4, 5, 6, 7, 8];
 const PROFILE_EDIT_GROUP_GOALS: [usize; 2] = [9, 10];
 const PROFILE_EDIT_GROUP_WAKATIME: [usize; 2] = [11, 12];
-const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 14] =
-    [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26];
+const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 15] =
+    [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27];
 const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 5] = [
     ("Timer", &PROFILE_EDIT_GROUP_TIMER),
     ("Automation", &PROFILE_EDIT_GROUP_AUTOMATION),
@@ -807,7 +807,7 @@ fn profile_manager_hints(app: &App) -> Vec<Line<'static>> {
         vec![
             Line::from("Sections: Timer · Automation · Goals · WakaTime · Schedule"),
             Line::from(
-                "Edit: [↑/↓] Field  [←/→] Change value (schedule recurring + one-time windows)",
+                "Edit: [↑/↓] Field  [←/→] Change value (schedule recurring + one-time windows; inspector is read-only)",
             ),
             Line::from("Text input: [Type/Backspace] WakaTime project/language"),
             Line::from(if app.strict_mode_enforced_for_focus() {
@@ -861,6 +861,7 @@ fn profile_edit_field_display_label(field_index: usize) -> &'static str {
         24 => "One-time start",
         25 => "One-time end",
         26 => "One-time add/remove",
+        27 => "Conflict inspector",
         _ => "",
     }
 }
@@ -1969,6 +1970,7 @@ mod tests {
         assert!(text.contains("One-time start"));
         assert!(text.contains("One-time end"));
         assert!(text.contains("One-time add/remove"));
+        assert!(text.contains("Conflict inspector"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Add a non-blocking schedule conflict inspector that detects overlapping recurring and one-time windows, then surfaces those findings in both the TUI and CLI.

- Added schedule conflict detection and formatting in `src/schedule.rs` with deterministic ordering.
- Added a read-only `Conflict inspector` field in the profile schedule editor so users can inspect overlap findings in-app.
- Extended `--schedule` / `--schedule-set` outputs so text and JSON now include inspection results (`conflict_count` and `conflicts`).
- Updated schedule docs in `README.md` and added coverage in schedule/app/ui/cli tests.

## Why

Closes #183.

Users can configure overlapping schedule windows today, but there was no explicit inspector surface to review conflicts. This change keeps schedule updates backward compatible (`--schedule-set` still saves) while reporting conflicts so users can fix or accept overlaps intentionally.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A, none added)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR (N/A, no breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schedule conflict detection that identifies overlapping time windows and returns a count plus human-readable descriptions in both text and JSON outputs.
  * Profile editor includes a read-only "Conflict inspector" field that summarizes detected overlaps or shows "none detected".
  * The --schedule command now performs overlap inspection and appends inspection results.

* **Documentation**
  * README updated to document the conflict inspection behavior and TUI help entry for the Conflict inspector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->