### PR TITLE
Add weekly focus score KPI across stats, history, and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ Override events are recorded for audit visibility in the History view and includ
 - daily aggregates persisted in `stats.toml` (in the same config directory as `config.toml`)
 - weekly totals derived from daily aggregates in the History view
 - weekly consistency score (`active_days / 7`, rounded to `%`) derived from daily activity
+- weekly focus score KPI (50/50 blend of consistency and weekly goal completion; `n/a` when weekly goal is off)
 - profile effectiveness comparison (focus share % and average focused minutes per completed session)
 - per-task totals (pomodoros and focused minutes) derived from labeled focus sessions
 - per-task trend summaries in History (`last 7 days` vs `previous 7 days`)
@@ -479,12 +480,13 @@ From timer view:
 - while the history panel is open, press **`e`** to export `focustime-stats.json` and `focustime-stats.csv` into the current working directory
 - press **`h`** or **`Esc`** to return to timer view
 
-Exports include daily/weekly aggregates, weekly consistency, profile
+Exports include daily/weekly aggregates, weekly consistency, weekly focus score,
+profile
 effectiveness, task summaries/trends, and labeled focus-session records where
 task labels were attached. Focus-session rows persist and export first-class
 `focus_intention` and `task_note` fields; when dedicated metadata input is not
 provided, both fields default to the selected `task_label`. Export files expose
-`schema_version` (currently `3`) so downstream consumers can handle versioned
+`schema_version` (currently `4`) so downstream consumers can handle versioned
 contracts explicitly.
 
 ## The way the system works

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,7 +29,7 @@ use crate::stats::{
     BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles,
     FocusSessionMetadata, FocusStats, GoalStreak, MonthlyHeatmap, MonthlyStats,
     ProfileEffectiveness, ProfileTotals, SessionStats, TaskGoalProgress, TaskTotals, TaskTrend,
-    WeeklyConsistency, WeeklyStats, carry_over_goal_target, current_day_key,
+    WeeklyConsistency, WeeklyFocusScore, WeeklyStats, carry_over_goal_target, current_day_key,
 };
 use crate::task_labels::{normalize_task_label, task_label_index};
 use crate::timer::{
@@ -1042,8 +1042,8 @@ impl App {
         self.stats.recent_weekly_consistency(limit)
     }
 
-    pub fn latest_weekly_consistency(&self) -> Option<WeeklyConsistency> {
-        self.stats.latest_weekly_consistency()
+    pub fn latest_weekly_focus_score(&self) -> Option<WeeklyFocusScore> {
+        self.stats.latest_weekly_focus_score()
     }
 
     pub fn recent_monthly_stats(&self, limit: usize) -> Vec<MonthlyStats> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -408,6 +408,14 @@ struct TodayOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct FocusScoreOutput {
+    available: bool,
+    focus_score_pct: Option<u8>,
+    consistency_score_pct: u8,
+    completion_score_pct: Option<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct LiveStatusOutput {
     state_source: &'static str,
     recovery_error: Option<String>,
@@ -439,6 +447,7 @@ struct StatusOutput {
     selected_task_goal: Option<TaskGoalOutput>,
     session: SessionOutput,
     today: TodayOutput,
+    focus_score: FocusScoreOutput,
     live: LiveStatusOutput,
 }
 
@@ -2761,6 +2770,21 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
         .map(|profile| effective_blocked_sites_for_profile(profile).len())
         .unwrap_or_default();
     let live = build_live_status_output(config, selected_task_label.clone());
+    let consistency_score_pct = stats
+        .weekly_focus_score_for_day(day_date)
+        .consistency_score_pct;
+    let completion_score_pct = if weekly_goal_snapshot.has_any_target() {
+        weekly_goal_completion_score_pct(
+            weekly_goal_snapshot,
+            week.focused_minutes(),
+            week.pomodoros_completed,
+        )
+    } else {
+        None
+    };
+    let focus_score_pct = completion_score_pct.map(|completion| {
+        (u16::from(consistency_score_pct) + u16::from(completion)).div_ceil(2) as u8
+    });
 
     StatusOutput {
         day,
@@ -2803,8 +2827,50 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
             focused_minutes: today.focused_minutes(),
             pomodoros_completed: today.pomodoros_completed,
         },
+        focus_score: FocusScoreOutput {
+            available: focus_score_pct.is_some(),
+            focus_score_pct,
+            consistency_score_pct,
+            completion_score_pct,
+        },
         live,
     }
+}
+
+fn weekly_goal_completion_score_pct(
+    goal: DailyGoalSnapshot,
+    focused_minutes: u64,
+    pomodoros_completed: u32,
+) -> Option<u8> {
+    let minute_score = if goal.minutes > 0 {
+        Some(percentage_round_nearest(
+            focused_minutes.min(goal.minutes),
+            goal.minutes,
+        ))
+    } else {
+        None
+    };
+    let pomodoro_score = if goal.pomodoros > 0 {
+        Some(percentage_round_nearest(
+            u64::from(pomodoros_completed.min(goal.pomodoros)),
+            u64::from(goal.pomodoros),
+        ))
+    } else {
+        None
+    };
+    match (minute_score, pomodoro_score) {
+        (None, None) => None,
+        (Some(score), None) | (None, Some(score)) => Some(score),
+        (Some(left), Some(right)) => Some((u16::from(left) + u16::from(right)).div_ceil(2) as u8),
+    }
+}
+
+fn percentage_round_nearest(part: u64, total: u64) -> u8 {
+    if total == 0 {
+        return 0;
+    }
+    let rounded = (u128::from(part) * 100 + (u128::from(total) / 2)) / u128::from(total);
+    rounded.min(u128::from(u8::MAX)) as u8
 }
 
 fn effective_daily_goal_snapshot_for_day(
@@ -3543,6 +3609,7 @@ fn print_status_output(payload: &StatusOutput) {
         "Session: {} focused minutes, {} pomodoros",
         payload.session.focused_minutes, payload.session.pomodoros_completed
     );
+    print_status_focus_score_line(&payload.focus_score);
     println!(
         "Live timer: {} {} ({} remaining, source: {})",
         payload.live.phase,
@@ -3601,6 +3668,22 @@ fn print_status_task_goal_line(task_goal: Option<&TaskGoalOutput>) {
         "Selected task progress (`{}`): {} min, {} pomodoros",
         task_goal.task_label, task_goal.focused_minutes, task_goal.pomodoros_completed
     );
+}
+
+fn print_status_focus_score_line(focus_score: &FocusScoreOutput) {
+    if focus_score.available {
+        println!(
+            "Focus score: {}% (consistency {}%, completion {}%)",
+            focus_score.focus_score_pct.unwrap_or(0),
+            focus_score.consistency_score_pct,
+            focus_score.completion_score_pct.unwrap_or(0)
+        );
+    } else {
+        println!(
+            "Focus score: n/a (weekly goal off; consistency {}%)",
+            focus_score.consistency_score_pct
+        );
+    }
 }
 
 fn print_timer_state_output(timer: &TimerStateOutput) {
@@ -5331,6 +5414,9 @@ mod tests {
         assert!(in_period_output.weekly_goal.met);
         assert!(in_period_output.monthly_goal.configured);
         assert!(in_period_output.monthly_goal.met);
+        assert!(in_period_output.focus_score.available);
+        assert_eq!(in_period_output.focus_score.completion_score_pct, Some(100));
+        assert!(in_period_output.focus_score.focus_score_pct.is_some());
 
         let boundary_config = AppConfig {
             daily_goal: DailyGoalConfig {
@@ -5353,6 +5439,7 @@ mod tests {
         assert!(boundary_output.goal.met);
         assert!(!boundary_output.weekly_goal.met);
         assert!(!boundary_output.monthly_goal.met);
+        assert!(boundary_output.focus_score.available);
     }
 
     #[test]
@@ -5401,6 +5488,8 @@ mod tests {
         assert_eq!(selected_task_goal.focused_minutes, 0);
         assert_eq!(selected_task_goal.pomodoros_completed, 0);
         assert!(!selected_task_goal.met);
+        assert!(!output.focus_score.available);
+        assert!(output.focus_score.focus_score_pct.is_none());
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -17,7 +17,7 @@ use crate::task_labels::{canonical_task_label, normalize_task_label, task_label_
 const STATS_FILE_NAME: &str = "stats.toml";
 const JSON_EXPORT_FILE_NAME: &str = "focustime-stats.json";
 const CSV_EXPORT_FILE_NAME: &str = "focustime-stats.csv";
-const EXPORT_SCHEMA_VERSION: u32 = 3;
+const EXPORT_SCHEMA_VERSION: u32 = 4;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -110,6 +110,17 @@ pub struct WeeklyConsistency {
     pub week_label: String,
     pub active_days: u8,
     pub consistency_score_pct: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WeeklyFocusScore {
+    pub year: i32,
+    pub week: u32,
+    pub week_label: String,
+    pub active_days: u8,
+    pub consistency_score_pct: u8,
+    pub completion_score_pct: Option<u8>,
+    pub focus_score_pct: Option<u8>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -345,6 +356,7 @@ struct StatsExport {
     task_totals: Vec<TaskTotalsExportRow>,
     task_trends: Vec<TaskTrendExportRow>,
     weekly_consistency: Vec<WeeklyConsistencyExportRow>,
+    focus_scores: Vec<FocusScoreExportRow>,
     profile_effectiveness: Vec<ProfileEffectivenessExportRow>,
 }
 
@@ -423,6 +435,17 @@ struct WeeklyConsistencyExportRow {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct FocusScoreExportRow {
+    year: i32,
+    week: u32,
+    week_label: String,
+    active_days: u8,
+    consistency_score_pct: u8,
+    completion_score_pct: Option<u8>,
+    focus_score_pct: Option<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 struct ProfileEffectivenessExportRow {
     profile: String,
     sessions_completed: u32,
@@ -465,6 +488,8 @@ struct CsvExportRow {
     sessions_completed: Option<u32>,
     active_days: Option<u32>,
     consistency_score_pct: Option<u8>,
+    completion_score_pct: Option<u8>,
+    focus_score_pct: Option<u8>,
     average_focused_minutes_per_session: Option<u64>,
     focus_share_pct: Option<u8>,
 }
@@ -815,6 +840,35 @@ impl FocusStats {
         self.monthly_goal_snapshots.get(&key).copied()
     }
 
+    pub fn weekly_focus_score_for_day(&self, day: chrono::NaiveDate) -> WeeklyFocusScore {
+        let iso_week = day.iso_week();
+        let year = iso_week.year();
+        let week = iso_week.week();
+        let week_label = format_week_label(year, week);
+        let active_days = self
+            .weekly_active_days()
+            .get(&(year, week))
+            .copied()
+            .unwrap_or(0);
+        let consistency_score_pct = consistency_score_from_active_days(active_days);
+        let totals = self.weekly_for_day(day);
+        let completion_score_pct = self
+            .weekly_goal_snapshot_for_day(day)
+            .and_then(|goal| weekly_completion_score_pct(goal, totals));
+        let focus_score_pct = completion_score_pct
+            .map(|completion| average_two_percentages(consistency_score_pct, completion));
+
+        WeeklyFocusScore {
+            year,
+            week,
+            week_label,
+            active_days,
+            consistency_score_pct,
+            completion_score_pct,
+            focus_score_pct,
+        }
+    }
+
     pub fn task_planner_state(&self) -> (Vec<String>, Option<String>) {
         (self.task_labels.clone(), self.selected_task_label.clone())
     }
@@ -1014,8 +1068,15 @@ impl FocusStats {
         weekly
     }
 
-    pub fn latest_weekly_consistency(&self) -> Option<WeeklyConsistency> {
-        self.recent_weekly_consistency(1).into_iter().next()
+    pub fn recent_weekly_focus_scores(&self, limit: usize) -> Vec<WeeklyFocusScore> {
+        let mut weekly = self.weekly_focus_score_stats();
+        weekly.reverse();
+        weekly.truncate(limit);
+        weekly
+    }
+
+    pub fn latest_weekly_focus_score(&self) -> Option<WeeklyFocusScore> {
+        self.recent_weekly_focus_scores(1).into_iter().next()
     }
 
     pub fn recent_monthly(&self, limit: usize) -> Vec<MonthlyStats> {
@@ -1279,6 +1340,7 @@ impl FocusStats {
             task_totals: self.export_task_totals_rows(),
             task_trends: self.export_task_trend_rows(),
             weekly_consistency: self.export_weekly_consistency_rows(),
+            focus_scores: self.export_focus_score_rows(),
             profile_effectiveness: self.export_profile_effectiveness_rows(),
         }
     }
@@ -1406,6 +1468,21 @@ impl FocusStats {
             .collect()
     }
 
+    fn export_focus_score_rows(&self) -> Vec<FocusScoreExportRow> {
+        self.weekly_focus_score_stats()
+            .into_iter()
+            .map(|entry| FocusScoreExportRow {
+                year: entry.year,
+                week: entry.week,
+                week_label: entry.week_label,
+                active_days: entry.active_days,
+                consistency_score_pct: entry.consistency_score_pct,
+                completion_score_pct: entry.completion_score_pct,
+                focus_score_pct: entry.focus_score_pct,
+            })
+            .collect()
+    }
+
     fn export_profile_effectiveness_rows(&self) -> Vec<ProfileEffectivenessExportRow> {
         self.profile_effectiveness()
             .into_iter()
@@ -1422,6 +1499,57 @@ impl FocusStats {
     }
 
     fn weekly_consistency_stats(&self) -> Vec<WeeklyConsistency> {
+        self.weekly_active_days()
+            .into_iter()
+            .map(|((year, week), active_days)| WeeklyConsistency {
+                year,
+                week,
+                week_label: format_week_label(year, week),
+                active_days,
+                consistency_score_pct: consistency_score_from_active_days(active_days),
+            })
+            .collect()
+    }
+
+    fn weekly_focus_score_stats(&self) -> Vec<WeeklyFocusScore> {
+        let weekly_totals_by_key: BTreeMap<(i32, u32), WeeklyStats> = self
+            .weekly_stats()
+            .into_iter()
+            .map(|stats| ((stats.year, stats.week), stats))
+            .collect();
+        self.weekly_consistency_stats()
+            .into_iter()
+            .map(|consistency| {
+                let totals = weekly_totals_by_key
+                    .get(&(consistency.year, consistency.week))
+                    .copied()
+                    .unwrap_or(WeeklyStats {
+                        year: consistency.year,
+                        week: consistency.week,
+                        ..WeeklyStats::default()
+                    });
+                let completion_score_pct = self
+                    .weekly_goal_snapshots
+                    .get(&consistency.week_label)
+                    .copied()
+                    .and_then(|goal| weekly_completion_score_pct(goal, totals));
+                let focus_score_pct = completion_score_pct.map(|completion| {
+                    average_two_percentages(consistency.consistency_score_pct, completion)
+                });
+                WeeklyFocusScore {
+                    year: consistency.year,
+                    week: consistency.week,
+                    week_label: consistency.week_label,
+                    active_days: consistency.active_days,
+                    consistency_score_pct: consistency.consistency_score_pct,
+                    completion_score_pct,
+                    focus_score_pct,
+                }
+            })
+            .collect()
+    }
+
+    fn weekly_active_days(&self) -> BTreeMap<(i32, u32), u8> {
         let mut weekly = BTreeMap::new();
         for (day_key, stats) in &self.daily {
             if !daily_has_activity(*stats) {
@@ -1436,17 +1564,7 @@ impl FocusStats {
                 .or_insert(0_u8);
             *active_days = active_days.saturating_add(1).min(7);
         }
-
         weekly
-            .into_iter()
-            .map(|((year, week), active_days)| WeeklyConsistency {
-                year,
-                week,
-                week_label: format_week_label(year, week),
-                active_days,
-                consistency_score_pct: consistency_score_from_active_days(active_days),
-            })
-            .collect()
     }
 
     fn weekly_stats(&self) -> Vec<WeeklyStats> {
@@ -1637,6 +1755,8 @@ impl StatsExport {
             sessions_completed: None,
             active_days: None,
             consistency_score_pct: None,
+            completion_score_pct: None,
+            focus_score_pct: None,
             average_focused_minutes_per_session: None,
             focus_share_pct: None,
         }
@@ -1651,6 +1771,7 @@ impl StatsExport {
                 + self.task_totals.len()
                 + self.task_trends.len()
                 + self.weekly_consistency.len()
+                + self.focus_scores.len()
                 + self.profile_effectiveness.len(),
         );
 
@@ -1739,6 +1860,19 @@ impl StatsExport {
                 active_days: Some(u32::from(consistency.active_days)),
                 consistency_score_pct: Some(consistency.consistency_score_pct),
                 ..Self::csv_row_defaults("weekly_consistency")
+            });
+        }
+
+        for focus_score in &self.focus_scores {
+            rows.push(CsvExportRow {
+                week_label: Some(focus_score.week_label.clone()),
+                year: Some(focus_score.year),
+                week: Some(focus_score.week),
+                active_days: Some(u32::from(focus_score.active_days)),
+                consistency_score_pct: Some(focus_score.consistency_score_pct),
+                completion_score_pct: focus_score.completion_score_pct,
+                focus_score_pct: focus_score.focus_score_pct,
+                ..Self::csv_row_defaults("focus_score")
             });
         }
 
@@ -1891,6 +2025,34 @@ fn consistency_score_from_active_days(active_days: u8) -> u8 {
     let capped_days = active_days.min(7);
     let rounded = (u32::from(capped_days) * 100 + 3) / 7;
     rounded.min(u32::from(u8::MAX)) as u8
+}
+
+fn weekly_completion_score_pct(goal: DailyGoalSnapshot, totals: WeeklyStats) -> Option<u8> {
+    let minute_score = if goal.minutes > 0 {
+        let completed_minutes = totals.focused_minutes().min(goal.minutes);
+        Some(percentage_round_nearest(completed_minutes, goal.minutes))
+    } else {
+        None
+    };
+    let pomodoro_score = if goal.pomodoros > 0 {
+        let completed_pomodoros = totals.pomodoros_completed.min(goal.pomodoros);
+        Some(percentage_round_nearest(
+            u64::from(completed_pomodoros),
+            u64::from(goal.pomodoros),
+        ))
+    } else {
+        None
+    };
+    match (minute_score, pomodoro_score) {
+        (None, None) => None,
+        (Some(score), None) | (None, Some(score)) => Some(score),
+        (Some(left), Some(right)) => Some(average_two_percentages(left, right)),
+    }
+}
+
+fn average_two_percentages(left: u8, right: u8) -> u8 {
+    let sum = u16::from(left) + u16::from(right);
+    sum.div_ceil(2) as u8
 }
 
 fn format_week_label(year: i32, week: u32) -> String {
@@ -2570,6 +2732,54 @@ mod tests {
     }
 
     #[test]
+    fn weekly_focus_score_combines_consistency_and_completion() {
+        let mut stats = FocusStats::default();
+        let week_day = chrono::NaiveDate::from_ymd_opt(2026, 4, 6).unwrap();
+        let day_key = week_day.format("%Y-%m-%d").to_string();
+        let other_day = week_day.succ_opt().unwrap();
+        let other_day_key = other_day.format("%Y-%m-%d").to_string();
+        let goal = DailyGoalSnapshot {
+            minutes: 50,
+            pomodoros: 2,
+        };
+
+        stats.sync_weekly_goal_snapshot(week_day, goal);
+        stats.record_focus_elapsed(&day_key, 25 * 60, goal);
+        stats.record_completed_pomodoro(&day_key, goal);
+        stats.record_focus_elapsed(&other_day_key, 25 * 60, goal);
+        stats.record_completed_pomodoro(&other_day_key, goal);
+
+        let focus_score = stats.latest_weekly_focus_score().unwrap();
+        let iso_week = week_day.iso_week();
+        assert_eq!(
+            focus_score.week_label,
+            format_week_label(iso_week.year(), iso_week.week())
+        );
+        assert_eq!(focus_score.active_days, 2);
+        assert_eq!(focus_score.consistency_score_pct, 29);
+        assert_eq!(focus_score.completion_score_pct, Some(100));
+        assert_eq!(focus_score.focus_score_pct, Some(65));
+    }
+
+    #[test]
+    fn weekly_focus_score_is_unavailable_when_weekly_goal_is_off() {
+        let mut stats = FocusStats::default();
+        stats.insert_daily_for_tests(
+            "2026-04-06",
+            DailyStats {
+                pomodoros_completed: 1,
+                focused_seconds: 25 * 60,
+                goal: None,
+            },
+        );
+
+        let focus_score = stats.latest_weekly_focus_score().unwrap();
+        assert_eq!(focus_score.completion_score_pct, None);
+        assert_eq!(focus_score.focus_score_pct, None);
+        assert_eq!(focus_score.consistency_score_pct, 14);
+    }
+
+    #[test]
     fn persisted_stats_round_trip_preserves_daily_history() {
         let mut original = FocusStats::default();
         let goal = DailyGoalSnapshot {
@@ -3128,6 +3338,7 @@ mod tests {
         let task_totals = json_value["task_totals"].as_array().unwrap();
         let task_trends = json_value["task_trends"].as_array().unwrap();
         let weekly_consistency = json_value["weekly_consistency"].as_array().unwrap();
+        let focus_scores = json_value["focus_scores"].as_array().unwrap();
         let profile_effectiveness = json_value["profile_effectiveness"].as_array().unwrap();
         assert_eq!(daily.len(), 2);
         assert!(!weekly.is_empty());
@@ -3136,6 +3347,7 @@ mod tests {
         assert_eq!(task_totals.len(), 1);
         assert_eq!(task_trends.len(), 1);
         assert!(!weekly_consistency.is_empty());
+        assert!(!focus_scores.is_empty());
         assert_eq!(profile_effectiveness.len(), 1);
         assert!(
             daily
@@ -3166,6 +3378,11 @@ mod tests {
                 .iter()
                 .any(|entry| entry["consistency_score_pct"].as_u64().unwrap_or(0) > 0)
         );
+        assert!(
+            focus_scores
+                .iter()
+                .any(|entry| entry.get("focus_score_pct").is_some())
+        );
         assert_eq!(profile_effectiveness[0]["profile"], "Classic");
         assert_eq!(
             profile_effectiveness[0]["average_focused_minutes_per_session"],
@@ -3174,22 +3391,23 @@ mod tests {
         assert_eq!(profile_effectiveness[0]["focus_share_pct"], 100);
 
         let csv = fs::read_to_string(&exported.csv_path).unwrap();
-        assert!(csv.contains("schema_version,record_type,date,week_label,year,week,pomodoros_completed,focused_seconds,focused_minutes,goal_minutes,goal_pomodoros,goal_met,task_label,break_glass_timestamp_epoch_secs,break_glass_duration_seconds,focus_intention,task_note,recent_window_start,recent_window_end,previous_window_start,previous_window_end,previous_pomodoros_completed,previous_focused_seconds,previous_focused_minutes,delta_focused_seconds,delta_focused_minutes,profile_name,sessions_completed,active_days,consistency_score_pct,average_focused_minutes_per_session,focus_share_pct"));
+        assert!(csv.contains("schema_version,record_type,date,week_label,year,week,pomodoros_completed,focused_seconds,focused_minutes,goal_minutes,goal_pomodoros,goal_met,task_label,break_glass_timestamp_epoch_secs,break_glass_duration_seconds,focus_intention,task_note,recent_window_start,recent_window_end,previous_window_start,previous_window_end,previous_pomodoros_completed,previous_focused_seconds,previous_focused_minutes,delta_focused_seconds,delta_focused_minutes,profile_name,sessions_completed,active_days,consistency_score_pct,completion_score_pct,focus_score_pct,average_focused_minutes_per_session,focus_share_pct"));
         assert!(csv.contains(&format!(
-            "3,daily,{labeled_day},,,,1,1800,30,25,1,true,,,,,"
+            "4,daily,{labeled_day},,,,1,1800,30,25,1,true,,,,,"
         )));
-        assert!(csv.contains("3,weekly,,"));
+        assert!(csv.contains("4,weekly,,"));
         assert!(csv.contains(&format!(
-            "3,focus_session,{labeled_day},,,,1,1800,30,,,,Project A,,,Project A,Project A"
+            "4,focus_session,{labeled_day},,,,1,1800,30,,,,Project A,,,Project A,Project A"
         )));
         assert!(csv.contains(&format!(
-            "3,break_glass_override,{labeled_day},,,,0,0,0,,,,Project A,1711000000,300,,"
+            "4,break_glass_override,{labeled_day},,,,0,0,0,,,,Project A,1711000000,300,,"
         )));
-        assert!(csv.contains("3,task_summary,,,,,1,1800,30,,,,Project A"));
-        assert!(csv.contains("3,task_trend,,,,,1,1800,30,,,,Project A"));
-        assert!(csv.contains("3,weekly_consistency,"));
-        assert!(csv.contains("3,profile_effectiveness,,,,,1,1800,30"));
-        assert!(csv.contains("Classic,1,1,,30,100"));
+        assert!(csv.contains("4,task_summary,,,,,1,1800,30,,,,Project A"));
+        assert!(csv.contains("4,task_trend,,,,,1,1800,30,,,,Project A"));
+        assert!(csv.contains("4,weekly_consistency,"));
+        assert!(csv.contains("4,focus_score,"));
+        assert!(csv.contains("4,profile_effectiveness,,,,,1,1800,30"));
+        assert!(csv.contains("Classic,1,1,"));
 
         fs::remove_dir_all(export_dir).unwrap();
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1512,36 +1512,53 @@ impl FocusStats {
     }
 
     fn weekly_focus_score_stats(&self) -> Vec<WeeklyFocusScore> {
+        let consistency_by_key: BTreeMap<(i32, u32), WeeklyConsistency> = self
+            .weekly_consistency_stats()
+            .into_iter()
+            .map(|consistency| ((consistency.year, consistency.week), consistency))
+            .collect();
         let weekly_totals_by_key: BTreeMap<(i32, u32), WeeklyStats> = self
             .weekly_stats()
             .into_iter()
             .map(|stats| ((stats.year, stats.week), stats))
             .collect();
-        self.weekly_consistency_stats()
+        let mut all_week_keys: BTreeSet<(i32, u32)> = consistency_by_key.keys().copied().collect();
+        for week_label in self.weekly_goal_snapshots.keys() {
+            if let Some(week_key) = parse_week_label(week_label) {
+                all_week_keys.insert(week_key);
+            }
+        }
+
+        all_week_keys
             .into_iter()
-            .map(|consistency| {
-                let totals = weekly_totals_by_key
-                    .get(&(consistency.year, consistency.week))
-                    .copied()
-                    .unwrap_or(WeeklyStats {
-                        year: consistency.year,
-                        week: consistency.week,
-                        ..WeeklyStats::default()
-                    });
+            .map(|(year, week)| {
+                let consistency = consistency_by_key.get(&(year, week));
+                let week_label = format_week_label(year, week);
+                let active_days = consistency.map_or(0, |entry| entry.active_days);
+                let consistency_score_pct =
+                    consistency.map_or(0, |entry| entry.consistency_score_pct);
+                let totals =
+                    weekly_totals_by_key
+                        .get(&(year, week))
+                        .copied()
+                        .unwrap_or(WeeklyStats {
+                            year,
+                            week,
+                            ..WeeklyStats::default()
+                        });
                 let completion_score_pct = self
                     .weekly_goal_snapshots
-                    .get(&consistency.week_label)
+                    .get(&week_label)
                     .copied()
                     .and_then(|goal| weekly_completion_score_pct(goal, totals));
-                let focus_score_pct = completion_score_pct.map(|completion| {
-                    average_two_percentages(consistency.consistency_score_pct, completion)
-                });
+                let focus_score_pct = completion_score_pct
+                    .map(|completion| average_two_percentages(consistency_score_pct, completion));
                 WeeklyFocusScore {
-                    year: consistency.year,
-                    week: consistency.week,
-                    week_label: consistency.week_label,
-                    active_days: consistency.active_days,
-                    consistency_score_pct: consistency.consistency_score_pct,
+                    year,
+                    week,
+                    week_label,
+                    active_days,
+                    consistency_score_pct,
                     completion_score_pct,
                     focus_score_pct,
                 }
@@ -2057,6 +2074,13 @@ fn average_two_percentages(left: u8, right: u8) -> u8 {
 
 fn format_week_label(year: i32, week: u32) -> String {
     format!("{year:04}-W{week:02}")
+}
+
+fn parse_week_label(week_label: &str) -> Option<(i32, u32)> {
+    let (year, week) = week_label.split_once("-W")?;
+    let parsed_year = year.parse::<i32>().ok()?;
+    let parsed_week = week.parse::<u32>().ok()?;
+    Some((parsed_year, parsed_week))
 }
 
 fn week_key_for_day(day: chrono::NaiveDate) -> String {
@@ -2777,6 +2801,28 @@ mod tests {
         assert_eq!(focus_score.completion_score_pct, None);
         assert_eq!(focus_score.focus_score_pct, None);
         assert_eq!(focus_score.consistency_score_pct, 14);
+    }
+
+    #[test]
+    fn weekly_focus_score_includes_goal_enabled_idle_weeks() {
+        let mut stats = FocusStats::default();
+        let week_day = chrono::NaiveDate::from_ymd_opt(2026, 4, 6).unwrap();
+        let goal = DailyGoalSnapshot {
+            minutes: 100,
+            pomodoros: 4,
+        };
+        stats.sync_weekly_goal_snapshot(week_day, goal);
+
+        let recent = stats.recent_weekly_focus_scores(1);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].active_days, 0);
+        assert_eq!(recent[0].consistency_score_pct, 0);
+        assert_eq!(recent[0].completion_score_pct, Some(0));
+        assert_eq!(recent[0].focus_score_pct, Some(0));
+
+        let latest = stats.latest_weekly_focus_score().unwrap();
+        assert_eq!(latest.week_label, recent[0].week_label);
+        assert_eq!(latest.focus_score_pct, Some(0));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1115,7 +1115,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
     let goal_and_consistency_summary = format!(
         "{}   |   {}",
         format_history_goal_streak_line(app),
-        format_history_weekly_consistency_line(app)
+        format_history_focus_score_line(app)
     );
     let goal_summary =
         Paragraph::new(goal_and_consistency_summary).style(Style::default().fg(Color::DarkGray));
@@ -1585,13 +1585,19 @@ fn format_history_goal_streak_line(app: &App) -> String {
     }
 }
 
-fn format_history_weekly_consistency_line(app: &App) -> String {
-    match app.latest_weekly_consistency() {
-        Some(consistency) => format!(
-            "Weekly consistency: {}% ({}/7 days)",
-            consistency.consistency_score_pct, consistency.active_days
-        ),
-        None => "Weekly consistency: n/a".to_string(),
+fn format_history_focus_score_line(app: &App) -> String {
+    match app.latest_weekly_focus_score() {
+        Some(score) => match (score.focus_score_pct, score.completion_score_pct) {
+            (Some(focus_score), Some(completion_score)) => format!(
+                "Focus score: {focus_score}% (consistency {}% · completion {completion_score}%)",
+                score.consistency_score_pct
+            ),
+            _ => format!(
+                "Focus score: n/a (weekly goal off; consistency {}% ({}/7 days))",
+                score.consistency_score_pct, score.active_days
+            ),
+        },
+        None => "Focus score: n/a".to_string(),
     }
 }
 
@@ -2072,7 +2078,7 @@ mod tests {
         assert!(text.contains("Task Totals"));
         assert!(text.contains("Task Trends"));
         assert!(text.contains("Break-glass Audit"));
-        assert!(text_lower.contains("weekly consistency"));
+        assert!(text_lower.contains("focus score"));
         assert!(text.contains(&format_month_label(2026, 4)));
     }
 

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -102,6 +102,15 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload["weekly_goal"].get("carry_over").is_some());
     assert!(payload["monthly_goal"].get("carry_over").is_some());
     assert!(payload.get("selected_task_goal").is_some());
+    assert!(payload.get("focus_score").is_some());
+    assert!(payload["focus_score"].get("available").is_some());
+    assert!(
+        payload["focus_score"]
+            .get("consistency_score_pct")
+            .is_some()
+    );
+    assert!(payload["focus_score"].get("completion_score_pct").is_some());
+    assert!(payload["focus_score"].get("focus_score_pct").is_some());
     assert!(payload.get("live").is_some());
     assert!(payload["live"].get("focus_intention").is_some());
     assert!(payload["live"].get("task_note").is_some());


### PR DESCRIPTION
## What

Add a unified weekly focus score KPI that combines existing consistency and completion signals into a single metric for quick review.

- Add weekly focus score modeling and calculation in `src/stats.rs`.
  - 50/50 blend of weekly consistency and weekly goal completion.
  - Score is `n/a` when weekly goal is off.
- Surface the KPI in the history summary in `src/ui.rs` via `src/app.rs` accessors.
- Extend CLI status output in `src/cli.rs`:
  - JSON includes `focus_score` payload.
  - Text mode prints a focus score line.
- Extend stats export contracts in `src/stats.rs`:
  - Add `focus_scores` to JSON export.
  - Add `focus_score` rows and columns to CSV export.
  - Bump export `schema_version` from `3` to `4`.
- Update docs and tests:
  - README focus score and schema version docs.
  - Unit tests for score math and export coverage.
  - UI and CLI contract test updates.

## Why

Issue #187 asks for a single focus score KPI that combines consistency and completion so users can read progress at a glance without stitching together multiple metrics.

This change keeps existing consistency and goal signals while adding a clear top-line score in history, status output, and exports.

Close #187.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weekly focus score metric combining consistency and goal completion (shows "n/a" when weekly goals disabled).
  * Status output displays focus score with consistency and completion percentages.
  * History view now shows focus score as the secondary metric alongside goal/streak.
  * Stats exports include weekly focus score data.

* **Documentation**
  * README updated to document the new KPI and bumped export schema to v4.

* **Tests**
  * Status JSON and history tests updated to validate focus score fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->