### PR TITLE
Add configurable break templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,11 @@ Open profile manager from timer view with **`p`**.
 - `↑/↓`: move between profiles
 - `Enter`: apply selected profile
 - `e`: open profile/settings editor
+- `[` / `]`: cycle the active break template for fast short/long break switching
 - In editor: `↑/↓` selects field, `←/→` adjusts numeric/boolean values, `Type/Backspace` edits WakaTime project/language, `Enter` saves
 
-Profile selection, custom durations, and profile-scoped automation settings are
-persisted in `config.toml`.
+Profile selection, break template selection, custom durations, and profile-scoped
+automation settings are persisted in `config.toml`.
 
 ## Session planner
 
@@ -294,10 +295,23 @@ and interruption/completed-session history export fields.
 
 ```toml
 selected_profile = "custom"
+selected_break_template = "Classic"
 selected_blocklist_profile = "Work"
 # Legacy compatibility mirror for the selected profile's automation strict mode.
 strict_mode = false
 break_glass_duration_secs = 300
+
+[[break_templates]]
+name = "Classic"
+short_break_secs = 300
+long_break_secs = 900
+long_break_interval = 4
+
+[[break_templates]]
+name = "Deep Work"
+short_break_secs = 600
+long_break_secs = 1800
+long_break_interval = 3
 
 [[blocklist_profiles]]
 name = "Work"

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,7 +107,7 @@ const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 34;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
-const DEFAULT_BREAK_TEMPLATE_NAME: &str = "Classic";
+const UNLINKED_BREAK_TEMPLATE_NAME: &str = "Custom";
 pub(crate) const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
 const SCHEDULE_TIME_STEP_MINUTES: u16 = 15;
 const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
@@ -187,11 +187,48 @@ fn blocklist_profile_index(profiles: &[BlocklistProfileConfig], selected_name: &
         .unwrap_or(0)
 }
 
-fn break_template_index(templates: &[BreakTemplateConfig], selected_name: &str) -> usize {
+fn break_template_index(templates: &[BreakTemplateConfig], selected_name: &str) -> Option<usize> {
     templates
         .iter()
         .position(|template| template.name.eq_ignore_ascii_case(selected_name))
-        .unwrap_or(0)
+}
+
+fn break_template_matches_custom_profile(
+    template: &BreakTemplateConfig,
+    custom_profile: &CustomProfileConfig,
+) -> bool {
+    let template = template.normalized();
+    let custom_profile = custom_profile.normalized();
+    template.short_break_secs == custom_profile.short_break_secs
+        && template.long_break_secs == custom_profile.long_break_secs
+        && template.long_break_interval == custom_profile.long_break_interval
+}
+
+fn break_template_index_for_custom_profile(
+    templates: &[BreakTemplateConfig],
+    custom_profile: &CustomProfileConfig,
+) -> Option<usize> {
+    templates
+        .iter()
+        .position(|template| break_template_matches_custom_profile(template, custom_profile))
+}
+
+fn resolve_active_break_template(
+    templates: &[BreakTemplateConfig],
+    selected_name: &str,
+    custom_profile: &CustomProfileConfig,
+) -> Option<usize> {
+    let selected = break_template_index(templates, selected_name);
+    if let Some(selected_index) = selected {
+        if templates
+            .get(selected_index)
+            .is_some_and(|template| break_template_matches_custom_profile(template, custom_profile))
+        {
+            return Some(selected_index);
+        }
+    }
+
+    break_template_index_for_custom_profile(templates, custom_profile)
 }
 
 #[derive(Debug, Clone)]
@@ -435,7 +472,7 @@ pub struct App {
     pub blocklist_profiles: Vec<BlocklistProfileConfig>,
     active_blocklist_profile: usize,
     pub break_templates: Vec<BreakTemplateConfig>,
-    active_break_template: usize,
+    active_break_template: Option<usize>,
     pub blocklist_profile_input: String,
     pub blocklist_profile_input_active: bool,
     blocklist_profile_input_mode: Option<BlocklistProfileInputMode>,
@@ -542,8 +579,11 @@ impl App {
         let active_blocklist_profile =
             blocklist_profile_index(&blocklist_profiles, &config.selected_blocklist_profile);
         let break_templates = config.break_templates.clone();
-        let active_break_template =
-            break_template_index(&break_templates, &config.selected_break_template);
+        let active_break_template = resolve_active_break_template(
+            &break_templates,
+            &config.selected_break_template,
+            &custom_profile,
+        );
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
         let (stats, stats_error) = match FocusStats::load() {
             Ok(stats) => (stats, None),
@@ -1965,26 +2005,52 @@ impl App {
     }
 
     pub fn active_break_template_name(&self) -> &str {
-        self.break_templates
-            .get(self.active_break_template)
-            .or_else(|| self.break_templates.first())
+        self.active_break_template
+            .and_then(|index| self.break_templates.get(index))
             .map(|template| template.name.as_str())
-            .unwrap_or(DEFAULT_BREAK_TEMPLATE_NAME)
+            .unwrap_or(UNLINKED_BREAK_TEMPLATE_NAME)
     }
 
     pub fn active_break_template_summary(&self) -> String {
-        self.break_templates
-            .get(self.active_break_template)
-            .or_else(|| self.break_templates.first())
-            .map(|template| {
-                format!(
-                    "{}/{}, every {} focus",
-                    format_duration_label(template.short_break_secs),
-                    format_duration_label(template.long_break_secs),
-                    template.long_break_interval
-                )
-            })
-            .unwrap_or_else(|| "n/a".to_string())
+        if let Some(template) = self
+            .active_break_template
+            .and_then(|index| self.break_templates.get(index))
+        {
+            format!(
+                "{}/{}, every {} focus",
+                format_duration_label(template.short_break_secs),
+                format_duration_label(template.long_break_secs),
+                template.long_break_interval
+            )
+        } else {
+            let custom_profile = self.custom_profile.normalized();
+            format!(
+                "{}/{}, every {} focus",
+                format_duration_label(custom_profile.short_break_secs),
+                format_duration_label(custom_profile.long_break_secs),
+                custom_profile.long_break_interval
+            )
+        }
+    }
+
+    fn selected_break_template_for_persistence(&self) -> String {
+        self.active_break_template
+            .and_then(|index| self.break_templates.get(index))
+            .map(|template| template.name.clone())
+            .unwrap_or_default()
+    }
+
+    fn sync_active_break_template_to_custom_profile(&mut self) {
+        let selected_name = self
+            .active_break_template
+            .and_then(|index| self.break_templates.get(index))
+            .map(|template| template.name.clone())
+            .unwrap_or_default();
+        self.active_break_template = resolve_active_break_template(
+            &self.break_templates,
+            &selected_name,
+            &self.custom_profile,
+        );
     }
 
     fn restore_in_progress_session(&mut self) {
@@ -2168,7 +2234,7 @@ impl App {
             selected_profile: self.selected_profile,
             custom_profile: Some(custom_profile),
             break_templates: self.break_templates.clone(),
-            selected_break_template: self.active_break_template_name().to_string(),
+            selected_break_template: self.selected_break_template_for_persistence(),
             notifications: self.notification_settings,
             auto_start: self.auto_start,
             recurring_schedule: self.recurring_schedule.clone(),
@@ -3085,6 +3151,7 @@ impl App {
             .as_ref()
             .is_some_and(|snapshot| snapshot.goal_carry_over != self.goal_carry_over);
         self.custom_profile = self.custom_profile.normalized();
+        self.sync_active_break_template_to_custom_profile();
         self.recurring_schedule = normalized_schedule;
         self.wakatime_metadata = self.wakatime_metadata.normalized();
         if self.selected_profile == ProfileId::Custom {
@@ -3770,52 +3837,57 @@ impl App {
     fn clamp_break_template_selection(&mut self) {
         if self.break_templates.is_empty() {
             self.break_templates.push(BreakTemplateConfig::default());
-            self.active_break_template = 0;
             return;
         }
-        self.active_break_template = self
-            .active_break_template
-            .min(self.break_templates.len().saturating_sub(1));
+        if let Some(active_break_template) = self.active_break_template {
+            self.active_break_template =
+                Some(active_break_template.min(self.break_templates.len().saturating_sub(1)));
+        }
     }
 
     fn select_previous_break_template(&mut self) {
         self.clamp_break_template_selection();
-        if self.break_templates.len() <= 1 {
+        if self.break_templates.is_empty() {
             return;
         }
-        let next = if self.active_break_template == 0 {
+        let current = self
+            .active_break_template
+            .unwrap_or(0)
+            .min(self.break_templates.len().saturating_sub(1));
+        let next = if current == 0 {
             self.break_templates.len().saturating_sub(1)
         } else {
-            self.active_break_template.saturating_sub(1)
+            current.saturating_sub(1)
         };
         self.switch_break_template(next);
     }
 
     fn select_next_break_template(&mut self) {
         self.clamp_break_template_selection();
-        if self.break_templates.len() <= 1 {
+        if self.break_templates.is_empty() {
             return;
         }
-        let next = (self.active_break_template + 1) % self.break_templates.len();
+        let current = self
+            .active_break_template
+            .unwrap_or(0)
+            .min(self.break_templates.len().saturating_sub(1));
+        let next = (current + 1) % self.break_templates.len();
         self.switch_break_template(next);
     }
 
     fn switch_break_template(&mut self, next_index: usize) {
-        if next_index >= self.break_templates.len() || next_index == self.active_break_template {
+        if next_index >= self.break_templates.len()
+            || self.active_break_template == Some(next_index)
+        {
             return;
         }
 
         let previous_index = self.active_break_template;
         let previous_custom_profile = self.custom_profile.clone();
-        self.active_break_template = next_index;
-        let Some(template) = self
-            .break_templates
-            .get(self.active_break_template)
-            .cloned()
-        else {
-            self.active_break_template = previous_index;
+        let Some(template) = self.break_templates.get(next_index).cloned() else {
             return;
         };
+        self.active_break_template = Some(next_index);
         let template = template.normalized();
         self.custom_profile.short_break_secs = template.short_break_secs;
         self.custom_profile.long_break_secs = template.long_break_secs;
@@ -5524,6 +5596,59 @@ mod tests {
         assert_eq!(app.timer.short_break_secs, original_short);
         assert_eq!(app.timer.long_break_secs, original_long);
         assert_eq!(app.timer.long_break_interval, original_cadence);
+    }
+
+    #[test]
+    fn startup_recomputes_selected_break_template_from_custom_values() {
+        let config = AppConfig {
+            selected_profile: ProfileId::Classic,
+            custom_profile: Some(CustomProfileConfig {
+                focus_secs: DEFAULT_FOCUS_SECS,
+                short_break_secs: 10 * 60,
+                long_break_secs: 30 * 60,
+                long_break_interval: 3,
+            }),
+            break_templates: vec![
+                BreakTemplateConfig {
+                    name: "Classic".to_string(),
+                    short_break_secs: 5 * 60,
+                    long_break_secs: 15 * 60,
+                    long_break_interval: 4,
+                },
+                BreakTemplateConfig {
+                    name: "Deep Work".to_string(),
+                    short_break_secs: 10 * 60,
+                    long_break_secs: 30 * 60,
+                    long_break_interval: 3,
+                },
+            ],
+            selected_break_template: "Classic".to_string(),
+            ..AppConfig::default()
+        };
+
+        let app = App::from_config(config);
+
+        assert_eq!(app.active_break_template_name(), "Deep Work");
+    }
+
+    #[test]
+    fn committing_custom_profile_edit_clears_unmatched_template_selection() {
+        let config = AppConfig {
+            selected_profile: ProfileId::Custom,
+            custom_profile: Some(CustomProfileConfig::default()),
+            selected_break_template: "Classic".to_string(),
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char('e')));
+        app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Right));
+        app.handle_key(key(KeyCode::Enter));
+
+        assert_eq!(app.active_break_template_name(), "Custom");
+        assert_eq!(app.persisted_config().selected_break_template, "");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,9 +12,9 @@ use crate::blocker::{
     HostsFileDiagnostics, InvalidSiteInput, SiteBlocker,
 };
 use crate::config::{
-    AppConfig, AutoStartConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig,
-    GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig, OneTimeFocusWindowConfig,
-    ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
+    AppConfig, AutoStartConfig, BlocklistProfileConfig, BreakTemplateConfig, CustomProfileConfig,
+    DailyGoalConfig, GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig,
+    OneTimeFocusWindowConfig, ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
     RecurringFocusWindowConfig, RecurringScheduleConfig, WakatimeMetadataConfig, WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
@@ -107,6 +107,7 @@ const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 34;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
+const DEFAULT_BREAK_TEMPLATE_NAME: &str = "Classic";
 pub(crate) const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
 const SCHEDULE_TIME_STEP_MINUTES: u16 = 15;
 const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
@@ -183,6 +184,13 @@ fn blocklist_profile_index(profiles: &[BlocklistProfileConfig], selected_name: &
     profiles
         .iter()
         .position(|profile| profile.name.eq_ignore_ascii_case(selected_name))
+        .unwrap_or(0)
+}
+
+fn break_template_index(templates: &[BreakTemplateConfig], selected_name: &str) -> usize {
+    templates
+        .iter()
+        .position(|template| template.name.eq_ignore_ascii_case(selected_name))
         .unwrap_or(0)
 }
 
@@ -426,6 +434,8 @@ pub struct App {
     site_edit_index: Option<usize>,
     pub blocklist_profiles: Vec<BlocklistProfileConfig>,
     active_blocklist_profile: usize,
+    pub break_templates: Vec<BreakTemplateConfig>,
+    active_break_template: usize,
     pub blocklist_profile_input: String,
     pub blocklist_profile_input_active: bool,
     blocklist_profile_input_mode: Option<BlocklistProfileInputMode>,
@@ -531,6 +541,9 @@ impl App {
         let blocklist_profiles = config.blocklist_profiles.clone();
         let active_blocklist_profile =
             blocklist_profile_index(&blocklist_profiles, &config.selected_blocklist_profile);
+        let break_templates = config.break_templates.clone();
+        let active_break_template =
+            break_template_index(&break_templates, &config.selected_break_template);
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
         let (stats, stats_error) = match FocusStats::load() {
             Ok(stats) => (stats, None),
@@ -558,6 +571,8 @@ impl App {
             site_edit_index: None,
             blocklist_profiles,
             active_blocklist_profile,
+            break_templates,
+            active_break_template,
             blocklist_profile_input: String::new(),
             blocklist_profile_input_active: false,
             blocklist_profile_input_mode: None,
@@ -626,6 +641,7 @@ impl App {
             stats_dirty: false,
             stats_has_unsaved_elapsed: false,
         };
+        app.clamp_break_template_selection();
         app.recompute_blocker_sites_from_active_profile();
         app.restore_in_progress_session();
         app.sync_planner_selection_to_selected_label();
@@ -1948,6 +1964,29 @@ impl App {
         self.blocklist_profiles.len()
     }
 
+    pub fn active_break_template_name(&self) -> &str {
+        self.break_templates
+            .get(self.active_break_template)
+            .or_else(|| self.break_templates.first())
+            .map(|template| template.name.as_str())
+            .unwrap_or(DEFAULT_BREAK_TEMPLATE_NAME)
+    }
+
+    pub fn active_break_template_summary(&self) -> String {
+        self.break_templates
+            .get(self.active_break_template)
+            .or_else(|| self.break_templates.first())
+            .map(|template| {
+                format!(
+                    "{}/{}, every {} focus",
+                    format_duration_label(template.short_break_secs),
+                    format_duration_label(template.long_break_secs),
+                    template.long_break_interval
+                )
+            })
+            .unwrap_or_else(|| "n/a".to_string())
+    }
+
     fn restore_in_progress_session(&mut self) {
         let loaded_snapshot = match session_recovery::load() {
             Ok(snapshot) => snapshot,
@@ -2128,6 +2167,8 @@ impl App {
             selected_blocklist_profile,
             selected_profile: self.selected_profile,
             custom_profile: Some(custom_profile),
+            break_templates: self.break_templates.clone(),
+            selected_break_template: self.active_break_template_name().to_string(),
             notifications: self.notification_settings,
             auto_start: self.auto_start,
             recurring_schedule: self.recurring_schedule.clone(),
@@ -2526,6 +2567,12 @@ impl App {
             }
             KeyCode::Char('e') => {
                 self.begin_profile_edit();
+            }
+            KeyCode::Char('[') => {
+                self.select_previous_break_template();
+            }
+            KeyCode::Char(']') => {
+                self.select_next_break_template();
             }
             _ => {}
         }
@@ -3720,6 +3767,81 @@ impl App {
         );
     }
 
+    fn clamp_break_template_selection(&mut self) {
+        if self.break_templates.is_empty() {
+            self.break_templates.push(BreakTemplateConfig::default());
+            self.active_break_template = 0;
+            return;
+        }
+        self.active_break_template = self
+            .active_break_template
+            .min(self.break_templates.len().saturating_sub(1));
+    }
+
+    fn select_previous_break_template(&mut self) {
+        self.clamp_break_template_selection();
+        if self.break_templates.len() <= 1 {
+            return;
+        }
+        let next = if self.active_break_template == 0 {
+            self.break_templates.len().saturating_sub(1)
+        } else {
+            self.active_break_template.saturating_sub(1)
+        };
+        self.switch_break_template(next);
+    }
+
+    fn select_next_break_template(&mut self) {
+        self.clamp_break_template_selection();
+        if self.break_templates.len() <= 1 {
+            return;
+        }
+        let next = (self.active_break_template + 1) % self.break_templates.len();
+        self.switch_break_template(next);
+    }
+
+    fn switch_break_template(&mut self, next_index: usize) {
+        if next_index >= self.break_templates.len() || next_index == self.active_break_template {
+            return;
+        }
+
+        let previous_index = self.active_break_template;
+        let previous_custom_profile = self.custom_profile.clone();
+        self.active_break_template = next_index;
+        let Some(template) = self
+            .break_templates
+            .get(self.active_break_template)
+            .cloned()
+        else {
+            self.active_break_template = previous_index;
+            return;
+        };
+        let template = template.normalized();
+        self.custom_profile.short_break_secs = template.short_break_secs;
+        self.custom_profile.long_break_secs = template.long_break_secs;
+        self.custom_profile.long_break_interval = template.long_break_interval;
+        self.custom_profile = self.custom_profile.normalized();
+        let custom_profile_changed = self.custom_profile != previous_custom_profile;
+
+        if self.selected_profile == ProfileId::Custom && custom_profile_changed {
+            let original_profile_automation = self.profile_automation.clone();
+            if !self.apply_profile(ProfileId::Custom) {
+                self.profile_automation = original_profile_automation;
+                self.active_break_template = previous_index;
+                self.custom_profile = previous_custom_profile;
+                return;
+            }
+        } else {
+            self.save_config();
+        }
+
+        self.phase_notification = Some(format!(
+            "Break template selected: {} ({})",
+            self.active_break_template_name(),
+            self.active_break_template_summary()
+        ));
+    }
+
     pub fn is_running(&self) -> bool {
         self.timer.status == TimerStatus::Running
     }
@@ -3961,6 +4083,7 @@ impl App {
         self.profile_selection_index = profile_index(self.selected_profile);
         self.clamp_profile_selection();
         self.clamp_profile_edit_schedule_selection();
+        self.clamp_break_template_selection();
     }
 
     fn open_session_planner(&mut self) {
@@ -5095,6 +5218,8 @@ mod tests {
         assert!(app.blocker.sites.is_empty());
         assert_eq!(app.blocklist_profile_count(), 1);
         assert_eq!(app.active_blocklist_profile_name(), "Default");
+        assert_eq!(app.break_templates.len(), 2);
+        assert_eq!(app.active_break_template_name(), "Classic");
         assert_eq!(app.timer.focus_secs, DEFAULT_FOCUS_SECS);
         assert_eq!(app.timer.short_break_secs, DEFAULT_SHORT_BREAK_SECS);
         assert_eq!(app.timer.long_break_secs, DEFAULT_LONG_BREAK_SECS);
@@ -5124,6 +5249,21 @@ mod tests {
                 long_break_secs: 16 * 60,
                 long_break_interval: 2,
             }),
+            break_templates: vec![
+                BreakTemplateConfig {
+                    name: "Classic".to_string(),
+                    short_break_secs: 5 * 60,
+                    long_break_secs: 15 * 60,
+                    long_break_interval: 4,
+                },
+                BreakTemplateConfig {
+                    name: "Deep Work".to_string(),
+                    short_break_secs: 10 * 60,
+                    long_break_secs: 30 * 60,
+                    long_break_interval: 3,
+                },
+            ],
+            selected_break_template: "Classic".to_string(),
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             recurring_schedule: RecurringScheduleConfig::default(),
@@ -5339,6 +5479,51 @@ mod tests {
         assert_eq!(app.timer.short_break_secs, short_break);
         assert_eq!(app.timer.long_break_secs, long_break);
         assert_eq!(app.timer.long_break_interval, cadence);
+    }
+
+    #[test]
+    fn profile_manager_cycles_break_template_for_custom_profile() {
+        let config = AppConfig {
+            selected_profile: ProfileId::Custom,
+            custom_profile: Some(CustomProfileConfig::default()),
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char(']')));
+
+        assert_eq!(app.active_break_template_name(), "Deep Work");
+        assert_eq!(app.custom_profile.short_break_secs, 10 * 60);
+        assert_eq!(app.custom_profile.long_break_secs, 30 * 60);
+        assert_eq!(app.custom_profile.long_break_interval, 3);
+        assert_eq!(app.timer.short_break_secs, 10 * 60);
+        assert_eq!(app.timer.long_break_secs, 30 * 60);
+        assert_eq!(app.timer.long_break_interval, 3);
+    }
+
+    #[test]
+    fn profile_manager_cycles_break_template_without_replacing_builtin_timer() {
+        let config = AppConfig {
+            selected_profile: ProfileId::Classic,
+            custom_profile: Some(CustomProfileConfig::default()),
+            ..AppConfig::default()
+        };
+        let mut app = App::from_config(config);
+        let original_short = app.timer.short_break_secs;
+        let original_long = app.timer.long_break_secs;
+        let original_cadence = app.timer.long_break_interval;
+
+        app.handle_key(key(KeyCode::Char('p')));
+        app.handle_key(key(KeyCode::Char(']')));
+
+        assert_eq!(app.active_break_template_name(), "Deep Work");
+        assert_eq!(app.custom_profile.short_break_secs, 10 * 60);
+        assert_eq!(app.custom_profile.long_break_secs, 30 * 60);
+        assert_eq!(app.custom_profile.long_break_interval, 3);
+        assert_eq!(app.timer.short_break_secs, original_short);
+        assert_eq!(app.timer.long_break_secs, original_long);
+        assert_eq!(app.timer.long_break_interval, original_cadence);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3850,14 +3850,10 @@ impl App {
         if self.break_templates.is_empty() {
             return;
         }
-        let current = self
-            .active_break_template
-            .unwrap_or(0)
-            .min(self.break_templates.len().saturating_sub(1));
-        let next = if current == 0 {
-            self.break_templates.len().saturating_sub(1)
-        } else {
-            current.saturating_sub(1)
+        let last = self.break_templates.len().saturating_sub(1);
+        let next = match self.active_break_template {
+            None | Some(0) => last,
+            Some(current) => current.min(last).saturating_sub(1),
         };
         self.switch_break_template(next);
     }
@@ -3867,11 +3863,11 @@ impl App {
         if self.break_templates.is_empty() {
             return;
         }
-        let current = self
-            .active_break_template
-            .unwrap_or(0)
-            .min(self.break_templates.len().saturating_sub(1));
-        let next = (current + 1) % self.break_templates.len();
+        let last = self.break_templates.len().saturating_sub(1);
+        let next = match self.active_break_template {
+            None => 0,
+            Some(current) => (current.min(last) + 1) % self.break_templates.len(),
+        };
         self.switch_break_template(next);
     }
 
@@ -5649,6 +5645,21 @@ mod tests {
 
         assert_eq!(app.active_break_template_name(), "Custom");
         assert_eq!(app.persisted_config().selected_break_template, "");
+    }
+
+    #[test]
+    fn cycling_break_templates_from_unlinked_state_uses_first_and_last_entries() {
+        let mut app = App::default();
+        app.active_break_template = None;
+
+        app.select_next_break_template();
+        assert_eq!(app.active_break_template, Some(0));
+        assert_eq!(app.active_break_template_name(), "Classic");
+
+        app.active_break_template = None;
+        app.select_previous_break_template();
+        assert_eq!(app.active_break_template, Some(1));
+        assert_eq!(app.active_break_template_name(), "Deep Work");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3141,15 +3141,55 @@ fn break_template_view(template: &BreakTemplateConfig) -> BreakTemplateView {
     }
 }
 
-fn selected_break_template_view(config: &AppConfig) -> BreakTemplateView {
+fn break_template_matches_custom_profile(
+    template: &BreakTemplateConfig,
+    custom_profile: &CustomProfileConfig,
+) -> bool {
+    let template = template.normalized();
+    let custom_profile = custom_profile.normalized();
+    template.short_break_secs == custom_profile.short_break_secs
+        && template.long_break_secs == custom_profile.long_break_secs
+        && template.long_break_interval == custom_profile.long_break_interval
+}
+
+fn selected_break_template_index(config: &AppConfig) -> Option<usize> {
+    let custom_profile = config.effective_custom_profile();
     let selected_name = config.selected_break_template.trim();
+    let selected_index = config
+        .break_templates
+        .iter()
+        .position(|template| template.name.eq_ignore_ascii_case(selected_name));
+
+    if let Some(index) = selected_index {
+        if config.break_templates.get(index).is_some_and(|template| {
+            break_template_matches_custom_profile(template, &custom_profile)
+        }) {
+            return Some(index);
+        }
+    }
+
     config
         .break_templates
         .iter()
-        .find(|template| template.name.eq_ignore_ascii_case(selected_name))
-        .map(break_template_view)
-        .or_else(|| config.break_templates.first().map(break_template_view))
-        .unwrap_or_else(|| break_template_view(&BreakTemplateConfig::default()))
+        .position(|template| break_template_matches_custom_profile(template, &custom_profile))
+}
+
+fn selected_break_template_view(config: &AppConfig) -> BreakTemplateView {
+    if let Some(index) = selected_break_template_index(config) {
+        return config
+            .break_templates
+            .get(index)
+            .map(break_template_view)
+            .unwrap_or_else(|| break_template_view(&BreakTemplateConfig::default()));
+    }
+
+    let custom = config.effective_custom_profile();
+    BreakTemplateView {
+        name: "Custom".to_string(),
+        short_break_secs: custom.short_break_secs,
+        long_break_secs: custom.long_break_secs,
+        long_break_interval: custom.long_break_interval,
+    }
 }
 
 fn available_break_template_views(config: &AppConfig) -> Vec<BreakTemplateView> {
@@ -5433,6 +5473,12 @@ mod tests {
     fn build_status_output_trims_selected_break_template_name() {
         let config = AppConfig {
             selected_break_template: "  deep work  ".to_string(),
+            custom_profile: Some(CustomProfileConfig {
+                focus_secs: DEFAULT_FOCUS_SECS,
+                short_break_secs: 10 * 60,
+                long_break_secs: 30 * 60,
+                long_break_interval: 3,
+            }),
             ..AppConfig::default()
         };
         let stats = FocusStats::default();
@@ -5440,6 +5486,28 @@ mod tests {
         let output = build_status_output(&config, &stats);
 
         assert_eq!(output.selected_break_template.name, "Deep Work");
+    }
+
+    #[test]
+    fn build_status_output_uses_custom_template_sentinel_when_unmatched() {
+        let config = AppConfig {
+            selected_break_template: String::new(),
+            custom_profile: Some(CustomProfileConfig {
+                focus_secs: DEFAULT_FOCUS_SECS,
+                short_break_secs: 7 * 60,
+                long_break_secs: 21 * 60,
+                long_break_interval: 5,
+            }),
+            ..AppConfig::default()
+        };
+        let stats = FocusStats::default();
+
+        let output = build_status_output(&config, &stats);
+
+        assert_eq!(output.selected_break_template.name, "Custom");
+        assert_eq!(output.selected_break_template.short_break_secs, 7 * 60);
+        assert_eq!(output.selected_break_template.long_break_secs, 21 * 60);
+        assert_eq!(output.selected_break_template.long_break_interval, 5);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3142,14 +3142,11 @@ fn break_template_view(template: &BreakTemplateConfig) -> BreakTemplateView {
 }
 
 fn selected_break_template_view(config: &AppConfig) -> BreakTemplateView {
+    let selected_name = config.selected_break_template.trim();
     config
         .break_templates
         .iter()
-        .find(|template| {
-            template
-                .name
-                .eq_ignore_ascii_case(&config.selected_break_template)
-        })
+        .find(|template| template.name.eq_ignore_ascii_case(selected_name))
         .map(break_template_view)
         .or_else(|| config.break_templates.first().map(break_template_view))
         .unwrap_or_else(|| break_template_view(&BreakTemplateConfig::default()))
@@ -5430,6 +5427,19 @@ mod tests {
         let output = build_status_output(&config, &stats);
 
         assert_eq!(output.blocked_sites_count, 2);
+    }
+
+    #[test]
+    fn build_status_output_trims_selected_break_template_name() {
+        let config = AppConfig {
+            selected_break_template: "  deep work  ".to_string(),
+            ..AppConfig::default()
+        };
+        let stats = FocusStats::default();
+
+        let output = build_status_output(&config, &stats);
+
+        assert_eq!(output.selected_break_template.name, "Deep Work");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,9 +14,9 @@ use serde::Serialize;
 use crate::app::{App, SetupCheck, SetupCheckLevel, SetupDiagnostics};
 use crate::blocker::{BlockingPreviewAction, EditSiteResult, InvalidSiteInput, SiteBlocker};
 use crate::config::{
-    AppConfig, BlocklistProfileConfig, CustomProfileConfig, DailyGoalConfig, MonthlyGoalConfig,
-    OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig,
-    WeeklyGoalConfig,
+    AppConfig, BlocklistProfileConfig, BreakTemplateConfig, CustomProfileConfig, DailyGoalConfig,
+    MonthlyGoalConfig, OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig,
+    RecurringScheduleConfig, WeeklyGoalConfig,
 };
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
@@ -372,10 +372,20 @@ struct ProfileView {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct BreakTemplateView {
+    name: String,
+    short_break_secs: u64,
+    long_break_secs: u64,
+    long_break_interval: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct ProfileOutput {
     updated: bool,
     selected: ProfileView,
     available: Vec<ProfileView>,
+    selected_break_template: BreakTemplateView,
+    available_break_templates: Vec<BreakTemplateView>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -438,6 +448,8 @@ struct LiveStatusOutput {
 struct StatusOutput {
     day: String,
     selected_profile: ProfileView,
+    selected_break_template: BreakTemplateView,
+    available_break_templates: Vec<BreakTemplateView>,
     selected_task_label: Option<String>,
     focus_intention: Option<String>,
     task_note: Option<String>,
@@ -2383,10 +2395,14 @@ fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Re
         .into_iter()
         .map(|candidate| profile_view(candidate, &custom))
         .collect();
+    let selected_break_template = selected_break_template_view(&config);
+    let available_break_templates = available_break_template_views(&config);
     let payload = ProfileOutput {
         updated,
         selected,
         available,
+        selected_break_template,
+        available_break_templates,
     };
 
     match output {
@@ -2801,6 +2817,8 @@ fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     StatusOutput {
         day,
         selected_profile: profile_view(config.selected_profile, &config.effective_custom_profile()),
+        selected_break_template: selected_break_template_view(config),
+        available_break_templates: available_break_template_views(config),
         selected_task_label,
         focus_intention,
         task_note,
@@ -3111,6 +3129,38 @@ fn profile_id(profile: ProfileId) -> &'static str {
         ProfileId::DeepWork => "deep-work",
         ProfileId::Custom => "custom",
     }
+}
+
+fn break_template_view(template: &BreakTemplateConfig) -> BreakTemplateView {
+    let template = template.normalized();
+    BreakTemplateView {
+        name: template.name,
+        short_break_secs: template.short_break_secs,
+        long_break_secs: template.long_break_secs,
+        long_break_interval: template.long_break_interval,
+    }
+}
+
+fn selected_break_template_view(config: &AppConfig) -> BreakTemplateView {
+    config
+        .break_templates
+        .iter()
+        .find(|template| {
+            template
+                .name
+                .eq_ignore_ascii_case(&config.selected_break_template)
+        })
+        .map(break_template_view)
+        .or_else(|| config.break_templates.first().map(break_template_view))
+        .unwrap_or_else(|| break_template_view(&BreakTemplateConfig::default()))
+}
+
+fn available_break_template_views(config: &AppConfig) -> Vec<BreakTemplateView> {
+    config
+        .break_templates
+        .iter()
+        .map(break_template_view)
+        .collect()
 }
 
 fn timer_phase_id(phase: TimerPhase) -> &'static str {
@@ -3444,6 +3494,23 @@ fn print_profile_output(payload: &ProfileOutput) {
         format_duration(payload.selected.long_break_secs),
         payload.selected.long_break_interval
     );
+    println!(
+        "Selected break template: {} ({}/{}, every {} focus)",
+        payload.selected_break_template.name,
+        format_duration(payload.selected_break_template.short_break_secs),
+        format_duration(payload.selected_break_template.long_break_secs),
+        payload.selected_break_template.long_break_interval
+    );
+    println!("Available break templates:");
+    for template in &payload.available_break_templates {
+        println!(
+            "  - {}: {}/{}, every {} focus",
+            template.name,
+            format_duration(template.short_break_secs),
+            format_duration(template.long_break_secs),
+            template.long_break_interval
+        );
+    }
     println!("Available profiles:");
     for profile in &payload.available {
         println!(
@@ -3589,6 +3656,13 @@ fn print_status_output(payload: &StatusOutput) {
     println!(
         "Selected profile: {} ({})",
         payload.selected_profile.label, payload.selected_profile.id
+    );
+    println!(
+        "Selected break template: {} ({}/{}, every {} focus)",
+        payload.selected_break_template.name,
+        format_duration(payload.selected_break_template.short_break_secs),
+        format_duration(payload.selected_break_template.long_break_secs),
+        payload.selected_break_template.long_break_interval
     );
     println!(
         "Task label: {}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -977,10 +977,7 @@ fn normalize_selected_break_template(
 ) -> String {
     let selected_name = selected_name.trim();
     if selected_name.is_empty() {
-        return templates
-            .first()
-            .map(|template| template.name.clone())
-            .unwrap_or_else(default_break_template_name);
+        return String::new();
     }
 
     if let Some(template) = templates
@@ -1331,7 +1328,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_break_templates_applies_defaults_when_empty() {
+    fn normalize_break_templates_preserves_empty_selection() {
         let cfg = AppConfig {
             break_templates: Vec::new(),
             selected_break_template: String::new(),
@@ -1340,7 +1337,7 @@ mod tests {
         .normalize();
 
         assert_eq!(cfg.break_templates.len(), 2);
-        assert_eq!(cfg.selected_break_template, "Classic");
+        assert_eq!(cfg.selected_break_template, "");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -794,8 +794,12 @@ impl AppConfig {
         );
         self.custom_profile = self.custom_profile.map(|profile| profile.normalized());
         self.break_templates = normalize_break_templates(&self.break_templates);
-        self.selected_break_template =
-            normalize_selected_break_template(&self.selected_break_template, &self.break_templates);
+        let effective_custom_profile = self.effective_custom_profile();
+        self.selected_break_template = normalize_selected_break_template(
+            &self.selected_break_template,
+            &self.break_templates,
+            &effective_custom_profile,
+        );
         self.recurring_schedule = self.recurring_schedule.normalized();
         let fallback_automation = self.legacy_profile_automation();
         let normalized_profile_automation = self
@@ -974,23 +978,36 @@ fn normalize_break_templates(templates: &[BreakTemplateConfig]) -> Vec<BreakTemp
 fn normalize_selected_break_template(
     selected_name: &str,
     templates: &[BreakTemplateConfig],
+    custom_profile: &CustomProfileConfig,
 ) -> String {
     let selected_name = selected_name.trim();
     if selected_name.is_empty() {
         return String::new();
     }
 
-    if let Some(template) = templates
-        .iter()
-        .find(|template| template.name.eq_ignore_ascii_case(selected_name))
-    {
+    if let Some(template) = templates.iter().find(|template| {
+        template.name.eq_ignore_ascii_case(selected_name)
+            && break_template_matches_custom_profile(template, custom_profile)
+    }) {
         template.name.clone()
     } else {
         templates
-            .first()
+            .iter()
+            .find(|template| break_template_matches_custom_profile(template, custom_profile))
             .map(|template| template.name.clone())
-            .unwrap_or_else(default_break_template_name)
+            .unwrap_or_default()
     }
+}
+
+fn break_template_matches_custom_profile(
+    template: &BreakTemplateConfig,
+    custom_profile: &CustomProfileConfig,
+) -> bool {
+    let template = template.normalized();
+    let custom_profile = custom_profile.normalized();
+    template.short_break_secs == custom_profile.short_break_secs
+        && template.long_break_secs == custom_profile.long_break_secs
+        && template.long_break_interval == custom_profile.long_break_interval
 }
 
 fn normalize_blocklist_profiles(
@@ -1377,6 +1394,40 @@ mod tests {
         );
         assert_eq!(cfg.break_templates[1].name, "recovery (2)");
         assert_eq!(cfg.selected_break_template, "Recovery");
+    }
+
+    #[test]
+    fn normalize_selected_break_template_uses_template_matching_custom_values() {
+        let cfg = AppConfig {
+            selected_break_template: "Classic".to_string(),
+            custom_profile: Some(CustomProfileConfig {
+                focus_secs: default_focus_secs(),
+                short_break_secs: 10 * 60,
+                long_break_secs: 30 * 60,
+                long_break_interval: 3,
+            }),
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        assert_eq!(cfg.selected_break_template, "Deep Work");
+    }
+
+    #[test]
+    fn normalize_selected_break_template_clears_unknown_when_no_template_matches_custom_values() {
+        let cfg = AppConfig {
+            selected_break_template: "Classic".to_string(),
+            custom_profile: Some(CustomProfileConfig {
+                focus_secs: default_focus_secs(),
+                short_break_secs: 7 * 60,
+                long_break_secs: 21 * 60,
+                long_break_interval: 5,
+            }),
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        assert_eq!(cfg.selected_break_template, "");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,7 @@ pub struct AppConfig {
     #[serde(default = "default_break_templates")]
     pub break_templates: Vec<BreakTemplateConfig>,
     /// Name of the active break template.
-    #[serde(default = "default_break_template_name")]
+    #[serde(default)]
     pub selected_break_template: String,
     /// Notification preferences for phase transitions.
     #[serde(default)]
@@ -1293,7 +1293,7 @@ mod tests {
         assert_eq!(cfg.long_break_interval, 4);
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
-        assert_eq!(cfg.selected_break_template, "Classic");
+        assert_eq!(cfg.selected_break_template, "");
         assert_eq!(cfg.break_templates.len(), 2);
         assert!(cfg.blocked_sites.is_empty());
         assert!(cfg.blocklist_profiles.is_empty());

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,12 @@ pub struct AppConfig {
     /// When this is absent, the app derives it from the legacy duration fields.
     #[serde(default)]
     pub custom_profile: Option<CustomProfileConfig>,
+    /// Globally reusable break templates for quick selection.
+    #[serde(default = "default_break_templates")]
+    pub break_templates: Vec<BreakTemplateConfig>,
+    /// Name of the active break template.
+    #[serde(default = "default_break_template_name")]
+    pub selected_break_template: String,
     /// Notification preferences for phase transitions.
     #[serde(default)]
     pub notifications: NotificationConfig,
@@ -462,6 +468,27 @@ fn default_break_glass_duration_secs() -> u64 {
     5 * 60
 }
 
+fn default_break_template_name() -> String {
+    "Classic".to_string()
+}
+
+fn default_break_templates() -> Vec<BreakTemplateConfig> {
+    vec![
+        BreakTemplateConfig {
+            name: "Classic".to_string(),
+            short_break_secs: default_short_break_secs(),
+            long_break_secs: default_long_break_secs(),
+            long_break_interval: default_long_break_interval(),
+        },
+        BreakTemplateConfig {
+            name: "Deep Work".to_string(),
+            short_break_secs: 10 * 60,
+            long_break_secs: 30 * 60,
+            long_break_interval: 3,
+        },
+    ]
+}
+
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum ProfileId {
@@ -543,6 +570,49 @@ impl Default for CustomProfileConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BreakTemplateConfig {
+    #[serde(default = "default_break_template_name")]
+    pub name: String,
+    #[serde(default = "default_short_break_secs")]
+    pub short_break_secs: u64,
+    #[serde(default = "default_long_break_secs")]
+    pub long_break_secs: u64,
+    #[serde(default = "default_long_break_interval")]
+    pub long_break_interval: u32,
+}
+
+impl BreakTemplateConfig {
+    pub fn normalized(&self) -> Self {
+        Self {
+            name: normalize_nonempty_or_default_string(&self.name, &default_break_template_name()),
+            short_break_secs: nonzero_or_default_u64(
+                self.short_break_secs,
+                default_short_break_secs(),
+            ),
+            long_break_secs: nonzero_or_default_u64(
+                self.long_break_secs,
+                default_long_break_secs(),
+            ),
+            long_break_interval: nonzero_or_default_u32(
+                self.long_break_interval,
+                default_long_break_interval(),
+            ),
+        }
+    }
+}
+
+impl Default for BreakTemplateConfig {
+    fn default() -> Self {
+        Self {
+            name: default_break_template_name(),
+            short_break_secs: default_short_break_secs(),
+            long_break_secs: default_long_break_secs(),
+            long_break_interval: default_long_break_interval(),
+        }
+    }
+}
+
 fn default_focus_secs() -> u64 {
     crate::timer::DEFAULT_FOCUS_SECS
 }
@@ -568,6 +638,8 @@ impl Default for AppConfig {
             selected_blocklist_profile: default_blocklist_profile_name(),
             selected_profile: ProfileId::default(),
             custom_profile: None,
+            break_templates: default_break_templates(),
+            selected_break_template: default_break_template_name(),
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             recurring_schedule: RecurringScheduleConfig::default(),
@@ -721,6 +793,9 @@ impl AppConfig {
             default_break_glass_duration_secs(),
         );
         self.custom_profile = self.custom_profile.map(|profile| profile.normalized());
+        self.break_templates = normalize_break_templates(&self.break_templates);
+        self.selected_break_template =
+            normalize_selected_break_template(&self.selected_break_template, &self.break_templates);
         self.recurring_schedule = self.recurring_schedule.normalized();
         let fallback_automation = self.legacy_profile_automation();
         let normalized_profile_automation = self
@@ -879,6 +954,48 @@ fn parse_schedule_exception_date(value: &str) -> Option<NaiveDate> {
     NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").ok()
 }
 
+fn normalize_break_templates(templates: &[BreakTemplateConfig]) -> Vec<BreakTemplateConfig> {
+    let mut normalized = Vec::new();
+    let mut seen_names = HashSet::new();
+
+    for template in templates {
+        let template = template.normalized();
+        let name = make_unique_profile_name(&template.name, &mut seen_names);
+        normalized.push(BreakTemplateConfig { name, ..template });
+    }
+
+    if normalized.is_empty() {
+        return default_break_templates();
+    }
+
+    normalized
+}
+
+fn normalize_selected_break_template(
+    selected_name: &str,
+    templates: &[BreakTemplateConfig],
+) -> String {
+    let selected_name = selected_name.trim();
+    if selected_name.is_empty() {
+        return templates
+            .first()
+            .map(|template| template.name.clone())
+            .unwrap_or_else(default_break_template_name);
+    }
+
+    if let Some(template) = templates
+        .iter()
+        .find(|template| template.name.eq_ignore_ascii_case(selected_name))
+    {
+        template.name.clone()
+    } else {
+        templates
+            .first()
+            .map(|template| template.name.clone())
+            .unwrap_or_else(default_break_template_name)
+    }
+}
+
 fn normalize_blocklist_profiles(
     profiles: &[BlocklistProfileConfig],
     legacy_blocked_sites: &[String],
@@ -981,6 +1098,8 @@ mod tests {
         assert_eq!(cfg.long_break_interval, 4);
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
+        assert_eq!(cfg.selected_break_template, "Classic");
+        assert_eq!(cfg.break_templates.len(), 2);
         assert!(cfg.blocked_sites.is_empty());
         assert_eq!(cfg.selected_blocklist_profile, "Default");
         assert!(cfg.blocklist_profiles.is_empty());
@@ -1028,6 +1147,21 @@ mod tests {
                 long_break_secs: 12 * 60,
                 long_break_interval: 5,
             }),
+            break_templates: vec![
+                BreakTemplateConfig {
+                    name: "Quick".to_string(),
+                    short_break_secs: 3 * 60,
+                    long_break_secs: 10 * 60,
+                    long_break_interval: 4,
+                },
+                BreakTemplateConfig {
+                    name: "Recovery".to_string(),
+                    short_break_secs: 8 * 60,
+                    long_break_secs: 20 * 60,
+                    long_break_interval: 3,
+                },
+            ],
+            selected_break_template: "Recovery".to_string(),
             notifications: NotificationConfig {
                 enabled: true,
                 sound: true,
@@ -1131,6 +1265,11 @@ mod tests {
         );
         assert_eq!(parsed.selected_profile, original.selected_profile);
         assert_eq!(parsed.custom_profile, original.custom_profile);
+        assert_eq!(parsed.break_templates, original.break_templates);
+        assert_eq!(
+            parsed.selected_break_template,
+            original.selected_break_template
+        );
         assert_eq!(parsed.notifications, original.notifications);
         assert_eq!(parsed.auto_start, original.auto_start);
         assert_eq!(parsed.recurring_schedule, original.recurring_schedule);
@@ -1157,6 +1296,8 @@ mod tests {
         assert_eq!(cfg.long_break_interval, 4);
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
+        assert_eq!(cfg.selected_break_template, "Classic");
+        assert_eq!(cfg.break_templates.len(), 2);
         assert!(cfg.blocked_sites.is_empty());
         assert!(cfg.blocklist_profiles.is_empty());
         assert_eq!(cfg.selected_blocklist_profile, "Default");
@@ -1187,6 +1328,58 @@ mod tests {
             cfg.break_glass_duration_secs,
             default_break_glass_duration_secs()
         );
+    }
+
+    #[test]
+    fn normalize_break_templates_applies_defaults_when_empty() {
+        let cfg = AppConfig {
+            break_templates: Vec::new(),
+            selected_break_template: String::new(),
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        assert_eq!(cfg.break_templates.len(), 2);
+        assert_eq!(cfg.selected_break_template, "Classic");
+    }
+
+    #[test]
+    fn normalize_break_templates_deduplicates_names_and_clamps_values() {
+        let cfg = AppConfig {
+            break_templates: vec![
+                BreakTemplateConfig {
+                    name: "Recovery".to_string(),
+                    short_break_secs: 0,
+                    long_break_secs: 0,
+                    long_break_interval: 0,
+                },
+                BreakTemplateConfig {
+                    name: "recovery".to_string(),
+                    short_break_secs: 2 * 60,
+                    long_break_secs: 12 * 60,
+                    long_break_interval: 2,
+                },
+            ],
+            selected_break_template: "missing".to_string(),
+            ..AppConfig::default()
+        }
+        .normalize();
+
+        assert_eq!(cfg.break_templates[0].name, "Recovery");
+        assert_eq!(
+            cfg.break_templates[0].short_break_secs,
+            default_short_break_secs()
+        );
+        assert_eq!(
+            cfg.break_templates[0].long_break_secs,
+            default_long_break_secs()
+        );
+        assert_eq!(
+            cfg.break_templates[0].long_break_interval,
+            default_long_break_interval()
+        );
+        assert_eq!(cfg.break_templates[1].name, "recovery (2)");
+        assert_eq!(cfg.selected_break_template, "Recovery");
     }
 
     #[test]
@@ -1410,6 +1603,8 @@ long_break_interval = 3
                 long_break_secs: 16 * 60,
                 long_break_interval: 2,
             }),
+            break_templates: default_break_templates(),
+            selected_break_template: default_break_template_name(),
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             recurring_schedule: RecurringScheduleConfig::default(),
@@ -1461,6 +1656,8 @@ long_break_interval = 3
         );
         assert_eq!(cfg.selected_profile, ProfileId::Custom);
         assert!(cfg.custom_profile.is_none());
+        assert_eq!(cfg.selected_break_template, "Classic");
+        assert_eq!(cfg.break_templates.len(), 2);
         assert!(cfg.blocked_sites.is_empty());
         assert_eq!(cfg.selected_blocklist_profile, "Default");
         assert!(cfg.blocklist_profiles.is_empty());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -738,12 +738,18 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
         ])
         .split(outer);
 
-    let current = Paragraph::new(format!("Current profile: {}", app.selected_profile_name()))
-        .style(
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
-        );
+    let current = Paragraph::new(format!(
+        "Current profile: {} · Break template: {} ({})",
+        app.selected_profile_name(),
+        app.active_break_template_name(),
+        app.active_break_template_summary()
+    ))
+    .style(
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
+    )
+    .wrap(Wrap { trim: true });
     frame.render_widget(current, inner[0]);
 
     let items = profile_list_items(app);
@@ -886,6 +892,7 @@ fn profile_manager_hints(app: &App) -> Vec<Line<'static>> {
             } else {
                 "Profiles: [↑/↓] Move  [Enter] Apply  [e] Edit"
             }),
+            Line::from("Templates: [[ ] Cycle break template"),
             Line::from(if app.strict_mode_enforced_for_focus() {
                 "View: [p/Esc] Back  [q] Quit (Locked)"
             } else {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -729,7 +729,7 @@ fn render_profile_manager(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(1), // current profile
+            Constraint::Length(2), // current profile + break template
             Constraint::Length(6), // profile list
             Constraint::Length(editor_height),
             Constraint::Min(0),    // spacer

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -93,6 +93,8 @@ fn status_json_success_emits_payload_on_stdout() {
 
     let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
     assert!(payload.get("day").is_some());
+    assert!(payload.get("selected_break_template").is_some());
+    assert!(payload.get("available_break_templates").is_some());
     assert!(payload.get("focus_intention").is_some());
     assert!(payload.get("task_note").is_some());
     assert!(payload.get("goal").is_some());


### PR DESCRIPTION
## What

Add global named break templates and a fast selection flow in the profile manager so users can switch break settings quickly. Persist template data in config, expose selected and available template context in CLI profile/status outputs, and document the workflow.

## Why

Issue #192 requests configurable break templates to reduce repetitive manual break-duration edits. This change adds the template workflow while keeping existing profile and automation behavior backward compatible.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`) - Closes #192

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable) - N/A
- [ ] WakaTime integration behavior was verified for this change (if applicable) - N/A
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed) - N/A
- [ ] Breaking behavior changes are clearly described in this PR - N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Break templates: cycle between predefined break configurations using `[` / `]` from timer view
  * Included templates: "Classic" and "Deep Work" with configurable short/long breaks and long-break intervals
  * Selected template persists; Profile Manager shows active template name and summary

* **CLI**
  * Status and profile outputs show the selected template and list available templates

* **Documentation**
  * README documents break-template usage and example config entries

* **Tests**
  * Status JSON tests updated to require template fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->