### PR TITLE
Make automation rules profile-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Profile-aware automation rules (#191):** automation settings (`notifications`, `auto_start`, `strict_mode`, and recurring schedule windows) are now stored and applied per timer profile across config, TUI profile editing, and CLI automation commands.
+
 ## [0.7.1] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cargo run -- --goal-carry-weekly=on
 cargo run -- --goal-carry-monthly=off
 cargo run -- --goal-carry --json
 
-# Show or set strict mode
+# Show or set strict mode for the selected profile
 cargo run -- --strict
 cargo run -- --strict=on
 cargo run -- --strict --json
@@ -145,7 +145,7 @@ cargo run -- --allowlist-site-add "reddit.com"
 cargo run -- --blocklist-site-edit "youtube.com=news.ycombinator.com"
 cargo run -- --allowlist-site-delete reddit.com
 
-# Show schedule (including overlap/conflict inspection) or replace recurring + one-time windows atomically from JSON
+# Show/set schedule for the selected profile (including overlap/conflict inspection)
 cargo run -- --schedule
 cargo run -- --schedule-set='{"windows":[{"days":["mon","tue"],"start":"09:00","end":"11:00"}],"exception_dates":["2026-12-25"],"one_time_windows":[{"date":"2026-05-02","start":"14:00","end":"16:00"}]}'
 cargo run -- --schedule --json
@@ -257,7 +257,8 @@ Open profile manager from timer view with **`p`**.
 - `e`: open profile/settings editor
 - In editor: `↑/↓` selects field, `←/→` adjusts numeric/boolean values, `Type/Backspace` edits WakaTime project/language, `Enter` saves
 
-Profile selection and custom values are persisted in `config.toml`.
+Profile selection, custom durations, and profile-scoped automation settings are
+persisted in `config.toml`.
 
 ## Session planner
 
@@ -294,6 +295,7 @@ and interruption/completed-session history export fields.
 ```toml
 selected_profile = "custom"
 selected_blocklist_profile = "Work"
+# Legacy compatibility mirror for the selected profile's automation strict mode.
 strict_mode = false
 break_glass_duration_secs = 300
 
@@ -313,21 +315,21 @@ short_break_secs = 360
 long_break_secs = 900
 long_break_interval = 3
 
-[notifications]
+[profile_automation.custom.notifications]
 enabled = true
 sound = false
 
-[auto_start]
+[profile_automation.custom.auto_start]
 focus_to_break = false
 break_to_focus = false
 
-[recurring_schedule]
+[profile_automation.custom.recurring_schedule]
 exception_dates = ["2026-12-25", "2027-01-01"]
-[[recurring_schedule.windows]]
+[[profile_automation.custom.recurring_schedule.windows]]
 days = ["mon", "tue", "wed", "thu", "fri"]
 start = "09:00"
 end = "11:00"
-[[recurring_schedule.one_time_windows]]
+[[profile_automation.custom.recurring_schedule.one_time_windows]]
 date = "2026-05-02"
 start = "14:00"
 end = "16:00"
@@ -409,19 +411,19 @@ Notifications are delivered best-effort:
 
 - terminal notice in the timer view
 - desktop notification via platform-specific delivery (`winrt-toast-reborn` toast on Windows with a `msg` fallback, `osascript` on macOS, `notify-send` on Linux)
-- optional sound alert using platform audio capabilities when `notifications.sound = true`
+- optional sound alert using platform audio capabilities when `profile_automation.<profile>.notifications.sound = true`
 
 Natural, non-catchup phase transitions can also auto-start the next timer with safe defaults (`Off`):
 
-- `auto_start.focus_to_break` starts break timers automatically after focus completion on non-catchup ticks
-- `auto_start.break_to_focus` starts focus timers automatically after break completion on non-catchup ticks
+- `profile_automation.<profile>.auto_start.focus_to_break` starts break timers automatically after focus completion on non-catchup ticks
+- `profile_automation.<profile>.auto_start.break_to_focus` starts focus timers automatically after break completion on non-catchup ticks
 
 Recurring schedule windows can also trigger focus behavior at wall-clock times:
 
-- `recurring_schedule.windows[].days` accepts day tokens (`mon`..`sun`, case-insensitive)
-- `recurring_schedule.windows[].start` / `end` use 24-hour `HH:MM` local time (`start < end`)
-- `recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
-- `recurring_schedule.one_time_windows[]` accepts one-time date windows with `date` (`YYYY-MM-DD`) plus `start`/`end` (`HH:MM`)
+- `profile_automation.<profile>.recurring_schedule.windows[].days` accepts day tokens (`mon`..`sun`, case-insensitive)
+- `profile_automation.<profile>.recurring_schedule.windows[].start` / `end` use 24-hour `HH:MM` local time (`start < end`)
+- `profile_automation.<profile>.recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
+- `profile_automation.<profile>.recurring_schedule.one_time_windows[]` accepts one-time date windows with `date` (`YYYY-MM-DD`) plus `start`/`end` (`HH:MM`)
 - when a window begins, focus auto-starts if possible; otherwise schedule mode arms and shows a reminder until you manually start focus
 - while a schedule window is active and focus is not already running, press `z` to delay the scheduled start by 10 minutes
 - recurring exception dates only skip recurring windows; one-time windows still apply on their configured date
@@ -433,6 +435,7 @@ You can configure notification and auto-start settings directly from the TUI:
 
 - open profile manager with `p`
 - press `e` to open the editor
+- automation and schedule edits apply to the currently selected profile only
 - the editor is grouped into sections (**Timer**, **Automation**, **Goals**, **WakaTime**, **Schedule**) to keep settings easier to scan
 - use `↑/↓` to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily/Weekly/Monthly goal (minutes)**, **Daily/Weekly/Monthly goal (pomodoros)**, **WakaTime project/language**, or the **Schedule** fields
 - use `←/→` to adjust values (or toggle `Off`/`On` for boolean fields), use `Type/Backspace` for WakaTime text fields, then `Enter` to save

--- a/src/app.rs
+++ b/src/app.rs
@@ -2014,14 +2014,12 @@ impl App {
 
         self.selected_profile = snapshot.selected_profile;
         self.profile_selection_index = profile_index(snapshot.selected_profile);
+        self.load_automation_runtime_for_profile(snapshot.selected_profile);
+        self.current_frame_now = Local::now();
         self.timer = recovered_timer;
         self.selected_task_label = Some(selected_task_label);
         self.pending_timer_action = None;
         self.break_glass_expires_at = None;
-        self.schedule_armed_occurrence_key = None;
-        self.schedule_delayed_occurrence_key = None;
-        self.schedule_delay_until = None;
-        self.last_schedule_occurrence_key = None;
         self.active_focus_task_label = if self.timer.phase == TimerPhase::Focus {
             self.selected_task_label.clone()
         } else {
@@ -3225,7 +3223,7 @@ impl App {
             .set_for_profile(self.selected_profile, self.selected_profile_automation());
     }
 
-    fn apply_automation_for_profile(&mut self, profile: ProfileId) {
+    fn load_automation_runtime_for_profile(&mut self, profile: ProfileId) {
         let automation = self
             .profile_automation
             .for_profile(profile, &ProfileAutomationConfig::default());
@@ -3238,6 +3236,10 @@ impl App {
         self.schedule_armed_occurrence_key = None;
         self.clear_schedule_delay_state();
         self.last_schedule_occurrence_key = None;
+    }
+
+    fn apply_automation_for_profile(&mut self, profile: ProfileId) {
+        self.load_automation_runtime_for_profile(profile);
         let now = Local::now();
         self.current_frame_now = now;
         self.sync_recurring_schedule(now);
@@ -9124,6 +9126,59 @@ mod tests {
                 .as_deref()
                 .is_some_and(|message| message.contains("Recovered in-progress Focus session"))
         );
+    }
+
+    #[test]
+    fn startup_recovery_rehydrates_profile_automation_runtime_for_snapshot_profile() {
+        let deep_work_schedule = RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec!["mon".to_string()],
+                start: "09:00".to_string(),
+                end: "11:00".to_string(),
+            }],
+            exception_dates: vec!["2026-12-25".to_string()],
+            one_time_windows: Vec::new(),
+        };
+        let config = AppConfig {
+            selected_profile: ProfileId::Custom,
+            strict_mode: false,
+            profile_automation: Some(ProfileAutomationSettingsConfig {
+                classic: Some(ProfileAutomationConfig::default()),
+                deep_work: Some(ProfileAutomationConfig {
+                    notifications: NotificationConfig {
+                        enabled: false,
+                        sound: true,
+                    },
+                    auto_start: AutoStartConfig {
+                        focus_to_break: true,
+                        break_to_focus: true,
+                    },
+                    strict_mode: true,
+                    recurring_schedule: deep_work_schedule.clone(),
+                }),
+                custom: Some(ProfileAutomationConfig::default()),
+            }),
+            ..AppConfig::default()
+        };
+        session_recovery::set_test_load_snapshot(Some(snapshot_for_tests(
+            TimerPhase::Focus,
+            TimerStatus::Running,
+            42,
+            Some("Docs"),
+            ProfileId::DeepWork,
+        )));
+
+        let app = App::from_config(config);
+
+        assert_eq!(app.selected_profile, ProfileId::DeepWork);
+        assert_eq!(app.timer.phase, TimerPhase::Focus);
+        assert_eq!(app.timer.status, TimerStatus::Running);
+        assert!(!app.notification_settings.enabled);
+        assert!(app.notification_settings.sound);
+        assert!(app.auto_start.focus_to_break);
+        assert!(app.auto_start.break_to_focus);
+        assert!(app.strict_mode);
+        assert_eq!(app.recurring_schedule, deep_work_schedule);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3222,8 +3222,9 @@ impl App {
     }
 
     fn apply_automation_for_profile(&mut self, profile: ProfileId) {
-        let fallback = self.selected_profile_automation();
-        let automation = self.profile_automation.for_profile(profile, &fallback);
+        let automation = self
+            .profile_automation
+            .for_profile(profile, &ProfileAutomationConfig::default());
         self.notification_settings = automation.notifications;
         self.auto_start = automation.auto_start;
         self.strict_mode = automation.strict_mode;
@@ -5192,6 +5193,37 @@ mod tests {
         assert!(app.auto_start.focus_to_break);
         assert!(app.auto_start.break_to_focus);
         assert!(!app.notification_settings.enabled);
+    }
+
+    #[test]
+    fn applying_profile_with_missing_automation_uses_neutral_defaults() {
+        let mut app = App::default();
+        app.notification_settings = NotificationConfig {
+            enabled: false,
+            sound: true,
+        };
+        app.auto_start = AutoStartConfig {
+            focus_to_break: true,
+            break_to_focus: true,
+        };
+        app.strict_mode = true;
+        app.recurring_schedule = RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec!["mon".to_string()],
+                start: "09:00".to_string(),
+                end: "10:00".to_string(),
+            }],
+            exception_dates: vec!["2026-12-25".to_string()],
+            one_time_windows: Vec::new(),
+        };
+        app.profile_automation.deep_work = None;
+
+        assert!(app.apply_profile(ProfileId::DeepWork));
+        assert_eq!(app.selected_profile, ProfileId::DeepWork);
+        assert_eq!(app.notification_settings, NotificationConfig::default());
+        assert_eq!(app.auto_start, AutoStartConfig::default());
+        assert!(!app.strict_mode);
+        assert_eq!(app.recurring_schedule, RecurringScheduleConfig::default());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,8 +14,8 @@ use crate::blocker::{
 use crate::config::{
     AppConfig, AutoStartConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
     GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig, OneTimeFocusWindowConfig,
-    ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig, WakatimeMetadataConfig,
-    WeeklyGoalConfig,
+    ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
+    RecurringFocusWindowConfig, RecurringScheduleConfig, WakatimeMetadataConfig, WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -460,6 +460,7 @@ pub struct App {
     pub phase_notification: Option<String>,
     pub wakatime: WakatimeTracker,
     pub selected_profile: ProfileId,
+    profile_automation: ProfileAutomationSettingsConfig,
     pub custom_profile: CustomProfileConfig,
     pub profile_selection_index: usize,
     pub profile_edit_active: bool,
@@ -511,14 +512,16 @@ impl App {
         let config = config.normalized();
         let selected_profile = config.selected_profile;
         let custom_profile = config.effective_custom_profile();
-        let notification_settings = config.notifications;
-        let auto_start = config.auto_start;
-        let recurring_schedule = config.recurring_schedule.clone();
+        let profile_automation = config.profile_automation.clone().unwrap_or_default();
+        let selected_automation = config.profile_automation_for(selected_profile);
+        let notification_settings = selected_automation.notifications;
+        let auto_start = selected_automation.auto_start;
+        let recurring_schedule = selected_automation.recurring_schedule.clone();
         let recurring_windows = compile_windows(&recurring_schedule.windows);
         let recurring_exception_dates =
             compile_exception_dates(&recurring_schedule.exception_dates);
         let one_time_windows = compile_one_time_windows(&recurring_schedule.one_time_windows);
-        let strict_mode = config.strict_mode;
+        let strict_mode = selected_automation.strict_mode;
         let break_glass_duration_secs = config.break_glass_duration_secs;
         let daily_goal = config.daily_goal;
         let weekly_goal = config.weekly_goal;
@@ -588,6 +591,7 @@ impl App {
                 language: wakatime_metadata.language.clone(),
             }),
             selected_profile,
+            profile_automation,
             custom_profile,
             profile_selection_index: profile_index(selected_profile),
             profile_edit_active: false,
@@ -2111,6 +2115,9 @@ impl App {
             .get(active_index)
             .map(effective_blocked_sites_for_profile)
             .unwrap_or_default();
+        let mut profile_automation = self.profile_automation.clone();
+        profile_automation
+            .set_for_profile(self.selected_profile, self.selected_profile_automation());
         AppConfig {
             // Keep legacy fields aligned with the editable custom profile so
             // older releases retain user-configured values.
@@ -2126,6 +2133,7 @@ impl App {
             notifications: self.notification_settings,
             auto_start: self.auto_start,
             recurring_schedule: self.recurring_schedule.clone(),
+            profile_automation: Some(profile_automation),
             strict_mode: self.strict_mode,
             break_glass_duration_secs: self.break_glass_duration_secs,
             daily_goal: self.daily_goal,
@@ -3034,6 +3042,7 @@ impl App {
         self.custom_profile = self.custom_profile.normalized();
         self.recurring_schedule = normalized_schedule;
         self.wakatime_metadata = self.wakatime_metadata.normalized();
+        self.update_selected_profile_automation();
         if self.selected_profile == ProfileId::Custom {
             if custom_profile_changed {
                 if !self.apply_profile(ProfileId::Custom) {
@@ -3197,6 +3206,38 @@ impl App {
         self.one_time_windows = compile_one_time_windows(&self.recurring_schedule.one_time_windows);
     }
 
+    fn selected_profile_automation(&self) -> ProfileAutomationConfig {
+        ProfileAutomationConfig {
+            notifications: self.notification_settings,
+            auto_start: self.auto_start,
+            strict_mode: self.strict_mode,
+            recurring_schedule: self.recurring_schedule.clone(),
+        }
+        .normalized()
+    }
+
+    fn update_selected_profile_automation(&mut self) {
+        self.profile_automation
+            .set_for_profile(self.selected_profile, self.selected_profile_automation());
+    }
+
+    fn apply_automation_for_profile(&mut self, profile: ProfileId) {
+        let fallback = self.selected_profile_automation();
+        let automation = self.profile_automation.for_profile(profile, &fallback);
+        self.notification_settings = automation.notifications;
+        self.auto_start = automation.auto_start;
+        self.strict_mode = automation.strict_mode;
+        self.recurring_schedule = automation.recurring_schedule;
+        self.rebuild_notifier();
+        self.rebuild_recurring_schedule_runtime();
+        self.schedule_armed_occurrence_key = None;
+        self.clear_schedule_delay_state();
+        self.last_schedule_occurrence_key = None;
+        let now = Local::now();
+        self.current_frame_now = now;
+        self.sync_recurring_schedule(now);
+    }
+
     fn apply_profile(&mut self, profile: ProfileId) -> bool {
         if self.strict_mode_enforced_for_focus() {
             self.config_error = Some(
@@ -3217,6 +3258,7 @@ impl App {
         self.active_focus_profile = None;
         self.selected_profile = profile;
         self.profile_selection_index = profile_index(profile);
+        self.apply_automation_for_profile(profile);
         self.pending_timer_action = None;
         self.save_config();
         self.apply_blocking_for_phase();
@@ -5078,6 +5120,7 @@ mod tests {
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             recurring_schedule: RecurringScheduleConfig::default(),
+            profile_automation: None,
             strict_mode: false,
             break_glass_duration_secs: 5 * 60,
             daily_goal: DailyGoalConfig::default(),
@@ -5092,6 +5135,63 @@ mod tests {
         assert_eq!(app.timer.short_break_secs, DEFAULT_SHORT_BREAK_SECS);
         assert_eq!(app.timer.long_break_secs, DEFAULT_LONG_BREAK_SECS);
         assert_eq!(app.timer.long_break_interval, DEFAULT_LONG_BREAK_INTERVAL);
+    }
+
+    #[test]
+    fn applying_profile_loads_profile_scoped_automation_rules() {
+        let classic_schedule = RecurringScheduleConfig::default();
+        let deep_work_schedule = RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec!["mon".to_string()],
+                start: "09:00".to_string(),
+                end: "11:00".to_string(),
+            }],
+            exception_dates: Vec::new(),
+            one_time_windows: Vec::new(),
+        };
+        let config = AppConfig {
+            selected_profile: ProfileId::Classic,
+            profile_automation: Some(ProfileAutomationSettingsConfig {
+                classic: Some(ProfileAutomationConfig {
+                    notifications: NotificationConfig {
+                        enabled: true,
+                        sound: false,
+                    },
+                    auto_start: AutoStartConfig {
+                        focus_to_break: false,
+                        break_to_focus: false,
+                    },
+                    strict_mode: false,
+                    recurring_schedule: classic_schedule.clone(),
+                }),
+                deep_work: Some(ProfileAutomationConfig {
+                    notifications: NotificationConfig {
+                        enabled: false,
+                        sound: false,
+                    },
+                    auto_start: AutoStartConfig {
+                        focus_to_break: true,
+                        break_to_focus: true,
+                    },
+                    strict_mode: true,
+                    recurring_schedule: deep_work_schedule.clone(),
+                }),
+                custom: None,
+            }),
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        assert_eq!(app.recurring_schedule, classic_schedule);
+        assert!(!app.strict_mode);
+        assert!(!app.auto_start.focus_to_break);
+        assert!(app.apply_profile(ProfileId::DeepWork));
+        assert_eq!(app.selected_profile, ProfileId::DeepWork);
+        assert_eq!(app.recurring_schedule, deep_work_schedule);
+        assert!(app.strict_mode);
+        assert!(app.auto_start.focus_to_break);
+        assert!(app.auto_start.break_to_focus);
+        assert!(!app.notification_settings.enabled);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3042,16 +3042,20 @@ impl App {
         self.custom_profile = self.custom_profile.normalized();
         self.recurring_schedule = normalized_schedule;
         self.wakatime_metadata = self.wakatime_metadata.normalized();
-        self.update_selected_profile_automation();
         if self.selected_profile == ProfileId::Custom {
             if custom_profile_changed {
+                let original_profile_automation = self.profile_automation.clone();
+                self.update_selected_profile_automation();
                 if !self.apply_profile(ProfileId::Custom) {
+                    self.profile_automation = original_profile_automation;
                     return;
                 }
             } else {
+                self.update_selected_profile_automation();
                 self.save_config();
             }
         } else {
+            self.update_selected_profile_automation();
             self.save_config();
         }
         self.sync_wakatime_metadata_to_tracker();
@@ -8046,6 +8050,9 @@ mod tests {
             goal_carry_over: app.goal_carry_over,
             wakatime_metadata: app.wakatime_metadata.clone(),
         });
+        let original_profile_automation = app
+            .profile_automation
+            .for_profile(ProfileId::Custom, &ProfileAutomationConfig::default());
         app.custom_profile.focus_secs = app.custom_profile.focus_secs.saturating_add(60);
         app.notification_settings.enabled = false;
 
@@ -8057,6 +8064,11 @@ mod tests {
             app.config_error
                 .as_deref()
                 .is_some_and(|err| err.contains("strict focus active"))
+        );
+        assert_eq!(
+            app.profile_automation
+                .for_profile(ProfileId::Custom, &ProfileAutomationConfig::default()),
+            original_profile_automation
         );
 
         app.timer.remaining_secs = 1;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,9 +88,9 @@ Options:
   --goal-carry          Show daily goal carry-over, or set on/off
   --goal-carry-weekly   Show weekly goal carry-over, or set on/off
   --goal-carry-monthly  Show monthly goal carry-over, or set on/off
-  --strict        Show strict mode, or set on/off
-  --schedule      Show recurring schedule with overlap/conflict inspection
-  --schedule-set  Replace schedule (recurring + one-time) from JSON payload
+  --strict        Show strict mode for selected profile, or set on/off
+  --schedule      Show selected profile schedule with overlap/conflict inspection
+  --schedule-set  Replace selected profile schedule (recurring + one-time) from JSON payload
   --blocklist-profile         Show active blocklist profile, or set active profile
   --blocklist-profile-create  Create a blocklist profile and select it
   --blocklist-profile-rename  Rename the active blocklist profile
@@ -2370,6 +2370,7 @@ fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Re
     let mut updated = false;
     if let Some(profile) = profile {
         config.selected_profile = profile;
+        config.align_legacy_automation_with_selected_profile();
         config
             .save()
             .map_err(|error| format!("Failed to save selected profile: {error}"))?;
@@ -2552,7 +2553,9 @@ fn execute_strict_command(enabled: Option<bool>, output: OutputMode) -> Result<(
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(enabled) = enabled {
-        config.strict_mode = enabled;
+        let mut automation = config.profile_automation_for(config.selected_profile);
+        automation.strict_mode = enabled;
+        config.set_profile_automation_for(config.selected_profile, automation);
         config
             .save()
             .map_err(|error| format!("Failed to save strict mode: {error}"))?;
@@ -2561,7 +2564,9 @@ fn execute_strict_command(enabled: Option<bool>, output: OutputMode) -> Result<(
 
     let payload = StrictCommandOutput {
         updated,
-        strict_mode: config.strict_mode,
+        strict_mode: config
+            .profile_automation_for(config.selected_profile)
+            .strict_mode,
     };
 
     match output {
@@ -2578,17 +2583,19 @@ fn execute_schedule_command(
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(schedule) = schedule {
-        config.recurring_schedule = schedule.normalized();
+        let mut automation = config.profile_automation_for(config.selected_profile);
+        automation.recurring_schedule = schedule.normalized();
+        config.set_profile_automation_for(config.selected_profile, automation);
         config
             .save()
             .map_err(|error| format!("Failed to save recurring schedule: {error}"))?;
         updated = true;
     }
-
-    let inspection = build_schedule_inspection_output(&config.recurring_schedule);
+    let selected_automation = config.profile_automation_for(config.selected_profile);
+    let inspection = build_schedule_inspection_output(&selected_automation.recurring_schedule);
     let payload = ScheduleCommandOutput {
         updated,
-        schedule: config.recurring_schedule,
+        schedule: selected_automation.recurring_schedule,
         inspection,
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,12 @@ pub struct AppConfig {
     /// Recurring schedule windows for automatic focus startup.
     #[serde(default)]
     pub recurring_schedule: RecurringScheduleConfig,
+    /// Profile-scoped automation settings.
+    ///
+    /// When absent, legacy global automation fields are used as shared defaults
+    /// for all profiles during normalization.
+    #[serde(default)]
+    pub profile_automation: Option<ProfileAutomationSettingsConfig>,
     /// Whether strict focus mode is enabled.
     ///
     /// When enabled, active focus sessions disallow skip and require
@@ -177,6 +183,95 @@ impl RecurringScheduleConfig {
             windows,
             exception_dates,
             one_time_windows,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ProfileAutomationConfig {
+    #[serde(default)]
+    pub notifications: NotificationConfig,
+    #[serde(default)]
+    pub auto_start: AutoStartConfig,
+    #[serde(default)]
+    pub strict_mode: bool,
+    #[serde(default)]
+    pub recurring_schedule: RecurringScheduleConfig,
+}
+
+impl ProfileAutomationConfig {
+    pub fn normalized(&self) -> Self {
+        Self {
+            notifications: self.notifications,
+            auto_start: self.auto_start,
+            strict_mode: self.strict_mode,
+            recurring_schedule: self.recurring_schedule.normalized(),
+        }
+    }
+
+    fn from_legacy(
+        notifications: NotificationConfig,
+        auto_start: AutoStartConfig,
+        strict_mode: bool,
+        recurring_schedule: RecurringScheduleConfig,
+    ) -> Self {
+        Self {
+            notifications,
+            auto_start,
+            strict_mode,
+            recurring_schedule,
+        }
+        .normalized()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ProfileAutomationSettingsConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub classic: Option<ProfileAutomationConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deep_work: Option<ProfileAutomationConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom: Option<ProfileAutomationConfig>,
+}
+
+impl ProfileAutomationSettingsConfig {
+    fn with_shared_defaults(shared: ProfileAutomationConfig) -> Self {
+        let shared = Some(shared.normalized());
+        Self {
+            classic: shared.clone(),
+            deep_work: shared.clone(),
+            custom: shared,
+        }
+    }
+
+    fn normalized_with_fallback(&self, fallback: &ProfileAutomationConfig) -> Self {
+        Self {
+            classic: Some(self.for_profile(ProfileId::Classic, fallback).normalized()),
+            deep_work: Some(self.for_profile(ProfileId::DeepWork, fallback).normalized()),
+            custom: Some(self.for_profile(ProfileId::Custom, fallback).normalized()),
+        }
+    }
+
+    pub fn for_profile(
+        &self,
+        profile: ProfileId,
+        fallback: &ProfileAutomationConfig,
+    ) -> ProfileAutomationConfig {
+        let configured = match profile {
+            ProfileId::Classic => self.classic.clone(),
+            ProfileId::DeepWork => self.deep_work.clone(),
+            ProfileId::Custom => self.custom.clone(),
+        };
+        configured.unwrap_or_else(|| fallback.clone()).normalized()
+    }
+
+    pub fn set_for_profile(&mut self, profile: ProfileId, config: ProfileAutomationConfig) {
+        let value = Some(config.normalized());
+        match profile {
+            ProfileId::Classic => self.classic = value,
+            ProfileId::DeepWork => self.deep_work = value,
+            ProfileId::Custom => self.custom = value,
         }
     }
 }
@@ -476,6 +571,7 @@ impl Default for AppConfig {
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             recurring_schedule: RecurringScheduleConfig::default(),
+            profile_automation: None,
             strict_mode: false,
             break_glass_duration_secs: default_break_glass_duration_secs(),
             daily_goal: DailyGoalConfig::default(),
@@ -513,6 +609,49 @@ impl AppConfig {
                 long_break_interval: self.long_break_interval,
             })
             .normalized()
+    }
+
+    fn legacy_profile_automation(&self) -> ProfileAutomationConfig {
+        ProfileAutomationConfig::from_legacy(
+            self.notifications,
+            self.auto_start,
+            self.strict_mode,
+            self.recurring_schedule.clone(),
+        )
+    }
+
+    pub fn profile_automation_for(&self, profile: ProfileId) -> ProfileAutomationConfig {
+        let fallback = self.legacy_profile_automation();
+        self.profile_automation
+            .as_ref()
+            .map(|settings| settings.for_profile(profile, &fallback))
+            .unwrap_or(fallback)
+    }
+
+    pub fn set_profile_automation_for(
+        &mut self,
+        profile: ProfileId,
+        automation: ProfileAutomationConfig,
+    ) {
+        let fallback = self.legacy_profile_automation();
+        let mut settings = self
+            .profile_automation
+            .clone()
+            .unwrap_or_else(|| {
+                ProfileAutomationSettingsConfig::with_shared_defaults(fallback.clone())
+            })
+            .normalized_with_fallback(&fallback);
+        settings.set_for_profile(profile, automation);
+        self.profile_automation = Some(settings.normalized_with_fallback(&fallback));
+        self.align_legacy_automation_with_selected_profile();
+    }
+
+    pub(crate) fn align_legacy_automation_with_selected_profile(&mut self) {
+        let selected = self.profile_automation_for(self.selected_profile);
+        self.notifications = selected.notifications;
+        self.auto_start = selected.auto_start;
+        self.strict_mode = selected.strict_mode;
+        self.recurring_schedule = selected.recurring_schedule;
     }
 
     #[cfg_attr(test, allow(dead_code))]
@@ -583,6 +722,16 @@ impl AppConfig {
         );
         self.custom_profile = self.custom_profile.map(|profile| profile.normalized());
         self.recurring_schedule = self.recurring_schedule.normalized();
+        let fallback_automation = self.legacy_profile_automation();
+        let normalized_profile_automation = self
+            .profile_automation
+            .clone()
+            .unwrap_or_else(|| {
+                ProfileAutomationSettingsConfig::with_shared_defaults(fallback_automation.clone())
+            })
+            .normalized_with_fallback(&fallback_automation);
+        self.profile_automation = Some(normalized_profile_automation);
+        self.align_legacy_automation_with_selected_profile();
         self.blocklist_profiles =
             normalize_blocklist_profiles(&self.blocklist_profiles, &self.blocked_sites);
         self.selected_blocklist_profile = normalize_selected_blocklist_profile(
@@ -838,6 +987,7 @@ mod tests {
         assert_eq!(cfg.notifications, NotificationConfig::default());
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert_eq!(cfg.recurring_schedule, RecurringScheduleConfig::default());
+        assert!(cfg.profile_automation.is_none());
         assert!(!cfg.strict_mode);
         assert_eq!(
             cfg.break_glass_duration_secs,
@@ -899,6 +1049,50 @@ mod tests {
                     end: "15:00".to_string(),
                 }],
             },
+            profile_automation: Some(ProfileAutomationSettingsConfig {
+                classic: Some(ProfileAutomationConfig {
+                    notifications: NotificationConfig {
+                        enabled: true,
+                        sound: false,
+                    },
+                    auto_start: AutoStartConfig {
+                        focus_to_break: false,
+                        break_to_focus: false,
+                    },
+                    strict_mode: false,
+                    recurring_schedule: RecurringScheduleConfig::default(),
+                }),
+                deep_work: Some(ProfileAutomationConfig {
+                    notifications: NotificationConfig {
+                        enabled: true,
+                        sound: true,
+                    },
+                    auto_start: AutoStartConfig {
+                        focus_to_break: true,
+                        break_to_focus: false,
+                    },
+                    strict_mode: true,
+                    recurring_schedule: RecurringScheduleConfig {
+                        windows: vec![RecurringFocusWindowConfig {
+                            days: vec!["mon".to_string(), "wed".to_string()],
+                            start: "09:15".to_string(),
+                            end: "11:00".to_string(),
+                        }],
+                        exception_dates: vec!["2026-04-27".to_string(), "2026-05-05".to_string()],
+                        one_time_windows: vec![OneTimeFocusWindowConfig {
+                            date: "2026-05-10".to_string(),
+                            start: "14:00".to_string(),
+                            end: "15:00".to_string(),
+                        }],
+                    },
+                }),
+                custom: Some(ProfileAutomationConfig {
+                    notifications: NotificationConfig::default(),
+                    auto_start: AutoStartConfig::default(),
+                    strict_mode: false,
+                    recurring_schedule: RecurringScheduleConfig::default(),
+                }),
+            }),
             strict_mode: true,
             break_glass_duration_secs: 7 * 60,
             daily_goal: DailyGoalConfig {
@@ -940,6 +1134,7 @@ mod tests {
         assert_eq!(parsed.notifications, original.notifications);
         assert_eq!(parsed.auto_start, original.auto_start);
         assert_eq!(parsed.recurring_schedule, original.recurring_schedule);
+        assert_eq!(parsed.profile_automation, original.profile_automation);
         assert_eq!(parsed.strict_mode, original.strict_mode);
         assert_eq!(
             parsed.break_glass_duration_secs,
@@ -968,6 +1163,7 @@ mod tests {
         assert_eq!(cfg.notifications, NotificationConfig::default());
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert_eq!(cfg.recurring_schedule, RecurringScheduleConfig::default());
+        assert!(cfg.profile_automation.is_none());
         assert!(!cfg.strict_mode);
         assert_eq!(
             cfg.break_glass_duration_secs,
@@ -1217,6 +1413,7 @@ long_break_interval = 3
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             recurring_schedule: RecurringScheduleConfig::default(),
+            profile_automation: None,
             strict_mode: false,
             break_glass_duration_secs: default_break_glass_duration_secs(),
             daily_goal: DailyGoalConfig::default(),
@@ -1269,6 +1466,7 @@ long_break_interval = 3
         assert!(cfg.blocklist_profiles.is_empty());
         assert_eq!(cfg.auto_start, AutoStartConfig::default());
         assert_eq!(cfg.recurring_schedule, RecurringScheduleConfig::default());
+        assert!(cfg.profile_automation.is_none());
         assert!(!cfg.strict_mode);
         assert_eq!(
             cfg.break_glass_duration_secs,
@@ -1415,5 +1613,114 @@ language = ""
         .normalize();
 
         assert_eq!(cfg.blocked_sites, vec!["a.com".to_string()]);
+    }
+
+    #[test]
+    fn normalize_migrates_legacy_automation_into_per_profile_settings() {
+        let legacy_schedule = RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec!["mon".to_string(), "tue".to_string()],
+                start: "09:00".to_string(),
+                end: "10:30".to_string(),
+            }],
+            exception_dates: vec!["2026-12-25".to_string()],
+            one_time_windows: vec![OneTimeFocusWindowConfig {
+                date: "2026-05-02".to_string(),
+                start: "14:00".to_string(),
+                end: "16:00".to_string(),
+            }],
+        };
+        let cfg = AppConfig {
+            selected_profile: ProfileId::DeepWork,
+            notifications: NotificationConfig {
+                enabled: true,
+                sound: true,
+            },
+            auto_start: AutoStartConfig {
+                focus_to_break: true,
+                break_to_focus: true,
+            },
+            recurring_schedule: legacy_schedule.clone(),
+            profile_automation: None,
+            strict_mode: true,
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        let expected = ProfileAutomationConfig::from_legacy(
+            NotificationConfig {
+                enabled: true,
+                sound: true,
+            },
+            AutoStartConfig {
+                focus_to_break: true,
+                break_to_focus: true,
+            },
+            true,
+            legacy_schedule,
+        );
+        assert_eq!(cfg.profile_automation_for(ProfileId::Classic), expected);
+        assert_eq!(cfg.profile_automation_for(ProfileId::DeepWork), expected);
+        assert_eq!(cfg.profile_automation_for(ProfileId::Custom), expected);
+        assert_eq!(cfg.notifications, expected.notifications);
+        assert_eq!(cfg.auto_start, expected.auto_start);
+        assert_eq!(cfg.strict_mode, expected.strict_mode);
+        assert_eq!(cfg.recurring_schedule, expected.recurring_schedule);
+    }
+
+    #[test]
+    fn normalize_selected_profile_automation_updates_legacy_view() {
+        let classic = ProfileAutomationConfig {
+            notifications: NotificationConfig {
+                enabled: true,
+                sound: false,
+            },
+            auto_start: AutoStartConfig {
+                focus_to_break: true,
+                break_to_focus: false,
+            },
+            strict_mode: false,
+            recurring_schedule: RecurringScheduleConfig::default(),
+        };
+        let deep_work = ProfileAutomationConfig {
+            notifications: NotificationConfig {
+                enabled: false,
+                sound: false,
+            },
+            auto_start: AutoStartConfig {
+                focus_to_break: false,
+                break_to_focus: true,
+            },
+            strict_mode: true,
+            recurring_schedule: RecurringScheduleConfig {
+                windows: vec![RecurringFocusWindowConfig {
+                    days: vec!["fri".to_string()],
+                    start: "13:00".to_string(),
+                    end: "15:00".to_string(),
+                }],
+                exception_dates: Vec::new(),
+                one_time_windows: Vec::new(),
+            },
+        };
+
+        let cfg = AppConfig {
+            selected_profile: ProfileId::DeepWork,
+            notifications: NotificationConfig::default(),
+            auto_start: AutoStartConfig::default(),
+            recurring_schedule: RecurringScheduleConfig::default(),
+            strict_mode: false,
+            profile_automation: Some(ProfileAutomationSettingsConfig {
+                classic: Some(classic),
+                deep_work: Some(deep_work.clone()),
+                custom: None,
+            }),
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        assert_eq!(cfg.notifications, deep_work.notifications);
+        assert_eq!(cfg.auto_start, deep_work.auto_start);
+        assert_eq!(cfg.strict_mode, deep_work.strict_mode);
+        assert_eq!(cfg.recurring_schedule, deep_work.recurring_schedule);
     }
 }

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -267,3 +267,93 @@ fn blocking_preview_json_emits_payload_on_stdout() {
     assert!(payload.get("effective_blocked_sites").is_some());
     assert!(payload.get("section").is_some());
 }
+
+#[test]
+fn strict_mode_is_profile_scoped_via_cli_commands() {
+    let env = TestEnv::new("strict-profile-scoped");
+
+    let select_deep_work = env.run(&["--profile", "deep-work", "--json"]);
+    assert_eq!(select_deep_work.status.code(), Some(0));
+    assert!(stderr_text(&select_deep_work).trim().is_empty());
+
+    let set_strict_on = env.run(&["--strict=on", "--json"]);
+    assert_eq!(set_strict_on.status.code(), Some(0));
+    assert!(stderr_text(&set_strict_on).trim().is_empty());
+    let set_payload: Value = serde_json::from_slice(&set_strict_on.stdout).unwrap();
+    assert_eq!(set_payload["updated"], true);
+    assert_eq!(set_payload["strict_mode"], true);
+
+    let select_custom = env.run(&["--profile", "custom", "--json"]);
+    assert_eq!(select_custom.status.code(), Some(0));
+    assert!(stderr_text(&select_custom).trim().is_empty());
+
+    let custom_strict = env.run(&["--strict", "--json"]);
+    assert_eq!(custom_strict.status.code(), Some(0));
+    assert!(stderr_text(&custom_strict).trim().is_empty());
+    let custom_payload: Value = serde_json::from_slice(&custom_strict.stdout).unwrap();
+    assert_eq!(custom_payload["strict_mode"], false);
+
+    let select_deep_work_again = env.run(&["--profile", "deep-work", "--json"]);
+    assert_eq!(select_deep_work_again.status.code(), Some(0));
+    assert!(stderr_text(&select_deep_work_again).trim().is_empty());
+
+    let deep_work_strict = env.run(&["--strict", "--json"]);
+    assert_eq!(deep_work_strict.status.code(), Some(0));
+    assert!(stderr_text(&deep_work_strict).trim().is_empty());
+    let deep_work_payload: Value = serde_json::from_slice(&deep_work_strict.stdout).unwrap();
+    assert_eq!(deep_work_payload["strict_mode"], true);
+}
+
+#[test]
+fn recurring_schedule_is_profile_scoped_via_cli_commands() {
+    let env = TestEnv::new("schedule-profile-scoped");
+
+    let select_deep_work = env.run(&["--profile", "deep-work", "--json"]);
+    assert_eq!(select_deep_work.status.code(), Some(0));
+    assert!(stderr_text(&select_deep_work).trim().is_empty());
+
+    let set_schedule = env.run(&[
+        "--schedule-set={\"windows\":[{\"days\":[\"mon\"],\"start\":\"09:00\",\"end\":\"11:00\"}],\"exception_dates\":[],\"one_time_windows\":[]}",
+        "--json",
+    ]);
+    assert_eq!(set_schedule.status.code(), Some(0));
+    assert!(stderr_text(&set_schedule).trim().is_empty());
+    let set_payload: Value = serde_json::from_slice(&set_schedule.stdout).unwrap();
+    assert_eq!(set_payload["updated"], true);
+    assert_eq!(
+        set_payload["schedule"]["windows"].as_array().unwrap().len(),
+        1
+    );
+
+    let select_custom = env.run(&["--profile", "custom", "--json"]);
+    assert_eq!(select_custom.status.code(), Some(0));
+    assert!(stderr_text(&select_custom).trim().is_empty());
+
+    let custom_schedule = env.run(&["--schedule", "--json"]);
+    assert_eq!(custom_schedule.status.code(), Some(0));
+    assert!(stderr_text(&custom_schedule).trim().is_empty());
+    let custom_payload: Value = serde_json::from_slice(&custom_schedule.stdout).unwrap();
+    assert_eq!(
+        custom_payload["schedule"]["windows"]
+            .as_array()
+            .unwrap()
+            .len(),
+        0
+    );
+
+    let select_deep_work_again = env.run(&["--profile", "deep-work", "--json"]);
+    assert_eq!(select_deep_work_again.status.code(), Some(0));
+    assert!(stderr_text(&select_deep_work_again).trim().is_empty());
+
+    let deep_work_schedule = env.run(&["--schedule", "--json"]);
+    assert_eq!(deep_work_schedule.status.code(), Some(0));
+    assert!(stderr_text(&deep_work_schedule).trim().is_empty());
+    let deep_work_payload: Value = serde_json::from_slice(&deep_work_schedule.stdout).unwrap();
+    assert_eq!(
+        deep_work_payload["schedule"]["windows"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+}


### PR DESCRIPTION
## What

Implement profile-aware automation rules so `notifications`, `auto_start`, `strict_mode`, and `recurring_schedule` are stored per timer profile and applied when profile changes.

This PR also:
- updates runtime and profile-switch behavior to rehydrate notifier and schedule state from the selected profile
- updates CLI `--strict`, `--schedule`, and `--schedule-set` to read and mutate the selected profile automation settings
- adds migration and regression coverage for legacy config compatibility and profile-scoped CLI behavior
- updates README and changelog for the new semantics

## Why

Closes #191.

Automation settings were previously global even though users edited them inside profile flows. That caused cross-profile leakage and made profile switching less predictable. This change aligns behavior with user expectation: automation rules now follow the selected profile while remaining backward compatible with existing config files.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation settings (notifications, auto-start, strict mode, recurring schedules and windows) are now stored and applied per profile; switching profiles loads that profile's automation and preserves profile-specific settings.

* **Documentation**
  * CLI help, README examples, and TUI instructions updated to reflect profile-scoped automation and a legacy top-level strict_mode mirror for compatibility.

* **Tests**
  * Added CLI JSON tests validating profile-scoped strict mode and schedule behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->