### PR TITLE
Add mid-session notes during active focus sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ While a focus session is running or paused, press **`m`** in timer view to edit 
 quick session note.
 
 - type or paste note text
-- `Enter`: save (replaces the previous note)
+- `Enter`: save (replaces the previous note); if the draft is blank or only whitespace, the note is not saved and the task label is used instead
 - `Esc`: cancel without changing the current note
 
 Saved notes are reflected in live status metadata (`task_note`), recovery state,
@@ -452,7 +452,7 @@ You can configure notification and auto-start settings directly from the TUI:
 `focustime` persists in-progress timer sessions so restart/crash recovery can resume where you left off.
 
 - while a focus/break phase is running or paused, the app saves phase, remaining time, task metadata (`task_label`, `focus_intention`, `task_note`), and active profile
-- while editing with `m`, pressing `Enter` replaces the in-progress session `task_note` and immediately syncs recovery metadata
+- while editing with `m`, pressing `Enter` replaces the in-progress session `task_note` and immediately syncs recovery metadata; if the draft is blank or only whitespace, the note is not saved and the task label is used instead
 - on startup, valid in-progress state is restored and shown in the timer notice line
 - on startup, blocking is reconciled with recovered timer state: recovered active focus re-applies blocking, while non-recovered startup attempts to remove stale crash-era block entries
 - stale or invalid saved recovery state is ignored safely with a warning notice

--- a/README.md
+++ b/README.md
@@ -274,6 +274,18 @@ Open the session planner from timer view with **`t`**.
 Starting a focus session from idle now requires a selected task label. The timer
 view always shows the current task label (or a reminder to select one).
 
+### Mid-session notes
+
+While a focus session is running or paused, press **`m`** in timer view to edit a
+quick session note.
+
+- type or paste note text
+- `Enter`: save (replaces the previous note)
+- `Esc`: cancel without changing the current note
+
+Saved notes are reflected in live status metadata (`task_note`), recovery state,
+and interruption/completed-session history export fields.
+
 ### Example config
 
 ```toml
@@ -440,6 +452,7 @@ You can configure notification and auto-start settings directly from the TUI:
 `focustime` persists in-progress timer sessions so restart/crash recovery can resume where you left off.
 
 - while a focus/break phase is running or paused, the app saves phase, remaining time, task metadata (`task_label`, `focus_intention`, `task_note`), and active profile
+- while editing with `m`, pressing `Enter` replaces the in-progress session `task_note` and immediately syncs recovery metadata
 - on startup, valid in-progress state is restored and shown in the timer notice line
 - on startup, blocking is reconciled with recovered timer state: recovered active focus re-applies blocking, while non-recovered startup attempts to remove stale crash-era block entries
 - stale or invalid saved recovery state is ignored safely with a warning notice

--- a/src/app.rs
+++ b/src/app.rs
@@ -973,6 +973,10 @@ impl App {
             .or(self.selected_task_label.as_deref())
     }
 
+    pub fn can_edit_session_note(&self) -> bool {
+        self.focus_session_active_for_current_state()
+    }
+
     pub fn timer_note_input_active(&self) -> bool {
         self.timer_note_input_active
     }
@@ -2607,7 +2611,13 @@ impl App {
         {
             self.active_focus_task_label = Some(label.clone());
             self.active_focus_intention = Some(label.clone());
-            self.active_focus_task_note = Some(label.clone());
+            let should_sync_note_to_label = match self.active_focus_task_note.as_deref() {
+                None => true,
+                Some(note) => note.eq_ignore_ascii_case(&current_label),
+            };
+            if should_sync_note_to_label {
+                self.active_focus_task_note = Some(label.clone());
+            }
         }
         self.stats.rename_task_goal_target(&current_label, &label);
 
@@ -8052,6 +8062,31 @@ mod tests {
             interruptions[0].task_note.as_deref(),
             Some("Pulled into production incident")
         );
+    }
+
+    #[test]
+    fn planner_rename_preserves_custom_mid_session_note() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(key(KeyCode::Char(' ')));
+
+        app.handle_key(key(KeyCode::Char('m')));
+        app.timer_note_input = "Keep this custom note".to_string();
+        app.handle_key(key(KeyCode::Enter));
+
+        app.open_session_planner();
+        app.planner_selection_index = 0;
+        app.commit_planner_rename_input("Writing".to_string());
+
+        assert_eq!(app.active_focus_task_label.as_deref(), Some("Writing"));
+        assert_eq!(app.active_focus_intention.as_deref(), Some("Writing"));
+        assert_eq!(
+            app.active_focus_task_note.as_deref(),
+            Some("Keep this custom note")
+        );
+        let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
+        assert_eq!(snapshot.task_note.as_deref(), Some("Keep this custom note"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -440,6 +440,8 @@ pub struct App {
     active_focus_task_label: Option<String>,
     active_focus_intention: Option<String>,
     active_focus_task_note: Option<String>,
+    timer_note_input: String,
+    timer_note_input_active: bool,
     active_focus_profile: Option<ProfileId>,
     site_list_mode: SiteListMode,
     /// Index of the highlighted site in the SiteManager list.
@@ -566,6 +568,8 @@ impl App {
             active_focus_task_label: None,
             active_focus_intention: None,
             active_focus_task_note: None,
+            timer_note_input: String::new(),
+            timer_note_input_active: false,
             active_focus_profile: None,
             site_list_mode: SiteListMode::Blocklist,
             selected_site: 0,
@@ -668,6 +672,7 @@ impl App {
             self.active_focus_task_label = None;
             self.active_focus_intention = None;
             self.active_focus_task_note = None;
+            self.clear_timer_note_input();
             self.active_focus_profile = None;
         }
 
@@ -683,6 +688,7 @@ impl App {
             self.active_focus_task_label = None;
             self.active_focus_intention = None;
             self.active_focus_task_note = None;
+            self.clear_timer_note_input();
             self.active_focus_profile = None;
             self.break_glass_expires_at = None;
         }
@@ -955,6 +961,24 @@ impl App {
         } else {
             self.selected_task_label.as_deref()
         }
+    }
+
+    pub fn current_task_note(&self) -> Option<&str> {
+        if !self.focus_session_active_for_current_state() {
+            return None;
+        }
+        self.active_focus_task_note
+            .as_deref()
+            .or(self.active_focus_task_label.as_deref())
+            .or(self.selected_task_label.as_deref())
+    }
+
+    pub fn timer_note_input_active(&self) -> bool {
+        self.timer_note_input_active
+    }
+
+    pub fn timer_note_input_value(&self) -> &str {
+        &self.timer_note_input
     }
 
     pub fn profile_values(&self, profile: ProfileId) -> (u64, u64, u64, u32) {
@@ -2064,6 +2088,11 @@ impl App {
     }
 
     pub fn handle_paste(&mut self, text: String) {
+        if self.mode == AppMode::Timer && self.timer_note_input_active {
+            self.timer_note_input.push_str(&text);
+            return;
+        }
+
         if self.mode != AppMode::SiteManager {
             return;
         }
@@ -2080,6 +2109,11 @@ impl App {
     }
 
     fn handle_key_timer(&mut self, key: KeyEvent) {
+        if self.timer_note_input_active {
+            self.handle_timer_note_input_key(key);
+            return;
+        }
+
         if self.handle_quit_key(&key, true) {
             return;
         }
@@ -2161,6 +2195,10 @@ impl App {
             KeyCode::Char('d') => {
                 self.open_setup_diagnostics();
             }
+            // Edit mid-session note
+            KeyCode::Char('m') => {
+                self.start_timer_note_input();
+            }
             // Break-glass override (temporary unblock)
             KeyCode::Char('u') => {
                 self.handle_break_glass_key();
@@ -2171,6 +2209,76 @@ impl App {
             }
             _ => {}
         }
+    }
+
+    fn start_timer_note_input(&mut self) {
+        if !self.focus_session_active_for_current_state() {
+            self.phase_notification = Some(
+                "Mid-session notes are available only during active or paused focus.".to_string(),
+            );
+            return;
+        }
+
+        self.timer_note_input = self
+            .current_task_note()
+            .map(str::to_string)
+            .unwrap_or_default();
+        self.timer_note_input_active = true;
+        self.phase_notification =
+            Some("Editing session note: type text, then press [Enter] to save.".to_string());
+    }
+
+    fn handle_timer_note_input_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Enter => self.commit_timer_note_input(),
+            KeyCode::Esc => {
+                self.clear_timer_note_input();
+                self.phase_notification = Some("Session note edit canceled.".to_string());
+            }
+            KeyCode::Backspace => {
+                self.timer_note_input.pop();
+            }
+            KeyCode::Char(c)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                self.timer_note_input.push(c);
+            }
+            _ => {}
+        }
+    }
+
+    fn commit_timer_note_input(&mut self) {
+        if !self.focus_session_active_for_current_state() {
+            self.clear_timer_note_input();
+            self.phase_notification =
+                Some("Session note save failed: focus is no longer active.".to_string());
+            return;
+        }
+
+        let note = if self.timer_note_input.trim().is_empty() {
+            self.active_focus_task_label
+                .clone()
+                .or_else(|| self.selected_task_label.clone())
+        } else {
+            Some(self.timer_note_input.trim().to_string())
+        };
+
+        self.clear_timer_note_input();
+        if let Some(note) = note {
+            self.active_focus_task_note = Some(note);
+            self.sync_recovery_snapshot();
+            self.phase_notification = Some("Session note updated.".to_string());
+        } else {
+            self.phase_notification =
+                Some("Session note save failed: no task selected.".to_string());
+        }
+    }
+
+    fn clear_timer_note_input(&mut self) {
+        self.timer_note_input.clear();
+        self.timer_note_input_active = false;
     }
 
     fn delay_active_schedule_start(&mut self) {
@@ -3468,6 +3576,7 @@ impl App {
             self.active_focus_task_label = self.selected_task_label.clone();
             self.active_focus_intention = self.selected_task_label.clone();
             self.active_focus_task_note = self.selected_task_label.clone();
+            self.clear_timer_note_input();
             self.active_focus_profile = Some(self.selected_profile);
             self.schedule_armed_occurrence_key = None;
             self.clear_schedule_delay_state();
@@ -3475,6 +3584,7 @@ impl App {
             self.active_focus_task_label = None;
             self.active_focus_intention = None;
             self.active_focus_task_note = None;
+            self.clear_timer_note_input();
             self.active_focus_profile = None;
             self.break_glass_expires_at = None;
         }
@@ -7863,6 +7973,84 @@ mod tests {
         assert_eq!(
             app.phase_notification.as_deref(),
             Some("Select a task label with [t] before starting focus.")
+        );
+    }
+
+    #[test]
+    fn mid_session_note_input_requires_active_focus() {
+        let mut app = App::default();
+        app.selected_task_label = Some("Docs".to_string());
+
+        app.handle_key(key(KeyCode::Char('m')));
+
+        assert!(!app.timer_note_input_active);
+        assert_eq!(
+            app.phase_notification.as_deref(),
+            Some("Mid-session notes are available only during active or paused focus.")
+        );
+    }
+
+    #[test]
+    fn mid_session_note_input_commits_and_syncs_recovery_snapshot() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(key(KeyCode::Char(' ')));
+
+        app.handle_key(key(KeyCode::Char('m')));
+        assert!(app.timer_note_input_active);
+        assert_eq!(app.timer_note_input, "Docs");
+
+        app.timer_note_input = "Capture blockers for retro".to_string();
+        app.handle_key(key(KeyCode::Enter));
+
+        assert!(!app.timer_note_input_active);
+        assert_eq!(
+            app.active_focus_task_note.as_deref(),
+            Some("Capture blockers for retro")
+        );
+        let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
+        assert_eq!(
+            snapshot.task_note.as_deref(),
+            Some("Capture blockers for retro")
+        );
+    }
+
+    #[test]
+    fn mid_session_note_input_empty_commit_falls_back_to_task_label() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(key(KeyCode::Char(' ')));
+
+        app.handle_key(key(KeyCode::Char('m')));
+        app.timer_note_input = "   ".to_string();
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(app.active_focus_task_note.as_deref(), Some("Docs"));
+        let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
+        assert_eq!(snapshot.task_note.as_deref(), Some("Docs"));
+    }
+
+    #[test]
+    fn mid_session_note_input_updates_interruption_metadata() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(key(KeyCode::Char(' ')));
+
+        app.handle_key(key(KeyCode::Char('m')));
+        app.timer_note_input = "Pulled into production incident".to_string();
+        app.handle_key(key(KeyCode::Enter));
+        app.timer.remaining_secs = 1_000;
+
+        app.handle_key(key(KeyCode::Char('s')));
+
+        let interruptions = app.recent_session_interruptions(1);
+        assert_eq!(interruptions.len(), 1);
+        assert_eq!(
+            interruptions[0].task_note.as_deref(),
+            Some("Pulled into production incident")
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2093,7 +2093,13 @@ impl App {
 
     pub fn handle_paste(&mut self, text: String) {
         if self.mode == AppMode::Timer && self.timer_note_input_active {
-            self.timer_note_input.push_str(&text);
+            let sanitized = normalize_timer_note_paste(&text);
+            if !sanitized.is_empty() {
+                if !self.timer_note_input.is_empty() {
+                    self.timer_note_input.push(' ');
+                }
+                self.timer_note_input.push_str(&sanitized);
+            }
             return;
         }
 
@@ -4269,6 +4275,22 @@ fn adjust_duration_minutes(value: &mut u64, increase: bool) {
     }
 }
 
+fn normalize_timer_note_paste(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            if c == '\r' || c == '\n' || c.is_control() {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn adjust_daily_goal_minutes(value: &mut u64, increase: bool) {
     if increase {
         *value = if *value == 0 {
@@ -6318,6 +6340,20 @@ mod tests {
         assert_eq!(app.blocklist_profile_input, "Work");
         assert!(!app.site_input_active);
         assert!(app.site_input.is_empty());
+    }
+
+    #[test]
+    fn timer_note_paste_sanitizes_multiline_and_control_characters() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(key(KeyCode::Char(' ')));
+        app.handle_key(key(KeyCode::Char('m')));
+        app.timer_note_input.clear();
+
+        app.handle_paste("  line1\nline2\r\n\tline3\u{0007}  ".to_string());
+
+        assert_eq!(app.timer_note_input, "line1 line2 line3");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -176,11 +176,17 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(Color::Yellow),
         )
     };
+    let can_edit_session_note = app.can_edit_session_note();
     let (note_text, note_style) = if let Some(note) = app.current_task_note() {
         (format!("📝 Note: {note}"), Style::default().fg(Color::Cyan))
+    } else if can_edit_session_note {
+        (
+            "📝 Note: none yet ([m] Edit note)".to_string(),
+            Style::default().fg(Color::DarkGray),
+        )
     } else {
         (
-            "📝 Note: available during active/paused focus ([m])".to_string(),
+            "📝 Note: unavailable (start or resume focus to edit)".to_string(),
             Style::default().fg(Color::DarkGray),
         )
     };
@@ -395,8 +401,10 @@ fn timer_primary_hint(app: &App) -> &'static str {
         "Timer: [Space] Run/Pause  [s] Confirm reset  [n] Next (Locked)  [m] Note  [u] Unblock  [z] Delay 10m"
     } else if app.strict_mode_enforced_for_focus() {
         "Timer: [Space] Run/Pause  [s] Stop/Reset (Confirm)  [n] Next (Locked)  [m] Note  [u] Unblock  [z] Delay 10m"
-    } else {
+    } else if app.can_edit_session_note() {
         "Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next  [m] Note  [u] Unblock  [z] Delay 10m"
+    } else {
+        "Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next  [m] Note (Focus only)  [u] Unblock  [z] Delay 10m"
     }
 }
 
@@ -411,7 +419,9 @@ fn timer_secondary_hint(app: &App) -> &'static str {
 }
 
 fn timer_tertiary_hint(app: &App) -> &'static str {
-    if app.strict_mode_enforced_for_focus() {
+    if app.timer_note_input_active() {
+        "Note edit: [Esc] Cancel"
+    } else if app.strict_mode_enforced_for_focus() {
         "Navigate: [q/Esc] Quit (Locked during active focus)"
     } else {
         "Navigate: [q/Esc] Quit"
@@ -1812,6 +1822,12 @@ mod tests {
     }
 
     #[test]
+    fn timer_primary_hint_marks_note_as_focus_only_when_not_editable() {
+        let app = App::default();
+        assert!(timer_primary_hint(&app).contains("[m] Note (Focus only)"));
+    }
+
+    #[test]
     fn timer_hints_switch_when_note_edit_is_active() {
         let mut app = App::default();
         app.task_labels = vec!["Docs".to_string()];
@@ -1833,6 +1849,7 @@ mod tests {
             timer_secondary_hint(&app),
             "Views: shortcuts paused while editing note"
         );
+        assert_eq!(timer_tertiary_hint(&app), "Note edit: [Esc] Cancel");
     }
 
     #[test]
@@ -2251,6 +2268,22 @@ mod tests {
 
         let text = terminal_text(&terminal, width, height);
         assert!(text.contains("Task: Docs"));
+    }
+
+    #[test]
+    fn timer_view_shows_note_unavailable_outside_active_focus() {
+        let width = 100;
+        let height = 24;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let app = App::default();
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("Note: unavailable"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -176,6 +176,14 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(Color::Yellow),
         )
     };
+    let (note_text, note_style) = if let Some(note) = app.current_task_note() {
+        (format!("📝 Note: {note}"), Style::default().fg(Color::Cyan))
+    } else {
+        (
+            "📝 Note: available during active/paused focus ([m])".to_string(),
+            Style::default().fg(Color::DarkGray),
+        )
+    };
     let (stats_text, stats_style) = timer_stats_line(app);
     let goal_text = readable_goal_streak_text(&format_timer_goal_streak_line(app));
     let (waka_text, waka_color) = wakatime_status_line(app);
@@ -184,6 +192,7 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
 
     let mut lines = vec![
         Line::styled(task_text, task_style),
+        Line::styled(note_text, note_style),
         Line::styled(status_text, Style::default().fg(Color::Gray)),
         Line::styled(profile_line, Style::default().fg(Color::DarkGray)),
         Line::styled(schedule_next_text, Style::default().fg(Color::DarkGray)),
@@ -251,6 +260,15 @@ fn render_timer_phase_notice(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn phase_notice_line(app: &App) -> (String, Style) {
+    if app.timer_note_input_active() {
+        let draft = app.timer_note_input_value().trim();
+        let draft = if draft.is_empty() { "<empty>" } else { draft };
+        return (
+            format!("📝 Note: {draft}   [Enter] Save   [Esc] Cancel"),
+            Style::default().fg(Color::Cyan),
+        );
+    }
+
     if let Some(message) = app.phase_notification.as_ref() {
         (format!("🔔 {message}"), Style::default().fg(Color::Yellow))
     } else {
@@ -369,19 +387,23 @@ fn render_hint_lines(frame: &mut Frame, area: Rect, lines: Vec<Line<'static>>) {
 }
 
 fn timer_primary_hint(app: &App) -> &'static str {
-    if app.break_glass_confirmation_pending() {
-        "Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next  [u] Confirm unblock  [z] Delay 10m"
+    if app.timer_note_input_active() {
+        "Note: Type text  [Enter] Save  [Esc] Cancel"
+    } else if app.break_glass_confirmation_pending() {
+        "Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next  [m] Note  [u] Confirm unblock  [z] Delay 10m"
     } else if app.strict_reset_confirmation_pending() {
-        "Timer: [Space] Run/Pause  [s] Confirm reset  [n] Next (Locked)  [u] Unblock  [z] Delay 10m"
+        "Timer: [Space] Run/Pause  [s] Confirm reset  [n] Next (Locked)  [m] Note  [u] Unblock  [z] Delay 10m"
     } else if app.strict_mode_enforced_for_focus() {
-        "Timer: [Space] Run/Pause  [s] Stop/Reset (Confirm)  [n] Next (Locked)  [u] Unblock  [z] Delay 10m"
+        "Timer: [Space] Run/Pause  [s] Stop/Reset (Confirm)  [n] Next (Locked)  [m] Note  [u] Unblock  [z] Delay 10m"
     } else {
-        "Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next  [u] Unblock  [z] Delay 10m"
+        "Timer: [Space] Run/Pause  [s] Stop/Reset  [n] Next  [m] Note  [u] Unblock  [z] Delay 10m"
     }
 }
 
 fn timer_secondary_hint(app: &App) -> &'static str {
-    if app.strict_mode_enforced_for_focus() {
+    if app.timer_note_input_active() {
+        "Views: shortcuts paused while editing note"
+    } else if app.strict_mode_enforced_for_focus() {
         "Views: [t] Planner  [h] History  [b] Sites  [p] Profiles (Locked)  [d] Setup"
     } else {
         "Views: [t] Planner  [h] History  [b] Sites  [p] Profiles  [d] Setup"
@@ -1784,6 +1806,36 @@ mod tests {
     }
 
     #[test]
+    fn timer_primary_hint_includes_note_shortcut() {
+        let app = App::default();
+        assert!(timer_primary_hint(&app).contains("[m] Note"));
+    }
+
+    #[test]
+    fn timer_hints_switch_when_note_edit_is_active() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('m'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        assert_eq!(
+            timer_primary_hint(&app),
+            "Note: Type text  [Enter] Save  [Esc] Cancel"
+        );
+        assert_eq!(
+            timer_secondary_hint(&app),
+            "Views: shortcuts paused while editing note"
+        );
+    }
+
+    #[test]
     fn goal_streak_lines_show_off_when_all_goals_disabled() {
         let app = App::default();
 
@@ -2199,6 +2251,55 @@ mod tests {
 
         let text = terminal_text(&terminal, width, height);
         assert!(text.contains("Task: Docs"));
+    }
+
+    #[test]
+    fn timer_view_renders_active_session_note() {
+        let width = 100;
+        let height = 24;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("Note: Docs"));
+    }
+
+    #[test]
+    fn timer_view_renders_note_edit_notice() {
+        let width = 100;
+        let height = 24;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('m'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .expect("render should succeed");
+
+        let text = terminal_text(&terminal, width, height);
+        assert!(text.contains("[Enter] Save"));
+        assert!(text.contains("Cancel"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1853,6 +1853,38 @@ mod tests {
     }
 
     #[test]
+    fn timer_hints_allow_note_edit_while_focus_is_paused() {
+        let mut app = App::default();
+        app.task_labels = vec!["Docs".to_string()];
+        app.selected_task_label = Some("Docs".to_string());
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(app.timer.status, TimerStatus::Paused);
+        assert!(timer_primary_hint(&app).contains("[m] Note"));
+        assert!(!timer_primary_hint(&app).contains("Focus only"));
+
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('m'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(
+            timer_primary_hint(&app),
+            "Note: Type text  [Enter] Save  [Esc] Cancel"
+        );
+        assert_eq!(
+            timer_secondary_hint(&app),
+            "Views: shortcuts paused while editing note"
+        );
+        assert_eq!(timer_tertiary_hint(&app), "Note edit: [Esc] Cancel");
+    }
+
+    #[test]
     fn goal_streak_lines_show_off_when_all_goals_disabled() {
         let app = App::default();
 


### PR DESCRIPTION
## What

Add a timer-mode mid-session note workflow so users can quickly capture and update notes during active or paused focus sessions.

This PR adds `m`-shortcut note editing in timer mode, surfaces the current note in the timer session panel, updates live hint/notice rendering while editing, and keeps note changes synced to recovery and interruption metadata paths. It also includes app/UI regression tests and README updates.

## Why

Issue #189 requests quick note capture during an in-progress session without breaking flow. This makes note-taking available directly in timer mode and ensures the updated note persists through existing status/recovery/history data paths.

Closes #189

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A - none introduced)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) (N/A for this feature)
- [x] Breaking behavior changes are clearly described in this PR (N/A - no breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mid-session note editing: press `m` during an active or paused focus session to edit a quick note; `Enter` saves (blank/whitespace falls back to the task label) and `Esc` cancels. Notes appear in the timer UI as a cyan "Note" line and update live session metadata, interruption/completion exports, and session recovery.
* **Documentation**
  * README updated with note-editing workflow and explicit recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->