### PR TITLE
Add weekly and monthly goals across CLI and TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ cargo run -- --goal
 cargo run -- --goal=120,4
 cargo run -- --goal --json
 
+# Show or set weekly goal targets (minutes,pomodoros)
+cargo run -- --goal-weekly
+cargo run -- --goal-weekly=600,20
+cargo run -- --goal-weekly --json
+
+# Show or set monthly goal targets (minutes,pomodoros)
+cargo run -- --goal-monthly
+cargo run -- --goal-monthly=2400,80
+cargo run -- --goal-monthly --json
+
 # Show or set strict mode
 cargo run -- --strict
 cargo run -- --strict=on
@@ -282,6 +292,14 @@ end = "16:00"
 minutes = 120
 pomodoros = 4
 
+[weekly_goal]
+minutes = 600
+pomodoros = 20
+
+[monthly_goal]
+minutes = 2400
+pomodoros = 80
+
 [wakatime]
 project = "focustime"
 language = "Pomodoro"
@@ -370,7 +388,7 @@ You can configure notification and auto-start settings directly from the TUI:
 - open profile manager with `p`
 - press `e` to open the editor
 - the editor is grouped into sections (**Timer**, **Automation**, **Goals**, **WakaTime**, **Schedule**) to keep settings easier to scan
-- use `↑/↓` to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily goal (minutes)**, **Daily goal (pomodoros)**, **WakaTime project/language**, or the **Schedule** fields
+- use `↑/↓` to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily/Weekly/Monthly goal (minutes)**, **Daily/Weekly/Monthly goal (pomodoros)**, **WakaTime project/language**, or the **Schedule** fields
 - use `←/→` to adjust values (or toggle `Off`/`On` for boolean fields), use `Type/Backspace` for WakaTime text fields, then `Enter` to save
 - schedule editing is in-app:
   - **Schedule add/remove**: `→` adds a window, `←` removes selected window
@@ -432,8 +450,8 @@ Override events are recorded for audit visibility in the History view and includ
 - per-task trend summaries in History (`last 7 days` vs `previous 7 days`)
 - current streak and best streak based on completed daily goals
 
-If a daily goal is configured, timer and history views also show live progress for
-both:
+If daily, weekly, or monthly goals are configured, timer and history views also
+show live progress for each period:
 
 - target focused minutes
 - target completed pomodoros

--- a/src/app.rs
+++ b/src/app.rs
@@ -4912,6 +4912,38 @@ mod tests {
     }
 
     #[test]
+    fn editing_weekly_and_monthly_goal_fields_updates_and_persists_settings() {
+        let mut app = App::default();
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX;
+        app.handle_key(key(KeyCode::Right)); // weekly minutes -> 5m
+        app.handle_key(key(KeyCode::Right)); // weekly minutes -> 10m
+        app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX;
+        app.handle_key(key(KeyCode::Right)); // weekly pomodoros -> 1
+        app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX;
+        app.handle_key(key(KeyCode::Right)); // monthly minutes -> 5m
+        app.handle_key(key(KeyCode::Right)); // monthly minutes -> 10m
+        app.handle_key(key(KeyCode::Right)); // monthly minutes -> 15m
+        app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX;
+        app.handle_key(key(KeyCode::Right)); // monthly pomodoros -> 1
+        app.handle_key(key(KeyCode::Right)); // monthly pomodoros -> 2
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(app.weekly_goal.minutes, 10);
+        assert_eq!(app.weekly_goal.pomodoros, 1);
+        assert_eq!(app.monthly_goal.minutes, 15);
+        assert_eq!(app.monthly_goal.pomodoros, 2);
+
+        let persisted = app.persisted_config();
+        assert_eq!(persisted.weekly_goal.minutes, 10);
+        assert_eq!(persisted.weekly_goal.pomodoros, 1);
+        assert_eq!(persisted.monthly_goal.minutes, 15);
+        assert_eq!(persisted.monthly_goal.pomodoros, 2);
+    }
+
+    #[test]
     fn cancelling_profile_edit_restores_recurring_schedule_settings() {
         let original_schedule = RecurringScheduleConfig {
             windows: vec![RecurringFocusWindowConfig {
@@ -5036,6 +5068,39 @@ mod tests {
 
         assert_eq!(app.daily_goal.minutes, 25);
         assert_eq!(app.daily_goal.pomodoros, 3);
+    }
+
+    #[test]
+    fn cancelling_profile_edit_restores_weekly_and_monthly_goal_settings() {
+        let config = AppConfig {
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 120,
+                pomodoros: 4,
+            },
+            monthly_goal: MonthlyGoalConfig {
+                minutes: 600,
+                pomodoros: 20,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX;
+        app.handle_key(key(KeyCode::Right)); // weekly minutes -> 125m
+        app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX;
+        app.handle_key(key(KeyCode::Right)); // weekly pomodoros -> 5
+        app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX;
+        app.handle_key(key(KeyCode::Left)); // monthly minutes -> 595m
+        app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX;
+        app.handle_key(key(KeyCode::Left)); // monthly pomodoros -> 19
+        app.handle_key(key(KeyCode::Esc)); // cancel
+
+        assert_eq!(app.weekly_goal.minutes, 120);
+        assert_eq!(app.weekly_goal.pomodoros, 4);
+        assert_eq!(app.monthly_goal.minutes, 600);
+        assert_eq!(app.monthly_goal.pomodoros, 20);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,8 +13,8 @@ use crate::blocker::{
 };
 use crate::config::{
     AppConfig, AutoStartConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
-    NotificationConfig, OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig,
-    RecurringScheduleConfig, WakatimeMetadataConfig,
+    MonthlyGoalConfig, NotificationConfig, OneTimeFocusWindowConfig, ProfileId,
+    RecurringFocusWindowConfig, RecurringScheduleConfig, WakatimeMetadataConfig, WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -39,7 +39,7 @@ use crate::wakatime::{WakatimeConfigStatus, WakatimeHeartbeatMetadata, WakatimeT
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
-pub const PROFILE_EDIT_FIELD_LABELS: [&str; 28] = [
+pub const PROFILE_EDIT_FIELD_LABELS: [&str; 32] = [
     "Focus",
     "Short Break",
     "Long Break",
@@ -49,8 +49,12 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 28] = [
     "Auto-start break",
     "Auto-start focus",
     "Strict focus mode",
-    "Goal minutes",
-    "Goal pomodoros",
+    "Daily goal minutes",
+    "Daily goal pomodoros",
+    "Weekly goal minutes",
+    "Weekly goal pomodoros",
+    "Monthly goal minutes",
+    "Monthly goal pomodoros",
     "WakaTime project",
     "WakaTime language",
     "Schedule window",
@@ -69,23 +73,29 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 28] = [
     "One-time add/remove",
     "Schedule conflicts",
 ];
-const PROFILE_EDIT_WAKATIME_PROJECT_INDEX: usize = 11;
-const PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX: usize = 12;
-const PROFILE_EDIT_SCHEDULE_WINDOW_INDEX: usize = 13;
-const PROFILE_EDIT_SCHEDULE_DAY_INDEX: usize = 14;
-const PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX: usize = 15;
-const PROFILE_EDIT_SCHEDULE_START_INDEX: usize = 16;
-const PROFILE_EDIT_SCHEDULE_END_INDEX: usize = 17;
-const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 18;
-const PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX: usize = 19;
-const PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX: usize = 20;
-const PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX: usize = 21;
-const PROFILE_EDIT_ONE_TIME_WINDOW_INDEX: usize = 22;
-const PROFILE_EDIT_ONE_TIME_DATE_INDEX: usize = 23;
-const PROFILE_EDIT_ONE_TIME_START_INDEX: usize = 24;
-const PROFILE_EDIT_ONE_TIME_END_INDEX: usize = 25;
-const PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX: usize = 26;
-const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 27;
+const PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX: usize = 9;
+const PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX: usize = 10;
+const PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX: usize = 11;
+const PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX: usize = 12;
+const PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX: usize = 13;
+const PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX: usize = 14;
+const PROFILE_EDIT_WAKATIME_PROJECT_INDEX: usize = 15;
+const PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX: usize = 16;
+const PROFILE_EDIT_SCHEDULE_WINDOW_INDEX: usize = 17;
+const PROFILE_EDIT_SCHEDULE_DAY_INDEX: usize = 18;
+const PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX: usize = 19;
+const PROFILE_EDIT_SCHEDULE_START_INDEX: usize = 20;
+const PROFILE_EDIT_SCHEDULE_END_INDEX: usize = 21;
+const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 22;
+const PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX: usize = 23;
+const PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX: usize = 24;
+const PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX: usize = 25;
+const PROFILE_EDIT_ONE_TIME_WINDOW_INDEX: usize = 26;
+const PROFILE_EDIT_ONE_TIME_DATE_INDEX: usize = 27;
+const PROFILE_EDIT_ONE_TIME_START_INDEX: usize = 28;
+const PROFILE_EDIT_ONE_TIME_END_INDEX: usize = 29;
+const PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX: usize = 30;
+const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 31;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
@@ -176,6 +186,8 @@ struct ProfileEditSnapshot {
     recurring_schedule: RecurringScheduleConfig,
     strict_mode: bool,
     daily_goal: DailyGoalConfig,
+    weekly_goal: WeeklyGoalConfig,
+    monthly_goal: MonthlyGoalConfig,
     wakatime_metadata: WakatimeMetadataConfig,
 }
 
@@ -447,6 +459,8 @@ pub struct App {
     break_glass_duration_secs: u64,
     break_glass_expires_at: Option<Instant>,
     daily_goal: DailyGoalConfig,
+    weekly_goal: WeeklyGoalConfig,
+    monthly_goal: MonthlyGoalConfig,
     wakatime_metadata: WakatimeMetadataConfig,
     pending_timer_action: Option<PendingTimerAction>,
     notifier: PhaseNotifier,
@@ -481,6 +495,8 @@ impl App {
         let strict_mode = config.strict_mode;
         let break_glass_duration_secs = config.break_glass_duration_secs;
         let daily_goal = config.daily_goal;
+        let weekly_goal = config.weekly_goal;
+        let monthly_goal = config.monthly_goal;
         let wakatime_metadata = config.wakatime;
         let blocklist_profiles = config.blocklist_profiles.clone();
         let active_blocklist_profile =
@@ -566,6 +582,8 @@ impl App {
             break_glass_duration_secs,
             break_glass_expires_at: None,
             daily_goal,
+            weekly_goal,
+            monthly_goal,
             wakatime_metadata,
             pending_timer_action: None,
             notifier: PhaseNotifier::new(notification_settings),
@@ -939,6 +957,28 @@ impl App {
         self.daily_goal_progress_for(self.today_stats())
     }
 
+    pub fn current_week_goal_progress(&self) -> DailyGoalProgress {
+        let today = Local::now().date_naive();
+        let week = self.stats.weekly_for_day(today);
+        goal_progress_for_totals(
+            week.focused_minutes(),
+            week.pomodoros_completed,
+            self.weekly_goal.minutes,
+            self.weekly_goal.pomodoros,
+        )
+    }
+
+    pub fn current_month_goal_progress(&self) -> DailyGoalProgress {
+        let today = Local::now().date_naive();
+        let month = self.stats.monthly_for_day(today);
+        goal_progress_for_totals(
+            month.focused_minutes(),
+            month.pomodoros_completed,
+            self.monthly_goal.minutes,
+            self.monthly_goal.pomodoros,
+        )
+    }
+
     pub fn goal_streak(&self) -> GoalStreak {
         self.goal_streak_for_day_key(&current_day_key())
     }
@@ -956,13 +996,12 @@ impl App {
     }
 
     pub fn daily_goal_progress_for(&self, stats: DailyStats) -> DailyGoalProgress {
-        DailyGoalProgress {
-            minutes: goal_progress(stats.focused_minutes(), self.daily_goal.minutes),
-            pomodoros: goal_progress(
-                u64::from(stats.pomodoros_completed),
-                u64::from(self.daily_goal.pomodoros),
-            ),
-        }
+        goal_progress_for_totals(
+            stats.focused_minutes(),
+            stats.pomodoros_completed,
+            self.daily_goal.minutes,
+            self.daily_goal.pomodoros,
+        )
     }
 
     pub fn recent_daily_stats(&self, limit: usize) -> Vec<(String, DailyStats)> {
@@ -1033,8 +1072,24 @@ impl App {
             6 => bool_label(self.auto_start.focus_to_break).to_string(),
             7 => bool_label(self.auto_start.break_to_focus).to_string(),
             8 => bool_label(self.strict_mode).to_string(),
-            9 => format_daily_goal_minutes_label(self.daily_goal.minutes),
-            10 => format_daily_goal_pomodoros_label(self.daily_goal.pomodoros),
+            PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX => {
+                format_daily_goal_minutes_label(self.daily_goal.minutes)
+            }
+            PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX => {
+                format_daily_goal_pomodoros_label(self.daily_goal.pomodoros)
+            }
+            PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX => {
+                format_daily_goal_minutes_label(self.weekly_goal.minutes)
+            }
+            PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX => {
+                format_daily_goal_pomodoros_label(self.weekly_goal.pomodoros)
+            }
+            PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX => {
+                format_daily_goal_minutes_label(self.monthly_goal.minutes)
+            }
+            PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX => {
+                format_daily_goal_pomodoros_label(self.monthly_goal.pomodoros)
+            }
             PROFILE_EDIT_WAKATIME_PROJECT_INDEX => self.wakatime_metadata.project.clone(),
             PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX => self.wakatime_metadata.language.clone(),
             _ => String::new(),
@@ -1890,6 +1945,8 @@ impl App {
             strict_mode: self.strict_mode,
             break_glass_duration_secs: self.break_glass_duration_secs,
             daily_goal: self.daily_goal,
+            weekly_goal: self.weekly_goal,
+            monthly_goal: self.monthly_goal,
             wakatime: self.wakatime_metadata.clone(),
         }
     }
@@ -2459,6 +2516,8 @@ impl App {
             recurring_schedule: self.recurring_schedule.clone(),
             strict_mode: self.strict_mode,
             daily_goal: self.daily_goal,
+            weekly_goal: self.weekly_goal,
+            monthly_goal: self.monthly_goal,
             wakatime_metadata: self.wakatime_metadata.clone(),
         });
         self.profile_edit_active = true;
@@ -2478,6 +2537,8 @@ impl App {
             self.recurring_schedule = snapshot.recurring_schedule;
             self.strict_mode = snapshot.strict_mode;
             self.daily_goal = snapshot.daily_goal;
+            self.weekly_goal = snapshot.weekly_goal;
+            self.monthly_goal = snapshot.monthly_goal;
             self.wakatime_metadata = snapshot.wakatime_metadata;
             self.sync_wakatime_metadata_to_tracker();
             self.rebuild_notifier();
@@ -2504,6 +2565,14 @@ impl App {
             .profile_edit_snapshot
             .as_ref()
             .is_some_and(|snapshot| snapshot.daily_goal != self.daily_goal);
+        let weekly_goal_changed = self
+            .profile_edit_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.weekly_goal != self.weekly_goal);
+        let monthly_goal_changed = self
+            .profile_edit_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.monthly_goal != self.monthly_goal);
         self.custom_profile = self.custom_profile.normalized();
         self.recurring_schedule = normalized_schedule;
         self.wakatime_metadata = self.wakatime_metadata.normalized();
@@ -2529,7 +2598,7 @@ impl App {
             self.current_frame_now = now;
             self.sync_recurring_schedule(now);
         }
-        if daily_goal_changed {
+        if daily_goal_changed || weekly_goal_changed || monthly_goal_changed {
             self.sync_today_goal_snapshot();
         }
         self.profile_edit_active = false;
@@ -2577,11 +2646,23 @@ impl App {
                 }
                 self.strict_mode = increase;
             }
-            9 => {
+            PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX => {
                 adjust_daily_goal_minutes(&mut self.daily_goal.minutes, increase);
             }
-            10 => {
+            PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX => {
                 adjust_daily_goal_pomodoros(&mut self.daily_goal.pomodoros, increase);
+            }
+            PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX => {
+                adjust_daily_goal_minutes(&mut self.weekly_goal.minutes, increase);
+            }
+            PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX => {
+                adjust_daily_goal_pomodoros(&mut self.weekly_goal.pomodoros, increase);
+            }
+            PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX => {
+                adjust_daily_goal_minutes(&mut self.monthly_goal.minutes, increase);
+            }
+            PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX => {
+                adjust_daily_goal_pomodoros(&mut self.monthly_goal.pomodoros, increase);
             }
             PROFILE_EDIT_SCHEDULE_WINDOW_INDEX => {
                 self.cycle_schedule_window(increase);
@@ -4070,6 +4151,18 @@ fn goal_progress(completed: u64, target: u64) -> GoalProgress {
     }
 }
 
+fn goal_progress_for_totals(
+    focused_minutes: u64,
+    pomodoros_completed: u32,
+    target_minutes: u64,
+    target_pomodoros: u32,
+) -> DailyGoalProgress {
+    DailyGoalProgress {
+        minutes: goal_progress(focused_minutes, target_minutes),
+        pomodoros: goal_progress(u64::from(pomodoros_completed), u64::from(target_pomodoros)),
+    }
+}
+
 fn ceil_duration_secs(duration: Duration) -> u64 {
     let secs = duration.as_secs();
     if duration.subsec_nanos() > 0 {
@@ -4285,6 +4378,8 @@ mod tests {
         assert_eq!(app.recurring_schedule, RecurringScheduleConfig::default());
         assert!(!app.strict_mode);
         assert_eq!(app.daily_goal, DailyGoalConfig::default());
+        assert_eq!(app.weekly_goal, WeeklyGoalConfig::default());
+        assert_eq!(app.monthly_goal, MonthlyGoalConfig::default());
     }
 
     #[test]
@@ -4310,6 +4405,8 @@ mod tests {
             strict_mode: false,
             break_glass_duration_secs: 5 * 60,
             daily_goal: DailyGoalConfig::default(),
+            weekly_goal: WeeklyGoalConfig::default(),
+            monthly_goal: MonthlyGoalConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
         };
         let app = App::from_config(config);
@@ -4607,8 +4704,12 @@ mod tests {
         assert_eq!(app.profile_edit_field_value(8), "Off");
         assert_eq!(app.profile_edit_field_value(9), "Off");
         assert_eq!(app.profile_edit_field_value(10), "Off");
-        assert_eq!(app.profile_edit_field_value(11), "focustime");
-        assert_eq!(app.profile_edit_field_value(12), "Pomodoro");
+        assert_eq!(app.profile_edit_field_value(11), "Off");
+        assert_eq!(app.profile_edit_field_value(12), "Off");
+        assert_eq!(app.profile_edit_field_value(13), "Off");
+        assert_eq!(app.profile_edit_field_value(14), "Off");
+        assert_eq!(app.profile_edit_field_value(15), "focustime");
+        assert_eq!(app.profile_edit_field_value(16), "Pomodoro");
     }
 
     #[test]
@@ -4851,7 +4952,7 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char('p')));
         app.handle_key(key(KeyCode::Char('e')));
-        for _ in 0..11 {
+        for _ in 0..PROFILE_EDIT_WAKATIME_PROJECT_INDEX {
             app.handle_key(key(KeyCode::Down));
         }
         app.handle_key(key(KeyCode::Backspace));
@@ -4895,7 +4996,7 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char('p')));
         app.handle_key(key(KeyCode::Char('e')));
-        for _ in 0..11 {
+        for _ in 0..PROFILE_EDIT_WAKATIME_PROJECT_INDEX {
             app.handle_key(key(KeyCode::Down));
         }
         app.handle_key(key(KeyCode::Backspace));
@@ -4986,6 +5087,44 @@ mod tests {
         assert_eq!(progress.pomodoros.completed, 1);
         assert_eq!(progress.pomodoros.target, 4);
         assert!((progress.pomodoros.ratio - 0.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn weekly_and_monthly_goal_progress_use_current_period_totals() {
+        let config = AppConfig {
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 100,
+                pomodoros: 3,
+            },
+            monthly_goal: MonthlyGoalConfig {
+                minutes: 90,
+                pomodoros: 3,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let day_key = current_day_key();
+        app.stats
+            .record_focus_elapsed(&day_key, 120 * 60, app.current_goal_snapshot());
+        app.stats
+            .record_completed_pomodoro(&day_key, app.current_goal_snapshot());
+
+        let weekly = app.current_week_goal_progress();
+        let monthly = app.current_month_goal_progress();
+
+        assert_eq!(weekly.minutes.completed, 120);
+        assert_eq!(weekly.minutes.target, 100);
+        assert!((weekly.minutes.ratio - 1.0).abs() < f64::EPSILON);
+        assert_eq!(weekly.pomodoros.completed, 1);
+        assert_eq!(weekly.pomodoros.target, 3);
+        assert!((weekly.pomodoros.ratio - (1.0 / 3.0)).abs() < f64::EPSILON);
+
+        assert_eq!(monthly.minutes.completed, 120);
+        assert_eq!(monthly.minutes.target, 90);
+        assert!((monthly.minutes.ratio - 1.0).abs() < f64::EPSILON);
+        assert_eq!(monthly.pomodoros.completed, 1);
+        assert_eq!(monthly.pomodoros.target, 3);
+        assert!((monthly.pomodoros.ratio - (1.0 / 3.0)).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -6472,6 +6611,8 @@ mod tests {
             recurring_schedule: app.recurring_schedule.clone(),
             strict_mode: app.strict_mode,
             daily_goal: app.daily_goal,
+            weekly_goal: app.weekly_goal,
+            monthly_goal: app.monthly_goal,
             wakatime_metadata: app.wakatime_metadata.clone(),
         });
         app.custom_profile.focus_secs = app.custom_profile.focus_secs.saturating_add(60);
@@ -6514,6 +6655,8 @@ mod tests {
             recurring_schedule: app.recurring_schedule.clone(),
             strict_mode: app.strict_mode,
             daily_goal: app.daily_goal,
+            weekly_goal: app.weekly_goal,
+            monthly_goal: app.monthly_goal,
             wakatime_metadata: app.wakatime_metadata.clone(),
         });
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,8 +14,9 @@ use serde::Serialize;
 use crate::app::{App, SetupCheck, SetupCheckLevel, SetupDiagnostics};
 use crate::blocker::{BlockingPreviewAction, EditSiteResult, InvalidSiteInput, SiteBlocker};
 use crate::config::{
-    AppConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
+    AppConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig, MonthlyGoalConfig,
     OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig,
+    WeeklyGoalConfig,
 };
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
@@ -36,6 +37,10 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --profile [classic|deep-work|custom] [--json]
   focustime --goal [--json]
   focustime --goal=MINUTES,POMODOROS [--json]
+  focustime --goal-weekly [--json]
+  focustime --goal-weekly=MINUTES,POMODOROS [--json]
+  focustime --goal-monthly [--json]
+  focustime --goal-monthly=MINUTES,POMODOROS [--json]
   focustime --strict [--json]
   focustime --strict=on|off [--json]
   focustime --schedule [--json]
@@ -66,6 +71,8 @@ Options:
   --task          Select task label (auto-creates unknown labels)
   --profile       Show current profile, or set it when value is provided
   --goal          Show current daily goal, or set minutes/pomodoros targets
+  --goal-weekly   Show current weekly goal, or set minutes/pomodoros targets
+  --goal-monthly  Show current monthly goal, or set minutes/pomodoros targets
   --strict        Show strict mode, or set on/off
   --schedule      Show recurring schedule with overlap/conflict inspection
   --schedule-set  Replace schedule (recurring + one-time) from JSON payload
@@ -150,6 +157,12 @@ pub enum CommandKind {
     Goal {
         goal: Option<DailyGoalConfig>,
     },
+    GoalWeekly {
+        goal: Option<WeeklyGoalConfig>,
+    },
+    GoalMonthly {
+        goal: Option<MonthlyGoalConfig>,
+    },
     Strict {
         enabled: Option<bool>,
     },
@@ -196,6 +209,8 @@ enum PrimaryCommand {
     Task(String),
     Profile(Option<ProfileId>),
     Goal(Option<DailyGoalConfig>),
+    GoalWeekly(Option<WeeklyGoalConfig>),
+    GoalMonthly(Option<MonthlyGoalConfig>),
     Strict(Option<bool>),
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
@@ -231,6 +246,8 @@ enum ParsedToken {
     Watch(Option<u64>),
     Profile(Option<ProfileId>),
     Goal(Option<DailyGoalConfig>),
+    GoalWeekly(Option<WeeklyGoalConfig>),
+    GoalMonthly(Option<MonthlyGoalConfig>),
     Strict(Option<bool>),
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
@@ -366,6 +383,8 @@ struct StatusOutput {
     blocked_sites_count: usize,
     strict_mode: bool,
     goal: GoalOutput,
+    weekly_goal: GoalOutput,
+    monthly_goal: GoalOutput,
     session: SessionOutput,
     today: TodayOutput,
     live: LiveStatusOutput,
@@ -641,10 +660,12 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 16] = [
+    let parsers: [(&str, ValueArgParser); 18] = [
         ("--task", classify_task_arg),
         ("--profile", classify_profile_arg),
         ("--goal", classify_goal_arg),
+        ("--goal-weekly", classify_goal_weekly_arg),
+        ("--goal-monthly", classify_goal_monthly_arg),
         ("--strict", classify_strict_arg),
         ("--schedule-set", classify_schedule_set_arg),
         ("--watch", classify_watch_arg),
@@ -908,6 +929,33 @@ fn classify_goal_arg(args: &[String], index: usize) -> Result<(ParsedToken, usiz
     Ok((ParsedToken::Goal(None), 1))
 }
 
+fn classify_goal_weekly_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((
+            ParsedToken::GoalWeekly(Some(parse_weekly_goal_value(next)?)),
+            2,
+        ));
+    }
+    Ok((ParsedToken::GoalWeekly(None), 1))
+}
+
+fn classify_goal_monthly_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((
+            ParsedToken::GoalMonthly(Some(parse_monthly_goal_value(next)?)),
+            2,
+        ));
+    }
+    Ok((ParsedToken::GoalMonthly(None), 1))
+}
+
 fn classify_strict_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
     if let Some(next) = args.get(index + 1)
         && !next.starts_with('-')
@@ -932,10 +980,12 @@ fn classify_schedule_set_arg(
 }
 
 fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 16] = [
+    let parsers: [KeyValueParser; 18] = [
         parse_task_key_value_arg,
         parse_profile_key_value_arg,
         parse_goal_key_value_arg,
+        parse_goal_weekly_key_value_arg,
+        parse_goal_monthly_key_value_arg,
         parse_strict_key_value_arg,
         parse_schedule_set_key_value_arg,
         parse_watch_key_value_arg,
@@ -983,6 +1033,32 @@ fn parse_goal_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
             "`--goal=` requires values in `MINUTES,POMODOROS` format.",
         )?;
         return Ok(Some(ParsedToken::Goal(Some(parse_goal_value(value)?))));
+    }
+    Ok(None)
+}
+
+fn parse_goal_weekly_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--goal-weekly=") {
+        let value = require_nonempty_key_value(
+            value,
+            "`--goal-weekly=` requires values in `MINUTES,POMODOROS` format.",
+        )?;
+        return Ok(Some(ParsedToken::GoalWeekly(Some(
+            parse_weekly_goal_value(value)?,
+        ))));
+    }
+    Ok(None)
+}
+
+fn parse_goal_monthly_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--goal-monthly=") {
+        let value = require_nonempty_key_value(
+            value,
+            "`--goal-monthly=` requires values in `MINUTES,POMODOROS` format.",
+        )?;
+        return Ok(Some(ParsedToken::GoalMonthly(Some(
+            parse_monthly_goal_value(value)?,
+        ))));
     }
     Ok(None)
 }
@@ -1148,6 +1224,8 @@ fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), Str
             | ParsedToken::Watch(_)
             | ParsedToken::Profile(_)
             | ParsedToken::Goal(_)
+            | ParsedToken::GoalWeekly(_)
+            | ParsedToken::GoalMonthly(_)
             | ParsedToken::Strict(_)
             | ParsedToken::Schedule
             | ParsedToken::ScheduleSet(_)
@@ -1190,6 +1268,12 @@ fn parse_primary_command(tokens: &[ParsedToken]) -> Result<Option<PrimaryCommand
             }
             ParsedToken::Goal(goal) => {
                 set_primary_command(&mut primary, PrimaryCommand::Goal(*goal))?
+            }
+            ParsedToken::GoalWeekly(goal) => {
+                set_primary_command(&mut primary, PrimaryCommand::GoalWeekly(*goal))?
+            }
+            ParsedToken::GoalMonthly(goal) => {
+                set_primary_command(&mut primary, PrimaryCommand::GoalMonthly(*goal))?
             }
             ParsedToken::Strict(enabled) => {
                 set_primary_command(&mut primary, PrimaryCommand::Strict(*enabled))?
@@ -1300,6 +1384,14 @@ fn finalize_cli_action(
         })),
         Some(PrimaryCommand::Goal(goal)) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Goal { goal },
+            output,
+        })),
+        Some(PrimaryCommand::GoalWeekly(goal)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::GoalWeekly { goal },
+            output,
+        })),
+        Some(PrimaryCommand::GoalMonthly(goal)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::GoalMonthly { goal },
             output,
         })),
         Some(PrimaryCommand::Strict(enabled)) => Ok(CliAction::RunCommand(CliCommand {
@@ -1450,6 +1542,8 @@ pub fn execute_command(cli_command: CliCommand) -> Result<(), String> {
         CommandKind::Task { label } => execute_task_command(label, cli_command.output),
         CommandKind::Profile { profile } => execute_profile_command(profile, cli_command.output),
         CommandKind::Goal { goal } => execute_goal_command(goal, cli_command.output),
+        CommandKind::GoalWeekly { goal } => execute_weekly_goal_command(goal, cli_command.output),
+        CommandKind::GoalMonthly { goal } => execute_monthly_goal_command(goal, cli_command.output),
         CommandKind::Strict { enabled } => execute_strict_command(enabled, cli_command.output),
         CommandKind::Schedule { schedule } => {
             execute_schedule_command(schedule, cli_command.output)
@@ -2016,7 +2110,63 @@ fn execute_goal_command(goal: Option<DailyGoalConfig>, output: OutputMode) -> Re
     };
 
     match output {
-        OutputMode::Text => print_goal_command_output(&payload),
+        OutputMode::Text => print_goal_command_output("Daily", &payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_weekly_goal_command(
+    goal: Option<WeeklyGoalConfig>,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let mut updated = false;
+    if let Some(goal) = goal {
+        config.weekly_goal = goal;
+        config
+            .save()
+            .map_err(|error| format!("Failed to save weekly goal: {error}"))?;
+        updated = true;
+    }
+
+    let payload = GoalCommandOutput {
+        updated,
+        configured: config.weekly_goal.minutes > 0 || config.weekly_goal.pomodoros > 0,
+        minutes_target: config.weekly_goal.minutes,
+        pomodoros_target: config.weekly_goal.pomodoros,
+    };
+
+    match output {
+        OutputMode::Text => print_goal_command_output("Weekly", &payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_monthly_goal_command(
+    goal: Option<MonthlyGoalConfig>,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let mut updated = false;
+    if let Some(goal) = goal {
+        config.monthly_goal = goal;
+        config
+            .save()
+            .map_err(|error| format!("Failed to save monthly goal: {error}"))?;
+        updated = true;
+    }
+
+    let payload = GoalCommandOutput {
+        updated,
+        configured: config.monthly_goal.minutes > 0 || config.monthly_goal.pomodoros > 0,
+        minutes_target: config.monthly_goal.minutes,
+        pomodoros_target: config.monthly_goal.pomodoros,
+    };
+
+    match output {
+        OutputMode::Text => print_goal_command_output("Monthly", &payload),
         OutputMode::Json => print_json(&payload)?,
     }
     Ok(())
@@ -2222,7 +2372,11 @@ fn build_timer_state_output(app: &App) -> TimerStateOutput {
 
 fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let day = current_day_key();
+    let day_date = NaiveDate::parse_from_str(&day, "%Y-%m-%d")
+        .expect("current_day_key should always be a valid ISO date");
     let today = stats.daily_for(&day);
+    let week = stats.weekly_for_day(day_date);
+    let month = stats.monthly_for_day(day_date);
     let session = stats.session();
     let (_, selected_task_label) = stats.task_planner_state();
     let (selected_task_label, focus_intention, task_note) =
@@ -2230,6 +2384,14 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let goal_snapshot = DailyGoalSnapshot {
         minutes: config.daily_goal.minutes,
         pomodoros: config.daily_goal.pomodoros,
+    };
+    let weekly_goal_snapshot = DailyGoalSnapshot {
+        minutes: config.weekly_goal.minutes,
+        pomodoros: config.weekly_goal.pomodoros,
+    };
+    let monthly_goal_snapshot = DailyGoalSnapshot {
+        minutes: config.monthly_goal.minutes,
+        pomodoros: config.monthly_goal.pomodoros,
     };
     let active_sites_count = config
         .blocklist_profiles
@@ -2257,6 +2419,20 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
             minutes_target: goal_snapshot.minutes,
             pomodoros_target: goal_snapshot.pomodoros,
             met: goal_snapshot.is_met_by(today),
+        },
+        weekly_goal: GoalOutput {
+            configured: weekly_goal_snapshot.has_any_target(),
+            minutes_target: weekly_goal_snapshot.minutes,
+            pomodoros_target: weekly_goal_snapshot.pomodoros,
+            met: weekly_goal_snapshot
+                .is_met_by_totals(week.focused_minutes(), week.pomodoros_completed),
+        },
+        monthly_goal: GoalOutput {
+            configured: monthly_goal_snapshot.has_any_target(),
+            minutes_target: monthly_goal_snapshot.minutes,
+            pomodoros_target: monthly_goal_snapshot.pomodoros,
+            met: monthly_goal_snapshot
+                .is_met_by_totals(month.focused_minutes(), month.pomodoros_completed),
         },
         session: SessionOutput {
             focused_minutes: session.focused_minutes(),
@@ -2420,23 +2596,38 @@ fn parse_profile_id(value: &str) -> Result<ProfileId, String> {
 }
 
 fn parse_goal_value(value: &str) -> Result<DailyGoalConfig, String> {
+    let (minutes, pomodoros) = parse_goal_components(value, "--goal")?;
+    Ok(DailyGoalConfig { minutes, pomodoros })
+}
+
+fn parse_weekly_goal_value(value: &str) -> Result<WeeklyGoalConfig, String> {
+    let (minutes, pomodoros) = parse_goal_components(value, "--goal-weekly")?;
+    Ok(WeeklyGoalConfig { minutes, pomodoros })
+}
+
+fn parse_monthly_goal_value(value: &str) -> Result<MonthlyGoalConfig, String> {
+    let (minutes, pomodoros) = parse_goal_components(value, "--goal-monthly")?;
+    Ok(MonthlyGoalConfig { minutes, pomodoros })
+}
+
+fn parse_goal_components(value: &str, flag: &str) -> Result<(u64, u32), String> {
     let trimmed = value.trim();
     let (minutes_raw, pomodoros_raw) = trimmed.split_once(',').ok_or_else(|| {
         invalid_usage(&format!(
-            "Invalid goal `{value}`. Use `--goal=MINUTES,POMODOROS` (for example `--goal=120,4`)."
+            "Invalid goal `{value}`. Use `{flag}=MINUTES,POMODOROS` (for example `{flag}=120,4`)."
         ))
     })?;
     let minutes = minutes_raw.trim().parse::<u64>().map_err(|_| {
         invalid_usage(&format!(
-            "Invalid goal minutes in `{value}`. Use a non-negative integer."
+            "Invalid goal minutes in `{value}` for `{flag}`. Use a non-negative integer."
         ))
     })?;
     let pomodoros = pomodoros_raw.trim().parse::<u32>().map_err(|_| {
         invalid_usage(&format!(
-            "Invalid goal pomodoros in `{value}`. Use a non-negative integer."
+            "Invalid goal pomodoros in `{value}` for `{flag}`. Use a non-negative integer."
         ))
     })?;
-    Ok(DailyGoalConfig { minutes, pomodoros })
+    Ok((minutes, pomodoros))
 }
 
 fn parse_strict_value(value: &str) -> Result<bool, String> {
@@ -2633,6 +2824,8 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Task(_) => "--task",
         PrimaryCommand::Profile(_) => "--profile",
         PrimaryCommand::Goal(_) => "--goal",
+        PrimaryCommand::GoalWeekly(_) => "--goal-weekly",
+        PrimaryCommand::GoalMonthly(_) => "--goal-monthly",
         PrimaryCommand::Strict(_) => "--strict",
         PrimaryCommand::Schedule => "--schedule",
         PrimaryCommand::ScheduleSet(_) => "--schedule-set",
@@ -2840,20 +3033,9 @@ fn print_status_output(payload: &StatusOutput) {
         "Today: {} focused minutes, {} pomodoros",
         payload.today.focused_minutes, payload.today.pomodoros_completed
     );
-    if payload.goal.configured {
-        println!(
-            "Goal: {} min, {} pomodoros ({})",
-            payload.goal.minutes_target,
-            payload.goal.pomodoros_target,
-            if payload.goal.met {
-                "met"
-            } else {
-                "in progress"
-            }
-        );
-    } else {
-        println!("Goal: off");
-    }
+    print_status_goal_line("Daily goal", &payload.goal);
+    print_status_goal_line("Weekly goal", &payload.weekly_goal);
+    print_status_goal_line("Monthly goal", &payload.monthly_goal);
     println!(
         "Session: {} focused minutes, {} pomodoros",
         payload.session.focused_minutes, payload.session.pomodoros_completed
@@ -2875,6 +3057,19 @@ fn print_status_output(payload: &StatusOutput) {
     );
     if let Some(error) = payload.live.recovery_error.as_deref() {
         println!("Live timer warning: {error}");
+    }
+}
+
+fn print_status_goal_line(label: &str, goal: &GoalOutput) {
+    if goal.configured {
+        println!(
+            "{label}: {} min, {} pomodoros ({})",
+            goal.minutes_target,
+            goal.pomodoros_target,
+            if goal.met { "met" } else { "in progress" }
+        );
+    } else {
+        println!("{label}: off");
     }
 }
 
@@ -2910,17 +3105,17 @@ fn print_export_output(payload: &ExportOutput) {
     println!("CSV: {}", payload.csv_path.display());
 }
 
-fn print_goal_command_output(payload: &GoalCommandOutput) {
+fn print_goal_command_output(label: &str, payload: &GoalCommandOutput) {
     if payload.updated {
-        println!("Daily goal updated.");
+        println!("{label} goal updated.");
     }
     if payload.configured {
         println!(
-            "Daily goal: {} min, {} pomodoros",
+            "{label} goal: {} min, {} pomodoros",
             payload.minutes_target, payload.pomodoros_target
         );
     } else {
-        println!("Daily goal: off");
+        println!("{label} goal: off");
     }
 }
 
@@ -3384,6 +3579,52 @@ mod tests {
     }
 
     #[test]
+    fn parse_weekly_goal_without_value_reads_current_goal() {
+        let parsed = parse(&["--goal-weekly"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::GoalWeekly { goal: None },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_weekly_goal_with_equals_sets_goal() {
+        let parsed = parse(&["--goal-weekly=420,14"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::GoalWeekly {
+                    goal: Some(WeeklyGoalConfig {
+                        minutes: 420,
+                        pomodoros: 14
+                    })
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_monthly_goal_with_value_sets_goal() {
+        let parsed = parse(&["--goal-monthly", "1800,60"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::GoalMonthly {
+                    goal: Some(MonthlyGoalConfig {
+                        minutes: 1800,
+                        pomodoros: 60
+                    })
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
     fn parse_strict_without_value_reads_current_state() {
         let parsed = parse(&["--strict"]).unwrap();
         assert_eq!(
@@ -3726,6 +3967,30 @@ mod tests {
     }
 
     #[test]
+    fn classify_key_value_arg_accepts_weekly_goal_equals_value() {
+        let parsed = classify_key_value_arg("--goal-weekly=420,14").unwrap();
+        assert_eq!(
+            parsed,
+            Some(ParsedToken::GoalWeekly(Some(WeeklyGoalConfig {
+                minutes: 420,
+                pomodoros: 14
+            })))
+        );
+    }
+
+    #[test]
+    fn classify_key_value_arg_accepts_monthly_goal_equals_value() {
+        let parsed = classify_key_value_arg("--goal-monthly=1800,60").unwrap();
+        assert_eq!(
+            parsed,
+            Some(ParsedToken::GoalMonthly(Some(MonthlyGoalConfig {
+                minutes: 1800,
+                pomodoros: 60
+            })))
+        );
+    }
+
+    #[test]
     fn classify_key_value_arg_accepts_strict_equals_value() {
         let parsed = classify_key_value_arg("--strict=off").unwrap();
         assert_eq!(parsed, Some(ParsedToken::Strict(Some(false))));
@@ -3759,6 +4024,18 @@ mod tests {
     fn classify_key_value_arg_rejects_empty_goal_equals_value() {
         let error = classify_key_value_arg("--goal=").unwrap_err();
         assert!(error.contains("`--goal=` requires values"));
+    }
+
+    #[test]
+    fn classify_key_value_arg_rejects_empty_weekly_goal_equals_value() {
+        let error = classify_key_value_arg("--goal-weekly=").unwrap_err();
+        assert!(error.contains("`--goal-weekly=` requires values"));
+    }
+
+    #[test]
+    fn classify_key_value_arg_rejects_empty_monthly_goal_equals_value() {
+        let error = classify_key_value_arg("--goal-monthly=").unwrap_err();
+        assert!(error.contains("`--goal-monthly=` requires values"));
     }
 
     #[test]
@@ -3800,6 +4077,18 @@ mod tests {
     #[test]
     fn parse_rejects_goal_without_two_numbers() {
         let error = parse(&["--goal=120"]).unwrap_err();
+        assert!(error.contains("Invalid goal"));
+    }
+
+    #[test]
+    fn parse_rejects_weekly_goal_without_two_numbers() {
+        let error = parse(&["--goal-weekly=120"]).unwrap_err();
+        assert!(error.contains("Invalid goal"));
+    }
+
+    #[test]
+    fn parse_rejects_monthly_goal_without_two_numbers() {
+        let error = parse(&["--goal-monthly=120"]).unwrap_err();
         assert!(error.contains("Invalid goal"));
     }
 
@@ -4226,6 +4515,43 @@ mod tests {
         let output = build_status_output(&config, &stats);
 
         assert_eq!(output.blocked_sites_count, 1);
+    }
+
+    #[test]
+    fn build_status_output_reports_daily_weekly_monthly_goal_state() {
+        let mut stats = FocusStats::default();
+        let today = current_day_key();
+        let daily_snapshot = DailyGoalSnapshot {
+            minutes: 30,
+            pomodoros: 1,
+        };
+        stats.record_focus_elapsed(&today, 30 * 60, daily_snapshot);
+        stats.record_completed_pomodoro(&today, daily_snapshot);
+
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 30,
+                pomodoros: 1,
+            },
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 30,
+                pomodoros: 1,
+            },
+            monthly_goal: MonthlyGoalConfig {
+                minutes: 30,
+                pomodoros: 1,
+            },
+            ..AppConfig::default()
+        };
+
+        let output = build_status_output(&config, &stats);
+
+        assert!(output.goal.configured);
+        assert!(output.goal.met);
+        assert!(output.weekly_goal.configured);
+        assert!(output.weekly_goal.met);
+        assert!(output.monthly_goal.configured);
+        assert!(output.monthly_goal.met);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3351,6 +3351,7 @@ mod tests {
     use crate::session_recovery::{
         self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
     };
+    use chrono::{Datelike, Duration};
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
 
@@ -4521,37 +4522,86 @@ mod tests {
     fn build_status_output_reports_daily_weekly_monthly_goal_state() {
         let mut stats = FocusStats::default();
         let today = current_day_key();
+        let today_date = NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse as a date");
+        let weekly_day = (-6..=6)
+            .filter(|offset| *offset != 0)
+            .map(|offset| today_date + Duration::days(i64::from(offset)))
+            .find(|candidate| candidate.iso_week() == today_date.iso_week())
+            .expect("there should be at least one nearby day in the current ISO week");
+        let monthly_day = (-31..=31)
+            .filter(|offset| *offset != 0)
+            .map(|offset| today_date + Duration::days(i64::from(offset)))
+            .find(|candidate| {
+                candidate.year() == today_date.year()
+                    && candidate.month() == today_date.month()
+                    && candidate.iso_week() != today_date.iso_week()
+            })
+            .expect("there should be at least one nearby day in the current month");
+        let outside_period_day = today_date - Duration::days(40);
+
         let daily_snapshot = DailyGoalSnapshot {
             minutes: 30,
             pomodoros: 1,
         };
         stats.record_focus_elapsed(&today, 30 * 60, daily_snapshot);
         stats.record_completed_pomodoro(&today, daily_snapshot);
+        let weekly_day_key = weekly_day.format("%Y-%m-%d").to_string();
+        stats.record_focus_elapsed(&weekly_day_key, 20 * 60, daily_snapshot);
+        stats.record_completed_pomodoro(&weekly_day_key, daily_snapshot);
+        let monthly_day_key = monthly_day.format("%Y-%m-%d").to_string();
+        stats.record_focus_elapsed(&monthly_day_key, 25 * 60, daily_snapshot);
+        stats.record_completed_pomodoro(&monthly_day_key, daily_snapshot);
+        let outside_period_day_key = outside_period_day.format("%Y-%m-%d").to_string();
+        stats.record_focus_elapsed(&outside_period_day_key, 200 * 60, daily_snapshot);
+        stats.record_completed_pomodoro(&outside_period_day_key, daily_snapshot);
 
-        let config = AppConfig {
+        let in_period_config = AppConfig {
             daily_goal: DailyGoalConfig {
                 minutes: 30,
                 pomodoros: 1,
             },
             weekly_goal: WeeklyGoalConfig {
-                minutes: 30,
-                pomodoros: 1,
+                minutes: 50,
+                pomodoros: 2,
             },
             monthly_goal: MonthlyGoalConfig {
-                minutes: 30,
-                pomodoros: 1,
+                minutes: 55,
+                pomodoros: 2,
             },
             ..AppConfig::default()
         };
 
-        let output = build_status_output(&config, &stats);
+        let in_period_output = build_status_output(&in_period_config, &stats);
 
-        assert!(output.goal.configured);
-        assert!(output.goal.met);
-        assert!(output.weekly_goal.configured);
-        assert!(output.weekly_goal.met);
-        assert!(output.monthly_goal.configured);
-        assert!(output.monthly_goal.met);
+        assert!(in_period_output.goal.configured);
+        assert!(in_period_output.goal.met);
+        assert!(in_period_output.weekly_goal.configured);
+        assert!(in_period_output.weekly_goal.met);
+        assert!(in_period_output.monthly_goal.configured);
+        assert!(in_period_output.monthly_goal.met);
+
+        let boundary_config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 30,
+                pomodoros: 1,
+            },
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 120,
+                pomodoros: 3,
+            },
+            monthly_goal: MonthlyGoalConfig {
+                minutes: 120,
+                pomodoros: 3,
+            },
+            ..AppConfig::default()
+        };
+
+        let boundary_output = build_status_output(&boundary_config, &stats);
+
+        assert!(boundary_output.goal.met);
+        assert!(!boundary_output.weekly_goal.met);
+        assert!(!boundary_output.monthly_goal.met);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,16 @@ pub struct AppConfig {
     /// A value of `0` disables the corresponding goal.
     #[serde(default)]
     pub daily_goal: DailyGoalConfig,
+    /// Weekly goal settings for focus minutes and completed pomodoros.
+    ///
+    /// A value of `0` disables the corresponding goal.
+    #[serde(default)]
+    pub weekly_goal: WeeklyGoalConfig,
+    /// Monthly goal settings for focus minutes and completed pomodoros.
+    ///
+    /// A value of `0` disables the corresponding goal.
+    #[serde(default)]
+    pub monthly_goal: MonthlyGoalConfig,
     /// WakaTime heartbeat metadata labels.
     #[serde(default)]
     pub wakatime: WakatimeMetadataConfig,
@@ -234,6 +244,26 @@ pub struct DailyGoalConfig {
     #[serde(default)]
     pub minutes: u64,
     /// Target completed pomodoros for the current day.
+    #[serde(default)]
+    pub pomodoros: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct WeeklyGoalConfig {
+    /// Target focused minutes for the current week.
+    #[serde(default)]
+    pub minutes: u64,
+    /// Target completed pomodoros for the current week.
+    #[serde(default)]
+    pub pomodoros: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct MonthlyGoalConfig {
+    /// Target focused minutes for the current month.
+    #[serde(default)]
+    pub minutes: u64,
+    /// Target completed pomodoros for the current month.
     #[serde(default)]
     pub pomodoros: u32,
 }
@@ -433,6 +463,8 @@ impl Default for AppConfig {
             strict_mode: false,
             break_glass_duration_secs: default_break_glass_duration_secs(),
             daily_goal: DailyGoalConfig::default(),
+            weekly_goal: WeeklyGoalConfig::default(),
+            monthly_goal: MonthlyGoalConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
         }
     }
@@ -795,6 +827,8 @@ mod tests {
             default_break_glass_duration_secs()
         );
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
+        assert_eq!(cfg.weekly_goal, WeeklyGoalConfig::default());
+        assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
         assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }
 
@@ -853,6 +887,14 @@ mod tests {
                 minutes: 180,
                 pomodoros: 6,
             },
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 600,
+                pomodoros: 20,
+            },
+            monthly_goal: MonthlyGoalConfig {
+                minutes: 2400,
+                pomodoros: 80,
+            },
             wakatime: WakatimeMetadataConfig {
                 project: "Team Focus".to_string(),
                 language: "Focus Session".to_string(),
@@ -881,6 +923,8 @@ mod tests {
             original.break_glass_duration_secs
         );
         assert_eq!(parsed.daily_goal, original.daily_goal);
+        assert_eq!(parsed.weekly_goal, original.weekly_goal);
+        assert_eq!(parsed.monthly_goal, original.monthly_goal);
         assert_eq!(parsed.wakatime, original.wakatime);
     }
 
@@ -906,6 +950,8 @@ mod tests {
             default_break_glass_duration_secs()
         );
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
+        assert_eq!(cfg.weekly_goal, WeeklyGoalConfig::default());
+        assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
         assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }
 
@@ -1104,6 +1150,8 @@ blocked_sites = ["reddit.com", "youtube.com"]
             RecurringScheduleConfig::default()
         );
         assert_eq!(parsed.daily_goal, DailyGoalConfig::default());
+        assert_eq!(parsed.weekly_goal, WeeklyGoalConfig::default());
+        assert_eq!(parsed.monthly_goal, MonthlyGoalConfig::default());
         assert_eq!(parsed.wakatime, WakatimeMetadataConfig::default());
     }
 
@@ -1146,6 +1194,8 @@ long_break_interval = 3
             strict_mode: false,
             break_glass_duration_secs: default_break_glass_duration_secs(),
             daily_goal: DailyGoalConfig::default(),
+            weekly_goal: WeeklyGoalConfig::default(),
+            monthly_goal: MonthlyGoalConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
         };
         let custom = cfg.effective_custom_profile();
@@ -1198,6 +1248,8 @@ long_break_interval = 3
             default_break_glass_duration_secs()
         );
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
+        assert_eq!(cfg.weekly_goal, WeeklyGoalConfig::default());
+        assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
         assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -45,10 +45,14 @@ impl DailyGoalSnapshot {
         self.minutes > 0 || self.pomodoros > 0
     }
 
-    pub fn is_met_by(self, stats: DailyStats) -> bool {
+    pub fn is_met_by_totals(self, focused_minutes: u64, pomodoros_completed: u32) -> bool {
         self.has_any_target()
-            && (self.minutes == 0 || stats.focused_minutes() >= self.minutes)
-            && (self.pomodoros == 0 || stats.pomodoros_completed >= self.pomodoros)
+            && (self.minutes == 0 || focused_minutes >= self.minutes)
+            && (self.pomodoros == 0 || pomodoros_completed >= self.pomodoros)
+    }
+
+    pub fn is_met_by(self, stats: DailyStats) -> bool {
+        self.is_met_by_totals(stats.focused_minutes(), stats.pomodoros_completed)
     }
 }
 
@@ -663,6 +667,50 @@ impl FocusStats {
 
     pub fn daily_for(&self, day_key: &str) -> DailyStats {
         self.daily.get(day_key).copied().unwrap_or_default()
+    }
+
+    pub fn weekly_for_day(&self, day: chrono::NaiveDate) -> WeeklyStats {
+        let week = day.iso_week();
+        let mut totals = WeeklyStats {
+            year: week.year(),
+            week: week.week(),
+            ..WeeklyStats::default()
+        };
+        for (day_key, stats) in &self.daily {
+            let Ok(candidate) = chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d") else {
+                continue;
+            };
+            let candidate_week = candidate.iso_week();
+            if candidate_week.year() != totals.year || candidate_week.week() != totals.week {
+                continue;
+            }
+            totals.pomodoros_completed = totals
+                .pomodoros_completed
+                .saturating_add(stats.pomodoros_completed);
+            totals.focused_seconds = totals.focused_seconds.saturating_add(stats.focused_seconds);
+        }
+        totals
+    }
+
+    pub fn monthly_for_day(&self, day: chrono::NaiveDate) -> MonthlyStats {
+        let mut totals = MonthlyStats {
+            year: day.year(),
+            month: day.month(),
+            ..MonthlyStats::default()
+        };
+        for (day_key, stats) in &self.daily {
+            let Ok(candidate) = chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d") else {
+                continue;
+            };
+            if candidate.year() != totals.year || candidate.month() != totals.month {
+                continue;
+            }
+            totals.pomodoros_completed = totals
+                .pomodoros_completed
+                .saturating_add(stats.pomodoros_completed);
+            totals.focused_seconds = totals.focused_seconds.saturating_add(stats.focused_seconds);
+        }
+        totals
     }
 
     pub fn task_planner_state(&self) -> (Vec<String>, Option<String>) {
@@ -1995,6 +2043,44 @@ mod tests {
     }
 
     #[test]
+    fn weekly_for_day_aggregates_selected_iso_week_only() {
+        let mut stats = FocusStats::default();
+        stats.insert_daily_for_tests(
+            "2026-04-06",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 30 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2026-04-08",
+            DailyStats {
+                pomodoros_completed: 2,
+                focused_seconds: 45 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2026-04-14",
+            DailyStats {
+                pomodoros_completed: 3,
+                focused_seconds: 90 * 60,
+                goal: None,
+            },
+        );
+
+        let week = stats.weekly_for_day(chrono::NaiveDate::from_ymd_opt(2026, 4, 7).unwrap());
+        let iso_week = chrono::NaiveDate::from_ymd_opt(2026, 4, 7)
+            .unwrap()
+            .iso_week();
+        assert_eq!(week.year, iso_week.year());
+        assert_eq!(week.week, iso_week.week());
+        assert_eq!(week.pomodoros_completed, 3);
+        assert_eq!(week.focused_minutes(), 75);
+    }
+
+    #[test]
     fn recent_weekly_is_sorted_newest_first_across_iso_year_boundaries() {
         let mut stats = FocusStats::default();
         stats.insert_daily_for_tests(
@@ -2316,6 +2402,41 @@ mod tests {
     }
 
     #[test]
+    fn monthly_for_day_aggregates_selected_calendar_month_only() {
+        let mut stats = FocusStats::default();
+        stats.insert_daily_for_tests(
+            "2026-04-06",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 30 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2026-04-08",
+            DailyStats {
+                pomodoros_completed: 2,
+                focused_seconds: 45 * 60,
+                goal: None,
+            },
+        );
+        stats.insert_daily_for_tests(
+            "2026-05-01",
+            DailyStats {
+                pomodoros_completed: 4,
+                focused_seconds: 120 * 60,
+                goal: None,
+            },
+        );
+
+        let month = stats.monthly_for_day(chrono::NaiveDate::from_ymd_opt(2026, 4, 10).unwrap());
+        assert_eq!(month.year, 2026);
+        assert_eq!(month.month, 4);
+        assert_eq!(month.pomodoros_completed, 3);
+        assert_eq!(month.focused_minutes(), 75);
+    }
+
+    #[test]
     fn latest_monthly_heatmap_uses_latest_recorded_month_data() {
         let mut stats = FocusStats::default();
         stats.insert_daily_for_tests(
@@ -2490,11 +2611,12 @@ mod tests {
         };
         let today = chrono::Local::now().date_naive();
         let labeled_day = today.format("%Y-%m-%d").to_string();
-        let other_day = today
-            .checked_sub_signed(chrono::Duration::days(2))
-            .unwrap()
-            .format("%Y-%m-%d")
-            .to_string();
+        let other_day_date = [today.pred_opt(), today.succ_opt()]
+            .into_iter()
+            .flatten()
+            .find(|candidate| candidate.iso_week() == today.iso_week())
+            .unwrap_or(today);
+        let other_day = other_day_date.format("%Y-%m-%d").to_string();
         let recent_window_start = today
             .checked_sub_signed(chrono::Duration::days(6))
             .unwrap()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1663,8 +1663,10 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{Datelike, Duration, NaiveDate};
     use ratatui::{Terminal, backend::TestBackend};
 
+    use crate::stats::current_day_key;
     use crate::wakatime::WakatimeTracker;
 
     fn terminal_text(terminal: &Terminal<TestBackend>, width: u16, height: u16) -> String {
@@ -1695,6 +1697,113 @@ mod tests {
     fn timer_primary_hint_includes_break_glass_shortcut() {
         let app = App::default();
         assert!(timer_primary_hint(&app).contains("[u] Unblock"));
+    }
+
+    #[test]
+    fn goal_streak_lines_show_off_when_all_goals_disabled() {
+        let app = App::default();
+
+        assert_eq!(
+            format_timer_goal_streak_line(&app),
+            "Goals: Off (set via [p] -> [e])   Streaks: Off"
+        );
+        assert_eq!(
+            format_history_goal_streak_line(&app),
+            "Goals: Off   Streaks: Off"
+        );
+    }
+
+    #[test]
+    fn goal_streak_lines_render_daily_weekly_monthly_period_progress() {
+        let mut app = App::default();
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('p'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('e'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.profile_edit_field = PROFILE_EDIT_GROUP_GOALS[2];
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Right,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.profile_edit_field = PROFILE_EDIT_GROUP_GOALS[3];
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Right,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.profile_edit_field = PROFILE_EDIT_GROUP_GOALS[4];
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Right,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.profile_edit_field = PROFILE_EDIT_GROUP_GOALS[5];
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Right,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Enter,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        let today = current_day_key();
+        let today_date = NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse as a date");
+        let weekly_day = (-6..=6)
+            .filter(|offset| *offset != 0)
+            .map(|offset| today_date + Duration::days(i64::from(offset)))
+            .find(|candidate| candidate.iso_week() == today_date.iso_week())
+            .expect("there should be at least one nearby day in the current ISO week");
+        let monthly_day = (-31..=31)
+            .filter(|offset| *offset != 0)
+            .map(|offset| today_date + Duration::days(i64::from(offset)))
+            .find(|candidate| {
+                candidate.year() == today_date.year()
+                    && candidate.month() == today_date.month()
+                    && candidate.iso_week() != today_date.iso_week()
+            })
+            .expect("there should be at least one nearby day in the current month");
+
+        app.insert_daily_stats_for_tests(
+            &today,
+            crate::stats::DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 5 * 60,
+                goal: None,
+            },
+        );
+        app.insert_daily_stats_for_tests(
+            &weekly_day.format("%Y-%m-%d").to_string(),
+            crate::stats::DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 5 * 60,
+                goal: None,
+            },
+        );
+        app.insert_daily_stats_for_tests(
+            &monthly_day.format("%Y-%m-%d").to_string(),
+            crate::stats::DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 5 * 60,
+                goal: None,
+            },
+        );
+
+        let streak = app.goal_streak();
+        let expected = format!(
+            "Goals: {} · {} · {}   Streaks: {}d current · {}d best",
+            format_goal_period_progress("D", app.today_goal_progress()),
+            format_goal_period_progress("W", app.current_week_goal_progress()),
+            format_goal_period_progress("M", app.current_month_goal_progress()),
+            streak.current,
+            streak.best
+        );
+
+        assert_eq!(format_timer_goal_streak_line(&app), expected);
+        assert_eq!(format_history_goal_streak_line(&app), expected);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -18,10 +18,10 @@ use crate::wakatime::WakatimeRuntimeState;
 
 const PROFILE_EDIT_GROUP_TIMER: [usize; 4] = [0, 1, 2, 3];
 const PROFILE_EDIT_GROUP_AUTOMATION: [usize; 5] = [4, 5, 6, 7, 8];
-const PROFILE_EDIT_GROUP_GOALS: [usize; 2] = [9, 10];
-const PROFILE_EDIT_GROUP_WAKATIME: [usize; 2] = [11, 12];
+const PROFILE_EDIT_GROUP_GOALS: [usize; 6] = [9, 10, 11, 12, 13, 14];
+const PROFILE_EDIT_GROUP_WAKATIME: [usize; 2] = [15, 16];
 const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 15] =
-    [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27];
+    [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31];
 const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 5] = [
     ("Timer", &PROFILE_EDIT_GROUP_TIMER),
     ("Automation", &PROFILE_EDIT_GROUP_AUTOMATION),
@@ -843,25 +843,29 @@ fn profile_edit_field_display_label(field_index: usize) -> &'static str {
         6 => "Auto-start break",
         7 => "Auto-start focus",
         8 => "Strict focus mode",
-        9 => "Goal minutes",
-        10 => "Goal pomodoros",
-        11 => "WakaTime project",
-        12 => "WakaTime language",
-        13 => "Window selector",
-        14 => "Day selector",
-        15 => "Day enabled",
-        16 => "Start time",
-        17 => "End time",
-        18 => "Add/remove",
-        19 => "Exception selector",
-        20 => "Exception date",
-        21 => "Exception add/remove",
-        22 => "One-time selector",
-        23 => "One-time date",
-        24 => "One-time start",
-        25 => "One-time end",
-        26 => "One-time add/remove",
-        27 => "Conflict inspector",
+        9 => "Daily goal minutes",
+        10 => "Daily goal pomodoros",
+        11 => "Weekly goal minutes",
+        12 => "Weekly goal pomodoros",
+        13 => "Monthly goal minutes",
+        14 => "Monthly goal pomodoros",
+        15 => "WakaTime project",
+        16 => "WakaTime language",
+        17 => "Window selector",
+        18 => "Day selector",
+        19 => "Day enabled",
+        20 => "Start time",
+        21 => "End time",
+        22 => "Add/remove",
+        23 => "Exception selector",
+        24 => "Exception date",
+        25 => "Exception add/remove",
+        26 => "One-time selector",
+        27 => "One-time date",
+        28 => "One-time start",
+        29 => "One-time end",
+        30 => "One-time add/remove",
+        31 => "Conflict inspector",
         _ => "",
     }
 }
@@ -1509,7 +1513,11 @@ fn format_goal_progress_line(progress: DailyGoalProgress) -> String {
         progress.minutes.target,
         "m",
     );
-    format!("Goal: {pomodoros}   {minutes}")
+    format!("{pomodoros}   {minutes}")
+}
+
+fn format_goal_period_progress(period: &str, progress: DailyGoalProgress) -> String {
+    format!("{period} {}", format_goal_progress_line(progress))
 }
 
 fn format_goal_metric_progress(
@@ -1526,32 +1534,46 @@ fn format_goal_metric_progress(
 }
 
 fn format_timer_goal_streak_line(app: &App) -> String {
-    let goal_progress = app.today_goal_progress();
+    let daily_goal_progress = app.today_goal_progress();
+    let weekly_goal_progress = app.current_week_goal_progress();
+    let monthly_goal_progress = app.current_month_goal_progress();
     let streak = app.goal_streak();
-    if goal_progress.has_any_target() {
+    if daily_goal_progress.has_any_target()
+        || weekly_goal_progress.has_any_target()
+        || monthly_goal_progress.has_any_target()
+    {
         format!(
-            "{}   Streaks: {}d current · {}d best",
-            format_goal_progress_line(goal_progress),
+            "Goals: {} · {} · {}   Streaks: {}d current · {}d best",
+            format_goal_period_progress("D", daily_goal_progress),
+            format_goal_period_progress("W", weekly_goal_progress),
+            format_goal_period_progress("M", monthly_goal_progress),
             streak.current,
             streak.best
         )
     } else {
-        "Goal: Off (set via [p] -> [e])   Streaks: Off".to_string()
+        "Goals: Off (set via [p] -> [e])   Streaks: Off".to_string()
     }
 }
 
 fn format_history_goal_streak_line(app: &App) -> String {
-    let goal_progress = app.today_goal_progress();
+    let daily_goal_progress = app.today_goal_progress();
+    let weekly_goal_progress = app.current_week_goal_progress();
+    let monthly_goal_progress = app.current_month_goal_progress();
     let streak = app.goal_streak();
-    if goal_progress.has_any_target() {
+    if daily_goal_progress.has_any_target()
+        || weekly_goal_progress.has_any_target()
+        || monthly_goal_progress.has_any_target()
+    {
         format!(
-            "{}   Streaks: {}d current · {}d best",
-            format_goal_progress_line(goal_progress),
+            "Goals: {} · {} · {}   Streaks: {}d current · {}d best",
+            format_goal_period_progress("D", daily_goal_progress),
+            format_goal_period_progress("W", weekly_goal_progress),
+            format_goal_period_progress("M", monthly_goal_progress),
             streak.current,
             streak.best
         )
     } else {
-        "Daily goal: Off   Streaks: Off".to_string()
+        "Goals: Off   Streaks: Off".to_string()
     }
 }
 

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -95,6 +95,9 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload.get("day").is_some());
     assert!(payload.get("focus_intention").is_some());
     assert!(payload.get("task_note").is_some());
+    assert!(payload.get("goal").is_some());
+    assert!(payload.get("weekly_goal").is_some());
+    assert!(payload.get("monthly_goal").is_some());
     assert!(payload.get("live").is_some());
     assert!(payload["live"].get("focus_intention").is_some());
     assert!(payload["live"].get("task_note").is_some());


### PR DESCRIPTION
## What

Add weekly and monthly goal targets (minutes and pomodoros) on top of existing daily goals, and wire them through config, app state, stats aggregation, CLI, TUI, docs, and tests.

## Why

The project already tracks weekly/monthly aggregates, but users could only set and evaluate daily goals. This adds target-setting and progress visibility for week and month periods while keeping existing daily workflows backward compatible.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

Closes #184

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable) - N/A
- [ ] WakaTime integration behavior was verified for this change (if applicable) - N/A
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR (none)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weekly and monthly goal tracking across CLI, config, profile editor, timer and history (consolidated Daily · Weekly · Monthly progress display).
  * Status output now reports goal met/configured for week and month periods.

* **Documentation**
  * README updated with CLI flags, examples, config fields, and editor key-help for weekly/monthly goals.

* **Tests**
  * Expanded unit and integration tests for weekly/monthly parsing, aggregation, status JSON, and UI rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->