### PR TITLE
Add optional goal carry-over rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ cargo run -- --goal-monthly
 cargo run -- --goal-monthly=2400,80
 cargo run -- --goal-monthly --json
 
+# Show or set goal carry-over behavior (on/off)
+cargo run -- --goal-carry
+cargo run -- --goal-carry=on
+cargo run -- --goal-carry-weekly=on
+cargo run -- --goal-carry-monthly=off
+cargo run -- --goal-carry --json
+
 # Show or set strict mode
 cargo run -- --strict
 cargo run -- --strict=on

--- a/src/app.rs
+++ b/src/app.rs
@@ -5575,9 +5575,12 @@ mod tests {
         };
         let mut app = App::from_config(config);
 
-        let week1 = chrono::NaiveDate::from_ymd_opt(2026, 4, 6).expect("week1 date should be valid");
-        let week2 = chrono::NaiveDate::from_ymd_opt(2026, 4, 13).expect("week2 date should be valid");
-        let week3 = chrono::NaiveDate::from_ymd_opt(2026, 4, 20).expect("week3 date should be valid");
+        let week1 =
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 6).expect("week1 date should be valid");
+        let week2 =
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 13).expect("week2 date should be valid");
+        let week3 =
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 20).expect("week3 date should be valid");
         app.sync_goal_snapshot_for_day(week1);
         app.sync_goal_snapshot_for_day(week2);
         let weekly_target = app.effective_weekly_goal_snapshot_for_day(week3);

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use chrono::{DateTime, Local, NaiveDate};
+use chrono::{DateTime, Datelike, Local, NaiveDate};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use crate::blocker::{
@@ -13,8 +13,9 @@ use crate::blocker::{
 };
 use crate::config::{
     AppConfig, AutoStartConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
-    MonthlyGoalConfig, NotificationConfig, OneTimeFocusWindowConfig, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, WakatimeMetadataConfig, WeeklyGoalConfig,
+    GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig, OneTimeFocusWindowConfig,
+    ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig, WakatimeMetadataConfig,
+    WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -28,7 +29,7 @@ use crate::stats::{
     BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles,
     FocusSessionMetadata, FocusStats, GoalStreak, MonthlyHeatmap, MonthlyStats,
     ProfileEffectiveness, ProfileTotals, SessionStats, TaskTotals, TaskTrend, WeeklyConsistency,
-    WeeklyStats, current_day_key,
+    WeeklyStats, carry_over_goal_target, current_day_key,
 };
 use crate::task_labels::{normalize_task_label, task_label_index};
 use crate::timer::{
@@ -39,7 +40,7 @@ use crate::wakatime::{WakatimeConfigStatus, WakatimeHeartbeatMetadata, WakatimeT
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
-pub const PROFILE_EDIT_FIELD_LABELS: [&str; 32] = [
+pub const PROFILE_EDIT_FIELD_LABELS: [&str; 35] = [
     "Focus",
     "Short Break",
     "Long Break",
@@ -51,10 +52,13 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 32] = [
     "Strict focus mode",
     "Daily goal minutes",
     "Daily goal pomodoros",
+    "Daily goal carry-over",
     "Weekly goal minutes",
     "Weekly goal pomodoros",
+    "Weekly goal carry-over",
     "Monthly goal minutes",
     "Monthly goal pomodoros",
+    "Monthly goal carry-over",
     "WakaTime project",
     "WakaTime language",
     "Schedule window",
@@ -75,27 +79,30 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 32] = [
 ];
 const PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX: usize = 9;
 const PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX: usize = 10;
-const PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX: usize = 11;
-const PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX: usize = 12;
-const PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX: usize = 13;
-const PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX: usize = 14;
-const PROFILE_EDIT_WAKATIME_PROJECT_INDEX: usize = 15;
-const PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX: usize = 16;
-const PROFILE_EDIT_SCHEDULE_WINDOW_INDEX: usize = 17;
-const PROFILE_EDIT_SCHEDULE_DAY_INDEX: usize = 18;
-const PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX: usize = 19;
-const PROFILE_EDIT_SCHEDULE_START_INDEX: usize = 20;
-const PROFILE_EDIT_SCHEDULE_END_INDEX: usize = 21;
-const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 22;
-const PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX: usize = 23;
-const PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX: usize = 24;
-const PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX: usize = 25;
-const PROFILE_EDIT_ONE_TIME_WINDOW_INDEX: usize = 26;
-const PROFILE_EDIT_ONE_TIME_DATE_INDEX: usize = 27;
-const PROFILE_EDIT_ONE_TIME_START_INDEX: usize = 28;
-const PROFILE_EDIT_ONE_TIME_END_INDEX: usize = 29;
-const PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX: usize = 30;
-const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 31;
+const PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX: usize = 11;
+const PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX: usize = 12;
+const PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX: usize = 13;
+const PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX: usize = 14;
+const PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX: usize = 15;
+const PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX: usize = 16;
+const PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX: usize = 17;
+const PROFILE_EDIT_WAKATIME_PROJECT_INDEX: usize = 18;
+const PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX: usize = 19;
+const PROFILE_EDIT_SCHEDULE_WINDOW_INDEX: usize = 20;
+const PROFILE_EDIT_SCHEDULE_DAY_INDEX: usize = 21;
+const PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX: usize = 22;
+const PROFILE_EDIT_SCHEDULE_START_INDEX: usize = 23;
+const PROFILE_EDIT_SCHEDULE_END_INDEX: usize = 24;
+const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 25;
+const PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX: usize = 26;
+const PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX: usize = 27;
+const PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX: usize = 28;
+const PROFILE_EDIT_ONE_TIME_WINDOW_INDEX: usize = 29;
+const PROFILE_EDIT_ONE_TIME_DATE_INDEX: usize = 30;
+const PROFILE_EDIT_ONE_TIME_START_INDEX: usize = 31;
+const PROFILE_EDIT_ONE_TIME_END_INDEX: usize = 32;
+const PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX: usize = 33;
+const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 34;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
@@ -188,6 +195,7 @@ struct ProfileEditSnapshot {
     daily_goal: DailyGoalConfig,
     weekly_goal: WeeklyGoalConfig,
     monthly_goal: MonthlyGoalConfig,
+    goal_carry_over: GoalCarryOverConfig,
     wakatime_metadata: WakatimeMetadataConfig,
 }
 
@@ -461,6 +469,7 @@ pub struct App {
     daily_goal: DailyGoalConfig,
     weekly_goal: WeeklyGoalConfig,
     monthly_goal: MonthlyGoalConfig,
+    goal_carry_over: GoalCarryOverConfig,
     wakatime_metadata: WakatimeMetadataConfig,
     pending_timer_action: Option<PendingTimerAction>,
     notifier: PhaseNotifier,
@@ -497,6 +506,7 @@ impl App {
         let daily_goal = config.daily_goal;
         let weekly_goal = config.weekly_goal;
         let monthly_goal = config.monthly_goal;
+        let goal_carry_over = config.goal_carry_over;
         let wakatime_metadata = config.wakatime;
         let blocklist_profiles = config.blocklist_profiles.clone();
         let active_blocklist_profile =
@@ -584,6 +594,7 @@ impl App {
             daily_goal,
             weekly_goal,
             monthly_goal,
+            goal_carry_over,
             wakatime_metadata,
             pending_timer_action: None,
             notifier: PhaseNotifier::new(notification_settings),
@@ -954,28 +965,39 @@ impl App {
     }
 
     pub fn today_goal_progress(&self) -> DailyGoalProgress {
-        self.daily_goal_progress_for(self.today_stats())
+        let today = Local::now().date_naive();
+        let today_key = today.format("%Y-%m-%d").to_string();
+        let today_stats = self.stats.daily_for(&today_key);
+        let target = self.effective_daily_goal_snapshot_for_day(today);
+        goal_progress_for_totals(
+            today_stats.focused_minutes(),
+            today_stats.pomodoros_completed,
+            target.minutes,
+            target.pomodoros,
+        )
     }
 
     pub fn current_week_goal_progress(&self) -> DailyGoalProgress {
         let today = Local::now().date_naive();
         let week = self.stats.weekly_for_day(today);
+        let target = self.effective_weekly_goal_snapshot_for_day(today);
         goal_progress_for_totals(
             week.focused_minutes(),
             week.pomodoros_completed,
-            self.weekly_goal.minutes,
-            self.weekly_goal.pomodoros,
+            target.minutes,
+            target.pomodoros,
         )
     }
 
     pub fn current_month_goal_progress(&self) -> DailyGoalProgress {
         let today = Local::now().date_naive();
         let month = self.stats.monthly_for_day(today);
+        let target = self.effective_monthly_goal_snapshot_for_day(today);
         goal_progress_for_totals(
             month.focused_minutes(),
             month.pomodoros_completed,
-            self.monthly_goal.minutes,
-            self.monthly_goal.pomodoros,
+            target.minutes,
+            target.pomodoros,
         )
     }
 
@@ -988,13 +1010,17 @@ impl App {
             return GoalStreak::default();
         };
 
-        self.stats.goal_streak(
-            day,
-            self.current_goal_snapshot(),
-            self.stats.daily_for(day_key),
-        )
+        let today = Local::now().date_naive();
+        let current_goal = if day == today {
+            self.today_goal_snapshot()
+        } else {
+            self.current_goal_snapshot()
+        };
+        self.stats
+            .goal_streak(day, current_goal, self.stats.daily_for(day_key))
     }
 
+    #[allow(dead_code)]
     pub fn daily_goal_progress_for(&self, stats: DailyStats) -> DailyGoalProgress {
         goal_progress_for_totals(
             stats.focused_minutes(),
@@ -1078,17 +1104,26 @@ impl App {
             PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX => {
                 format_daily_goal_pomodoros_label(self.daily_goal.pomodoros)
             }
+            PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX => {
+                bool_label(self.goal_carry_over.daily).to_string()
+            }
             PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX => {
                 format_daily_goal_minutes_label(self.weekly_goal.minutes)
             }
             PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX => {
                 format_daily_goal_pomodoros_label(self.weekly_goal.pomodoros)
             }
+            PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX => {
+                bool_label(self.goal_carry_over.weekly).to_string()
+            }
             PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX => {
                 format_daily_goal_minutes_label(self.monthly_goal.minutes)
             }
             PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX => {
                 format_daily_goal_pomodoros_label(self.monthly_goal.pomodoros)
+            }
+            PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX => {
+                bool_label(self.goal_carry_over.monthly).to_string()
             }
             PROFILE_EDIT_WAKATIME_PROJECT_INDEX => self.wakatime_metadata.project.clone(),
             PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX => self.wakatime_metadata.language.clone(),
@@ -1947,6 +1982,7 @@ impl App {
             daily_goal: self.daily_goal,
             weekly_goal: self.weekly_goal,
             monthly_goal: self.monthly_goal,
+            goal_carry_over: self.goal_carry_over,
             wakatime: self.wakatime_metadata.clone(),
         }
     }
@@ -2518,6 +2554,7 @@ impl App {
             daily_goal: self.daily_goal,
             weekly_goal: self.weekly_goal,
             monthly_goal: self.monthly_goal,
+            goal_carry_over: self.goal_carry_over,
             wakatime_metadata: self.wakatime_metadata.clone(),
         });
         self.profile_edit_active = true;
@@ -2539,6 +2576,7 @@ impl App {
             self.daily_goal = snapshot.daily_goal;
             self.weekly_goal = snapshot.weekly_goal;
             self.monthly_goal = snapshot.monthly_goal;
+            self.goal_carry_over = snapshot.goal_carry_over;
             self.wakatime_metadata = snapshot.wakatime_metadata;
             self.sync_wakatime_metadata_to_tracker();
             self.rebuild_notifier();
@@ -2573,6 +2611,10 @@ impl App {
             .profile_edit_snapshot
             .as_ref()
             .is_some_and(|snapshot| snapshot.monthly_goal != self.monthly_goal);
+        let goal_carry_over_changed = self
+            .profile_edit_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.goal_carry_over != self.goal_carry_over);
         self.custom_profile = self.custom_profile.normalized();
         self.recurring_schedule = normalized_schedule;
         self.wakatime_metadata = self.wakatime_metadata.normalized();
@@ -2598,7 +2640,11 @@ impl App {
             self.current_frame_now = now;
             self.sync_recurring_schedule(now);
         }
-        if daily_goal_changed || weekly_goal_changed || monthly_goal_changed {
+        if daily_goal_changed
+            || weekly_goal_changed
+            || monthly_goal_changed
+            || goal_carry_over_changed
+        {
             self.sync_today_goal_snapshot();
         }
         self.profile_edit_active = false;
@@ -2652,17 +2698,26 @@ impl App {
             PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX => {
                 adjust_daily_goal_pomodoros(&mut self.daily_goal.pomodoros, increase);
             }
+            PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX => {
+                self.goal_carry_over.daily = increase;
+            }
             PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX => {
                 adjust_daily_goal_minutes(&mut self.weekly_goal.minutes, increase);
             }
             PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX => {
                 adjust_daily_goal_pomodoros(&mut self.weekly_goal.pomodoros, increase);
             }
+            PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX => {
+                self.goal_carry_over.weekly = increase;
+            }
             PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX => {
                 adjust_daily_goal_minutes(&mut self.monthly_goal.minutes, increase);
             }
             PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX => {
                 adjust_daily_goal_pomodoros(&mut self.monthly_goal.pomodoros, increase);
+            }
+            PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX => {
+                self.goal_carry_over.monthly = increase;
             }
             PROFILE_EDIT_SCHEDULE_WINDOW_INDEX => {
                 self.cycle_schedule_window(increase);
@@ -3487,7 +3542,7 @@ impl App {
         }
 
         let day_key = current_day_key();
-        let goal_snapshot = self.current_goal_snapshot();
+        let goal_snapshot = self.today_goal_snapshot();
         let session_minutes_before = self.stats.session().focused_minutes();
         let today_minutes_before = self.stats.daily_for(&day_key).focused_minutes();
 
@@ -3506,7 +3561,7 @@ impl App {
 
     fn record_completed_focus_session(&mut self, focused_seconds: u64) {
         let day_key = current_day_key();
-        let goal = self.current_goal_snapshot();
+        let goal = self.today_goal_snapshot();
         if let Some(active_task_label) = self.active_focus_task_label.clone() {
             let focus_intention = self
                 .active_focus_intention
@@ -3540,11 +3595,58 @@ impl App {
         }
     }
 
+    fn today_goal_snapshot(&self) -> DailyGoalSnapshot {
+        self.effective_daily_goal_snapshot_for_day(Local::now().date_naive())
+    }
+
+    fn effective_daily_goal_snapshot_for_day(&self, day: NaiveDate) -> DailyGoalSnapshot {
+        let base = self.current_goal_snapshot();
+        let previous = day.pred_opt().and_then(|previous_day| {
+            let day_key = previous_day.format("%Y-%m-%d").to_string();
+            self.stats.daily_entry(&day_key).map(|stats| {
+                (
+                    stats.goal.unwrap_or(base),
+                    stats.focused_minutes(),
+                    stats.pomodoros_completed,
+                )
+            })
+        });
+        carry_over_goal_target(base, self.goal_carry_over.daily, previous)
+    }
+
+    fn effective_weekly_goal_snapshot_for_day(&self, day: NaiveDate) -> DailyGoalSnapshot {
+        let base = DailyGoalSnapshot {
+            minutes: self.weekly_goal.minutes,
+            pomodoros: self.weekly_goal.pomodoros,
+        };
+        let previous =
+            day.checked_sub_signed(chrono::Duration::weeks(1))
+                .and_then(|previous_week_day| {
+                    self.stats
+                        .weekly_for_day_if_present(previous_week_day)
+                        .map(|week| (base, week.focused_minutes(), week.pomodoros_completed))
+                });
+        carry_over_goal_target(base, self.goal_carry_over.weekly, previous)
+    }
+
+    fn effective_monthly_goal_snapshot_for_day(&self, day: NaiveDate) -> DailyGoalSnapshot {
+        let base = DailyGoalSnapshot {
+            minutes: self.monthly_goal.minutes,
+            pomodoros: self.monthly_goal.pomodoros,
+        };
+        let previous = previous_month_reference_day(day).and_then(|previous_month_day| {
+            self.stats
+                .monthly_for_day_if_present(previous_month_day)
+                .map(|month| (base, month.focused_minutes(), month.pomodoros_completed))
+        });
+        carry_over_goal_target(base, self.goal_carry_over.monthly, previous)
+    }
+
     fn sync_today_goal_snapshot(&mut self) {
         let day_key = current_day_key();
         if self
             .stats
-            .sync_goal_snapshot(&day_key, self.current_goal_snapshot())
+            .sync_goal_snapshot(&day_key, self.today_goal_snapshot())
         {
             self.stats_dirty = true;
             self.flush_stats_if_dirty(false);
@@ -4138,6 +4240,11 @@ fn parse_day_key(day_key: &str) -> Option<chrono::NaiveDate> {
     chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d").ok()
 }
 
+fn previous_month_reference_day(day: NaiveDate) -> Option<NaiveDate> {
+    let month_start = NaiveDate::from_ymd_opt(day.year(), day.month(), 1)?;
+    month_start.pred_opt()
+}
+
 fn goal_progress(completed: u64, target: u64) -> GoalProgress {
     let ratio = if target == 0 {
         0.0
@@ -4407,6 +4514,7 @@ mod tests {
             daily_goal: DailyGoalConfig::default(),
             weekly_goal: WeeklyGoalConfig::default(),
             monthly_goal: MonthlyGoalConfig::default(),
+            goal_carry_over: GoalCarryOverConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
         };
         let app = App::from_config(config);
@@ -4708,8 +4816,11 @@ mod tests {
         assert_eq!(app.profile_edit_field_value(12), "Off");
         assert_eq!(app.profile_edit_field_value(13), "Off");
         assert_eq!(app.profile_edit_field_value(14), "Off");
-        assert_eq!(app.profile_edit_field_value(15), "focustime");
-        assert_eq!(app.profile_edit_field_value(16), "Pomodoro");
+        assert_eq!(app.profile_edit_field_value(15), "Off");
+        assert_eq!(app.profile_edit_field_value(16), "Off");
+        assert_eq!(app.profile_edit_field_value(17), "Off");
+        assert_eq!(app.profile_edit_field_value(18), "focustime");
+        assert_eq!(app.profile_edit_field_value(19), "Pomodoro");
     }
 
     #[test]
@@ -4944,6 +5055,30 @@ mod tests {
     }
 
     #[test]
+    fn editing_goal_carry_over_fields_updates_and_persists_settings() {
+        let mut app = App::default();
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        app.profile_edit_field = PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX;
+        app.handle_key(key(KeyCode::Right));
+        app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX;
+        app.handle_key(key(KeyCode::Right));
+        app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX;
+        app.handle_key(key(KeyCode::Right));
+        app.handle_key(key(KeyCode::Enter));
+
+        assert!(app.goal_carry_over.daily);
+        assert!(app.goal_carry_over.weekly);
+        assert!(app.goal_carry_over.monthly);
+
+        let persisted = app.persisted_config();
+        assert!(persisted.goal_carry_over.daily);
+        assert!(persisted.goal_carry_over.weekly);
+        assert!(persisted.goal_carry_over.monthly);
+    }
+
+    #[test]
     fn cancelling_profile_edit_restores_recurring_schedule_settings() {
         let original_schedule = RecurringScheduleConfig {
             windows: vec![RecurringFocusWindowConfig {
@@ -5104,6 +5239,33 @@ mod tests {
     }
 
     #[test]
+    fn cancelling_profile_edit_restores_goal_carry_over_settings() {
+        let config = AppConfig {
+            goal_carry_over: GoalCarryOverConfig {
+                daily: true,
+                weekly: false,
+                monthly: true,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        app.profile_edit_field = PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX;
+        app.handle_key(key(KeyCode::Left));
+        app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX;
+        app.handle_key(key(KeyCode::Right));
+        app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX;
+        app.handle_key(key(KeyCode::Left));
+        app.handle_key(key(KeyCode::Esc));
+
+        assert!(app.goal_carry_over.daily);
+        assert!(!app.goal_carry_over.weekly);
+        assert!(app.goal_carry_over.monthly);
+    }
+
+    #[test]
     fn cancelling_profile_edit_restores_auto_start_settings() {
         let config = AppConfig {
             auto_start: AutoStartConfig {
@@ -5190,6 +5352,122 @@ mod tests {
         assert_eq!(monthly.pomodoros.completed, 1);
         assert_eq!(monthly.pomodoros.target, 3);
         assert!((monthly.pomodoros.ratio - (1.0 / 3.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn daily_goal_progress_applies_previous_day_deficit_when_carry_over_is_enabled() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 2,
+            },
+            goal_carry_over: GoalCarryOverConfig {
+                daily: true,
+                ..GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let today = current_day_key();
+        let today_date = chrono::NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse");
+        let yesterday = today_date.pred_opt().expect("yesterday should exist");
+        let yesterday_key = yesterday.format("%Y-%m-%d").to_string();
+        let previous_target = DailyGoalSnapshot {
+            minutes: 50,
+            pomodoros: 3,
+        };
+
+        app.stats
+            .record_focus_elapsed(&yesterday_key, 30 * 60, previous_target);
+        app.stats
+            .record_completed_pomodoro(&yesterday_key, previous_target);
+        app.stats
+            .record_focus_elapsed(&today, 40 * 60, app.current_goal_snapshot());
+        app.stats
+            .record_completed_pomodoro(&today, app.current_goal_snapshot());
+
+        let progress = app.today_goal_progress();
+        assert_eq!(progress.minutes.completed, 40);
+        assert_eq!(progress.minutes.target, 80);
+        assert_eq!(progress.pomodoros.completed, 1);
+        assert_eq!(progress.pomodoros.target, 4);
+    }
+
+    #[test]
+    fn weekly_goal_progress_applies_previous_week_deficit_when_enabled() {
+        let config = AppConfig {
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 100,
+                pomodoros: 3,
+            },
+            goal_carry_over: GoalCarryOverConfig {
+                weekly: true,
+                ..GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let today = current_day_key();
+        let today_date = chrono::NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse");
+        let previous_week_day = today_date - chrono::Duration::days(7);
+        let previous_week_key = previous_week_day.format("%Y-%m-%d").to_string();
+        let goal = app.current_goal_snapshot();
+
+        app.stats
+            .record_focus_elapsed(&previous_week_key, 70 * 60, goal);
+        app.stats
+            .record_completed_pomodoro(&previous_week_key, goal);
+        app.stats.record_focus_elapsed(&today, 20 * 60, goal);
+        app.stats.record_completed_pomodoro(&today, goal);
+
+        let weekly = app.current_week_goal_progress();
+        assert_eq!(weekly.minutes.target, 130);
+        assert_eq!(weekly.pomodoros.target, 5);
+        assert_eq!(weekly.minutes.completed, 20);
+        assert_eq!(weekly.pomodoros.completed, 1);
+    }
+
+    #[test]
+    fn monthly_goal_progress_applies_previous_month_deficit_when_enabled() {
+        let config = AppConfig {
+            monthly_goal: MonthlyGoalConfig {
+                minutes: 300,
+                pomodoros: 10,
+            },
+            goal_carry_over: GoalCarryOverConfig {
+                monthly: true,
+                ..GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let today = current_day_key();
+        let today_date = chrono::NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse");
+        let month_start = chrono::NaiveDate::from_ymd_opt(today_date.year(), today_date.month(), 1)
+            .expect("current month start should be representable");
+        let previous_month_day = month_start
+            .pred_opt()
+            .expect("previous month day should be representable");
+        let previous_month_key = previous_month_day.format("%Y-%m-%d").to_string();
+        let goal = app.current_goal_snapshot();
+
+        app.stats
+            .record_focus_elapsed(&previous_month_key, 120 * 60, goal);
+        for _ in 0..4 {
+            app.stats
+                .record_completed_pomodoro(&previous_month_key, goal);
+        }
+        app.stats.record_focus_elapsed(&today, 20 * 60, goal);
+        app.stats.record_completed_pomodoro(&today, goal);
+
+        let monthly = app.current_month_goal_progress();
+        assert_eq!(monthly.minutes.target, 480);
+        assert_eq!(monthly.pomodoros.target, 16);
+        assert_eq!(monthly.minutes.completed, 20);
+        assert_eq!(monthly.pomodoros.completed, 1);
     }
 
     #[test]
@@ -6678,6 +6956,7 @@ mod tests {
             daily_goal: app.daily_goal,
             weekly_goal: app.weekly_goal,
             monthly_goal: app.monthly_goal,
+            goal_carry_over: app.goal_carry_over,
             wakatime_metadata: app.wakatime_metadata.clone(),
         });
         app.custom_profile.focus_secs = app.custom_profile.focus_secs.saturating_add(60);
@@ -6722,6 +7001,7 @@ mod tests {
             daily_goal: app.daily_goal,
             weekly_goal: app.weekly_goal,
             monthly_goal: app.monthly_goal,
+            goal_carry_over: app.goal_carry_over,
             wakatime_metadata: app.wakatime_metadata.clone(),
         });
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5920,11 +5920,9 @@ mod tests {
 
         app.handle_key(key(KeyCode::Char('p')));
         app.handle_key(key(KeyCode::Char('e')));
-        for _ in 0..11 {
-            app.handle_key(key(KeyCode::Down));
-        }
+        app.profile_edit_field = PROFILE_EDIT_WAKATIME_PROJECT_INDEX;
         app.handle_key(key(KeyCode::Char('X')));
-        app.handle_key(key(KeyCode::Down));
+        app.profile_edit_field = PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX;
         app.handle_key(key(KeyCode::Char('Y')));
         app.handle_key(key(KeyCode::Esc));
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5614,19 +5614,18 @@ mod tests {
             ..AppConfig::default()
         };
         let mut app = App::from_config(config);
-        let day1 =
-            chrono::NaiveDate::from_ymd_opt(2026, 4, 8).expect("day1 date should be valid");
-        let day2 =
-            chrono::NaiveDate::from_ymd_opt(2026, 4, 9).expect("day2 date should be valid");
-        let day3 =
-            chrono::NaiveDate::from_ymd_opt(2026, 4, 10).expect("day3 date should be valid");
+        let day1 = chrono::NaiveDate::from_ymd_opt(2026, 4, 8).expect("day1 date should be valid");
+        let day2 = chrono::NaiveDate::from_ymd_opt(2026, 4, 9).expect("day2 date should be valid");
+        let day3 = chrono::NaiveDate::from_ymd_opt(2026, 4, 10).expect("day3 date should be valid");
 
         app.sync_goal_snapshot_for_day(day1);
         app.sync_goal_snapshot_for_day(day2);
 
         let day2_key = day2.format("%Y-%m-%d").to_string();
         assert_eq!(
-            app.stats.daily_entry(&day2_key).and_then(|stats| stats.goal),
+            app.stats
+                .daily_entry(&day2_key)
+                .and_then(|stats| stats.goal),
             Some(DailyGoalSnapshot {
                 minutes: 60,
                 pomodoros: 0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -3606,10 +3606,15 @@ impl App {
     }
 
     fn effective_daily_goal_snapshot_for_day(&self, day: NaiveDate) -> DailyGoalSnapshot {
-        let base = self.current_goal_snapshot();
+        let day_key = day.format("%Y-%m-%d").to_string();
+        let base = self
+            .stats
+            .daily_entry(&day_key)
+            .and_then(|stats| stats.goal)
+            .unwrap_or_else(|| self.current_goal_snapshot());
         let previous = day.pred_opt().and_then(|previous_day| {
-            let day_key = previous_day.format("%Y-%m-%d").to_string();
-            self.stats.daily_entry(&day_key).and_then(|stats| {
+            let previous_day_key = previous_day.format("%Y-%m-%d").to_string();
+            self.stats.daily_entry(&previous_day_key).and_then(|stats| {
                 stats
                     .goal
                     .map(|goal| (goal, stats.focused_minutes(), stats.pomodoros_completed))
@@ -5745,6 +5750,49 @@ mod tests {
         let streak = app.goal_streak_for_day_key("2026-04-09");
         assert_eq!(streak.current, 0);
         assert_eq!(streak.best, 0);
+    }
+
+    #[test]
+    fn goal_streak_for_day_key_uses_historical_day_base_goal_when_config_changed() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 120,
+                pomodoros: 0,
+            },
+            goal_carry_over: GoalCarryOverConfig {
+                daily: true,
+                ..GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.stats.insert_daily_for_tests(
+            "2026-04-08",
+            DailyStats {
+                pomodoros_completed: 0,
+                focused_seconds: 0,
+                goal: Some(DailyGoalSnapshot {
+                    minutes: 40,
+                    pomodoros: 0,
+                }),
+            },
+        );
+        app.stats.insert_daily_for_tests(
+            "2026-04-09",
+            DailyStats {
+                pomodoros_completed: 0,
+                focused_seconds: 130 * 60,
+                goal: Some(DailyGoalSnapshot {
+                    minutes: 60,
+                    pomodoros: 0,
+                }),
+            },
+        );
+
+        let streak = app.goal_streak_for_day_key("2026-04-09");
+        assert_eq!(streak.current, 1);
+        assert_eq!(streak.best, 1);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1011,12 +1011,7 @@ impl App {
             return GoalStreak::default();
         };
 
-        let today = Local::now().date_naive();
-        let current_goal = if day == today {
-            self.today_goal_snapshot()
-        } else {
-            self.current_goal_snapshot()
-        };
+        let current_goal = self.effective_daily_goal_snapshot_for_day(day);
         self.stats
             .goal_streak(day, current_goal, self.stats.daily_for(day_key))
     }
@@ -3610,10 +3605,6 @@ impl App {
         }
     }
 
-    fn today_goal_snapshot(&self) -> DailyGoalSnapshot {
-        self.effective_daily_goal_snapshot_for_day(Local::now().date_naive())
-    }
-
     fn effective_daily_goal_snapshot_for_day(&self, day: NaiveDate) -> DailyGoalSnapshot {
         let base = self.current_goal_snapshot();
         let previous = day.pred_opt().and_then(|previous_day| {
@@ -5711,6 +5702,49 @@ mod tests {
         let streak = app.goal_streak_for_day_key("2026-04-09");
         assert_eq!(streak.current, 2);
         assert_eq!(streak.best, 2);
+    }
+
+    #[test]
+    fn goal_streak_for_day_key_applies_daily_carry_over_to_historical_day_targets() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 0,
+            },
+            goal_carry_over: GoalCarryOverConfig {
+                daily: true,
+                ..GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.stats.insert_daily_for_tests(
+            "2026-04-08",
+            DailyStats {
+                pomodoros_completed: 0,
+                focused_seconds: 0,
+                goal: Some(DailyGoalSnapshot {
+                    minutes: 30,
+                    pomodoros: 0,
+                }),
+            },
+        );
+        app.stats.insert_daily_for_tests(
+            "2026-04-09",
+            DailyStats {
+                pomodoros_completed: 0,
+                focused_seconds: 60 * 60,
+                goal: Some(DailyGoalSnapshot {
+                    minutes: 60,
+                    pomodoros: 0,
+                }),
+            },
+        );
+
+        let streak = app.goal_streak_for_day_key("2026-04-09");
+        assert_eq!(streak.current, 0);
+        assert_eq!(streak.best, 0);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -5601,6 +5601,44 @@ mod tests {
     }
 
     #[test]
+    fn sync_goal_snapshot_for_day_persists_idle_daily_snapshots_for_next_day_carry_over() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 0,
+            },
+            goal_carry_over: GoalCarryOverConfig {
+                daily: true,
+                ..GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let day1 =
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 8).expect("day1 date should be valid");
+        let day2 =
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 9).expect("day2 date should be valid");
+        let day3 =
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 10).expect("day3 date should be valid");
+
+        app.sync_goal_snapshot_for_day(day1);
+        app.sync_goal_snapshot_for_day(day2);
+
+        let day2_key = day2.format("%Y-%m-%d").to_string();
+        assert_eq!(
+            app.stats.daily_entry(&day2_key).and_then(|stats| stats.goal),
+            Some(DailyGoalSnapshot {
+                minutes: 60,
+                pomodoros: 0,
+            })
+        );
+
+        let day3_target = app.effective_daily_goal_snapshot_for_day(day3);
+        assert_eq!(day3_target.minutes, 120);
+        assert_eq!(day3_target.pomodoros, 0);
+    }
+
+    #[test]
     fn poll_wakatime_status_and_on_tick_sync_today_goal_snapshot() {
         let config = AppConfig {
             daily_goal: DailyGoalConfig {

--- a/src/app.rs
+++ b/src/app.rs
@@ -612,6 +612,7 @@ impl App {
     }
 
     pub fn on_tick(&mut self, is_catchup: bool) {
+        self.sync_today_goal_snapshot();
         let completed_phase = self.timer.phase;
         let completed_focus_secs = self.timer.focus_secs;
         if self.should_record_focus_elapsed(is_catchup) {
@@ -731,6 +732,7 @@ impl App {
     pub fn poll_wakatime_status(&mut self) {
         let now = Local::now();
         self.current_frame_now = now;
+        self.sync_today_goal_snapshot();
         self.wakatime.poll_events();
         self.sync_break_glass_override();
         self.sync_recurring_schedule(now);
@@ -3666,17 +3668,20 @@ impl App {
     }
 
     fn sync_today_goal_snapshot(&mut self) {
-        let today = Local::now().date_naive();
-        let day_key = current_day_key();
+        self.sync_goal_snapshot_for_day(Local::now().date_naive());
+    }
+
+    fn sync_goal_snapshot_for_day(&mut self, day: NaiveDate) {
+        let day_key = day.format("%Y-%m-%d").to_string();
         let daily_changed = self
             .stats
             .sync_goal_snapshot(&day_key, self.current_goal_snapshot());
         let weekly_changed = self
             .stats
-            .sync_weekly_goal_snapshot(today, self.current_week_goal_snapshot());
+            .sync_weekly_goal_snapshot(day, self.current_week_goal_snapshot());
         let monthly_changed = self
             .stats
-            .sync_monthly_goal_snapshot(today, self.current_month_goal_snapshot());
+            .sync_monthly_goal_snapshot(day, self.current_month_goal_snapshot());
         if daily_changed || weekly_changed || monthly_changed {
             self.stats_dirty = true;
             self.flush_stats_if_dirty(false);
@@ -5548,6 +5553,83 @@ mod tests {
         assert_eq!(weekly.pomodoros.target, 5);
         assert_eq!(weekly.minutes.completed, 20);
         assert_eq!(weekly.pomodoros.completed, 1);
+    }
+
+    #[test]
+    fn sync_goal_snapshot_for_day_keeps_weekly_and_monthly_carry_across_idle_boundaries() {
+        let config = AppConfig {
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 100,
+                pomodoros: 0,
+            },
+            monthly_goal: MonthlyGoalConfig {
+                minutes: 200,
+                pomodoros: 0,
+            },
+            goal_carry_over: GoalCarryOverConfig {
+                weekly: true,
+                monthly: true,
+                ..GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        let week1 = chrono::NaiveDate::from_ymd_opt(2026, 4, 6).expect("week1 date should be valid");
+        let week2 = chrono::NaiveDate::from_ymd_opt(2026, 4, 13).expect("week2 date should be valid");
+        let week3 = chrono::NaiveDate::from_ymd_opt(2026, 4, 20).expect("week3 date should be valid");
+        app.sync_goal_snapshot_for_day(week1);
+        app.sync_goal_snapshot_for_day(week2);
+        let weekly_target = app.effective_weekly_goal_snapshot_for_day(week3);
+        assert_eq!(weekly_target.minutes, 200);
+        assert_eq!(weekly_target.pomodoros, 0);
+
+        let month1 =
+            chrono::NaiveDate::from_ymd_opt(2026, 1, 15).expect("month1 date should be valid");
+        let month2 =
+            chrono::NaiveDate::from_ymd_opt(2026, 2, 15).expect("month2 date should be valid");
+        let month3 =
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 15).expect("month3 date should be valid");
+        app.sync_goal_snapshot_for_day(month1);
+        app.sync_goal_snapshot_for_day(month2);
+        let monthly_target = app.effective_monthly_goal_snapshot_for_day(month3);
+        assert_eq!(monthly_target.minutes, 400);
+        assert_eq!(monthly_target.pomodoros, 0);
+    }
+
+    #[test]
+    fn poll_wakatime_status_and_on_tick_sync_today_goal_snapshot() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 2,
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let day_key = current_day_key();
+
+        app.stats.insert_daily_for_tests(
+            &day_key,
+            DailyStats {
+                pomodoros_completed: 0,
+                focused_seconds: 0,
+                goal: None,
+            },
+        );
+        app.poll_wakatime_status();
+        assert_eq!(app.today_stats().goal, Some(app.current_goal_snapshot()));
+
+        app.stats.insert_daily_for_tests(
+            &day_key,
+            DailyStats {
+                pomodoros_completed: 0,
+                focused_seconds: 0,
+                goal: None,
+            },
+        );
+        app.on_tick(true);
+        assert_eq!(app.today_stats().goal, Some(app.current_goal_snapshot()));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -607,6 +607,7 @@ impl App {
         app.sync_recovery_snapshot();
         app.apply_blocking_for_phase();
         app.refresh_setup_diagnostics();
+        app.sync_today_goal_snapshot();
         app
     }
 
@@ -3542,7 +3543,7 @@ impl App {
         }
 
         let day_key = current_day_key();
-        let goal_snapshot = self.today_goal_snapshot();
+        let goal_snapshot = self.current_goal_snapshot();
         let session_minutes_before = self.stats.session().focused_minutes();
         let today_minutes_before = self.stats.daily_for(&day_key).focused_minutes();
 
@@ -3561,7 +3562,7 @@ impl App {
 
     fn record_completed_focus_session(&mut self, focused_seconds: u64) {
         let day_key = current_day_key();
-        let goal = self.today_goal_snapshot();
+        let goal = self.current_goal_snapshot();
         if let Some(active_task_label) = self.active_focus_task_label.clone() {
             let focus_intention = self
                 .active_focus_intention
@@ -3595,6 +3596,20 @@ impl App {
         }
     }
 
+    fn current_week_goal_snapshot(&self) -> DailyGoalSnapshot {
+        DailyGoalSnapshot {
+            minutes: self.weekly_goal.minutes,
+            pomodoros: self.weekly_goal.pomodoros,
+        }
+    }
+
+    fn current_month_goal_snapshot(&self) -> DailyGoalSnapshot {
+        DailyGoalSnapshot {
+            minutes: self.monthly_goal.minutes,
+            pomodoros: self.monthly_goal.pomodoros,
+        }
+    }
+
     fn today_goal_snapshot(&self) -> DailyGoalSnapshot {
         self.effective_daily_goal_snapshot_for_day(Local::now().date_naive())
     }
@@ -3603,12 +3618,10 @@ impl App {
         let base = self.current_goal_snapshot();
         let previous = day.pred_opt().and_then(|previous_day| {
             let day_key = previous_day.format("%Y-%m-%d").to_string();
-            self.stats.daily_entry(&day_key).map(|stats| {
-                (
-                    stats.goal.unwrap_or(base),
-                    stats.focused_minutes(),
-                    stats.pomodoros_completed,
-                )
+            self.stats.daily_entry(&day_key).and_then(|stats| {
+                stats
+                    .goal
+                    .map(|goal| (goal, stats.focused_minutes(), stats.pomodoros_completed))
             })
         });
         carry_over_goal_target(base, self.goal_carry_over.daily, previous)
@@ -3623,8 +3636,15 @@ impl App {
             day.checked_sub_signed(chrono::Duration::weeks(1))
                 .and_then(|previous_week_day| {
                     self.stats
-                        .weekly_for_day_if_present(previous_week_day)
-                        .map(|week| (base, week.focused_minutes(), week.pomodoros_completed))
+                        .weekly_goal_snapshot_for_day(previous_week_day)
+                        .map(|previous_target| {
+                            let week = self.stats.weekly_for_day(previous_week_day);
+                            (
+                                previous_target,
+                                week.focused_minutes(),
+                                week.pomodoros_completed,
+                            )
+                        })
                 });
         carry_over_goal_target(base, self.goal_carry_over.weekly, previous)
     }
@@ -3636,18 +3656,32 @@ impl App {
         };
         let previous = previous_month_reference_day(day).and_then(|previous_month_day| {
             self.stats
-                .monthly_for_day_if_present(previous_month_day)
-                .map(|month| (base, month.focused_minutes(), month.pomodoros_completed))
+                .monthly_goal_snapshot_for_day(previous_month_day)
+                .map(|previous_target| {
+                    let month = self.stats.monthly_for_day(previous_month_day);
+                    (
+                        previous_target,
+                        month.focused_minutes(),
+                        month.pomodoros_completed,
+                    )
+                })
         });
         carry_over_goal_target(base, self.goal_carry_over.monthly, previous)
     }
 
     fn sync_today_goal_snapshot(&mut self) {
+        let today = Local::now().date_naive();
         let day_key = current_day_key();
-        if self
+        let daily_changed = self
             .stats
-            .sync_goal_snapshot(&day_key, self.today_goal_snapshot())
-        {
+            .sync_goal_snapshot(&day_key, self.current_goal_snapshot());
+        let weekly_changed = self
+            .stats
+            .sync_weekly_goal_snapshot(today, self.current_week_goal_snapshot());
+        let monthly_changed = self
+            .stats
+            .sync_monthly_goal_snapshot(today, self.current_month_goal_snapshot());
+        if daily_changed || weekly_changed || monthly_changed {
             self.stats_dirty = true;
             self.flush_stats_if_dirty(false);
         }
@@ -5414,9 +5448,16 @@ mod tests {
         let previous_week_day = today_date - chrono::Duration::days(7);
         let previous_week_key = previous_week_day.format("%Y-%m-%d").to_string();
         let goal = app.current_goal_snapshot();
+        app.stats.sync_weekly_goal_snapshot(
+            previous_week_day,
+            DailyGoalSnapshot {
+                minutes: 50,
+                pomodoros: 2,
+            },
+        );
 
         app.stats
-            .record_focus_elapsed(&previous_week_key, 70 * 60, goal);
+            .record_focus_elapsed(&previous_week_key, 20 * 60, goal);
         app.stats
             .record_completed_pomodoro(&previous_week_key, goal);
         app.stats.record_focus_elapsed(&today, 20 * 60, goal);
@@ -5424,7 +5465,7 @@ mod tests {
 
         let weekly = app.current_week_goal_progress();
         assert_eq!(weekly.minutes.target, 130);
-        assert_eq!(weekly.pomodoros.target, 5);
+        assert_eq!(weekly.pomodoros.target, 4);
         assert_eq!(weekly.minutes.completed, 20);
         assert_eq!(weekly.pomodoros.completed, 1);
     }
@@ -5453,6 +5494,13 @@ mod tests {
             .expect("previous month day should be representable");
         let previous_month_key = previous_month_day.format("%Y-%m-%d").to_string();
         let goal = app.current_goal_snapshot();
+        app.stats.sync_monthly_goal_snapshot(
+            previous_month_day,
+            DailyGoalSnapshot {
+                minutes: 200,
+                pomodoros: 6,
+            },
+        );
 
         app.stats
             .record_focus_elapsed(&previous_month_key, 120 * 60, goal);
@@ -5464,10 +5512,83 @@ mod tests {
         app.stats.record_completed_pomodoro(&today, goal);
 
         let monthly = app.current_month_goal_progress();
-        assert_eq!(monthly.minutes.target, 480);
-        assert_eq!(monthly.pomodoros.target, 16);
+        assert_eq!(monthly.minutes.target, 380);
+        assert_eq!(monthly.pomodoros.target, 12);
         assert_eq!(monthly.minutes.completed, 20);
         assert_eq!(monthly.pomodoros.completed, 1);
+    }
+
+    #[test]
+    fn weekly_goal_progress_carries_full_previous_week_when_snapshot_exists_without_activity() {
+        let config = AppConfig {
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 100,
+                pomodoros: 3,
+            },
+            goal_carry_over: GoalCarryOverConfig {
+                weekly: true,
+                ..GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let today = current_day_key();
+        let today_date = chrono::NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse");
+        let previous_week_day = today_date - chrono::Duration::days(7);
+        let goal = app.current_goal_snapshot();
+        app.stats.sync_weekly_goal_snapshot(
+            previous_week_day,
+            DailyGoalSnapshot {
+                minutes: 40,
+                pomodoros: 2,
+            },
+        );
+        app.stats.record_focus_elapsed(&today, 20 * 60, goal);
+        app.stats.record_completed_pomodoro(&today, goal);
+
+        let weekly = app.current_week_goal_progress();
+        assert_eq!(weekly.minutes.target, 140);
+        assert_eq!(weekly.pomodoros.target, 5);
+        assert_eq!(weekly.minutes.completed, 20);
+        assert_eq!(weekly.pomodoros.completed, 1);
+    }
+
+    #[test]
+    fn record_focus_elapsed_persists_base_daily_goal_snapshot_when_carry_over_is_enabled() {
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 2,
+            },
+            goal_carry_over: GoalCarryOverConfig {
+                daily: true,
+                ..GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let today = chrono::Local::now().date_naive();
+        let yesterday = today.pred_opt().expect("yesterday should exist");
+        let yesterday_key = yesterday.format("%Y-%m-%d").to_string();
+        let previous_target = DailyGoalSnapshot {
+            minutes: 50,
+            pomodoros: 3,
+        };
+        app.stats
+            .record_focus_elapsed(&yesterday_key, 30 * 60, previous_target);
+        app.stats
+            .record_completed_pomodoro(&yesterday_key, previous_target);
+
+        app.record_focus_elapsed(60);
+
+        assert_eq!(
+            app.today_stats().goal,
+            Some(DailyGoalSnapshot {
+                minutes: 60,
+                pomodoros: 2,
+            })
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2667,12 +2667,10 @@ fn effective_daily_goal_snapshot(
     };
     let previous = day.pred_opt().and_then(|previous_day| {
         let day_key = previous_day.format("%Y-%m-%d").to_string();
-        stats.daily_entry(&day_key).map(|daily| {
-            (
-                daily.goal.unwrap_or(base),
-                daily.focused_minutes(),
-                daily.pomodoros_completed,
-            )
+        stats.daily_entry(&day_key).and_then(|daily| {
+            daily
+                .goal
+                .map(|goal| (goal, daily.focused_minutes(), daily.pomodoros_completed))
         })
     });
     carry_over_goal_target(base, config.goal_carry_over.daily, previous)
@@ -5049,6 +5047,95 @@ mod tests {
         assert_eq!(output.monthly_goal.minutes_target, 480);
         assert_eq!(output.monthly_goal.pomodoros_target, 16);
         assert!(output.monthly_goal.carry_over);
+    }
+
+    #[test]
+    fn build_status_output_daily_carry_over_does_not_reapply_older_day_debt() {
+        let mut stats = FocusStats::default();
+        let today = current_day_key();
+        let today_date = NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse as a date");
+        let yesterday = today_date.pred_opt().expect("yesterday should exist");
+        let yesterday_key = yesterday.format("%Y-%m-%d").to_string();
+        let day_before = yesterday.pred_opt().expect("day before should exist");
+        let day_before_key = day_before.format("%Y-%m-%d").to_string();
+
+        stats.record_focus_elapsed(
+            &day_before_key,
+            30 * 60,
+            DailyGoalSnapshot {
+                minutes: 50,
+                pomodoros: 2,
+            },
+        );
+        stats.record_completed_pomodoro(
+            &day_before_key,
+            DailyGoalSnapshot {
+                minutes: 50,
+                pomodoros: 2,
+            },
+        );
+        stats.insert_daily_for_tests(
+            &yesterday_key,
+            crate::stats::DailyStats {
+                pomodoros_completed: 0,
+                focused_seconds: 0,
+                goal: Some(DailyGoalSnapshot {
+                    minutes: 60,
+                    pomodoros: 2,
+                }),
+            },
+        );
+
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 2,
+            },
+            goal_carry_over: crate::config::GoalCarryOverConfig {
+                daily: true,
+                ..crate::config::GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let output = build_status_output(&config, &stats);
+        assert_eq!(output.goal.minutes_target, 120);
+        assert_eq!(output.goal.pomodoros_target, 4);
+    }
+
+    #[test]
+    fn build_status_output_daily_carry_over_skips_when_previous_day_goal_is_absent() {
+        let mut stats = FocusStats::default();
+        let today = current_day_key();
+        let today_date = NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse as a date");
+        let yesterday = today_date.pred_opt().expect("yesterday should exist");
+        let yesterday_key = yesterday.format("%Y-%m-%d").to_string();
+        stats.insert_daily_for_tests(
+            &yesterday_key,
+            crate::stats::DailyStats {
+                pomodoros_completed: 4,
+                focused_seconds: 120 * 60,
+                goal: None,
+            },
+        );
+
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 2,
+            },
+            goal_carry_over: crate::config::GoalCarryOverConfig {
+                daily: true,
+                ..crate::config::GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let output = build_status_output(&config, &stats);
+        assert_eq!(output.goal.minutes_target, 60);
+        assert_eq!(output.goal.pomodoros_target, 2);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use chrono::NaiveDate;
+use chrono::{Datelike, NaiveDate};
 use serde::Serialize;
 
 use crate::app::{App, SetupCheck, SetupCheckLevel, SetupDiagnostics};
@@ -20,7 +20,7 @@ use crate::config::{
 };
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
-use crate::stats::{DailyGoalSnapshot, FocusStats, current_day_key};
+use crate::stats::{DailyGoalSnapshot, FocusStats, carry_over_goal_target, current_day_key};
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
     DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerStatus,
@@ -41,6 +41,12 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --goal-weekly=MINUTES,POMODOROS [--json]
   focustime --goal-monthly [--json]
   focustime --goal-monthly=MINUTES,POMODOROS [--json]
+  focustime --goal-carry [--json]
+  focustime --goal-carry=on|off [--json]
+  focustime --goal-carry-weekly [--json]
+  focustime --goal-carry-weekly=on|off [--json]
+  focustime --goal-carry-monthly [--json]
+  focustime --goal-carry-monthly=on|off [--json]
   focustime --strict [--json]
   focustime --strict=on|off [--json]
   focustime --schedule [--json]
@@ -73,6 +79,9 @@ Options:
   --goal          Show current daily goal, or set minutes/pomodoros targets
   --goal-weekly   Show current weekly goal, or set minutes/pomodoros targets
   --goal-monthly  Show current monthly goal, or set minutes/pomodoros targets
+  --goal-carry          Show daily goal carry-over, or set on/off
+  --goal-carry-weekly   Show weekly goal carry-over, or set on/off
+  --goal-carry-monthly  Show monthly goal carry-over, or set on/off
   --strict        Show strict mode, or set on/off
   --schedule      Show recurring schedule with overlap/conflict inspection
   --schedule-set  Replace schedule (recurring + one-time) from JSON payload
@@ -163,6 +172,15 @@ pub enum CommandKind {
     GoalMonthly {
         goal: Option<MonthlyGoalConfig>,
     },
+    GoalCarry {
+        enabled: Option<bool>,
+    },
+    GoalCarryWeekly {
+        enabled: Option<bool>,
+    },
+    GoalCarryMonthly {
+        enabled: Option<bool>,
+    },
     Strict {
         enabled: Option<bool>,
     },
@@ -211,6 +229,9 @@ enum PrimaryCommand {
     Goal(Option<DailyGoalConfig>),
     GoalWeekly(Option<WeeklyGoalConfig>),
     GoalMonthly(Option<MonthlyGoalConfig>),
+    GoalCarry(Option<bool>),
+    GoalCarryWeekly(Option<bool>),
+    GoalCarryMonthly(Option<bool>),
     Strict(Option<bool>),
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
@@ -248,6 +269,9 @@ enum ParsedToken {
     Goal(Option<DailyGoalConfig>),
     GoalWeekly(Option<WeeklyGoalConfig>),
     GoalMonthly(Option<MonthlyGoalConfig>),
+    GoalCarry(Option<bool>),
+    GoalCarryWeekly(Option<bool>),
+    GoalCarryMonthly(Option<bool>),
     Strict(Option<bool>),
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
@@ -342,6 +366,7 @@ struct GoalOutput {
     minutes_target: u64,
     pomodoros_target: u32,
     met: bool,
+    carry_over: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -429,6 +454,12 @@ struct GoalCommandOutput {
     configured: bool,
     minutes_target: u64,
     pomodoros_target: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct GoalCarryCommandOutput {
+    updated: bool,
+    carry_over: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -660,12 +691,15 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 18] = [
+    let parsers: [(&str, ValueArgParser); 21] = [
         ("--task", classify_task_arg),
         ("--profile", classify_profile_arg),
         ("--goal", classify_goal_arg),
         ("--goal-weekly", classify_goal_weekly_arg),
         ("--goal-monthly", classify_goal_monthly_arg),
+        ("--goal-carry", classify_goal_carry_arg),
+        ("--goal-carry-weekly", classify_goal_carry_weekly_arg),
+        ("--goal-carry-monthly", classify_goal_carry_monthly_arg),
         ("--strict", classify_strict_arg),
         ("--schedule-set", classify_schedule_set_arg),
         ("--watch", classify_watch_arg),
@@ -965,6 +999,48 @@ fn classify_strict_arg(args: &[String], index: usize) -> Result<(ParsedToken, us
     Ok((ParsedToken::Strict(None), 1))
 }
 
+fn classify_goal_carry_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((
+            ParsedToken::GoalCarry(Some(parse_goal_carry_value(next)?)),
+            2,
+        ));
+    }
+    Ok((ParsedToken::GoalCarry(None), 1))
+}
+
+fn classify_goal_carry_weekly_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((
+            ParsedToken::GoalCarryWeekly(Some(parse_goal_carry_value(next)?)),
+            2,
+        ));
+    }
+    Ok((ParsedToken::GoalCarryWeekly(None), 1))
+}
+
+fn classify_goal_carry_monthly_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((
+            ParsedToken::GoalCarryMonthly(Some(parse_goal_carry_value(next)?)),
+            2,
+        ));
+    }
+    Ok((ParsedToken::GoalCarryMonthly(None), 1))
+}
+
 fn classify_schedule_set_arg(
     args: &[String],
     index: usize,
@@ -980,12 +1056,15 @@ fn classify_schedule_set_arg(
 }
 
 fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 18] = [
+    let parsers: [KeyValueParser; 21] = [
         parse_task_key_value_arg,
         parse_profile_key_value_arg,
         parse_goal_key_value_arg,
         parse_goal_weekly_key_value_arg,
         parse_goal_monthly_key_value_arg,
+        parse_goal_carry_key_value_arg,
+        parse_goal_carry_weekly_key_value_arg,
+        parse_goal_carry_monthly_key_value_arg,
         parse_strict_key_value_arg,
         parse_schedule_set_key_value_arg,
         parse_watch_key_value_arg,
@@ -1067,6 +1146,38 @@ fn parse_strict_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> 
     if let Some(value) = arg.strip_prefix("--strict=") {
         let value = require_nonempty_key_value(value, "`--strict=` requires `on` or `off`.")?;
         return Ok(Some(ParsedToken::Strict(Some(parse_strict_value(value)?))));
+    }
+    Ok(None)
+}
+
+fn parse_goal_carry_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--goal-carry=") {
+        let value = require_nonempty_key_value(value, "`--goal-carry=` requires `on` or `off`.")?;
+        return Ok(Some(ParsedToken::GoalCarry(Some(parse_goal_carry_value(
+            value,
+        )?))));
+    }
+    Ok(None)
+}
+
+fn parse_goal_carry_weekly_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--goal-carry-weekly=") {
+        let value =
+            require_nonempty_key_value(value, "`--goal-carry-weekly=` requires `on` or `off`.")?;
+        return Ok(Some(ParsedToken::GoalCarryWeekly(Some(
+            parse_goal_carry_value(value)?,
+        ))));
+    }
+    Ok(None)
+}
+
+fn parse_goal_carry_monthly_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--goal-carry-monthly=") {
+        let value =
+            require_nonempty_key_value(value, "`--goal-carry-monthly=` requires `on` or `off`.")?;
+        return Ok(Some(ParsedToken::GoalCarryMonthly(Some(
+            parse_goal_carry_value(value)?,
+        ))));
     }
     Ok(None)
 }
@@ -1226,6 +1337,9 @@ fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), Str
             | ParsedToken::Goal(_)
             | ParsedToken::GoalWeekly(_)
             | ParsedToken::GoalMonthly(_)
+            | ParsedToken::GoalCarry(_)
+            | ParsedToken::GoalCarryWeekly(_)
+            | ParsedToken::GoalCarryMonthly(_)
             | ParsedToken::Strict(_)
             | ParsedToken::Schedule
             | ParsedToken::ScheduleSet(_)
@@ -1274,6 +1388,15 @@ fn parse_primary_command(tokens: &[ParsedToken]) -> Result<Option<PrimaryCommand
             }
             ParsedToken::GoalMonthly(goal) => {
                 set_primary_command(&mut primary, PrimaryCommand::GoalMonthly(*goal))?
+            }
+            ParsedToken::GoalCarry(enabled) => {
+                set_primary_command(&mut primary, PrimaryCommand::GoalCarry(*enabled))?
+            }
+            ParsedToken::GoalCarryWeekly(enabled) => {
+                set_primary_command(&mut primary, PrimaryCommand::GoalCarryWeekly(*enabled))?
+            }
+            ParsedToken::GoalCarryMonthly(enabled) => {
+                set_primary_command(&mut primary, PrimaryCommand::GoalCarryMonthly(*enabled))?
             }
             ParsedToken::Strict(enabled) => {
                 set_primary_command(&mut primary, PrimaryCommand::Strict(*enabled))?
@@ -1392,6 +1515,18 @@ fn finalize_cli_action(
         })),
         Some(PrimaryCommand::GoalMonthly(goal)) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::GoalMonthly { goal },
+            output,
+        })),
+        Some(PrimaryCommand::GoalCarry(enabled)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::GoalCarry { enabled },
+            output,
+        })),
+        Some(PrimaryCommand::GoalCarryWeekly(enabled)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::GoalCarryWeekly { enabled },
+            output,
+        })),
+        Some(PrimaryCommand::GoalCarryMonthly(enabled)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::GoalCarryMonthly { enabled },
             output,
         })),
         Some(PrimaryCommand::Strict(enabled)) => Ok(CliAction::RunCommand(CliCommand {
@@ -1544,6 +1679,15 @@ pub fn execute_command(cli_command: CliCommand) -> Result<(), String> {
         CommandKind::Goal { goal } => execute_goal_command(goal, cli_command.output),
         CommandKind::GoalWeekly { goal } => execute_weekly_goal_command(goal, cli_command.output),
         CommandKind::GoalMonthly { goal } => execute_monthly_goal_command(goal, cli_command.output),
+        CommandKind::GoalCarry { enabled } => {
+            execute_goal_carry_command(enabled, cli_command.output)
+        }
+        CommandKind::GoalCarryWeekly { enabled } => {
+            execute_weekly_goal_carry_command(enabled, cli_command.output)
+        }
+        CommandKind::GoalCarryMonthly { enabled } => {
+            execute_monthly_goal_carry_command(enabled, cli_command.output)
+        }
         CommandKind::Strict { enabled } => execute_strict_command(enabled, cli_command.output),
         CommandKind::Schedule { schedule } => {
             execute_schedule_command(schedule, cli_command.output)
@@ -2172,6 +2316,78 @@ fn execute_monthly_goal_command(
     Ok(())
 }
 
+fn execute_goal_carry_command(enabled: Option<bool>, output: OutputMode) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let mut updated = false;
+    if let Some(enabled) = enabled {
+        config.goal_carry_over.daily = enabled;
+        config
+            .save()
+            .map_err(|error| format!("Failed to save daily goal carry-over: {error}"))?;
+        updated = true;
+    }
+
+    let payload = GoalCarryCommandOutput {
+        updated,
+        carry_over: config.goal_carry_over.daily,
+    };
+    match output {
+        OutputMode::Text => print_goal_carry_command_output("Daily", &payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_weekly_goal_carry_command(
+    enabled: Option<bool>,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let mut updated = false;
+    if let Some(enabled) = enabled {
+        config.goal_carry_over.weekly = enabled;
+        config
+            .save()
+            .map_err(|error| format!("Failed to save weekly goal carry-over: {error}"))?;
+        updated = true;
+    }
+
+    let payload = GoalCarryCommandOutput {
+        updated,
+        carry_over: config.goal_carry_over.weekly,
+    };
+    match output {
+        OutputMode::Text => print_goal_carry_command_output("Weekly", &payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_monthly_goal_carry_command(
+    enabled: Option<bool>,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let mut updated = false;
+    if let Some(enabled) = enabled {
+        config.goal_carry_over.monthly = enabled;
+        config
+            .save()
+            .map_err(|error| format!("Failed to save monthly goal carry-over: {error}"))?;
+        updated = true;
+    }
+
+    let payload = GoalCarryCommandOutput {
+        updated,
+        carry_over: config.goal_carry_over.monthly,
+    };
+    match output {
+        OutputMode::Text => print_goal_carry_command_output("Monthly", &payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
 fn execute_strict_command(enabled: Option<bool>, output: OutputMode) -> Result<(), String> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
@@ -2381,18 +2597,9 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let (_, selected_task_label) = stats.task_planner_state();
     let (selected_task_label, focus_intention, task_note) =
         mirror_metadata_from_task_label(selected_task_label);
-    let goal_snapshot = DailyGoalSnapshot {
-        minutes: config.daily_goal.minutes,
-        pomodoros: config.daily_goal.pomodoros,
-    };
-    let weekly_goal_snapshot = DailyGoalSnapshot {
-        minutes: config.weekly_goal.minutes,
-        pomodoros: config.weekly_goal.pomodoros,
-    };
-    let monthly_goal_snapshot = DailyGoalSnapshot {
-        minutes: config.monthly_goal.minutes,
-        pomodoros: config.monthly_goal.pomodoros,
-    };
+    let goal_snapshot = effective_daily_goal_snapshot(config, stats, day_date);
+    let weekly_goal_snapshot = effective_weekly_goal_snapshot(config, stats, day_date);
+    let monthly_goal_snapshot = effective_monthly_goal_snapshot(config, stats, day_date);
     let active_sites_count = config
         .blocklist_profiles
         .iter()
@@ -2419,6 +2626,7 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
             minutes_target: goal_snapshot.minutes,
             pomodoros_target: goal_snapshot.pomodoros,
             met: goal_snapshot.is_met_by(today),
+            carry_over: config.goal_carry_over.daily,
         },
         weekly_goal: GoalOutput {
             configured: weekly_goal_snapshot.has_any_target(),
@@ -2426,6 +2634,7 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
             pomodoros_target: weekly_goal_snapshot.pomodoros,
             met: weekly_goal_snapshot
                 .is_met_by_totals(week.focused_minutes(), week.pomodoros_completed),
+            carry_over: config.goal_carry_over.weekly,
         },
         monthly_goal: GoalOutput {
             configured: monthly_goal_snapshot.has_any_target(),
@@ -2433,6 +2642,7 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
             pomodoros_target: monthly_goal_snapshot.pomodoros,
             met: monthly_goal_snapshot
                 .is_met_by_totals(month.focused_minutes(), month.pomodoros_completed),
+            carry_over: config.goal_carry_over.monthly,
         },
         session: SessionOutput {
             focused_minutes: session.focused_minutes(),
@@ -2444,6 +2654,69 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
         },
         live,
     }
+}
+
+fn effective_daily_goal_snapshot(
+    config: &AppConfig,
+    stats: &FocusStats,
+    day: NaiveDate,
+) -> DailyGoalSnapshot {
+    let base = DailyGoalSnapshot {
+        minutes: config.daily_goal.minutes,
+        pomodoros: config.daily_goal.pomodoros,
+    };
+    let previous = day.pred_opt().and_then(|previous_day| {
+        let day_key = previous_day.format("%Y-%m-%d").to_string();
+        stats.daily_entry(&day_key).map(|daily| {
+            (
+                daily.goal.unwrap_or(base),
+                daily.focused_minutes(),
+                daily.pomodoros_completed,
+            )
+        })
+    });
+    carry_over_goal_target(base, config.goal_carry_over.daily, previous)
+}
+
+fn effective_weekly_goal_snapshot(
+    config: &AppConfig,
+    stats: &FocusStats,
+    day: NaiveDate,
+) -> DailyGoalSnapshot {
+    let base = DailyGoalSnapshot {
+        minutes: config.weekly_goal.minutes,
+        pomodoros: config.weekly_goal.pomodoros,
+    };
+    let previous =
+        day.checked_sub_signed(chrono::Duration::weeks(1))
+            .and_then(|previous_week_day| {
+                stats
+                    .weekly_for_day_if_present(previous_week_day)
+                    .map(|week| (base, week.focused_minutes(), week.pomodoros_completed))
+            });
+    carry_over_goal_target(base, config.goal_carry_over.weekly, previous)
+}
+
+fn effective_monthly_goal_snapshot(
+    config: &AppConfig,
+    stats: &FocusStats,
+    day: NaiveDate,
+) -> DailyGoalSnapshot {
+    let base = DailyGoalSnapshot {
+        minutes: config.monthly_goal.minutes,
+        pomodoros: config.monthly_goal.pomodoros,
+    };
+    let previous = previous_month_reference_day(day).and_then(|previous_month_day| {
+        stats
+            .monthly_for_day_if_present(previous_month_day)
+            .map(|month| (base, month.focused_minutes(), month.pomodoros_completed))
+    });
+    carry_over_goal_target(base, config.goal_carry_over.monthly, previous)
+}
+
+fn previous_month_reference_day(day: NaiveDate) -> Option<NaiveDate> {
+    let month_start = NaiveDate::from_ymd_opt(day.year(), day.month(), 1)?;
+    month_start.pred_opt()
 }
 
 fn build_live_status_output(
@@ -2640,6 +2913,16 @@ fn parse_strict_value(value: &str) -> Result<bool, String> {
     }
 }
 
+fn parse_goal_carry_value(value: &str) -> Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "on" => Ok(true),
+        "off" => Ok(false),
+        _ => Err(invalid_usage(&format!(
+            "Invalid goal carry-over `{value}`. Use `on` or `off`."
+        ))),
+    }
+}
+
 fn parse_site_edit_value(value: &str) -> Result<SiteEditValue, String> {
     let trimmed = value.trim();
     let (previous, next) = trimmed.split_once('=').ok_or_else(|| {
@@ -2826,6 +3109,9 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Goal(_) => "--goal",
         PrimaryCommand::GoalWeekly(_) => "--goal-weekly",
         PrimaryCommand::GoalMonthly(_) => "--goal-monthly",
+        PrimaryCommand::GoalCarry(_) => "--goal-carry",
+        PrimaryCommand::GoalCarryWeekly(_) => "--goal-carry-weekly",
+        PrimaryCommand::GoalCarryMonthly(_) => "--goal-carry-monthly",
         PrimaryCommand::Strict(_) => "--strict",
         PrimaryCommand::Schedule => "--schedule",
         PrimaryCommand::ScheduleSet(_) => "--schedule-set",
@@ -3063,13 +3349,17 @@ fn print_status_output(payload: &StatusOutput) {
 fn print_status_goal_line(label: &str, goal: &GoalOutput) {
     if goal.configured {
         println!(
-            "{label}: {} min, {} pomodoros ({})",
+            "{label}: {} min, {} pomodoros ({}, carry-over: {})",
             goal.minutes_target,
             goal.pomodoros_target,
-            if goal.met { "met" } else { "in progress" }
+            if goal.met { "met" } else { "in progress" },
+            if goal.carry_over { "on" } else { "off" }
         );
     } else {
-        println!("{label}: off");
+        println!(
+            "{label}: off (carry-over: {})",
+            if goal.carry_over { "on" } else { "off" }
+        );
     }
 }
 
@@ -3117,6 +3407,16 @@ fn print_goal_command_output(label: &str, payload: &GoalCommandOutput) {
     } else {
         println!("{label} goal: off");
     }
+}
+
+fn print_goal_carry_command_output(label: &str, payload: &GoalCarryCommandOutput) {
+    if payload.updated {
+        println!("{label} goal carry-over updated.");
+    }
+    println!(
+        "{label} goal carry-over: {}",
+        if payload.carry_over { "on" } else { "off" }
+    );
 }
 
 fn print_strict_command_output(payload: &StrictCommandOutput) {
@@ -3652,6 +3952,46 @@ mod tests {
     }
 
     #[test]
+    fn parse_goal_carry_without_value_reads_current_state() {
+        let parsed = parse(&["--goal-carry"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::GoalCarry { enabled: None },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_goal_carry_weekly_with_equals_sets_state() {
+        let parsed = parse(&["--goal-carry-weekly=on"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::GoalCarryWeekly {
+                    enabled: Some(true)
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_goal_carry_monthly_with_value_sets_state() {
+        let parsed = parse(&["--goal-carry-monthly", "off"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::GoalCarryMonthly {
+                    enabled: Some(false)
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
     fn parse_schedule_reads_current_schedule() {
         let parsed = parse(&["--schedule"]).unwrap();
         assert_eq!(
@@ -3998,6 +4338,24 @@ mod tests {
     }
 
     #[test]
+    fn classify_key_value_arg_accepts_goal_carry_equals_value() {
+        let parsed = classify_key_value_arg("--goal-carry=on").unwrap();
+        assert_eq!(parsed, Some(ParsedToken::GoalCarry(Some(true))));
+    }
+
+    #[test]
+    fn classify_key_value_arg_accepts_goal_carry_weekly_equals_value() {
+        let parsed = classify_key_value_arg("--goal-carry-weekly=off").unwrap();
+        assert_eq!(parsed, Some(ParsedToken::GoalCarryWeekly(Some(false))));
+    }
+
+    #[test]
+    fn classify_key_value_arg_accepts_goal_carry_monthly_equals_value() {
+        let parsed = classify_key_value_arg("--goal-carry-monthly=on").unwrap();
+        assert_eq!(parsed, Some(ParsedToken::GoalCarryMonthly(Some(true))));
+    }
+
+    #[test]
     fn classify_key_value_arg_accepts_schedule_set_equals_value() {
         let payload = "--schedule-set={\"windows\":[{\"days\":[\"fri\"],\"start\":\"10:00\",\"end\":\"11:00\"}],\"exception_dates\":[]}";
         let parsed = classify_key_value_arg(payload).unwrap();
@@ -4043,6 +4401,24 @@ mod tests {
     fn classify_key_value_arg_rejects_empty_strict_equals_value() {
         let error = classify_key_value_arg("--strict=").unwrap_err();
         assert!(error.contains("`--strict=` requires `on` or `off`"));
+    }
+
+    #[test]
+    fn classify_key_value_arg_rejects_empty_goal_carry_equals_value() {
+        let error = classify_key_value_arg("--goal-carry=").unwrap_err();
+        assert!(error.contains("`--goal-carry=` requires `on` or `off`"));
+    }
+
+    #[test]
+    fn classify_key_value_arg_rejects_empty_goal_carry_weekly_equals_value() {
+        let error = classify_key_value_arg("--goal-carry-weekly=").unwrap_err();
+        assert!(error.contains("`--goal-carry-weekly=` requires `on` or `off`"));
+    }
+
+    #[test]
+    fn classify_key_value_arg_rejects_empty_goal_carry_monthly_equals_value() {
+        let error = classify_key_value_arg("--goal-carry-monthly=").unwrap_err();
+        assert!(error.contains("`--goal-carry-monthly=` requires `on` or `off`"));
     }
 
     #[test]
@@ -4097,6 +4473,12 @@ mod tests {
     fn parse_rejects_strict_with_unknown_value() {
         let error = parse(&["--strict=enabled"]).unwrap_err();
         assert!(error.contains("Invalid strict mode"));
+    }
+
+    #[test]
+    fn parse_rejects_goal_carry_with_unknown_value() {
+        let error = parse(&["--goal-carry=enabled"]).unwrap_err();
+        assert!(error.contains("Invalid goal carry-over"));
     }
 
     #[test]
@@ -4602,6 +4984,106 @@ mod tests {
         assert!(boundary_output.goal.met);
         assert!(!boundary_output.weekly_goal.met);
         assert!(!boundary_output.monthly_goal.met);
+    }
+
+    #[test]
+    fn build_status_output_applies_carry_over_to_goal_targets_when_enabled() {
+        let mut stats = FocusStats::default();
+        let today = current_day_key();
+        let today_date = NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse as a date");
+        let yesterday = today_date.pred_opt().expect("yesterday should exist");
+        let yesterday_key = yesterday.format("%Y-%m-%d").to_string();
+        let month_start = NaiveDate::from_ymd_opt(today_date.year(), today_date.month(), 1)
+            .expect("month start should be representable");
+        let previous_month_day = month_start
+            .pred_opt()
+            .expect("previous month day should be representable");
+        let previous_month_key = previous_month_day.format("%Y-%m-%d").to_string();
+        let previous_daily_goal = DailyGoalSnapshot {
+            minutes: 50,
+            pomodoros: 3,
+        };
+
+        stats.record_focus_elapsed(&yesterday_key, 30 * 60, previous_daily_goal);
+        stats.record_completed_pomodoro(&yesterday_key, previous_daily_goal);
+
+        let base_daily_goal = DailyGoalSnapshot {
+            minutes: 60,
+            pomodoros: 2,
+        };
+        stats.record_focus_elapsed(&today, 40 * 60, base_daily_goal);
+        stats.record_completed_pomodoro(&today, base_daily_goal);
+
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 60,
+                pomodoros: 2,
+            },
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 100,
+                pomodoros: 3,
+            },
+            monthly_goal: MonthlyGoalConfig {
+                minutes: 300,
+                pomodoros: 10,
+            },
+            goal_carry_over: crate::config::GoalCarryOverConfig {
+                daily: true,
+                weekly: true,
+                monthly: true,
+            },
+            ..AppConfig::default()
+        };
+
+        let output = build_status_output(&config, &stats);
+        assert_eq!(output.goal.minutes_target, 80);
+        assert_eq!(output.goal.pomodoros_target, 4);
+        assert!(output.goal.carry_over);
+
+        stats.record_focus_elapsed(&previous_month_key, 120 * 60, base_daily_goal);
+        for _ in 0..4 {
+            stats.record_completed_pomodoro(&previous_month_key, base_daily_goal);
+        }
+        let output = build_status_output(&config, &stats);
+        assert_eq!(output.monthly_goal.minutes_target, 480);
+        assert_eq!(output.monthly_goal.pomodoros_target, 16);
+        assert!(output.monthly_goal.carry_over);
+    }
+
+    #[test]
+    fn build_status_output_applies_weekly_carry_over_to_goal_targets_when_enabled() {
+        let mut stats = FocusStats::default();
+        let today = current_day_key();
+        let today_date = NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse as a date");
+        let previous_week_day = today_date - Duration::days(7);
+        let previous_week_key = previous_week_day.format("%Y-%m-%d").to_string();
+        let goal = DailyGoalSnapshot {
+            minutes: 60,
+            pomodoros: 2,
+        };
+        stats.record_focus_elapsed(&previous_week_key, 70 * 60, goal);
+        stats.record_completed_pomodoro(&previous_week_key, goal);
+        stats.record_focus_elapsed(&today, 40 * 60, goal);
+        stats.record_completed_pomodoro(&today, goal);
+
+        let config = AppConfig {
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 100,
+                pomodoros: 3,
+            },
+            goal_carry_over: crate::config::GoalCarryOverConfig {
+                weekly: true,
+                ..crate::config::GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let output = build_status_output(&config, &stats);
+        assert_eq!(output.weekly_goal.minutes_target, 130);
+        assert_eq!(output.weekly_goal.pomodoros_target, 5);
+        assert!(output.weekly_goal.carry_over);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2689,8 +2689,15 @@ fn effective_weekly_goal_snapshot(
         day.checked_sub_signed(chrono::Duration::weeks(1))
             .and_then(|previous_week_day| {
                 stats
-                    .weekly_for_day_if_present(previous_week_day)
-                    .map(|week| (base, week.focused_minutes(), week.pomodoros_completed))
+                    .weekly_goal_snapshot_for_day(previous_week_day)
+                    .map(|previous_target| {
+                        let week = stats.weekly_for_day(previous_week_day);
+                        (
+                            previous_target,
+                            week.focused_minutes(),
+                            week.pomodoros_completed,
+                        )
+                    })
             });
     carry_over_goal_target(base, config.goal_carry_over.weekly, previous)
 }
@@ -2706,8 +2713,15 @@ fn effective_monthly_goal_snapshot(
     };
     let previous = previous_month_reference_day(day).and_then(|previous_month_day| {
         stats
-            .monthly_for_day_if_present(previous_month_day)
-            .map(|month| (base, month.focused_minutes(), month.pomodoros_completed))
+            .monthly_goal_snapshot_for_day(previous_month_day)
+            .map(|previous_target| {
+                let month = stats.monthly_for_day(previous_month_day);
+                (
+                    previous_target,
+                    month.focused_minutes(),
+                    month.pomodoros_completed,
+                )
+            })
     });
     carry_over_goal_target(base, config.goal_carry_over.monthly, previous)
 }
@@ -5039,13 +5053,20 @@ mod tests {
         assert_eq!(output.goal.pomodoros_target, 4);
         assert!(output.goal.carry_over);
 
+        stats.sync_monthly_goal_snapshot(
+            previous_month_day,
+            DailyGoalSnapshot {
+                minutes: 200,
+                pomodoros: 6,
+            },
+        );
         stats.record_focus_elapsed(&previous_month_key, 120 * 60, base_daily_goal);
         for _ in 0..4 {
             stats.record_completed_pomodoro(&previous_month_key, base_daily_goal);
         }
         let output = build_status_output(&config, &stats);
-        assert_eq!(output.monthly_goal.minutes_target, 480);
-        assert_eq!(output.monthly_goal.pomodoros_target, 16);
+        assert_eq!(output.monthly_goal.minutes_target, 380);
+        assert_eq!(output.monthly_goal.pomodoros_target, 12);
         assert!(output.monthly_goal.carry_over);
     }
 
@@ -5150,7 +5171,14 @@ mod tests {
             minutes: 60,
             pomodoros: 2,
         };
-        stats.record_focus_elapsed(&previous_week_key, 70 * 60, goal);
+        stats.sync_weekly_goal_snapshot(
+            previous_week_day,
+            DailyGoalSnapshot {
+                minutes: 50,
+                pomodoros: 2,
+            },
+        );
+        stats.record_focus_elapsed(&previous_week_key, 20 * 60, goal);
         stats.record_completed_pomodoro(&previous_week_key, goal);
         stats.record_focus_elapsed(&today, 40 * 60, goal);
         stats.record_completed_pomodoro(&today, goal);
@@ -5169,8 +5197,85 @@ mod tests {
 
         let output = build_status_output(&config, &stats);
         assert_eq!(output.weekly_goal.minutes_target, 130);
-        assert_eq!(output.weekly_goal.pomodoros_target, 5);
+        assert_eq!(output.weekly_goal.pomodoros_target, 4);
         assert!(output.weekly_goal.carry_over);
+    }
+
+    #[test]
+    fn build_status_output_weekly_carry_over_skips_when_previous_period_has_no_snapshot() {
+        let mut stats = FocusStats::default();
+        let today = current_day_key();
+        let today_date = NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse as a date");
+        let previous_week_day = today_date - Duration::days(7);
+        let previous_week_key = previous_week_day.format("%Y-%m-%d").to_string();
+        let goal = DailyGoalSnapshot {
+            minutes: 60,
+            pomodoros: 2,
+        };
+        stats.record_focus_elapsed(&previous_week_key, 70 * 60, goal);
+        stats.record_completed_pomodoro(&previous_week_key, goal);
+
+        let config = AppConfig {
+            weekly_goal: WeeklyGoalConfig {
+                minutes: 100,
+                pomodoros: 3,
+            },
+            goal_carry_over: crate::config::GoalCarryOverConfig {
+                weekly: true,
+                ..crate::config::GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let output = build_status_output(&config, &stats);
+        assert_eq!(output.weekly_goal.minutes_target, 100);
+        assert_eq!(output.weekly_goal.pomodoros_target, 3);
+    }
+
+    #[test]
+    fn build_status_output_monthly_carry_over_uses_previous_snapshot_after_goal_change() {
+        let mut stats = FocusStats::default();
+        let today = current_day_key();
+        let today_date = NaiveDate::parse_from_str(&today, "%Y-%m-%d")
+            .expect("current day key should parse as a date");
+        let month_start = NaiveDate::from_ymd_opt(today_date.year(), today_date.month(), 1)
+            .expect("month start should be representable");
+        let previous_month_day = month_start
+            .pred_opt()
+            .expect("previous month day should be representable");
+        let previous_month_key = previous_month_day.format("%Y-%m-%d").to_string();
+        let goal = DailyGoalSnapshot {
+            minutes: 60,
+            pomodoros: 2,
+        };
+        stats.sync_monthly_goal_snapshot(
+            previous_month_day,
+            DailyGoalSnapshot {
+                minutes: 200,
+                pomodoros: 6,
+            },
+        );
+        stats.record_focus_elapsed(&previous_month_key, 120 * 60, goal);
+        for _ in 0..4 {
+            stats.record_completed_pomodoro(&previous_month_key, goal);
+        }
+
+        let config = AppConfig {
+            monthly_goal: MonthlyGoalConfig {
+                minutes: 300,
+                pomodoros: 10,
+            },
+            goal_carry_over: crate::config::GoalCarryOverConfig {
+                monthly: true,
+                ..crate::config::GoalCarryOverConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let output = build_status_output(&config, &stats);
+        assert_eq!(output.monthly_goal.minutes_target, 380);
+        assert_eq!(output.monthly_goal.pomodoros_target, 12);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,9 @@ pub struct AppConfig {
     /// A value of `0` disables the corresponding goal.
     #[serde(default)]
     pub monthly_goal: MonthlyGoalConfig,
+    /// Carry-over behavior for unmet daily/weekly/monthly targets.
+    #[serde(default)]
+    pub goal_carry_over: GoalCarryOverConfig,
     /// WakaTime heartbeat metadata labels.
     #[serde(default)]
     pub wakatime: WakatimeMetadataConfig,
@@ -266,6 +269,19 @@ pub struct MonthlyGoalConfig {
     /// Target completed pomodoros for the current month.
     #[serde(default)]
     pub pomodoros: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct GoalCarryOverConfig {
+    /// When enabled, unmet daily targets are added to the next day's target.
+    #[serde(default)]
+    pub daily: bool,
+    /// When enabled, unmet weekly targets are added to the next week's target.
+    #[serde(default)]
+    pub weekly: bool,
+    /// When enabled, unmet monthly targets are added to the next month's target.
+    #[serde(default)]
+    pub monthly: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -465,6 +481,7 @@ impl Default for AppConfig {
             daily_goal: DailyGoalConfig::default(),
             weekly_goal: WeeklyGoalConfig::default(),
             monthly_goal: MonthlyGoalConfig::default(),
+            goal_carry_over: GoalCarryOverConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
         }
     }
@@ -829,6 +846,7 @@ mod tests {
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
         assert_eq!(cfg.weekly_goal, WeeklyGoalConfig::default());
         assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
+        assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
         assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }
 
@@ -895,6 +913,11 @@ mod tests {
                 minutes: 2400,
                 pomodoros: 80,
             },
+            goal_carry_over: GoalCarryOverConfig {
+                daily: true,
+                weekly: false,
+                monthly: true,
+            },
             wakatime: WakatimeMetadataConfig {
                 project: "Team Focus".to_string(),
                 language: "Focus Session".to_string(),
@@ -925,6 +948,7 @@ mod tests {
         assert_eq!(parsed.daily_goal, original.daily_goal);
         assert_eq!(parsed.weekly_goal, original.weekly_goal);
         assert_eq!(parsed.monthly_goal, original.monthly_goal);
+        assert_eq!(parsed.goal_carry_over, original.goal_carry_over);
         assert_eq!(parsed.wakatime, original.wakatime);
     }
 
@@ -952,6 +976,7 @@ mod tests {
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
         assert_eq!(cfg.weekly_goal, WeeklyGoalConfig::default());
         assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
+        assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
         assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }
 
@@ -1152,6 +1177,7 @@ blocked_sites = ["reddit.com", "youtube.com"]
         assert_eq!(parsed.daily_goal, DailyGoalConfig::default());
         assert_eq!(parsed.weekly_goal, WeeklyGoalConfig::default());
         assert_eq!(parsed.monthly_goal, MonthlyGoalConfig::default());
+        assert_eq!(parsed.goal_carry_over, GoalCarryOverConfig::default());
         assert_eq!(parsed.wakatime, WakatimeMetadataConfig::default());
     }
 
@@ -1196,6 +1222,7 @@ long_break_interval = 3
             daily_goal: DailyGoalConfig::default(),
             weekly_goal: WeeklyGoalConfig::default(),
             monthly_goal: MonthlyGoalConfig::default(),
+            goal_carry_over: GoalCarryOverConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
         };
         let custom = cfg.effective_custom_profile();
@@ -1250,6 +1277,7 @@ long_break_interval = 3
         assert_eq!(cfg.daily_goal, DailyGoalConfig::default());
         assert_eq!(cfg.weekly_goal, WeeklyGoalConfig::default());
         assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
+        assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
         assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -759,14 +759,6 @@ impl FocusStats {
         totals
     }
 
-    pub fn weekly_for_day_if_present(&self, day: chrono::NaiveDate) -> Option<WeeklyStats> {
-        let week = self.weekly_for_day(day);
-        (week.focused_seconds > 0
-            || week.pomodoros_completed > 0
-            || self.weekly_goal_snapshot_for_day(day).is_some())
-        .then_some(week)
-    }
-
     pub fn monthly_for_day(&self, day: chrono::NaiveDate) -> MonthlyStats {
         let mut totals = MonthlyStats {
             year: day.year(),
@@ -786,14 +778,6 @@ impl FocusStats {
             totals.focused_seconds = totals.focused_seconds.saturating_add(stats.focused_seconds);
         }
         totals
-    }
-
-    pub fn monthly_for_day_if_present(&self, day: chrono::NaiveDate) -> Option<MonthlyStats> {
-        let month = self.monthly_for_day(day);
-        (month.focused_seconds > 0
-            || month.pomodoros_completed > 0
-            || self.monthly_goal_snapshot_for_day(day).is_some())
-        .then_some(month)
     }
 
     pub fn weekly_goal_snapshot_for_day(&self, day: chrono::NaiveDate) -> Option<DailyGoalSnapshot> {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -2413,8 +2413,14 @@ mod tests {
         let toml_str = toml::to_string_pretty(&original.to_persisted()).unwrap();
         let restored = FocusStats::try_from_toml(&toml_str).unwrap();
 
-        assert_eq!(restored.weekly_goal_snapshot_for_day(day), Some(weekly_goal));
-        assert_eq!(restored.monthly_goal_snapshot_for_day(day), Some(monthly_goal));
+        assert_eq!(
+            restored.weekly_goal_snapshot_for_day(day),
+            Some(weekly_goal)
+        );
+        assert_eq!(
+            restored.monthly_goal_snapshot_for_day(day),
+            Some(monthly_goal)
+        );
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -56,6 +56,33 @@ impl DailyGoalSnapshot {
     }
 }
 
+pub fn carry_over_goal_target(
+    base: DailyGoalSnapshot,
+    carry_enabled: bool,
+    previous: Option<(DailyGoalSnapshot, u64, u32)>,
+) -> DailyGoalSnapshot {
+    if !carry_enabled {
+        return base;
+    }
+    let Some((previous_target, previous_minutes, previous_pomodoros)) = previous else {
+        return base;
+    };
+    DailyGoalSnapshot {
+        minutes: if base.minutes == 0 {
+            0
+        } else {
+            base.minutes
+                .saturating_add(previous_target.minutes.saturating_sub(previous_minutes))
+        },
+        pomodoros: if base.pomodoros == 0 {
+            0
+        } else {
+            base.pomodoros
+                .saturating_add(previous_target.pomodoros.saturating_sub(previous_pomodoros))
+        },
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct GoalStreak {
     pub current: u32,
@@ -669,6 +696,10 @@ impl FocusStats {
         self.daily.get(day_key).copied().unwrap_or_default()
     }
 
+    pub fn daily_entry(&self, day_key: &str) -> Option<DailyStats> {
+        self.daily.get(day_key).copied()
+    }
+
     pub fn weekly_for_day(&self, day: chrono::NaiveDate) -> WeeklyStats {
         let week = day.iso_week();
         let mut totals = WeeklyStats {
@@ -692,6 +723,11 @@ impl FocusStats {
         totals
     }
 
+    pub fn weekly_for_day_if_present(&self, day: chrono::NaiveDate) -> Option<WeeklyStats> {
+        let week = self.weekly_for_day(day);
+        (week.focused_seconds > 0 || week.pomodoros_completed > 0).then_some(week)
+    }
+
     pub fn monthly_for_day(&self, day: chrono::NaiveDate) -> MonthlyStats {
         let mut totals = MonthlyStats {
             year: day.year(),
@@ -711,6 +747,11 @@ impl FocusStats {
             totals.focused_seconds = totals.focused_seconds.saturating_add(stats.focused_seconds);
         }
         totals
+    }
+
+    pub fn monthly_for_day_if_present(&self, day: chrono::NaiveDate) -> Option<MonthlyStats> {
+        let month = self.monthly_for_day(day);
+        (month.focused_seconds > 0 || month.pomodoros_completed > 0).then_some(month)
     }
 
     pub fn task_planner_state(&self) -> (Vec<String>, Option<String>) {
@@ -1746,6 +1787,56 @@ mod tests {
     use super::*;
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn carry_over_goal_target_returns_base_when_disabled() {
+        let base = DailyGoalSnapshot {
+            minutes: 60,
+            pomodoros: 2,
+        };
+        let carried = carry_over_goal_target(base, false, Some((base, 0, 0)));
+        assert_eq!(carried, base);
+    }
+
+    #[test]
+    fn carry_over_goal_target_adds_previous_period_deficit() {
+        let base = DailyGoalSnapshot {
+            minutes: 60,
+            pomodoros: 2,
+        };
+        let previous_target = DailyGoalSnapshot {
+            minutes: 50,
+            pomodoros: 3,
+        };
+        let carried = carry_over_goal_target(base, true, Some((previous_target, 30, 1)));
+        assert_eq!(
+            carried,
+            DailyGoalSnapshot {
+                minutes: 80,
+                pomodoros: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn carry_over_goal_target_keeps_disabled_metrics_off() {
+        let base = DailyGoalSnapshot {
+            minutes: 0,
+            pomodoros: 2,
+        };
+        let previous_target = DailyGoalSnapshot {
+            minutes: 120,
+            pomodoros: 5,
+        };
+        let carried = carry_over_goal_target(base, true, Some((previous_target, 0, 1)));
+        assert_eq!(
+            carried,
+            DailyGoalSnapshot {
+                minutes: 0,
+                pomodoros: 6,
+            }
+        );
+    }
 
     #[test]
     fn recording_updates_session_and_daily_totals() {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -780,7 +780,10 @@ impl FocusStats {
         totals
     }
 
-    pub fn weekly_goal_snapshot_for_day(&self, day: chrono::NaiveDate) -> Option<DailyGoalSnapshot> {
+    pub fn weekly_goal_snapshot_for_day(
+        &self,
+        day: chrono::NaiveDate,
+    ) -> Option<DailyGoalSnapshot> {
         let key = week_key_for_day(day);
         self.weekly_goal_snapshots.get(&key).copied()
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1890,6 +1890,28 @@ mod tests {
     }
 
     #[test]
+    fn weekly_and_monthly_goal_snapshot_sync_and_lookup_are_idempotent() {
+        let mut stats = FocusStats::default();
+        let day = chrono::NaiveDate::from_ymd_opt(2026, 4, 9).expect("day should be valid");
+        let weekly_goal = DailyGoalSnapshot {
+            minutes: 300,
+            pomodoros: 10,
+        };
+        let monthly_goal = DailyGoalSnapshot {
+            minutes: 1200,
+            pomodoros: 40,
+        };
+
+        assert!(stats.sync_weekly_goal_snapshot(day, weekly_goal));
+        assert!(!stats.sync_weekly_goal_snapshot(day, weekly_goal));
+        assert_eq!(stats.weekly_goal_snapshot_for_day(day), Some(weekly_goal));
+
+        assert!(stats.sync_monthly_goal_snapshot(day, monthly_goal));
+        assert!(!stats.sync_monthly_goal_snapshot(day, monthly_goal));
+        assert_eq!(stats.monthly_goal_snapshot_for_day(day), Some(monthly_goal));
+    }
+
+    #[test]
     fn recording_updates_session_and_daily_totals() {
         let mut stats = FocusStats::default();
         let goal = DailyGoalSnapshot {
@@ -2371,6 +2393,28 @@ mod tests {
         assert_eq!(profile_totals[0].profile, ProfileBucket::DeepWork);
         assert_eq!(profile_totals[0].pomodoros_completed, 1);
         assert_eq!(profile_totals[0].focused_minutes(), 25);
+    }
+
+    #[test]
+    fn persisted_stats_round_trip_preserves_weekly_and_monthly_goal_snapshots() {
+        let mut original = FocusStats::default();
+        let day = chrono::NaiveDate::from_ymd_opt(2026, 4, 9).expect("day should be valid");
+        let weekly_goal = DailyGoalSnapshot {
+            minutes: 300,
+            pomodoros: 10,
+        };
+        let monthly_goal = DailyGoalSnapshot {
+            minutes: 1200,
+            pomodoros: 40,
+        };
+        original.sync_weekly_goal_snapshot(day, weekly_goal);
+        original.sync_monthly_goal_snapshot(day, monthly_goal);
+
+        let toml_str = toml::to_string_pretty(&original.to_persisted()).unwrap();
+        let restored = FocusStats::try_from_toml(&toml_str).unwrap();
+
+        assert_eq!(restored.weekly_goal_snapshot_for_day(day), Some(weekly_goal));
+        assert_eq!(restored.monthly_goal_snapshot_for_day(day), Some(monthly_goal));
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -686,9 +686,7 @@ impl FocusStats {
     }
 
     pub fn sync_goal_snapshot(&mut self, day_key: &str, goal: DailyGoalSnapshot) -> bool {
-        let Some(daily) = self.daily.get_mut(day_key) else {
-            return false;
-        };
+        let daily = self.daily.entry(day_key.to_string()).or_default();
 
         if daily.goal == Some(goal) {
             return false;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -459,6 +459,10 @@ struct PersistedStats {
     #[serde(default)]
     daily: BTreeMap<String, DailyStats>,
     #[serde(default)]
+    weekly_goal_snapshots: BTreeMap<String, DailyGoalSnapshot>,
+    #[serde(default)]
+    monthly_goal_snapshots: BTreeMap<String, DailyGoalSnapshot>,
+    #[serde(default)]
     task_labels: Vec<String>,
     #[serde(default)]
     selected_task_label: Option<String>,
@@ -472,6 +476,8 @@ struct PersistedStats {
 pub struct FocusStats {
     session: SessionStats,
     daily: BTreeMap<String, DailyStats>,
+    weekly_goal_snapshots: BTreeMap<String, DailyGoalSnapshot>,
+    monthly_goal_snapshots: BTreeMap<String, DailyGoalSnapshot>,
     task_labels: Vec<String>,
     selected_task_label: Option<String>,
     focus_sessions: Vec<FocusSessionRecord>,
@@ -543,6 +549,8 @@ impl FocusStats {
         Self {
             session: SessionStats::default(),
             daily: persisted.daily,
+            weekly_goal_snapshots: persisted.weekly_goal_snapshots,
+            monthly_goal_snapshots: persisted.monthly_goal_snapshots,
             task_labels,
             selected_task_label,
             focus_sessions,
@@ -553,6 +561,8 @@ impl FocusStats {
     fn to_persisted(&self) -> PersistedStats {
         PersistedStats {
             daily: self.daily.clone(),
+            weekly_goal_snapshots: self.weekly_goal_snapshots.clone(),
+            monthly_goal_snapshots: self.monthly_goal_snapshots.clone(),
             task_labels: self.task_labels.clone(),
             selected_task_label: self.selected_task_label.clone(),
             focus_sessions: self.focus_sessions.clone(),
@@ -688,6 +698,32 @@ impl FocusStats {
         true
     }
 
+    pub fn sync_weekly_goal_snapshot(
+        &mut self,
+        day: chrono::NaiveDate,
+        goal: DailyGoalSnapshot,
+    ) -> bool {
+        let key = week_key_for_day(day);
+        if self.weekly_goal_snapshots.get(&key) == Some(&goal) {
+            return false;
+        }
+        self.weekly_goal_snapshots.insert(key, goal);
+        true
+    }
+
+    pub fn sync_monthly_goal_snapshot(
+        &mut self,
+        day: chrono::NaiveDate,
+        goal: DailyGoalSnapshot,
+    ) -> bool {
+        let key = month_key_for_day(day);
+        if self.monthly_goal_snapshots.get(&key) == Some(&goal) {
+            return false;
+        }
+        self.monthly_goal_snapshots.insert(key, goal);
+        true
+    }
+
     pub fn session(&self) -> SessionStats {
         self.session
     }
@@ -725,7 +761,10 @@ impl FocusStats {
 
     pub fn weekly_for_day_if_present(&self, day: chrono::NaiveDate) -> Option<WeeklyStats> {
         let week = self.weekly_for_day(day);
-        (week.focused_seconds > 0 || week.pomodoros_completed > 0).then_some(week)
+        (week.focused_seconds > 0
+            || week.pomodoros_completed > 0
+            || self.weekly_goal_snapshot_for_day(day).is_some())
+        .then_some(week)
     }
 
     pub fn monthly_for_day(&self, day: chrono::NaiveDate) -> MonthlyStats {
@@ -751,7 +790,23 @@ impl FocusStats {
 
     pub fn monthly_for_day_if_present(&self, day: chrono::NaiveDate) -> Option<MonthlyStats> {
         let month = self.monthly_for_day(day);
-        (month.focused_seconds > 0 || month.pomodoros_completed > 0).then_some(month)
+        (month.focused_seconds > 0
+            || month.pomodoros_completed > 0
+            || self.monthly_goal_snapshot_for_day(day).is_some())
+        .then_some(month)
+    }
+
+    pub fn weekly_goal_snapshot_for_day(&self, day: chrono::NaiveDate) -> Option<DailyGoalSnapshot> {
+        let key = week_key_for_day(day);
+        self.weekly_goal_snapshots.get(&key).copied()
+    }
+
+    pub fn monthly_goal_snapshot_for_day(
+        &self,
+        day: chrono::NaiveDate,
+    ) -> Option<DailyGoalSnapshot> {
+        let key = month_key_for_day(day);
+        self.monthly_goal_snapshots.get(&key).copied()
     }
 
     pub fn task_planner_state(&self) -> (Vec<String>, Option<String>) {
@@ -1685,6 +1740,15 @@ fn consistency_score_from_active_days(active_days: u8) -> u8 {
 
 fn format_week_label(year: i32, week: u32) -> String {
     format!("{year:04}-W{week:02}")
+}
+
+fn week_key_for_day(day: chrono::NaiveDate) -> String {
+    let week = day.iso_week();
+    format_week_label(week.year(), week.week())
+}
+
+fn month_key_for_day(day: chrono::NaiveDate) -> String {
+    format!("{:04}-{:02}", day.year(), day.month())
 }
 
 fn write_atomic_bytes(path: &Path, content: &[u8]) -> io::Result<()> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -18,10 +18,10 @@ use crate::wakatime::WakatimeRuntimeState;
 
 const PROFILE_EDIT_GROUP_TIMER: [usize; 4] = [0, 1, 2, 3];
 const PROFILE_EDIT_GROUP_AUTOMATION: [usize; 5] = [4, 5, 6, 7, 8];
-const PROFILE_EDIT_GROUP_GOALS: [usize; 6] = [9, 10, 11, 12, 13, 14];
-const PROFILE_EDIT_GROUP_WAKATIME: [usize; 2] = [15, 16];
+const PROFILE_EDIT_GROUP_GOALS: [usize; 9] = [9, 10, 11, 12, 13, 14, 15, 16, 17];
+const PROFILE_EDIT_GROUP_WAKATIME: [usize; 2] = [18, 19];
 const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 15] =
-    [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31];
+    [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34];
 const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 5] = [
     ("Timer", &PROFILE_EDIT_GROUP_TIMER),
     ("Automation", &PROFILE_EDIT_GROUP_AUTOMATION),
@@ -845,27 +845,30 @@ fn profile_edit_field_display_label(field_index: usize) -> &'static str {
         8 => "Strict focus mode",
         9 => "Daily goal minutes",
         10 => "Daily goal pomodoros",
-        11 => "Weekly goal minutes",
-        12 => "Weekly goal pomodoros",
-        13 => "Monthly goal minutes",
-        14 => "Monthly goal pomodoros",
-        15 => "WakaTime project",
-        16 => "WakaTime language",
-        17 => "Window selector",
-        18 => "Day selector",
-        19 => "Day enabled",
-        20 => "Start time",
-        21 => "End time",
-        22 => "Add/remove",
-        23 => "Exception selector",
-        24 => "Exception date",
-        25 => "Exception add/remove",
-        26 => "One-time selector",
-        27 => "One-time date",
-        28 => "One-time start",
-        29 => "One-time end",
-        30 => "One-time add/remove",
-        31 => "Conflict inspector",
+        11 => "Daily goal carry-over",
+        12 => "Weekly goal minutes",
+        13 => "Weekly goal pomodoros",
+        14 => "Weekly goal carry-over",
+        15 => "Monthly goal minutes",
+        16 => "Monthly goal pomodoros",
+        17 => "Monthly goal carry-over",
+        18 => "WakaTime project",
+        19 => "WakaTime language",
+        20 => "Window selector",
+        21 => "Day selector",
+        22 => "Day enabled",
+        23 => "Start time",
+        24 => "End time",
+        25 => "Add/remove",
+        26 => "Exception selector",
+        27 => "Exception date",
+        28 => "Exception add/remove",
+        29 => "One-time selector",
+        30 => "One-time date",
+        31 => "One-time start",
+        32 => "One-time end",
+        33 => "One-time add/remove",
+        34 => "Conflict inspector",
         _ => "",
     }
 }
@@ -1724,11 +1727,6 @@ mod tests {
             crossterm::event::KeyCode::Char('e'),
             crossterm::event::KeyModifiers::NONE,
         ));
-        app.profile_edit_field = PROFILE_EDIT_GROUP_GOALS[2];
-        app.handle_key(crossterm::event::KeyEvent::new(
-            crossterm::event::KeyCode::Right,
-            crossterm::event::KeyModifiers::NONE,
-        ));
         app.profile_edit_field = PROFILE_EDIT_GROUP_GOALS[3];
         app.handle_key(crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Right,
@@ -1739,7 +1737,12 @@ mod tests {
             crossterm::event::KeyCode::Right,
             crossterm::event::KeyModifiers::NONE,
         ));
-        app.profile_edit_field = PROFILE_EDIT_GROUP_GOALS[5];
+        app.profile_edit_field = PROFILE_EDIT_GROUP_GOALS[6];
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Right,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.profile_edit_field = PROFILE_EDIT_GROUP_GOALS[7];
         app.handle_key(crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Right,
             crossterm::event::KeyModifiers::NONE,

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -98,6 +98,9 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload.get("goal").is_some());
     assert!(payload.get("weekly_goal").is_some());
     assert!(payload.get("monthly_goal").is_some());
+    assert!(payload["goal"].get("carry_over").is_some());
+    assert!(payload["weekly_goal"].get("carry_over").is_some());
+    assert!(payload["monthly_goal"].get("carry_over").is_some());
     assert!(payload.get("live").is_some());
     assert!(payload["live"].get("focus_intention").is_some());
     assert!(payload["live"].get("task_note").is_some());


### PR DESCRIPTION
## What

- Add optional goal carry-over toggles for daily, weekly, and monthly targets in persisted config.
- Add CLI controls to show/set carry-over (`--goal-carry`, `--goal-carry-weekly`, `--goal-carry-monthly`) and include `carry_over` in status goal output.
- Add TUI Profile Edit fields for goal carry-over and wire them through snapshot, cancel, commit, and persistence paths.
- Apply carry-over to effective goal targets using only the immediate previous period deficit (no multi-period compounding).
- Update README command docs and extend tests across config, app logic, CLI parsing/output, stats helpers, and JSON contract coverage.

## Why

This adds the optional unmet-goal carry-over behavior requested in issue #185 so users can keep goal pressure from one period to the next without changing default behavior for existing workflows. The implementation keeps backward compatibility by defaulting carry-over to off and only changing target calculations when explicitly enabled. Closes #185.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flags to view/set goal carry-over for daily/weekly/monthly; status (text/JSON) shows carry-over state
  * Profile editor adds toggles for daily/weekly/monthly carry-over
  * Goal progress, streaks, and effective targets now account for carry-over and synchronize across sessions (daily/weekly/monthly)

* **Documentation**
  * README adds examples for goal carry-over CLI usage and JSON-mode output

* **Tests**
  * Unit and contract tests expanded for carry-over parsing, computation, sync, and persistence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->