### PR TITLE
Add cumulative task-level goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Task-level cumulative goals (#186):** added per-task goal targets (minutes/pomodoros) with CLI management via `--task-goal`, status JSON exposure for the selected task, and history-panel progress evaluation against each task target.
+
 ## [0.6.2] - 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ cargo run -- --next --json
 cargo run -- --task "Write docs"
 cargo run -- --task=Write-docs --json
 
+# Show or set cumulative goal targets for a task label
+cargo run -- --task-goal "Write docs"
+cargo run -- --task-goal "Write docs:120,4"
+cargo run -- --task-goal=Write-docs:120,4 --json
+
 # Show or set the active profile
 cargo run -- --profile
 cargo run -- --profile deep-work
@@ -152,7 +157,7 @@ cargo run -- --diagnostics --json
 cargo run -- --blocking-preview
 cargo run -- --blocking-preview --json
 
-# Show status (text or JSON, including live timer/session fields in JSON)
+# Show status (text or JSON, including live timer/session fields and selected task-goal progress in JSON)
 cargo run -- --status
 cargo run -- --status --json
 
@@ -455,6 +460,7 @@ Override events are recorded for audit visibility in the History view and includ
 - profile effectiveness comparison (focus share % and average focused minutes per completed session)
 - per-task totals (pomodoros and focused minutes) derived from labeled focus sessions
 - per-task trend summaries in History (`last 7 days` vs `previous 7 days`)
+- per-task cumulative goals (minutes/pomodoros) with per-label progress and met/in-progress evaluation
 - current streak and best streak based on completed daily goals
 
 If daily, weekly, or monthly goals are configured, timer and history views also

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ cargo run -- --diagnostics --json
 cargo run -- --blocking-preview
 cargo run -- --blocking-preview --json
 
-# Show status (text or JSON, including live timer/session fields and selected task-goal progress in JSON)
+# Show status (text or JSON, including live timer/session fields and `selected_task_goal` in JSON)
 cargo run -- --status
 cargo run -- --status --json
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -7912,13 +7912,11 @@ mod tests {
 
         assert_eq!(app.task_labels, vec!["Docs".to_string()]);
         assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
-        assert!(
-            app.planner_feedback.as_ref().is_some_and(|feedback| {
-                feedback
-                    .message
-                    .contains("destination task goal already exists")
-            })
-        );
+        assert!(app.planner_feedback.as_ref().is_some_and(|feedback| {
+            feedback
+                .message
+                .contains("destination task goal already exists")
+        }));
         let source_progress = app
             .task_goal_progress_for_label("Docs")
             .expect("source task progress should be available");

--- a/src/app.rs
+++ b/src/app.rs
@@ -2431,6 +2431,29 @@ impl App {
             return;
         }
 
+        let source_goal_target = self
+            .stats
+            .task_goal_progress_for_label(&current_label)
+            .map(|progress| progress.target)
+            .unwrap_or_default();
+        let destination_goal_target = self
+            .stats
+            .task_goal_progress_for_label(&label)
+            .map(|progress| progress.target)
+            .unwrap_or_default();
+        if !current_label.eq_ignore_ascii_case(&label)
+            && source_goal_target.has_any_target()
+            && destination_goal_target.has_any_target()
+        {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                format!(
+                    "Cannot rename `{current_label}` -> `{label}`: destination task goal already exists"
+                ),
+            );
+            return;
+        }
+
         if let Some(target) = self.task_labels.get_mut(self.planner_selection_index) {
             *target = label.clone();
         }
@@ -7859,6 +7882,51 @@ mod tests {
             .task_goal_progress_for_label("Writing")
             .expect("renamed task goal should exist");
         assert_eq!(progress.target, task_goal);
+    }
+
+    #[test]
+    fn session_planner_rename_rejects_when_destination_task_goal_exists() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.sync_task_planner_state();
+        let source_goal = DailyGoalSnapshot {
+            minutes: 120,
+            pomodoros: 4,
+        };
+        let destination_goal = DailyGoalSnapshot {
+            minutes: 90,
+            pomodoros: 3,
+        };
+        app.stats
+            .set_task_goal_target("Docs", source_goal)
+            .expect("source task goal should be set");
+        app.stats
+            .set_task_goal_target("Writing", destination_goal)
+            .expect("destination task goal should be set");
+
+        app.handle_key(key(KeyCode::Char('t')));
+        app.handle_key(key(KeyCode::Char('e')));
+        app.planner_input = "Writing".to_string();
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(app.task_labels, vec!["Docs".to_string()]);
+        assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
+        assert!(
+            app.planner_feedback.as_ref().is_some_and(|feedback| {
+                feedback
+                    .message
+                    .contains("destination task goal already exists")
+            })
+        );
+        let source_progress = app
+            .task_goal_progress_for_label("Docs")
+            .expect("source task progress should be available");
+        assert_eq!(source_progress.target, source_goal);
+        let destination_progress = app
+            .task_goal_progress_for_label("Writing")
+            .expect("destination task progress should be available");
+        assert_eq!(destination_progress.target, destination_goal);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,8 +28,8 @@ use crate::session_recovery::{self, InProgressSessionSnapshot};
 use crate::stats::{
     BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles,
     FocusSessionMetadata, FocusStats, GoalStreak, MonthlyHeatmap, MonthlyStats,
-    ProfileEffectiveness, ProfileTotals, SessionStats, TaskTotals, TaskTrend, WeeklyConsistency,
-    WeeklyStats, carry_over_goal_target, current_day_key,
+    ProfileEffectiveness, ProfileTotals, SessionStats, TaskGoalProgress, TaskTotals, TaskTrend,
+    WeeklyConsistency, WeeklyStats, carry_over_goal_target, current_day_key,
 };
 use crate::task_labels::{normalize_task_label, task_label_index};
 use crate::timer::{
@@ -1065,6 +1065,10 @@ impl App {
 
     pub fn task_focus_totals(&self, limit: usize) -> Vec<TaskTotals> {
         self.stats.task_totals(limit)
+    }
+
+    pub fn task_goal_progress_for_label(&self, label: &str) -> Option<TaskGoalProgress> {
+        self.stats.task_goal_progress_for_label(label)
     }
 
     pub fn recent_task_trends(&self, limit: usize) -> Vec<TaskTrend> {
@@ -2446,6 +2450,7 @@ impl App {
             self.active_focus_intention = Some(label.clone());
             self.active_focus_task_note = Some(label.clone());
         }
+        self.stats.rename_task_goal_target(&current_label, &label);
 
         self.sync_task_planner_state();
         self.sync_recovery_snapshot();
@@ -2465,6 +2470,7 @@ impl App {
         self.clamp_planner_selection();
         let removed = self.task_labels.remove(self.planner_selection_index);
         self.clamp_planner_selection();
+        self.stats.remove_task_goal_target(&removed);
 
         let removed_was_selected = self
             .selected_task_label
@@ -7831,6 +7837,31 @@ mod tests {
     }
 
     #[test]
+    fn session_planner_rename_moves_task_goal_target() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.sync_task_planner_state();
+        let task_goal = DailyGoalSnapshot {
+            minutes: 120,
+            pomodoros: 4,
+        };
+        app.stats
+            .set_task_goal_target("Docs", task_goal)
+            .expect("task goal should be set");
+
+        app.handle_key(key(KeyCode::Char('t')));
+        app.handle_key(key(KeyCode::Char('e')));
+        app.planner_input = "Writing".to_string();
+        app.handle_key(key(KeyCode::Enter));
+
+        let progress = app
+            .task_goal_progress_for_label("Writing")
+            .expect("renamed task goal should exist");
+        assert_eq!(progress.target, task_goal);
+    }
+
+    #[test]
     fn session_planner_delete_selected_label_selects_nearest_remaining() {
         let mut app = App::default();
         app.task_labels = vec![
@@ -7864,6 +7895,31 @@ mod tests {
         assert!(app.task_labels.is_empty());
         assert!(app.selected_task_label.is_none());
         assert_eq!(app.planner_selection_index, 0);
+    }
+
+    #[test]
+    fn session_planner_delete_removes_task_goal_target() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.sync_task_planner_state();
+        app.stats
+            .set_task_goal_target(
+                "Docs",
+                DailyGoalSnapshot {
+                    minutes: 90,
+                    pomodoros: 3,
+                },
+            )
+            .expect("task goal should be set");
+
+        app.handle_key(key(KeyCode::Char('t')));
+        app.handle_key(key(KeyCode::Delete));
+
+        let progress = app
+            .task_goal_progress_for_label("Docs")
+            .expect("task progress should be available");
+        assert_eq!(progress.target, DailyGoalSnapshot::default());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,8 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --stop [--json]
   focustime --next [--json]
   focustime --task=LABEL [--json]
+  focustime --task-goal [LABEL|LABEL:MINUTES,POMODOROS] [--json]
+  focustime --task-goal=LABEL[:MINUTES,POMODOROS] [--json]
   focustime --profile [classic|deep-work|custom] [--json]
   focustime --goal [--json]
   focustime --goal=MINUTES,POMODOROS [--json]
@@ -75,6 +77,7 @@ Options:
   --stop          Stop/reset the current phase
   --next          Skip to the next phase
   --task          Select task label (auto-creates unknown labels)
+  --task-goal     Show or set per-task cumulative goal targets
   --profile       Show current profile, or set it when value is provided
   --goal          Show current daily goal, or set minutes/pomodoros targets
   --goal-weekly   Show current weekly goal, or set minutes/pomodoros targets
@@ -160,6 +163,10 @@ pub enum CommandKind {
     Task {
         label: String,
     },
+    TaskGoal {
+        label: Option<String>,
+        goal: Option<DailyGoalConfig>,
+    },
     Profile {
         profile: Option<ProfileId>,
     },
@@ -225,6 +232,10 @@ enum PrimaryCommand {
     Stop,
     Next,
     Task(String),
+    TaskGoal {
+        label: Option<String>,
+        goal: Option<DailyGoalConfig>,
+    },
     Profile(Option<ProfileId>),
     Goal(Option<DailyGoalConfig>),
     GoalWeekly(Option<WeeklyGoalConfig>),
@@ -263,6 +274,10 @@ enum ParsedToken {
     Stop,
     Next,
     Task(String),
+    TaskGoal {
+        label: Option<String>,
+        goal: Option<DailyGoalConfig>,
+    },
     Status,
     Watch(Option<u64>),
     Profile(Option<ProfileId>),
@@ -370,6 +385,17 @@ struct GoalOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TaskGoalOutput {
+    task_label: String,
+    configured: bool,
+    minutes_target: u64,
+    pomodoros_target: u32,
+    focused_minutes: u64,
+    pomodoros_completed: u32,
+    met: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct SessionOutput {
     focused_minutes: u64,
     pomodoros_completed: u32,
@@ -410,6 +436,7 @@ struct StatusOutput {
     goal: GoalOutput,
     weekly_goal: GoalOutput,
     monthly_goal: GoalOutput,
+    selected_task_goal: Option<TaskGoalOutput>,
     session: SessionOutput,
     today: TodayOutput,
     live: LiveStatusOutput,
@@ -446,6 +473,18 @@ struct TaskCommandOutput {
     created: bool,
     selected_task_label: String,
     timer: TimerStateOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TaskGoalCommandOutput {
+    updated: bool,
+    task_label: String,
+    configured: bool,
+    minutes_target: u64,
+    pomodoros_target: u32,
+    focused_minutes: u64,
+    pomodoros_completed: u32,
+    met: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -691,8 +730,9 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 21] = [
+    let parsers: [(&str, ValueArgParser); 22] = [
         ("--task", classify_task_arg),
+        ("--task-goal", classify_task_goal_arg),
         ("--profile", classify_profile_arg),
         ("--goal", classify_goal_arg),
         ("--goal-weekly", classify_goal_weekly_arg),
@@ -769,6 +809,28 @@ fn classify_task_arg(args: &[String], index: usize) -> Result<(ParsedToken, usiz
     }
     Err(invalid_usage(
         "`--task` requires a task label. Use `--task=LABEL` or `--task LABEL`.",
+    ))
+}
+
+fn classify_task_goal_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let (label, goal) = parse_task_goal_value(next)?;
+        return Ok((
+            ParsedToken::TaskGoal {
+                label: Some(label),
+                goal,
+            },
+            2,
+        ));
+    }
+    Ok((
+        ParsedToken::TaskGoal {
+            label: None,
+            goal: None,
+        },
+        1,
     ))
 }
 
@@ -1056,8 +1118,9 @@ fn classify_schedule_set_arg(
 }
 
 fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 21] = [
+    let parsers: [KeyValueParser; 22] = [
         parse_task_key_value_arg,
+        parse_task_goal_key_value_arg,
         parse_profile_key_value_arg,
         parse_goal_key_value_arg,
         parse_goal_weekly_key_value_arg,
@@ -1093,6 +1156,21 @@ fn parse_task_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
     if let Some(value) = arg.strip_prefix("--task=") {
         let value = require_nonempty_key_value(value, "`--task=` requires a task label.")?;
         return Ok(Some(ParsedToken::Task(value.to_string())));
+    }
+    Ok(None)
+}
+
+fn parse_task_goal_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--task-goal=") {
+        let value = require_nonempty_key_value(
+            value,
+            "`--task-goal=` requires `LABEL` or `LABEL:MINUTES,POMODOROS`.",
+        )?;
+        let (label, goal) = parse_task_goal_value(value)?;
+        return Ok(Some(ParsedToken::TaskGoal {
+            label: Some(label),
+            goal,
+        }));
     }
     Ok(None)
 }
@@ -1331,6 +1409,7 @@ fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), Str
             | ParsedToken::Stop
             | ParsedToken::Next
             | ParsedToken::Task(_)
+            | ParsedToken::TaskGoal { .. }
             | ParsedToken::Status
             | ParsedToken::Watch(_)
             | ParsedToken::Profile(_)
@@ -1375,6 +1454,13 @@ fn parse_primary_command(tokens: &[ParsedToken]) -> Result<Option<PrimaryCommand
             ParsedToken::Task(label) => {
                 set_primary_command(&mut primary, PrimaryCommand::Task(label.clone()))?
             }
+            ParsedToken::TaskGoal { label, goal } => set_primary_command(
+                &mut primary,
+                PrimaryCommand::TaskGoal {
+                    label: label.clone(),
+                    goal: *goal,
+                },
+            )?,
             ParsedToken::Status => set_primary_command(&mut primary, PrimaryCommand::Status)?,
             ParsedToken::Watch(_) => {}
             ParsedToken::Profile(profile) => {
@@ -1571,6 +1657,10 @@ fn finalize_cli_action(
             kind: CommandKind::Task { label },
             output,
         })),
+        Some(PrimaryCommand::TaskGoal { label, goal }) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::TaskGoal { label, goal },
+            output,
+        })),
         Some(PrimaryCommand::Status) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Status {
                 watch_interval_secs,
@@ -1675,6 +1765,9 @@ pub fn execute_command(cli_command: CliCommand) -> Result<(), String> {
         CommandKind::Stop => execute_stop_command(cli_command.output),
         CommandKind::Next => execute_next_command(cli_command.output),
         CommandKind::Task { label } => execute_task_command(label, cli_command.output),
+        CommandKind::TaskGoal { label, goal } => {
+            execute_task_goal_command(label, goal, cli_command.output)
+        }
         CommandKind::Profile { profile } => execute_profile_command(profile, cli_command.output),
         CommandKind::Goal { goal } => execute_goal_command(goal, cli_command.output),
         CommandKind::GoalWeekly { goal } => execute_weekly_goal_command(goal, cli_command.output),
@@ -1756,6 +1849,55 @@ fn execute_task_command(label: String, output: OutputMode) -> Result<(), String>
             }
             print_timer_state_output(&payload.timer);
         }
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_task_goal_command(
+    label: Option<String>,
+    goal: Option<DailyGoalConfig>,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut stats = FocusStats::load()?;
+    let selected_task_label = stats.task_planner_state().1;
+    let requested_label = label.or(selected_task_label).ok_or_else(|| {
+        "No task label selected. Use `--task LABEL` first or pass `--task-goal LABEL`.".to_string()
+    })?;
+
+    let mut updated = false;
+    let task_label = if let Some(goal) = goal {
+        let target = DailyGoalSnapshot {
+            minutes: goal.minutes,
+            pomodoros: goal.pomodoros,
+        };
+        let canonical = stats.set_task_goal_target(&requested_label, target)?;
+        stats
+            .save()
+            .map_err(|error| format!("Failed to save task goals: {error}"))?;
+        updated = true;
+        canonical
+    } else {
+        requested_label
+    };
+
+    let progress = stats
+        .task_goal_progress_for_label(&task_label)
+        .ok_or_else(|| "Task goal lookup failed: invalid task label.".to_string())?;
+    let focused_minutes = progress.focused_minutes();
+    let payload = TaskGoalCommandOutput {
+        updated,
+        task_label: progress.task_label,
+        configured: progress.target.has_any_target(),
+        minutes_target: progress.target.minutes,
+        pomodoros_target: progress.target.pomodoros,
+        focused_minutes,
+        pomodoros_completed: progress.pomodoros_completed,
+        met: progress.met,
+    };
+
+    match output {
+        OutputMode::Text => print_task_goal_command_output(&payload),
         OutputMode::Json => print_json(&payload)?,
     }
     Ok(())
@@ -2600,6 +2742,20 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let goal_snapshot = effective_daily_goal_snapshot(config, stats, day_date);
     let weekly_goal_snapshot = effective_weekly_goal_snapshot(config, stats, day_date);
     let monthly_goal_snapshot = effective_monthly_goal_snapshot(config, stats, day_date);
+    let selected_task_goal = selected_task_label.as_ref().and_then(|label| {
+        stats.task_goal_progress_for_label(label).map(|progress| {
+            let focused_minutes = progress.focused_minutes();
+            TaskGoalOutput {
+                task_label: progress.task_label,
+                configured: progress.target.has_any_target(),
+                minutes_target: progress.target.minutes,
+                pomodoros_target: progress.target.pomodoros,
+                focused_minutes,
+                pomodoros_completed: progress.pomodoros_completed,
+                met: progress.met,
+            }
+        })
+    });
     let active_sites_count = config
         .blocklist_profiles
         .iter()
@@ -2644,6 +2800,7 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
                 .is_met_by_totals(month.focused_minutes(), month.pomodoros_completed),
             carry_over: config.goal_carry_over.monthly,
         },
+        selected_task_goal,
         session: SessionOutput {
             focused_minutes: session.focused_minutes(),
             pomodoros_completed: session.pomodoros_completed,
@@ -2878,6 +3035,28 @@ fn parse_profile_id(value: &str) -> Result<ProfileId, String> {
             "Invalid profile `{value}`. Use `classic`, `deep-work`, or `custom`."
         ))),
     }
+}
+
+fn parse_task_goal_value(value: &str) -> Result<(String, Option<DailyGoalConfig>), String> {
+    let trimmed = value.trim();
+    if let Some((label_raw, goal_raw)) = trimmed.split_once(':') {
+        let label =
+            require_nonempty_key_value(label_raw, "Task goal requires a task label before `:`.")?
+                .to_string();
+        let goal_raw = require_nonempty_key_value(
+            goal_raw,
+            "Task goal requires `MINUTES,POMODOROS` after `:`.",
+        )?;
+        let (minutes, pomodoros) = parse_goal_components(goal_raw, "--task-goal")?;
+        return Ok((label, Some(DailyGoalConfig { minutes, pomodoros })));
+    }
+
+    let label = require_nonempty_key_value(
+        trimmed,
+        "`--task-goal` requires `LABEL` or `LABEL:MINUTES,POMODOROS`.",
+    )?
+    .to_string();
+    Ok((label, None))
 }
 
 fn parse_goal_value(value: &str) -> Result<DailyGoalConfig, String> {
@@ -3117,6 +3296,7 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Stop => "--stop",
         PrimaryCommand::Next => "--next",
         PrimaryCommand::Task(_) => "--task",
+        PrimaryCommand::TaskGoal { .. } => "--task-goal",
         PrimaryCommand::Profile(_) => "--profile",
         PrimaryCommand::Goal(_) => "--goal",
         PrimaryCommand::GoalWeekly(_) => "--goal-weekly",
@@ -3334,6 +3514,7 @@ fn print_status_output(payload: &StatusOutput) {
     print_status_goal_line("Daily goal", &payload.goal);
     print_status_goal_line("Weekly goal", &payload.weekly_goal);
     print_status_goal_line("Monthly goal", &payload.monthly_goal);
+    print_status_task_goal_line(payload.selected_task_goal.as_ref());
     println!(
         "Session: {} focused minutes, {} pomodoros",
         payload.session.focused_minutes, payload.session.pomodoros_completed
@@ -3373,6 +3554,29 @@ fn print_status_goal_line(label: &str, goal: &GoalOutput) {
             if goal.carry_over { "on" } else { "off" }
         );
     }
+}
+
+fn print_status_task_goal_line(task_goal: Option<&TaskGoalOutput>) {
+    let Some(task_goal) = task_goal else {
+        println!("Selected task goal: none");
+        return;
+    };
+
+    if task_goal.configured {
+        println!(
+            "Selected task goal (`{}`): {} min, {} pomodoros ({})",
+            task_goal.task_label,
+            task_goal.minutes_target,
+            task_goal.pomodoros_target,
+            if task_goal.met { "met" } else { "in progress" }
+        );
+    } else {
+        println!("Selected task goal (`{}`): off", task_goal.task_label);
+    }
+    println!(
+        "Selected task progress (`{}`): {} min, {} pomodoros",
+        task_goal.task_label, task_goal.focused_minutes, task_goal.pomodoros_completed
+    );
 }
 
 fn print_timer_state_output(timer: &TimerStateOutput) {
@@ -3419,6 +3623,27 @@ fn print_goal_command_output(label: &str, payload: &GoalCommandOutput) {
     } else {
         println!("{label} goal: off");
     }
+}
+
+fn print_task_goal_command_output(payload: &TaskGoalCommandOutput) {
+    if payload.updated {
+        println!("Task goal updated for `{}`.", payload.task_label);
+    }
+    if payload.configured {
+        println!(
+            "Task goal (`{}`): {} min, {} pomodoros ({})",
+            payload.task_label,
+            payload.minutes_target,
+            payload.pomodoros_target,
+            if payload.met { "met" } else { "in progress" }
+        );
+    } else {
+        println!("Task goal (`{}`): off", payload.task_label);
+    }
+    println!(
+        "Task progress (`{}`): {} min, {} pomodoros",
+        payload.task_label, payload.focused_minutes, payload.pomodoros_completed
+    );
 }
 
 fn print_goal_carry_command_output(label: &str, payload: &GoalCarryCommandOutput) {
@@ -3787,6 +4012,54 @@ mod tests {
             CliAction::RunCommand(CliCommand {
                 kind: CommandKind::Task {
                     label: "Docs".to_string()
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_task_goal_without_value_reads_selected_label_goal() {
+        let parsed = parse(&["--task-goal"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::TaskGoal {
+                    label: None,
+                    goal: None
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_task_goal_with_label_reads_specific_goal() {
+        let parsed = parse(&["--task-goal", "Docs"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::TaskGoal {
+                    label: Some("Docs".to_string()),
+                    goal: None
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_task_goal_with_label_and_target_sets_goal() {
+        let parsed = parse(&["--task-goal", "Docs:120,4"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::TaskGoal {
+                    label: Some("Docs".to_string()),
+                    goal: Some(DailyGoalConfig {
+                        minutes: 120,
+                        pomodoros: 4
+                    })
                 },
                 output: OutputMode::Text
             })
@@ -4287,6 +4560,33 @@ mod tests {
     }
 
     #[test]
+    fn classify_key_value_arg_accepts_task_goal_equals_label() {
+        let parsed = classify_key_value_arg("--task-goal=Docs").unwrap();
+        assert_eq!(
+            parsed,
+            Some(ParsedToken::TaskGoal {
+                label: Some("Docs".to_string()),
+                goal: None
+            })
+        );
+    }
+
+    #[test]
+    fn classify_key_value_arg_accepts_task_goal_equals_label_and_target() {
+        let parsed = classify_key_value_arg("--task-goal=Docs:90,3").unwrap();
+        assert_eq!(
+            parsed,
+            Some(ParsedToken::TaskGoal {
+                label: Some("Docs".to_string()),
+                goal: Some(DailyGoalConfig {
+                    minutes: 90,
+                    pomodoros: 3
+                })
+            })
+        );
+    }
+
+    #[test]
     fn classify_key_value_arg_rejects_empty_task_equals_value() {
         let error = classify_key_value_arg("--task=").unwrap_err();
         assert!(error.contains("`--task=` requires a task label."));
@@ -4461,6 +4761,12 @@ mod tests {
     fn parse_rejects_task_with_blank_value() {
         let error = parse(&["--task", "   "]).unwrap_err();
         assert!(error.contains("`--task` requires a task label"));
+    }
+
+    #[test]
+    fn parse_rejects_task_goal_with_blank_label() {
+        let error = parse(&["--task-goal=:120,4"]).unwrap_err();
+        assert!(error.contains("Task goal requires a task label before `:`."));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1881,19 +1881,24 @@ fn execute_task_goal_command(
         requested_label
     };
 
-    let progress = stats
-        .task_goal_progress_for_label(&task_label)
-        .ok_or_else(|| "Task goal lookup failed: invalid task label.".to_string())?;
-    let focused_minutes = progress.focused_minutes();
+    let TaskGoalOutput {
+        task_label,
+        configured,
+        minutes_target,
+        pomodoros_target,
+        focused_minutes,
+        pomodoros_completed,
+        met,
+    } = build_task_goal_output(&stats, &task_label);
     let payload = TaskGoalCommandOutput {
         updated,
-        task_label: progress.task_label,
-        configured: progress.target.has_any_target(),
-        minutes_target: progress.target.minutes,
-        pomodoros_target: progress.target.pomodoros,
+        task_label,
+        configured,
+        minutes_target,
+        pomodoros_target,
         focused_minutes,
-        pomodoros_completed: progress.pomodoros_completed,
-        met: progress.met,
+        pomodoros_completed,
+        met,
     };
 
     match output {
@@ -2742,20 +2747,9 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let goal_snapshot = effective_daily_goal_snapshot_for_day(config, stats, day_date);
     let weekly_goal_snapshot = effective_weekly_goal_snapshot(config, stats, day_date);
     let monthly_goal_snapshot = effective_monthly_goal_snapshot(config, stats, day_date);
-    let selected_task_goal = selected_task_label.as_ref().and_then(|label| {
-        stats.task_goal_progress_for_label(label).map(|progress| {
-            let focused_minutes = progress.focused_minutes();
-            TaskGoalOutput {
-                task_label: progress.task_label,
-                configured: progress.target.has_any_target(),
-                minutes_target: progress.target.minutes,
-                pomodoros_target: progress.target.pomodoros,
-                focused_minutes,
-                pomodoros_completed: progress.pomodoros_completed,
-                met: progress.met,
-            }
-        })
-    });
+    let selected_task_goal = selected_task_label
+        .as_ref()
+        .map(|label| build_task_goal_output(stats, label));
     let active_sites_count = config
         .blocklist_profiles
         .iter()
@@ -2835,6 +2829,32 @@ fn effective_daily_goal_snapshot_for_day(
         })
     });
     carry_over_goal_target(base, config.goal_carry_over.daily, previous)
+}
+
+fn build_task_goal_output(stats: &FocusStats, label: &str) -> TaskGoalOutput {
+    match stats.task_goal_progress_for_label(label) {
+        Some(progress) => {
+            let focused_minutes = progress.focused_minutes();
+            TaskGoalOutput {
+                task_label: progress.task_label,
+                configured: progress.target.has_any_target(),
+                minutes_target: progress.target.minutes,
+                pomodoros_target: progress.target.pomodoros,
+                focused_minutes,
+                pomodoros_completed: progress.pomodoros_completed,
+                met: progress.met,
+            }
+        }
+        None => TaskGoalOutput {
+            task_label: label.to_string(),
+            configured: false,
+            minutes_target: 0,
+            pomodoros_target: 0,
+            focused_minutes: 0,
+            pomodoros_completed: 0,
+            met: false,
+        },
+    }
 }
 
 fn effective_weekly_goal_snapshot(
@@ -5359,6 +5379,28 @@ mod tests {
         assert_eq!(output.goal.minutes_target, 30);
         assert_eq!(output.goal.pomodoros_target, 1);
         assert!(output.goal.met);
+    }
+
+    #[test]
+    fn build_status_output_includes_unconfigured_selected_task_goal() {
+        let mut stats = FocusStats::default();
+        let changed =
+            stats.update_task_planner_state(vec!["Docs".to_string()], Some("Docs".to_string()));
+        assert!(changed);
+        let config = AppConfig::default();
+
+        let output = build_status_output(&config, &stats);
+        let selected_task_goal = output
+            .selected_task_goal
+            .expect("selected task goal should exist when a task is selected");
+
+        assert_eq!(selected_task_goal.task_label, "Docs");
+        assert!(!selected_task_goal.configured);
+        assert_eq!(selected_task_goal.minutes_target, 0);
+        assert_eq!(selected_task_goal.pomodoros_target, 0);
+        assert_eq!(selected_task_goal.focused_minutes, 0);
+        assert_eq!(selected_task_goal.pomodoros_completed, 0);
+        assert!(!selected_task_goal.met);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2739,7 +2739,7 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let (_, selected_task_label) = stats.task_planner_state();
     let (selected_task_label, focus_intention, task_note) =
         mirror_metadata_from_task_label(selected_task_label);
-    let goal_snapshot = effective_daily_goal_snapshot(config, stats, day_date);
+    let goal_snapshot = effective_daily_goal_snapshot_for_day(config, stats, day_date);
     let weekly_goal_snapshot = effective_weekly_goal_snapshot(config, stats, day_date);
     let monthly_goal_snapshot = effective_monthly_goal_snapshot(config, stats, day_date);
     let selected_task_goal = selected_task_label.as_ref().and_then(|label| {
@@ -2813,15 +2813,19 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     }
 }
 
-fn effective_daily_goal_snapshot(
+fn effective_daily_goal_snapshot_for_day(
     config: &AppConfig,
     stats: &FocusStats,
     day: NaiveDate,
 ) -> DailyGoalSnapshot {
-    let base = DailyGoalSnapshot {
-        minutes: config.daily_goal.minutes,
-        pomodoros: config.daily_goal.pomodoros,
-    };
+    let day_key = day.format("%Y-%m-%d").to_string();
+    let base = stats
+        .daily_entry(&day_key)
+        .and_then(|daily| daily.goal)
+        .unwrap_or(DailyGoalSnapshot {
+            minutes: config.daily_goal.minutes,
+            pomodoros: config.daily_goal.pomodoros,
+        });
     let previous = day.pred_opt().and_then(|previous_day| {
         let day_key = previous_day.format("%Y-%m-%d").to_string();
         stats.daily_entry(&day_key).and_then(|daily| {
@@ -5302,6 +5306,32 @@ mod tests {
         assert!(boundary_output.goal.met);
         assert!(!boundary_output.weekly_goal.met);
         assert!(!boundary_output.monthly_goal.met);
+    }
+
+    #[test]
+    fn build_status_output_daily_goal_uses_persisted_same_day_snapshot() {
+        let mut stats = FocusStats::default();
+        let today = current_day_key();
+        let persisted_snapshot = DailyGoalSnapshot {
+            minutes: 30,
+            pomodoros: 1,
+        };
+        stats.record_focus_elapsed(&today, 30 * 60, persisted_snapshot);
+        stats.record_completed_pomodoro(&today, persisted_snapshot);
+
+        let config = AppConfig {
+            daily_goal: DailyGoalConfig {
+                minutes: 120,
+                pomodoros: 4,
+            },
+            ..AppConfig::default()
+        };
+
+        let output = build_status_output(&config, &stats);
+
+        assert_eq!(output.goal.minutes_target, 30);
+        assert_eq!(output.goal.pomodoros_target, 1);
+        assert!(output.goal.met);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3043,16 +3043,15 @@ fn parse_profile_id(value: &str) -> Result<ProfileId, String> {
 
 fn parse_task_goal_value(value: &str) -> Result<(String, Option<DailyGoalConfig>), String> {
     let trimmed = value.trim();
-    if let Some((label_raw, goal_raw)) = trimmed.split_once(':') {
-        let label =
-            require_nonempty_key_value(label_raw, "Task goal requires a task label before `:`.")?
-                .to_string();
-        let goal_raw = require_nonempty_key_value(
-            goal_raw,
-            "Task goal requires `MINUTES,POMODOROS` after `:`.",
-        )?;
-        let (minutes, pomodoros) = parse_goal_components(goal_raw, "--task-goal")?;
-        return Ok((label, Some(DailyGoalConfig { minutes, pomodoros })));
+    if let Some((label_raw, goal_raw)) = trimmed.rsplit_once(':') {
+        if let Ok((minutes, pomodoros)) = parse_goal_components(goal_raw, "--task-goal") {
+            let label = require_nonempty_key_value(
+                label_raw,
+                "Task goal requires a task label before `:`.",
+            )?
+            .to_string();
+            return Ok((label, Some(DailyGoalConfig { minutes, pomodoros })));
+        }
     }
 
     let label = require_nonempty_key_value(
@@ -4064,6 +4063,21 @@ mod tests {
                         minutes: 120,
                         pomodoros: 4
                     })
+                },
+                output: OutputMode::Text
+            })
+        );
+    }
+
+    #[test]
+    fn parse_task_goal_with_colon_in_label_reads_specific_goal() {
+        let parsed = parse(&["--task-goal", "Docs:API"]).unwrap();
+        assert_eq!(
+            parsed,
+            CliAction::RunCommand(CliCommand {
+                kind: CommandKind::TaskGoal {
+                    label: Some("Docs:API".to_string()),
+                    goal: None
                 },
                 output: OutputMode::Text
             })

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3044,12 +3044,13 @@ fn parse_profile_id(value: &str) -> Result<ProfileId, String> {
 fn parse_task_goal_value(value: &str) -> Result<(String, Option<DailyGoalConfig>), String> {
     let trimmed = value.trim();
     if let Some((label_raw, goal_raw)) = trimmed.rsplit_once(':') {
-        if let Ok((minutes, pomodoros)) = parse_goal_components(goal_raw, "--task-goal") {
+        if goal_raw.contains(',') {
             let label = require_nonempty_key_value(
                 label_raw,
                 "Task goal requires a task label before `:`.",
             )?
             .to_string();
+            let (minutes, pomodoros) = parse_goal_components(goal_raw, "--task-goal")?;
             return Ok((label, Some(DailyGoalConfig { minutes, pomodoros })));
         }
     }
@@ -4785,6 +4786,18 @@ mod tests {
     fn parse_rejects_task_goal_with_blank_label() {
         let error = parse(&["--task-goal=:120,4"]).unwrap_err();
         assert!(error.contains("Task goal requires a task label before `:`."));
+    }
+
+    #[test]
+    fn parse_rejects_task_goal_with_non_numeric_pomodoros_suffix() {
+        let error = parse(&["--task-goal=Docs:120,abc"]).unwrap_err();
+        assert!(error.contains("Invalid goal pomodoros"));
+    }
+
+    #[test]
+    fn parse_rejects_task_goal_with_extra_goal_components() {
+        let error = parse(&["--task-goal=Docs:120,4,5"]).unwrap_err();
+        assert!(error.contains("Invalid goal pomodoros"));
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -289,6 +289,21 @@ impl TaskTrend {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskGoalProgress {
+    pub task_label: String,
+    pub target: DailyGoalSnapshot,
+    pub pomodoros_completed: u32,
+    pub focused_seconds: u64,
+    pub met: bool,
+}
+
+impl TaskGoalProgress {
+    pub fn focused_minutes(&self) -> u64 {
+        self.focused_seconds / 60
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct TaskTrendWindow {
     recent_start: chrono::NaiveDate,
@@ -470,6 +485,8 @@ struct PersistedStats {
     focus_sessions: Vec<FocusSessionRecord>,
     #[serde(default)]
     break_glass_overrides: Vec<BreakGlassOverrideEvent>,
+    #[serde(default)]
+    task_goal_targets: BTreeMap<String, DailyGoalSnapshot>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -482,6 +499,7 @@ pub struct FocusStats {
     selected_task_label: Option<String>,
     focus_sessions: Vec<FocusSessionRecord>,
     break_glass_overrides: Vec<BreakGlassOverrideEvent>,
+    task_goal_targets: BTreeMap<String, DailyGoalSnapshot>,
 }
 
 impl FocusStats {
@@ -515,6 +533,7 @@ impl FocusStats {
     fn from_persisted(persisted: PersistedStats) -> Self {
         let (task_labels, selected_task_label) =
             normalize_task_planner_state(persisted.task_labels, persisted.selected_task_label);
+        let task_goal_targets = normalize_task_goal_targets(persisted.task_goal_targets);
         let mut focus_sessions = Vec::new();
         for session in persisted.focus_sessions {
             if let Some(task_label) = normalize_task_label(&session.task_label) {
@@ -555,6 +574,7 @@ impl FocusStats {
             selected_task_label,
             focus_sessions,
             break_glass_overrides,
+            task_goal_targets,
         }
     }
 
@@ -567,6 +587,7 @@ impl FocusStats {
             selected_task_label: self.selected_task_label.clone(),
             focus_sessions: self.focus_sessions.clone(),
             break_glass_overrides: self.break_glass_overrides.clone(),
+            task_goal_targets: self.task_goal_targets.clone(),
         }
     }
 
@@ -798,6 +819,125 @@ impl FocusStats {
         (self.task_labels.clone(), self.selected_task_label.clone())
     }
 
+    pub fn set_task_goal_target(
+        &mut self,
+        label: &str,
+        target: DailyGoalSnapshot,
+    ) -> Result<String, String> {
+        let Some(normalized) = normalize_task_label(label) else {
+            return Err("Task label cannot be empty.".to_string());
+        };
+        let canonical = canonical_task_label(&self.task_labels, &normalized).unwrap_or(normalized);
+        if task_label_index(&self.task_labels, &canonical).is_none() {
+            self.task_labels.push(canonical.clone());
+        }
+        self.selected_task_label = Some(canonical.clone());
+        let key = canonical.to_ascii_lowercase();
+        if target.has_any_target() {
+            self.task_goal_targets.insert(key, target);
+        } else {
+            self.task_goal_targets.remove(&key);
+        }
+        Ok(canonical)
+    }
+
+    pub fn remove_task_goal_target(&mut self, label: &str) -> bool {
+        let Some(normalized) = normalize_task_label(label) else {
+            return false;
+        };
+        let canonical = canonical_task_label(&self.task_labels, &normalized).unwrap_or(normalized);
+        self.task_goal_targets
+            .remove(&canonical.to_ascii_lowercase())
+            .is_some()
+    }
+
+    pub fn rename_task_goal_target(&mut self, previous_label: &str, next_label: &str) -> bool {
+        let Some(previous_normalized) = normalize_task_label(previous_label) else {
+            return false;
+        };
+        let Some(next_normalized) = normalize_task_label(next_label) else {
+            return false;
+        };
+        let previous_canonical = canonical_task_label(&self.task_labels, &previous_normalized)
+            .unwrap_or(previous_normalized);
+        let next_canonical =
+            canonical_task_label(&self.task_labels, &next_normalized).unwrap_or(next_normalized);
+        let previous_key = previous_canonical.to_ascii_lowercase();
+        let next_key = next_canonical.to_ascii_lowercase();
+        if previous_key == next_key {
+            return false;
+        }
+
+        let Some(target) = self.task_goal_targets.remove(&previous_key) else {
+            return false;
+        };
+        self.task_goal_targets.insert(next_key, target);
+        true
+    }
+
+    pub fn task_goal_progress_for_label(&self, label: &str) -> Option<TaskGoalProgress> {
+        let normalized = normalize_task_label(label)?;
+        let task_label = canonical_task_label(&self.task_labels, &normalized).unwrap_or(normalized);
+        let key = task_label.to_ascii_lowercase();
+        let target = self
+            .task_goal_targets
+            .get(&key)
+            .copied()
+            .unwrap_or_default();
+        let totals_by_key = self.task_totals_by_key();
+        let (pomodoros_completed, focused_seconds) =
+            totals_by_key.get(&key).copied().unwrap_or((0, 0));
+        Some(TaskGoalProgress {
+            task_label,
+            target,
+            pomodoros_completed,
+            focused_seconds,
+            met: target.is_met_by_totals(focused_seconds / 60, pomodoros_completed),
+        })
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn task_goal_progress(&self, limit: usize) -> Vec<TaskGoalProgress> {
+        if limit == 0 {
+            return Vec::new();
+        }
+
+        let totals_by_key = self.task_totals_by_key();
+        let mut progress: Vec<TaskGoalProgress> = self
+            .task_goal_targets
+            .iter()
+            .filter_map(|(key, target)| {
+                if !target.has_any_target() {
+                    return None;
+                }
+                let (pomodoros_completed, focused_seconds) =
+                    totals_by_key.get(key).copied().unwrap_or((0, 0));
+                let task_label = self
+                    .task_labels
+                    .iter()
+                    .find(|label| label.eq_ignore_ascii_case(key))
+                    .cloned()
+                    .unwrap_or_else(|| key.clone());
+                Some(TaskGoalProgress {
+                    task_label,
+                    target: *target,
+                    pomodoros_completed,
+                    focused_seconds,
+                    met: target.is_met_by_totals(focused_seconds / 60, pomodoros_completed),
+                })
+            })
+            .collect();
+        progress.sort_by(|left, right| {
+            left.met
+                .cmp(&right.met)
+                .then_with(|| right.focused_seconds.cmp(&left.focused_seconds))
+                .then_with(|| right.pomodoros_completed.cmp(&left.pomodoros_completed))
+                .then_with(|| left.task_label.cmp(&right.task_label))
+        });
+        progress.truncate(limit);
+        progress
+    }
+
     pub fn update_task_planner_state(
         &mut self,
         labels: Vec<String>,
@@ -834,6 +974,20 @@ impl FocusStats {
             }
         }
         recent
+    }
+
+    fn task_totals_by_key(&self) -> BTreeMap<String, (u32, u64)> {
+        let mut by_task: BTreeMap<String, (u32, u64)> = BTreeMap::new();
+        for session in &self.focus_sessions {
+            let Some(task_label) = normalize_task_label(&session.task_label) else {
+                continue;
+            };
+            let key = task_label.to_ascii_lowercase();
+            let entry = by_task.entry(key).or_insert((0, 0));
+            entry.0 = entry.0.saturating_add(1);
+            entry.1 = entry.1.saturating_add(session.focused_seconds);
+        }
+        by_task
     }
 
     pub fn recent_daily(&self, limit: usize) -> Vec<(String, DailyStats)> {
@@ -1637,6 +1791,22 @@ fn normalize_task_planner_state(
     (normalized_labels, normalized_selected)
 }
 
+fn normalize_task_goal_targets(
+    task_goal_targets: BTreeMap<String, DailyGoalSnapshot>,
+) -> BTreeMap<String, DailyGoalSnapshot> {
+    let mut normalized = BTreeMap::new();
+    for (label, target) in task_goal_targets {
+        if !target.has_any_target() {
+            continue;
+        }
+        let Some(label) = normalize_task_label(&label) else {
+            continue;
+        };
+        normalized.insert(label.to_ascii_lowercase(), target);
+    }
+    normalized
+}
+
 fn normalize_session_metadata_text(input: &str) -> Option<String> {
     let trimmed = input.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())
@@ -2038,6 +2208,83 @@ mod tests {
     }
 
     #[test]
+    fn task_goal_progress_for_label_uses_cumulative_task_totals() {
+        let mut stats = FocusStats::default();
+        let daily_goal = DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        };
+        stats.record_completed_pomodoro_with_task(
+            "2026-04-01",
+            daily_goal,
+            Some("Docs"),
+            30 * 60,
+            None,
+        );
+        stats.record_completed_pomodoro_with_task(
+            "2026-04-02",
+            daily_goal,
+            Some("docs"),
+            30 * 60,
+            None,
+        );
+
+        let task_goal = DailyGoalSnapshot {
+            minutes: 60,
+            pomodoros: 2,
+        };
+        let canonical = stats.set_task_goal_target("docs", task_goal).unwrap();
+        assert_eq!(canonical, "Docs");
+
+        let progress = stats.task_goal_progress_for_label("DOCS").unwrap();
+        assert_eq!(progress.task_label, "Docs");
+        assert_eq!(progress.target, task_goal);
+        assert_eq!(progress.focused_minutes(), 60);
+        assert_eq!(progress.pomodoros_completed, 2);
+        assert!(progress.met);
+    }
+
+    #[test]
+    fn task_goal_progress_lists_configured_targets_without_history() {
+        let mut stats = FocusStats::default();
+        let task_goal = DailyGoalSnapshot {
+            minutes: 120,
+            pomodoros: 4,
+        };
+        stats
+            .set_task_goal_target("Project A", task_goal)
+            .expect("task goal should be set");
+
+        let progress = stats.task_goal_progress(5);
+        assert_eq!(progress.len(), 1);
+        assert_eq!(progress[0].task_label, "Project A");
+        assert_eq!(progress[0].target, task_goal);
+        assert_eq!(progress[0].focused_minutes(), 0);
+        assert_eq!(progress[0].pomodoros_completed, 0);
+        assert!(!progress[0].met);
+    }
+
+    #[test]
+    fn renaming_and_removing_task_goals_updates_lookup() {
+        let mut stats = FocusStats::default();
+        let task_goal = DailyGoalSnapshot {
+            minutes: 90,
+            pomodoros: 3,
+        };
+        stats
+            .set_task_goal_target("Docs", task_goal)
+            .expect("task goal should be set");
+        assert!(stats.rename_task_goal_target("Docs", "Writing"));
+
+        let renamed = stats.task_goal_progress_for_label("Writing").unwrap();
+        assert_eq!(renamed.target, task_goal);
+        assert!(stats.remove_task_goal_target("Writing"));
+
+        let removed = stats.task_goal_progress_for_label("Writing").unwrap();
+        assert_eq!(removed.target, DailyGoalSnapshot::default());
+    }
+
+    #[test]
     fn recent_task_trends_compare_last_seven_days_vs_previous_window() {
         let mut stats = FocusStats::default();
         let goal = DailyGoalSnapshot {
@@ -2419,6 +2666,27 @@ mod tests {
             restored.monthly_goal_snapshot_for_day(day),
             Some(monthly_goal)
         );
+    }
+
+    #[test]
+    fn persisted_stats_round_trip_preserves_task_goal_targets() {
+        let mut original = FocusStats::default();
+        let task_goal = DailyGoalSnapshot {
+            minutes: 180,
+            pomodoros: 6,
+        };
+        original
+            .set_task_goal_target("Project A", task_goal)
+            .expect("task goal should be set");
+
+        let toml_str = toml::to_string_pretty(&original.to_persisted()).unwrap();
+        let restored = FocusStats::try_from_toml(&toml_str).unwrap();
+        let progress = restored
+            .task_goal_progress_for_label("project a")
+            .expect("task goal progress should exist");
+
+        assert_eq!(progress.task_label, "Project A");
+        assert_eq!(progress.target, task_goal);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1608,26 +1608,13 @@ fn format_task_trend_delta(trend: &crate::stats::TaskTrend) -> String {
 
 fn format_task_goal_progress_summary(progress: &crate::stats::TaskGoalProgress) -> String {
     if !progress.target.has_any_target() {
-        return "goal off".to_string();
+        return "g:off".to_string();
     }
-    let pomodoros = format_goal_metric_progress(
-        "🍅",
-        u64::from(progress.pomodoros_completed),
-        u64::from(progress.target.pomodoros),
-        "",
-    );
-    let minutes = format_goal_metric_progress(
-        "⏱",
-        progress.focused_minutes(),
-        progress.target.minutes,
-        "m",
-    );
-    format!(
-        "goal {} · {} · {}",
-        if progress.met { "met" } else { "in progress" },
-        pomodoros,
-        minutes
-    )
+    if progress.met {
+        "g:met".to_string()
+    } else {
+        "g:in".to_string()
+    }
 }
 
 fn heatmap_cell_symbol(focused_minutes: u64, max_focused_minutes: u64) -> (char, Color) {
@@ -1851,9 +1838,7 @@ mod tests {
             met: false,
         };
         let configured_text = format_task_goal_progress_summary(&configured);
-        assert!(configured_text.contains("goal in progress"));
-        assert!(configured_text.contains("🍅 2/4"));
-        assert!(configured_text.contains("⏱ 60/120m"));
+        assert_eq!(configured_text, "g:in");
 
         let off = crate::stats::TaskGoalProgress {
             task_label: "Docs".to_string(),
@@ -1862,7 +1847,19 @@ mod tests {
             focused_seconds: 0,
             met: false,
         };
-        assert_eq!(format_task_goal_progress_summary(&off), "goal off");
+        assert_eq!(format_task_goal_progress_summary(&off), "g:off");
+
+        let met = crate::stats::TaskGoalProgress {
+            task_label: "Docs".to_string(),
+            target: crate::stats::DailyGoalSnapshot {
+                minutes: 60,
+                pomodoros: 2,
+            },
+            pomodoros_completed: 2,
+            focused_seconds: 60 * 60,
+            met: true,
+        };
+        assert_eq!(format_task_goal_progress_summary(&met), "g:met");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1182,11 +1182,16 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .task_focus_totals(5)
         .into_iter()
         .map(|stats| {
+            let goal_summary = app
+                .task_goal_progress_for_label(&stats.task_label)
+                .map(|progress| format_task_goal_progress_summary(&progress))
+                .unwrap_or_else(|| "goal off".to_string());
             ListItem::new(format!(
-                "  {} · 🍅{} · {}m",
+                "  {} · 🍅{} · {}m · {}",
                 stats.task_label,
                 stats.pomodoros_completed,
-                stats.focused_minutes()
+                stats.focused_minutes(),
+                goal_summary
             ))
         })
         .collect();
@@ -1601,6 +1606,30 @@ fn format_task_trend_delta(trend: &crate::stats::TaskTrend) -> String {
     }
 }
 
+fn format_task_goal_progress_summary(progress: &crate::stats::TaskGoalProgress) -> String {
+    if !progress.target.has_any_target() {
+        return "goal off".to_string();
+    }
+    let pomodoros = format_goal_metric_progress(
+        "🍅",
+        u64::from(progress.pomodoros_completed),
+        u64::from(progress.target.pomodoros),
+        "",
+    );
+    let minutes = format_goal_metric_progress(
+        "⏱",
+        progress.focused_minutes(),
+        progress.target.minutes,
+        "m",
+    );
+    format!(
+        "goal {} · {} · {}",
+        if progress.met { "met" } else { "in progress" },
+        pomodoros,
+        minutes
+    )
+}
+
 fn heatmap_cell_symbol(focused_minutes: u64, max_focused_minutes: u64) -> (char, Color) {
     if focused_minutes == 0 || max_focused_minutes == 0 {
         return ('.', Color::DarkGray);
@@ -1807,6 +1836,33 @@ mod tests {
 
         assert_eq!(format_timer_goal_streak_line(&app), expected);
         assert_eq!(format_history_goal_streak_line(&app), expected);
+    }
+
+    #[test]
+    fn task_goal_progress_summary_formats_state_and_metrics() {
+        let configured = crate::stats::TaskGoalProgress {
+            task_label: "Docs".to_string(),
+            target: crate::stats::DailyGoalSnapshot {
+                minutes: 120,
+                pomodoros: 4,
+            },
+            pomodoros_completed: 2,
+            focused_seconds: 60 * 60,
+            met: false,
+        };
+        let configured_text = format_task_goal_progress_summary(&configured);
+        assert!(configured_text.contains("goal in progress"));
+        assert!(configured_text.contains("🍅 2/4"));
+        assert!(configured_text.contains("⏱ 60/120m"));
+
+        let off = crate::stats::TaskGoalProgress {
+            task_label: "Docs".to_string(),
+            target: crate::stats::DailyGoalSnapshot::default(),
+            pomodoros_completed: 0,
+            focused_seconds: 0,
+            met: false,
+        };
+        assert_eq!(format_task_goal_progress_summary(&off), "goal off");
     }
 
     #[test]

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -139,6 +139,29 @@ fn task_goal_json_sets_and_reads_per_task_target() {
 }
 
 #[test]
+fn task_goal_json_reads_unconfigured_selected_task_goal() {
+    let env = TestEnv::new("task-goal-json-unconfigured");
+
+    let select_output = env.run(&["--task", "Docs", "--json"]);
+    assert_eq!(select_output.status.code(), Some(0));
+    assert!(stderr_text(&select_output).trim().is_empty());
+
+    let read_output = env.run(&["--task-goal", "Docs", "--json"]);
+    assert_eq!(read_output.status.code(), Some(0));
+    assert!(stderr_text(&read_output).trim().is_empty());
+    let read_payload: Value =
+        serde_json::from_slice(&read_output.stdout).expect("stdout should be JSON");
+    assert_eq!(read_payload["updated"], false);
+    assert_eq!(read_payload["task_label"], "Docs");
+    assert_eq!(read_payload["configured"], false);
+    assert_eq!(read_payload["minutes_target"], 0);
+    assert_eq!(read_payload["pomodoros_target"], 0);
+    assert_eq!(read_payload["focused_minutes"], 0);
+    assert_eq!(read_payload["pomodoros_completed"], 0);
+    assert_eq!(read_payload["met"], false);
+}
+
+#[test]
 fn status_watch_json_streams_multiple_snapshots() {
     let env = TestEnv::new("status-watch-json");
     let output = env.run_watch(

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -101,9 +101,39 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload["goal"].get("carry_over").is_some());
     assert!(payload["weekly_goal"].get("carry_over").is_some());
     assert!(payload["monthly_goal"].get("carry_over").is_some());
+    assert!(payload.get("selected_task_goal").is_some());
     assert!(payload.get("live").is_some());
     assert!(payload["live"].get("focus_intention").is_some());
     assert!(payload["live"].get("task_note").is_some());
+}
+
+#[test]
+fn task_goal_json_sets_and_reads_per_task_target() {
+    let env = TestEnv::new("task-goal-json");
+
+    let select_output = env.run(&["--task", "Docs", "--json"]);
+    assert_eq!(select_output.status.code(), Some(0));
+    assert!(stderr_text(&select_output).trim().is_empty());
+
+    let set_output = env.run(&["--task-goal", "Docs:120,4", "--json"]);
+    assert_eq!(set_output.status.code(), Some(0));
+    assert!(stderr_text(&set_output).trim().is_empty());
+    let set_payload: Value =
+        serde_json::from_slice(&set_output.stdout).expect("stdout should be JSON");
+    assert_eq!(set_payload["updated"], true);
+    assert_eq!(set_payload["task_label"], "Docs");
+    assert_eq!(set_payload["configured"], true);
+    assert_eq!(set_payload["minutes_target"], 120);
+    assert_eq!(set_payload["pomodoros_target"], 4);
+
+    let read_output = env.run(&["--task-goal", "Docs", "--json"]);
+    assert_eq!(read_output.status.code(), Some(0));
+    assert!(stderr_text(&read_output).trim().is_empty());
+    let read_payload: Value =
+        serde_json::from_slice(&read_output.stdout).expect("stdout should be JSON");
+    assert_eq!(read_payload["updated"], false);
+    assert_eq!(read_payload["task_label"], "Docs");
+    assert_eq!(read_payload["configured"], true);
 }
 
 #[test]

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -134,6 +134,8 @@ fn task_goal_json_sets_and_reads_per_task_target() {
     assert_eq!(read_payload["updated"], false);
     assert_eq!(read_payload["task_label"], "Docs");
     assert_eq!(read_payload["configured"], true);
+    assert_eq!(read_payload["minutes_target"], 120);
+    assert_eq!(read_payload["pomodoros_target"], 4);
 }
 
 #[test]


### PR DESCRIPTION
## What

- Add cumulative per-task goal targets (minutes and pomodoros) in stats persistence and evaluation logic.
- Add `--task-goal` CLI support to read or set task goals with text/JSON output.
- Extend `--status --json` to include `selected_task_goal` for the active selected label.
- Show task goal progress and met/in-progress state in the History Task Totals panel.
- Update README/CHANGELOG and add regression coverage across stats, app, ui, cli, and CLI JSON contract tests.

## Why

Issue #186 asks for tracking and evaluating progress against task-level goal targets. Existing goals were global (daily/weekly/monthly), so task-specific targets and visibility were missing from the workflow. This change adds first-class per-task cumulative goals while keeping existing behavior backward compatible.

Closes #186

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable) (N/A: timer state machine behavior was not changed)
- [x] Site blocking behavior was verified for this change (if applicable) (N/A: site blocking behavior was not changed)
- [x] WakaTime integration behavior was verified for this change (if applicable) (N/A: WakaTime behavior was not changed)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A: no new dependencies or config keys)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) (No security-sensitive changes)
- [x] Breaking behavior changes are clearly described in this PR (N/A: no breaking behavior changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task-level cumulative goal targets with CLI management; status output now includes the selected task's goal and per-task progress reporting.
  * History/Stats view displays per-task goal summaries (met / in-progress / off).

* **Documentation**
  * README and CHANGELOG updated with CLI examples, JSON output details, and feature notes.

* **Tests**
  * Added JSON contract and unit tests for CLI task-goal commands, status JSON, and task-goal lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->