### PR TITLE
Capture session interruption reasons for stop and skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ cargo run -- --diagnostics --json
 cargo run -- --blocking-preview
 cargo run -- --blocking-preview --json
 
-# Show status (text or JSON, including live timer/session fields and `selected_task_goal` in JSON)
+# Show status (text or JSON, including live timer/session fields, latest interruption summary, and `selected_task_goal` in JSON)
 cargo run -- --status
 cargo run -- --status --json
 
@@ -481,6 +481,7 @@ Override events are recorded for audit visibility in the History view and includ
 - per-task totals (pomodoros and focused minutes) derived from labeled focus sessions
 - per-task trend summaries in History (`last 7 days` vs `previous 7 days`)
 - per-task cumulative goals (minutes/pomodoros) with per-label progress and met/in-progress evaluation
+- structured interruption events for manual `stop/reset` and `skip/next` actions
 - current streak and best streak based on completed daily goals
 
 If daily, weekly, or monthly goals are configured, timer and history views also
@@ -500,13 +501,13 @@ From timer view:
 - press **`h`** or **`Esc`** to return to timer view
 
 Exports include daily/weekly aggregates, weekly consistency, weekly focus score,
-profile
-effectiveness, task summaries/trends, and labeled focus-session records where
-task labels were attached. Focus-session rows persist and export first-class
-`focus_intention` and `task_note` fields; when dedicated metadata input is not
-provided, both fields default to the selected `task_label`. Export files expose
-`schema_version` (currently `4`) so downstream consumers can handle versioned
-contracts explicitly.
+profile effectiveness, task summaries/trends, interruption records, and labeled
+focus-session records where task labels were attached. Focus-session rows
+persist and export first-class `focus_intention` and `task_note` fields; when
+dedicated metadata input is not provided, both fields default to the selected
+`task_label`. Interruption records include structured `reason` values and
+remaining-time metadata. Export files expose `schema_version` (currently `5`)
+so downstream consumers can handle versioned contracts explicitly.
 
 ## The way the system works
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3486,16 +3486,23 @@ impl App {
         &self,
         reason: SessionInterruptionReason,
     ) -> FocusInterruptionContext {
+        let now = Local::now();
+        let day_key = now.date_naive().format("%Y-%m-%d").to_string();
+        let timestamp_epoch_secs = now.timestamp().max(0) as u64;
+        let task_label = self
+            .active_focus_task_label
+            .clone()
+            .or_else(|| self.selected_task_label.clone());
         FocusInterruptionContext {
-            day_key: current_day_key(),
-            timestamp_epoch_secs: current_epoch_secs(),
+            day_key,
+            timestamp_epoch_secs,
             reason,
-            task_label: self
-                .active_focus_task_label
+            task_label: task_label.clone(),
+            focus_intention: self
+                .active_focus_intention
                 .clone()
-                .or_else(|| self.selected_task_label.clone()),
-            focus_intention: self.active_focus_intention.clone(),
-            task_note: self.active_focus_task_note.clone(),
+                .or_else(|| task_label.clone()),
+            task_note: self.active_focus_task_note.clone().or(task_label),
             remaining_secs: self.timer.remaining_secs,
             profile: self.active_focus_profile.or(Some(self.selected_profile)),
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,8 +28,9 @@ use crate::session_recovery::{self, InProgressSessionSnapshot};
 use crate::stats::{
     BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles,
     FocusSessionMetadata, FocusStats, GoalStreak, MonthlyHeatmap, MonthlyStats,
-    ProfileEffectiveness, ProfileTotals, SessionStats, TaskGoalProgress, TaskTotals, TaskTrend,
-    WeeklyConsistency, WeeklyFocusScore, WeeklyStats, carry_over_goal_target, current_day_key,
+    ProfileEffectiveness, ProfileTotals, SessionInterruptionEvent, SessionInterruptionReason,
+    SessionStats, TaskGoalProgress, TaskTotals, TaskTrend, WeeklyConsistency, WeeklyFocusScore,
+    WeeklyStats, carry_over_goal_target, current_day_key,
 };
 use crate::task_labels::{normalize_task_label, task_label_index};
 use crate::timer::{
@@ -216,6 +217,18 @@ struct ScheduleDisplayState {
     has_selected_task: bool,
     timer_phase: TimerPhase,
     timer_status: TimerStatus,
+}
+
+#[derive(Debug, Clone)]
+struct FocusInterruptionContext {
+    day_key: String,
+    timestamp_epoch_secs: u64,
+    reason: SessionInterruptionReason,
+    task_label: Option<String>,
+    focus_intention: Option<String>,
+    task_note: Option<String>,
+    remaining_secs: u64,
+    profile: Option<ProfileId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -775,7 +788,10 @@ impl App {
         if self.timer.status == TimerStatus::Idle {
             return Err("Cannot stop: timer is already idle.".to_string());
         }
-        self.update_timer_and_sync(TimerState::reset);
+        self.update_timer_and_sync_with_reason(
+            TimerState::reset,
+            Some(SessionInterruptionReason::ManualStop),
+        );
         Ok(())
     }
 
@@ -785,7 +801,10 @@ impl App {
                 "Cannot skip to next phase: strict mode is active during focus.".to_string(),
             );
         }
-        self.update_timer_and_sync(TimerState::next_phase);
+        self.update_timer_and_sync_with_reason(
+            TimerState::next_phase,
+            Some(SessionInterruptionReason::ManualSkip),
+        );
         Ok(())
     }
 
@@ -2068,7 +2087,10 @@ impl App {
         if self.strict_reset_confirmation_pending() {
             if key.code == KeyCode::Char('s') {
                 self.pending_timer_action = None;
-                self.update_timer_and_sync(TimerState::reset);
+                self.update_timer_and_sync_with_reason(
+                    TimerState::reset,
+                    Some(SessionInterruptionReason::ManualStop),
+                );
                 return;
             }
             self.pending_timer_action = None;
@@ -2101,14 +2123,20 @@ impl App {
                     self.pending_timer_action = Some(PendingTimerAction::Reset);
                     return;
                 }
-                self.update_timer_and_sync(TimerState::reset);
+                self.update_timer_and_sync_with_reason(
+                    TimerState::reset,
+                    Some(SessionInterruptionReason::ManualStop),
+                );
             }
             // Skip to next phase
             KeyCode::Char('n') => {
                 if self.strict_mode_enforced_for_focus() {
                     return;
                 }
-                self.update_timer_and_sync(TimerState::next_phase);
+                self.update_timer_and_sync_with_reason(
+                    TimerState::next_phase,
+                    Some(SessionInterruptionReason::ManualSkip),
+                );
             }
             // Open site manager
             KeyCode::Char('b') => {
@@ -3416,10 +3444,26 @@ impl App {
     }
 
     fn update_timer_and_sync(&mut self, action: fn(&mut TimerState)) {
+        self.update_timer_and_sync_with_reason(action, None);
+    }
+
+    fn update_timer_and_sync_with_reason(
+        &mut self,
+        action: fn(&mut TimerState),
+        interruption_reason: Option<SessionInterruptionReason>,
+    ) {
         let was_focus_active = self.focus_session_active_for_current_state();
+        let interruption_context = interruption_reason
+            .filter(|_| was_focus_active)
+            .map(|reason| self.build_focus_interruption_context(reason));
         self.pending_timer_action = None;
         action(&mut self.timer);
         let is_focus_active = self.focus_session_active_for_current_state();
+        if let Some(context) = interruption_context
+            && !is_focus_active
+        {
+            self.record_session_interruption_event(context);
+        }
         if !was_focus_active && is_focus_active {
             self.active_focus_task_label = self.selected_task_label.clone();
             self.active_focus_intention = self.selected_task_label.clone();
@@ -3436,6 +3480,41 @@ impl App {
         }
         self.apply_blocking_for_phase();
         self.sync_recovery_snapshot();
+    }
+
+    fn build_focus_interruption_context(
+        &self,
+        reason: SessionInterruptionReason,
+    ) -> FocusInterruptionContext {
+        FocusInterruptionContext {
+            day_key: current_day_key(),
+            timestamp_epoch_secs: current_epoch_secs(),
+            reason,
+            task_label: self
+                .active_focus_task_label
+                .clone()
+                .or_else(|| self.selected_task_label.clone()),
+            focus_intention: self.active_focus_intention.clone(),
+            task_note: self.active_focus_task_note.clone(),
+            remaining_secs: self.timer.remaining_secs,
+            profile: self.active_focus_profile.or(Some(self.selected_profile)),
+        }
+    }
+
+    fn record_session_interruption_event(&mut self, context: FocusInterruptionContext) {
+        self.stats.record_session_interruption_event(
+            &context.day_key,
+            context.timestamp_epoch_secs,
+            context.reason,
+            FocusSessionMetadata {
+                task_label: context.task_label.as_deref(),
+                focus_intention: context.focus_intention.as_deref(),
+                task_note: context.task_note.as_deref(),
+            },
+            context.remaining_secs,
+            context.profile,
+        );
+        self.stats_dirty = true;
     }
 
     fn open_site_manager(&mut self) {
@@ -4041,6 +4120,15 @@ impl App {
 
     pub fn recent_break_glass_overrides(&self, limit: usize) -> Vec<BreakGlassOverrideEvent> {
         self.stats.recent_break_glass_overrides(limit)
+    }
+
+    #[cfg(test)]
+    pub fn recent_session_interruptions(&self, limit: usize) -> Vec<SessionInterruptionEvent> {
+        self.stats.recent_session_interruptions(limit)
+    }
+
+    pub fn latest_session_interruption(&self) -> Option<SessionInterruptionEvent> {
+        self.stats.latest_session_interruption()
     }
 }
 
@@ -6409,6 +6497,58 @@ mod tests {
     }
 
     #[test]
+    fn manual_skip_records_session_interruption_reason() {
+        let mut app = App::default();
+        app.task_labels = vec!["Project A".to_string()];
+        app.selected_task_label = Some("Project A".to_string());
+        app.handle_key(key(KeyCode::Char(' ')));
+        app.timer.remaining_secs = 1200;
+
+        app.handle_key(key(KeyCode::Char('n')));
+
+        let interruptions = app.recent_session_interruptions(1);
+        assert_eq!(interruptions.len(), 1);
+        assert_eq!(
+            interruptions[0].reason,
+            SessionInterruptionReason::ManualSkip
+        );
+        assert_eq!(interruptions[0].task_label.as_deref(), Some("Project A"));
+        assert_eq!(interruptions[0].remaining_secs, 1200);
+    }
+
+    #[test]
+    fn manual_stop_records_session_interruption_reason() {
+        let mut app = App::default();
+        app.task_labels = vec!["Project A".to_string()];
+        app.selected_task_label = Some("Project A".to_string());
+        app.handle_key(key(KeyCode::Char(' ')));
+        app.timer.remaining_secs = 900;
+
+        app.handle_key(key(KeyCode::Char('s')));
+
+        let interruptions = app.recent_session_interruptions(1);
+        assert_eq!(interruptions.len(), 1);
+        assert_eq!(
+            interruptions[0].reason,
+            SessionInterruptionReason::ManualStop
+        );
+        assert_eq!(interruptions[0].task_label.as_deref(), Some("Project A"));
+        assert_eq!(interruptions[0].remaining_secs, 900);
+    }
+
+    #[test]
+    fn natural_focus_completion_does_not_record_session_interruption() {
+        let mut app = App::default();
+        app.timer.phase = TimerPhase::Focus;
+        app.timer.status = TimerStatus::Running;
+        app.timer.remaining_secs = 1;
+
+        app.on_tick(false);
+
+        assert!(app.recent_session_interruptions(1).is_empty());
+    }
+
+    #[test]
     fn natural_focus_completion_auto_starts_break_when_enabled() {
         let config = AppConfig {
             auto_start: AutoStartConfig {
@@ -7791,6 +7931,44 @@ mod tests {
         );
         assert_eq!(app.timer.phase, TimerPhase::Focus);
         assert_eq!(app.timer.status, TimerStatus::Running);
+    }
+
+    #[test]
+    fn cli_stop_records_session_interruption_reason() {
+        let mut app = App::default();
+        app.selected_task_label = Some("Docs".to_string());
+        app.start_focus_for_cli().unwrap();
+        app.timer.remaining_secs = 1000;
+
+        app.stop_for_cli().unwrap();
+
+        let interruptions = app.recent_session_interruptions(1);
+        assert_eq!(interruptions.len(), 1);
+        assert_eq!(
+            interruptions[0].reason,
+            SessionInterruptionReason::ManualStop
+        );
+        assert_eq!(interruptions[0].task_label.as_deref(), Some("Docs"));
+        assert_eq!(interruptions[0].remaining_secs, 1000);
+    }
+
+    #[test]
+    fn cli_next_records_session_interruption_reason() {
+        let mut app = App::default();
+        app.selected_task_label = Some("Docs".to_string());
+        app.start_focus_for_cli().unwrap();
+        app.timer.remaining_secs = 800;
+
+        app.next_phase_for_cli().unwrap();
+
+        let interruptions = app.recent_session_interruptions(1);
+        assert_eq!(interruptions.len(), 1);
+        assert_eq!(
+            interruptions[0].reason,
+            SessionInterruptionReason::ManualSkip
+        );
+        assert_eq!(interruptions[0].task_label.as_deref(), Some("Docs"));
+        assert_eq!(interruptions[0].remaining_secs, 800);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,10 @@ use crate::config::{
 };
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
-use crate::stats::{DailyGoalSnapshot, FocusStats, carry_over_goal_target, current_day_key};
+use crate::stats::{
+    DailyGoalSnapshot, FocusStats, SessionInterruptionEvent, carry_over_goal_target,
+    current_day_key,
+};
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
     DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerStatus,
@@ -102,7 +105,7 @@ Options:
   --allowlist-site-delete     Delete allowlist hostname in active profile
   --diagnostics   Show setup diagnostics checks
   --blocking-preview  Preview focustime hosts-section changes without writing
-  --status        Print status summary (includes live timer/session fields)
+  --status        Print status summary (includes live timer/session fields and latest interruption)
   --watch         Stream periodic status updates (status command only; default 1s)
   --export        Export stats to current directory or DIR
   --json          Emit machine-readable JSON output
@@ -447,6 +450,7 @@ struct StatusOutput {
     selected_task_goal: Option<TaskGoalOutput>,
     session: SessionOutput,
     today: TodayOutput,
+    latest_interruption: Option<SessionInterruptionEvent>,
     focus_score: FocusScoreOutput,
     live: LiveStatusOutput,
 }
@@ -2770,6 +2774,7 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
         .map(|profile| effective_blocked_sites_for_profile(profile).len())
         .unwrap_or_default();
     let live = build_live_status_output(config, selected_task_label.clone());
+    let latest_interruption = stats.latest_session_interruption();
     let consistency_score_pct = stats
         .weekly_focus_score_for_day(day_date)
         .consistency_score_pct;
@@ -2827,6 +2832,7 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
             focused_minutes: today.focused_minutes(),
             pomodoros_completed: today.pomodoros_completed,
         },
+        latest_interruption,
         focus_score: FocusScoreOutput {
             available: focus_score_pct.is_some(),
             focus_score_pct,
@@ -3609,6 +3615,17 @@ fn print_status_output(payload: &StatusOutput) {
         "Session: {} focused minutes, {} pomodoros",
         payload.session.focused_minutes, payload.session.pomodoros_completed
     );
+    if let Some(interruption) = payload.latest_interruption.as_ref() {
+        println!(
+            "Last interruption: {} ({}, {} remaining, task: {})",
+            interruption.reason.label(),
+            interruption.date,
+            format_duration(interruption.remaining_secs),
+            interruption.task_label.as_deref().unwrap_or("none")
+        );
+    } else {
+        println!("Last interruption: none");
+    }
     print_status_focus_score_line(&payload.focus_score);
     println!(
         "Live timer: {} {} ({} remaining, source: {})",
@@ -5800,6 +5817,34 @@ mod tests {
         assert_eq!(output.live.task_note.as_deref(), Some("API section"));
         assert_eq!(output.live.selected_profile.id, "deep-work");
         assert!(output.live.recovery_error.is_none());
+    }
+
+    #[test]
+    fn build_status_output_includes_latest_session_interruption() {
+        let mut stats = FocusStats::default();
+        stats.record_session_interruption_event(
+            "2026-04-09",
+            1_711_000_123,
+            crate::stats::SessionInterruptionReason::ManualSkip,
+            crate::stats::FocusSessionMetadata {
+                task_label: Some("Docs"),
+                focus_intention: Some("Write API docs"),
+                task_note: Some("Skipped due urgent review"),
+            },
+            600,
+            Some(ProfileId::Classic),
+        );
+
+        let output = build_status_output(&AppConfig::default(), &stats);
+        let interruption = output
+            .latest_interruption
+            .expect("latest interruption should be present");
+        assert_eq!(
+            interruption.reason,
+            crate::stats::SessionInterruptionReason::ManualSkip
+        );
+        assert_eq!(interruption.task_label.as_deref(), Some("Docs"));
+        assert_eq!(interruption.remaining_secs, 600);
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -17,7 +17,7 @@ use crate::task_labels::{canonical_task_label, normalize_task_label, task_label_
 const STATS_FILE_NAME: &str = "stats.toml";
 const JSON_EXPORT_FILE_NAME: &str = "focustime-stats.json";
 const CSV_EXPORT_FILE_NAME: &str = "focustime-stats.csv";
-const EXPORT_SCHEMA_VERSION: u32 = 4;
+const EXPORT_SCHEMA_VERSION: u32 = 5;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -202,6 +202,39 @@ pub struct FocusSessionMetadata<'a> {
     pub task_note: Option<&'a str>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionInterruptionReason {
+    ManualStop,
+    ManualSkip,
+}
+
+impl SessionInterruptionReason {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ManualStop => "stop/reset",
+            Self::ManualSkip => "skip/next",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionInterruptionEvent {
+    pub timestamp_epoch_secs: u64,
+    pub date: String,
+    pub reason: SessionInterruptionReason,
+    #[serde(default)]
+    pub task_label: Option<String>,
+    #[serde(default)]
+    pub focus_intention: Option<String>,
+    #[serde(default)]
+    pub task_note: Option<String>,
+    #[serde(default)]
+    pub remaining_secs: u64,
+    #[serde(default)]
+    pub profile: Option<ProfileId>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ProfileBucket {
     Classic,
@@ -352,6 +385,7 @@ struct StatsExport {
     daily: Vec<DailyExportRow>,
     weekly: Vec<WeeklyExportRow>,
     sessions: Vec<SessionExportRow>,
+    interruptions: Vec<SessionInterruptionExportRow>,
     overrides: Vec<BreakGlassOverrideExportRow>,
     task_totals: Vec<TaskTotalsExportRow>,
     task_trends: Vec<TaskTrendExportRow>,
@@ -398,6 +432,18 @@ struct BreakGlassOverrideExportRow {
     task_label: Option<String>,
     duration_seconds: u64,
     duration_minutes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct SessionInterruptionExportRow {
+    timestamp_epoch_secs: u64,
+    date: String,
+    reason: SessionInterruptionReason,
+    task_label: Option<String>,
+    focus_intention: Option<String>,
+    task_note: Option<String>,
+    remaining_secs: u64,
+    profile: Option<ProfileId>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -473,6 +519,9 @@ struct CsvExportRow {
     task_label: Option<String>,
     break_glass_timestamp_epoch_secs: Option<u64>,
     break_glass_duration_seconds: Option<u64>,
+    interruption_timestamp_epoch_secs: Option<u64>,
+    interruption_reason: Option<SessionInterruptionReason>,
+    interruption_remaining_secs: Option<u64>,
     focus_intention: Option<String>,
     task_note: Option<String>,
     recent_window_start: Option<String>,
@@ -509,6 +558,8 @@ struct PersistedStats {
     #[serde(default)]
     focus_sessions: Vec<FocusSessionRecord>,
     #[serde(default)]
+    session_interruptions: Vec<SessionInterruptionEvent>,
+    #[serde(default)]
     break_glass_overrides: Vec<BreakGlassOverrideEvent>,
     #[serde(default)]
     task_goal_targets: BTreeMap<String, DailyGoalSnapshot>,
@@ -523,6 +574,7 @@ pub struct FocusStats {
     task_labels: Vec<String>,
     selected_task_label: Option<String>,
     focus_sessions: Vec<FocusSessionRecord>,
+    session_interruptions: Vec<SessionInterruptionEvent>,
     break_glass_overrides: Vec<BreakGlassOverrideEvent>,
     task_goal_targets: BTreeMap<String, DailyGoalSnapshot>,
 }
@@ -576,6 +628,25 @@ impl FocusStats {
                 });
             }
         }
+        let mut session_interruptions = Vec::new();
+        for event in persisted.session_interruptions {
+            session_interruptions.push(SessionInterruptionEvent {
+                timestamp_epoch_secs: event.timestamp_epoch_secs,
+                date: event.date.trim().to_string(),
+                reason: event.reason,
+                task_label: event
+                    .task_label
+                    .and_then(|label| normalize_task_label(&label)),
+                focus_intention: event
+                    .focus_intention
+                    .and_then(|value| normalize_session_metadata_text(&value)),
+                task_note: event
+                    .task_note
+                    .and_then(|value| normalize_session_metadata_text(&value)),
+                remaining_secs: event.remaining_secs,
+                profile: event.profile,
+            });
+        }
         let mut break_glass_overrides = Vec::new();
         for event in persisted.break_glass_overrides {
             if event.duration_seconds == 0 {
@@ -598,6 +669,7 @@ impl FocusStats {
             task_labels,
             selected_task_label,
             focus_sessions,
+            session_interruptions,
             break_glass_overrides,
             task_goal_targets,
         }
@@ -611,6 +683,7 @@ impl FocusStats {
             task_labels: self.task_labels.clone(),
             selected_task_label: self.selected_task_label.clone(),
             focus_sessions: self.focus_sessions.clone(),
+            session_interruptions: self.session_interruptions.clone(),
             break_glass_overrides: self.break_glass_overrides.clone(),
             task_goal_targets: self.task_goal_targets.clone(),
         }
@@ -728,6 +801,36 @@ impl FocusStats {
             date: day_key.to_string(),
             task_label: normalized_task_label,
             duration_seconds,
+        });
+    }
+
+    pub fn record_session_interruption_event(
+        &mut self,
+        day_key: &str,
+        timestamp_epoch_secs: u64,
+        reason: SessionInterruptionReason,
+        metadata: FocusSessionMetadata<'_>,
+        remaining_secs: u64,
+        profile: Option<ProfileId>,
+    ) {
+        let normalized_task_label = metadata.task_label.and_then(normalize_task_label);
+        if let Some(task_label) = normalized_task_label.as_ref()
+            && task_label_index(&self.task_labels, task_label).is_none()
+        {
+            self.task_labels.push(task_label.clone());
+        }
+
+        self.session_interruptions.push(SessionInterruptionEvent {
+            timestamp_epoch_secs,
+            date: day_key.to_string(),
+            reason,
+            task_label: normalized_task_label,
+            focus_intention: metadata
+                .focus_intention
+                .and_then(normalize_session_metadata_text),
+            task_note: metadata.task_note.and_then(normalize_session_metadata_text),
+            remaining_secs,
+            profile,
         });
     }
 
@@ -1222,6 +1325,20 @@ impl FocusStats {
             .collect()
     }
 
+    #[cfg(test)]
+    pub fn recent_session_interruptions(&self, limit: usize) -> Vec<SessionInterruptionEvent> {
+        self.session_interruptions
+            .iter()
+            .rev()
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
+    pub fn latest_session_interruption(&self) -> Option<SessionInterruptionEvent> {
+        self.session_interruptions.last().cloned()
+    }
+
     fn task_trend_window(&self) -> Option<TaskTrendWindow> {
         if self.focus_sessions.is_empty() {
             return None;
@@ -1336,6 +1453,7 @@ impl FocusStats {
             daily: self.export_daily_rows(),
             weekly: self.export_weekly_rows(),
             sessions: self.export_session_rows(),
+            interruptions: self.export_session_interruption_rows(),
             overrides: self.export_break_glass_override_rows(),
             task_totals: self.export_task_totals_rows(),
             task_trends: self.export_task_trend_rows(),
@@ -1387,6 +1505,22 @@ impl FocusStats {
                 focused_seconds: session.focused_seconds,
                 focused_minutes: session.focused_seconds / 60,
                 profile: session.profile,
+            })
+            .collect()
+    }
+
+    fn export_session_interruption_rows(&self) -> Vec<SessionInterruptionExportRow> {
+        self.session_interruptions
+            .iter()
+            .map(|event| SessionInterruptionExportRow {
+                timestamp_epoch_secs: event.timestamp_epoch_secs,
+                date: event.date.clone(),
+                reason: event.reason,
+                task_label: event.task_label.clone(),
+                focus_intention: event.focus_intention.clone(),
+                task_note: event.task_note.clone(),
+                remaining_secs: event.remaining_secs,
+                profile: event.profile,
             })
             .collect()
     }
@@ -1757,6 +1891,9 @@ impl StatsExport {
             task_label: None,
             break_glass_timestamp_epoch_secs: None,
             break_glass_duration_seconds: None,
+            interruption_timestamp_epoch_secs: None,
+            interruption_reason: None,
+            interruption_remaining_secs: None,
             focus_intention: None,
             task_note: None,
             recent_window_start: None,
@@ -1784,6 +1921,7 @@ impl StatsExport {
             self.daily.len()
                 + self.weekly.len()
                 + self.sessions.len()
+                + self.interruptions.len()
                 + self.overrides.len()
                 + self.task_totals.len()
                 + self.task_trends.len()
@@ -1827,6 +1965,19 @@ impl StatsExport {
                 focus_intention: Some(session.focus_intention.clone()),
                 task_note: Some(session.task_note.clone()),
                 ..Self::csv_row_defaults("focus_session")
+            });
+        }
+
+        for interruption in &self.interruptions {
+            rows.push(CsvExportRow {
+                date: Some(interruption.date.clone()),
+                task_label: interruption.task_label.clone(),
+                interruption_timestamp_epoch_secs: Some(interruption.timestamp_epoch_secs),
+                interruption_reason: Some(interruption.reason),
+                interruption_remaining_secs: Some(interruption.remaining_secs),
+                focus_intention: interruption.focus_intention.clone(),
+                task_note: interruption.task_note.clone(),
+                ..Self::csv_row_defaults("session_interruption")
             });
         }
 
@@ -2870,6 +3021,41 @@ mod tests {
     }
 
     #[test]
+    fn persisted_stats_round_trip_preserves_session_interruptions() {
+        let mut original = FocusStats::default();
+        original.record_session_interruption_event(
+            "2026-04-09",
+            1_711_000_123,
+            SessionInterruptionReason::ManualStop,
+            FocusSessionMetadata {
+                task_label: Some("Project A"),
+                focus_intention: Some("Write release notes"),
+                task_note: Some("Urgent incident"),
+            },
+            720,
+            Some(ProfileId::DeepWork),
+        );
+
+        let persisted = original.to_persisted();
+        let toml_str = toml::to_string_pretty(&persisted).unwrap();
+        let restored = FocusStats::try_from_toml(&toml_str).unwrap();
+        let recent = restored.recent_session_interruptions(1);
+
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].date, "2026-04-09");
+        assert_eq!(recent[0].timestamp_epoch_secs, 1_711_000_123);
+        assert_eq!(recent[0].reason, SessionInterruptionReason::ManualStop);
+        assert_eq!(recent[0].task_label.as_deref(), Some("Project A"));
+        assert_eq!(
+            recent[0].focus_intention.as_deref(),
+            Some("Write release notes")
+        );
+        assert_eq!(recent[0].task_note.as_deref(), Some("Urgent incident"));
+        assert_eq!(recent[0].remaining_secs, 720);
+        assert_eq!(recent[0].profile, Some(ProfileId::DeepWork));
+    }
+
+    #[test]
     fn persisted_stats_round_trip_preserves_focus_session_profile() {
         let mut original = FocusStats::default();
         let goal = DailyGoalSnapshot {
@@ -3356,6 +3542,18 @@ mod tests {
             30 * 60,
             Some(ProfileId::Classic),
         );
+        stats.record_session_interruption_event(
+            &labeled_day,
+            1_711_000_111,
+            SessionInterruptionReason::ManualSkip,
+            FocusSessionMetadata {
+                task_label: Some("Project A"),
+                focus_intention: Some("Write release notes"),
+                task_note: Some("Pulled into urgent review"),
+            },
+            600,
+            Some(ProfileId::Classic),
+        );
         stats.record_break_glass_override_event(
             &labeled_day,
             1_711_000_000,
@@ -3380,6 +3578,7 @@ mod tests {
         let daily = json_value["daily"].as_array().unwrap();
         let weekly = json_value["weekly"].as_array().unwrap();
         let sessions = json_value["sessions"].as_array().unwrap();
+        let interruptions = json_value["interruptions"].as_array().unwrap();
         let overrides = json_value["overrides"].as_array().unwrap();
         let task_totals = json_value["task_totals"].as_array().unwrap();
         let task_trends = json_value["task_trends"].as_array().unwrap();
@@ -3389,6 +3588,7 @@ mod tests {
         assert_eq!(daily.len(), 2);
         assert!(!weekly.is_empty());
         assert_eq!(sessions.len(), 1);
+        assert_eq!(interruptions.len(), 1);
         assert_eq!(overrides.len(), 1);
         assert_eq!(task_totals.len(), 1);
         assert_eq!(task_trends.len(), 1);
@@ -3406,6 +3606,9 @@ mod tests {
         assert_eq!(sessions[0]["task_note"], "Project A");
         assert_eq!(sessions[0]["focused_minutes"], 30);
         assert_eq!(sessions[0]["profile"], "classic");
+        assert_eq!(interruptions[0]["reason"], "manual_skip");
+        assert_eq!(interruptions[0]["remaining_secs"], 600);
+        assert_eq!(interruptions[0]["task_label"], "Project A");
         assert_eq!(overrides[0]["duration_seconds"], 300);
         assert_eq!(overrides[0]["task_label"], "Project A");
         assert_eq!(task_totals[0]["task_label"], "Project A");
@@ -3437,22 +3640,33 @@ mod tests {
         assert_eq!(profile_effectiveness[0]["focus_share_pct"], 100);
 
         let csv = fs::read_to_string(&exported.csv_path).unwrap();
-        assert!(csv.contains("schema_version,record_type,date,week_label,year,week,pomodoros_completed,focused_seconds,focused_minutes,goal_minutes,goal_pomodoros,goal_met,task_label,break_glass_timestamp_epoch_secs,break_glass_duration_seconds,focus_intention,task_note,recent_window_start,recent_window_end,previous_window_start,previous_window_end,previous_pomodoros_completed,previous_focused_seconds,previous_focused_minutes,delta_focused_seconds,delta_focused_minutes,profile_name,sessions_completed,active_days,consistency_score_pct,completion_score_pct,focus_score_pct,average_focused_minutes_per_session,focus_share_pct"));
+        assert!(csv.contains("schema_version,record_type,date,week_label,year,week,pomodoros_completed,focused_seconds,focused_minutes,goal_minutes,goal_pomodoros,goal_met,task_label,break_glass_timestamp_epoch_secs,break_glass_duration_seconds,interruption_timestamp_epoch_secs,interruption_reason,interruption_remaining_secs,focus_intention,task_note,recent_window_start,recent_window_end,previous_window_start,previous_window_end,previous_pomodoros_completed,previous_focused_seconds,previous_focused_minutes,delta_focused_seconds,delta_focused_minutes,profile_name,sessions_completed,active_days,consistency_score_pct,completion_score_pct,focus_score_pct,average_focused_minutes_per_session,focus_share_pct"));
+        assert!(csv.contains(&format!("{},daily,{labeled_day}", EXPORT_SCHEMA_VERSION)));
+        assert!(csv.contains(&format!("{},weekly,,", EXPORT_SCHEMA_VERSION)));
         assert!(csv.contains(&format!(
-            "4,daily,{labeled_day},,,,1,1800,30,25,1,true,,,,,"
+            "{},focus_session,{labeled_day}",
+            EXPORT_SCHEMA_VERSION
         )));
-        assert!(csv.contains("4,weekly,,"));
+        assert!(csv.contains("Project A"));
         assert!(csv.contains(&format!(
-            "4,focus_session,{labeled_day},,,,1,1800,30,,,,Project A,,,Project A,Project A"
+            "{},session_interruption,{labeled_day}",
+            EXPORT_SCHEMA_VERSION
         )));
+        assert!(csv.contains("manual_skip"));
+        assert!(csv.contains("1711000111"));
         assert!(csv.contains(&format!(
-            "4,break_glass_override,{labeled_day},,,,0,0,0,,,,Project A,1711000000,300,,"
+            "{},break_glass_override,{labeled_day}",
+            EXPORT_SCHEMA_VERSION
         )));
-        assert!(csv.contains("4,task_summary,,,,,1,1800,30,,,,Project A"));
-        assert!(csv.contains("4,task_trend,,,,,1,1800,30,,,,Project A"));
-        assert!(csv.contains("4,weekly_consistency,"));
-        assert!(csv.contains("4,focus_score,"));
-        assert!(csv.contains("4,profile_effectiveness,,,,,1,1800,30"));
+        assert!(csv.contains("1711000000"));
+        assert!(csv.contains(&format!("{},task_summary", EXPORT_SCHEMA_VERSION)));
+        assert!(csv.contains(&format!("{},task_trend", EXPORT_SCHEMA_VERSION)));
+        assert!(csv.contains(&format!("{},weekly_consistency,", EXPORT_SCHEMA_VERSION)));
+        assert!(csv.contains(&format!("{},focus_score,", EXPORT_SCHEMA_VERSION)));
+        assert!(csv.contains(&format!(
+            "{},profile_effectiveness,,,,,1,1800,30",
+            EXPORT_SCHEMA_VERSION
+        )));
         assert!(csv.contains("Classic,1,1,"));
 
         fs::remove_dir_all(export_dir).unwrap();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1336,7 +1336,10 @@ impl FocusStats {
     }
 
     pub fn latest_session_interruption(&self) -> Option<SessionInterruptionEvent> {
-        self.session_interruptions.last().cloned()
+        self.session_interruptions
+            .iter()
+            .max_by_key(|event| event.timestamp_epoch_secs)
+            .cloned()
     }
 
     fn task_trend_window(&self) -> Option<TaskTrendWindow> {
@@ -3053,6 +3056,42 @@ mod tests {
         assert_eq!(recent[0].task_note.as_deref(), Some("Urgent incident"));
         assert_eq!(recent[0].remaining_secs, 720);
         assert_eq!(recent[0].profile, Some(ProfileId::DeepWork));
+    }
+
+    #[test]
+    fn latest_session_interruption_prefers_greatest_timestamp() {
+        let mut stats = FocusStats::default();
+        stats.record_session_interruption_event(
+            "2026-04-09",
+            200,
+            SessionInterruptionReason::ManualStop,
+            FocusSessionMetadata {
+                task_label: Some("Project A"),
+                focus_intention: Some("Write release notes"),
+                task_note: Some("Urgent incident"),
+            },
+            720,
+            Some(ProfileId::Classic),
+        );
+        stats.record_session_interruption_event(
+            "2026-04-09",
+            100,
+            SessionInterruptionReason::ManualSkip,
+            FocusSessionMetadata {
+                task_label: Some("Project B"),
+                focus_intention: Some("Prototype"),
+                task_note: Some("Interrupt"),
+            },
+            600,
+            Some(ProfileId::DeepWork),
+        );
+
+        let latest = stats
+            .latest_session_interruption()
+            .expect("latest interruption should exist");
+        assert_eq!(latest.timestamp_epoch_secs, 200);
+        assert_eq!(latest.reason, SessionInterruptionReason::ManualStop);
+        assert_eq!(latest.task_label.as_deref(), Some("Project A"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1102,7 +1102,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(6), // overview
+            Constraint::Length(7), // overview
             Constraint::Min(6),    // history panels
             Constraint::Length(1), // status line
             Constraint::Length(2), // hints
@@ -1118,6 +1118,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
         .count();
     let focus_score_line = readable_focus_score_text(&format_history_focus_score_line(app));
     let goals_line = readable_goal_streak_text(&format_history_goal_streak_line(app));
+    let interruption_line = format_history_interruption_line(app);
     let overview = Paragraph::new(vec![
         Line::styled(
             format!(
@@ -1137,6 +1138,7 @@ fn render_stats_history(frame: &mut Frame, app: &App) {
             format!("Active days (7d): {recent_active_days}"),
             Style::default().fg(Color::DarkGray),
         ),
+        Line::styled(interruption_line, Style::default().fg(Color::DarkGray)),
     ])
     .block(Block::default().borders(Borders::ALL).title(" Overview "))
     .wrap(Wrap { trim: true });
@@ -1646,6 +1648,18 @@ fn format_history_focus_score_line(app: &App) -> String {
     }
 }
 
+fn format_history_interruption_line(app: &App) -> String {
+    match app.latest_session_interruption() {
+        Some(event) => format!(
+            "Last interruption: {} · {} remaining · {}",
+            event.reason.label(),
+            format_duration_label(event.remaining_secs),
+            event.task_label.unwrap_or_else(|| "Unlabeled".to_string())
+        ),
+        None => "Last interruption: none".to_string(),
+    }
+}
+
 fn format_task_trend_delta(trend: &crate::stats::TaskTrend) -> String {
     let delta_minutes = trend.delta_focused_minutes();
     if delta_minutes > 0 {
@@ -2142,6 +2156,26 @@ mod tests {
 
         let text = terminal_text(&terminal, width, height);
         assert!(text.contains("[e] Export CSV + JSON"));
+    }
+
+    #[test]
+    fn history_view_shows_last_interruption_summary() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.timer.remaining_secs = 900;
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('n'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        let line = format_history_interruption_line(&app);
+        assert!(line.contains("Last interruption"));
+        assert!(line.contains("skip/next"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2174,8 +2174,13 @@ mod tests {
         ));
 
         let line = format_history_interruption_line(&app);
+        let event = app
+            .latest_session_interruption()
+            .expect("skip should record an interruption event");
         assert!(line.contains("Last interruption"));
-        assert!(line.contains("skip/next"));
+        assert!(line.contains(event.reason.label()));
+        assert!(line.contains(&format_duration_label(event.remaining_secs)));
+        assert!(line.contains(event.task_label.as_deref().unwrap_or("Unlabeled")));
     }
 
     #[test]


### PR DESCRIPTION
## What

Add structured session interruption tracking for manual stop/reset and skip/next flows. This wires interruption reasons through app state transitions, persists interruption events in stats storage, includes interruption rows in JSON/CSV export (schema_version 5), and surfaces the latest interruption in CLI status output and TUI history summary.

## Why

Issue #188 requests structured reporting for interrupted sessions so users and downstream consumers can understand why focus sessions ended early. This change adds that data path without altering timer state machine behavior.

Closes #188

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session interruption tracking: manual stops/resets and skips record structured interruption events (reason, remaining time, task).
  * CLI status shows the latest interruption summary.
  * Stats history/overview displays the last interruption.
  * Exports include interruption records and bump schema version to 5.

* **Documentation**
  * README updated to document interruption fields and export changes.

* **Tests**
  * Added unit tests validating interruption recording, display, and export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->