### PR TITLE
Prepare v0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-04-26
+
 ### Added
 
-- **One-time ad-hoc schedule windows (#181):** added date-specific one-time schedule windows across config/CLI/TUI/runtime flows while preserving recurring schedule defaults and compatibility.
+- **One-time ad-hoc schedule windows (#213):** added date-specific one-time schedule windows across config/CLI/TUI/runtime flows while preserving recurring schedule defaults and compatibility.
+- **Schedule delay shortcut for active windows (#214):** added a 10-minute schedule snooze/delay control for currently active schedule windows.
+- **Schedule conflict inspector for UI/CLI (#215):** added overlap/conflict inspection surfaces in both TUI and CLI schedule workflows.
+
+### Changed
+
+- **One-time schedule normalization hardening (#213):** prevented malformed one-time window date/time fields from being coerced into valid windows during normalization.
+- **Schedule conflict review hardening (#215):** refined conflict-inspection implementation and added direct one-time overlap regression coverage from review follow-up.
 
 ## [0.6.1] - 2026-04-26
 
@@ -162,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/utilForever/focustime/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/utilForever/focustime/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/utilForever/focustime/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/utilForever/focustime/compare/v0.5.1...v0.5.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -505,12 +505,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.6.1`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.6.2`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.6.1](https://github.com/utilForever/focustime/releases/tag/v0.6.1).
+The latest stable release is [v0.6.2](https://github.com/utilForever/focustime/releases/tag/v0.6.2).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Update release-facing metadata and docs for `v0.6.2`, including crate version bumps and changelog release content/link updates.

## Why

Issue #216 requests publishing `v0.6.2` details consistently across package metadata and documentation. This also fixes the `0.6.2` changelog section so it reflects the actual merged PRs for the release (`#213`, `#214`, `#215`) instead of an incorrect reference.

Closes #216

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable) (N/A, docs/version metadata only)
- [x] Site blocking behavior was verified for this change (if applicable) (N/A, docs/version metadata only)
- [x] WakaTime integration behavior was verified for this change (if applicable) (N/A, docs/version metadata only)
- [x] I added or updated tests for changed behavior (if applicable) (N/A, no runtime behavior changes)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A, none added)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) (N/A, docs/version metadata only)
- [x] Breaking behavior changes are clearly described in this PR (N/A, no breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.6.2

* **New Features**
  * Added schedule delay handling for active windows
  * Added schedule conflict inspection in UI and CLI

* **Bug Fixes**
  * Improved validation to prevent malformed date/time fields in one-time windows
  * Enhanced schedule conflict review with regression testing coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->