### PR TITLE
Add accessible global theme presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Theme presets with accessibility options (#194):** added global theme preset selection (`classic`, `high-contrast`, `deuteranopia-friendly`) across config persistence, TUI appearance rendering, profile editor controls, and CLI `--theme` management/status outputs.
+
 ## [0.8.0] - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ cargo run -- --profile
 cargo run -- --profile deep-work
 cargo run -- --profile --json
 
+# Show or set the active theme preset
+cargo run -- --theme
+cargo run -- --theme high-contrast
+cargo run -- --theme deuteranopia-friendly --json
+
 # Show or set daily goal targets (minutes,pomodoros)
 cargo run -- --goal
 cargo run -- --goal=120,4
@@ -280,10 +285,10 @@ Open profile manager from timer view with **`p`**.
 - `Enter`: apply selected profile
 - `e`: open profile/settings editor
 - `[` / `]`: cycle the active break template for fast short/long break switching
-- In editor: `↑/↓` selects field, `←/→` adjusts numeric/boolean values, `Type/Backspace` edits WakaTime project/language, `Enter` saves
+- In editor: `↑/↓` selects field, `←/→` adjusts numeric/boolean values (including **Theme preset**), `Type/Backspace` edits WakaTime project/language, `Enter` saves
 
-Profile selection, break template selection, custom durations, and profile-scoped
-automation settings are persisted in `config.toml`.
+Profile selection, break template selection, theme preset selection, custom durations,
+and profile-scoped automation settings are persisted in `config.toml`.
 
 ## Session planner
 
@@ -320,6 +325,7 @@ and interruption/completed-session history export fields.
 ```toml
 selected_profile = "custom"
 selected_break_template = "Classic"
+selected_theme_preset = "classic"
 selected_blocklist_profile = "Work"
 # Legacy compatibility mirror for the selected profile's automation strict mode.
 strict_mode = false
@@ -481,8 +487,8 @@ You can configure notification and auto-start settings directly from the TUI:
 - open profile manager with `p`
 - press `e` to open the editor
 - automation and schedule edits apply to the currently selected profile only
-- the editor is grouped into sections (**Timer**, **Automation**, **Goals**, **WakaTime**, **Schedule**) to keep settings easier to scan
-- use `↑/↓` to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily/Weekly/Monthly goal (minutes)**, **Daily/Weekly/Monthly goal (pomodoros)**, **WakaTime project/language**, or the **Schedule** fields
+- the editor is grouped into sections (**Timer**, **Automation**, **Goals**, **Appearance**, **WakaTime**, **Schedule**) to keep settings easier to scan
+- use `↑/↓` to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily/Weekly/Monthly goal (minutes)**, **Daily/Weekly/Monthly goal (pomodoros)**, **Theme preset**, **WakaTime project/language**, or the **Schedule** fields
 - use `←/→` to adjust values (or toggle `Off`/`On` for boolean fields), use `Type/Backspace` for WakaTime text fields, then `Enter` to save
 - schedule editing is in-app:
   - **Schedule add/remove**: `→` adds a window, `←` removes selected window

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,8 @@ use crate::config::{
     AppConfig, AutoStartConfig, BlocklistProfileConfig, BreakTemplateConfig, CustomProfileConfig,
     DailyGoalConfig, GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig,
     OneTimeFocusWindowConfig, ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, WakatimeMetadataConfig, WeeklyGoalConfig,
+    RecurringFocusWindowConfig, RecurringScheduleConfig, ThemePreset, WakatimeMetadataConfig,
+    WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -56,7 +57,7 @@ use shortcuts::ShortcutBindings;
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
-pub const PROFILE_EDIT_FIELD_LABELS: [&str; 35] = [
+pub const PROFILE_EDIT_FIELD_LABELS: [&str; 36] = [
     "Focus",
     "Short Break",
     "Long Break",
@@ -92,6 +93,7 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 35] = [
     "One-time end",
     "One-time add/remove",
     "Schedule conflicts",
+    "Theme preset",
 ];
 const PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX: usize = 9;
 const PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX: usize = 10;
@@ -119,6 +121,7 @@ const PROFILE_EDIT_ONE_TIME_START_INDEX: usize = 31;
 const PROFILE_EDIT_ONE_TIME_END_INDEX: usize = 32;
 const PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX: usize = 33;
 const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 34;
+const PROFILE_EDIT_THEME_PRESET_INDEX: usize = 35;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
@@ -257,6 +260,7 @@ struct ProfileEditSnapshot {
     weekly_goal: WeeklyGoalConfig,
     monthly_goal: MonthlyGoalConfig,
     goal_carry_over: GoalCarryOverConfig,
+    selected_theme_preset: ThemePreset,
     wakatime_metadata: WakatimeMetadataConfig,
 }
 
@@ -522,6 +526,7 @@ pub struct App {
     pub phase_notification: Option<String>,
     pub wakatime: WakatimeTracker,
     pub selected_profile: ProfileId,
+    selected_theme_preset: ThemePreset,
     profile_automation: ProfileAutomationSettingsConfig,
     pub custom_profile: CustomProfileConfig,
     pub profile_selection_index: usize,
@@ -574,6 +579,7 @@ impl App {
     fn from_config(config: AppConfig) -> Self {
         let config = config.normalized();
         let selected_profile = config.selected_profile;
+        let selected_theme_preset = config.selected_theme_preset;
         let custom_profile = config.effective_custom_profile();
         let profile_automation = config.profile_automation.clone().unwrap_or_default();
         let selected_automation = config.profile_automation_for(selected_profile);
@@ -663,6 +669,7 @@ impl App {
                 language: wakatime_metadata.language.clone(),
             }),
             selected_profile,
+            selected_theme_preset,
             profile_automation,
             custom_profile,
             profile_selection_index: profile_index(selected_profile),
@@ -739,6 +746,10 @@ impl App {
 
     pub fn selected_profile_name(&self) -> &'static str {
         self.selected_profile.label()
+    }
+
+    pub fn selected_theme_preset(&self) -> ThemePreset {
+        self.selected_theme_preset
     }
 
     pub fn current_task_label(&self) -> Option<&str> {
@@ -978,6 +989,7 @@ impl App {
             PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX => {
                 bool_label(self.goal_carry_over.monthly).to_string()
             }
+            PROFILE_EDIT_THEME_PRESET_INDEX => self.selected_theme_preset.label().to_string(),
             PROFILE_EDIT_WAKATIME_PROJECT_INDEX => self.wakatime_metadata.project.clone(),
             PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX => self.wakatime_metadata.language.clone(),
             _ => String::new(),

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -188,6 +188,7 @@ impl App {
             custom_profile: Some(custom_profile),
             break_templates: self.break_templates.clone(),
             selected_break_template: self.selected_break_template_for_persistence(),
+            selected_theme_preset: self.selected_theme_preset,
             notifications: self.notification_settings,
             auto_start: self.auto_start,
             recurring_schedule: self.recurring_schedule.clone(),

--- a/src/app/profile_management.rs
+++ b/src/app/profile_management.rs
@@ -10,13 +10,14 @@ use crate::app::{
     PROFILE_EDIT_SCHEDULE_DAY_INDEX, PROFILE_EDIT_SCHEDULE_END_INDEX,
     PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX,
     PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX, PROFILE_EDIT_SCHEDULE_START_INDEX,
-    PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX,
-    PROFILE_EDIT_WAKATIME_PROJECT_INDEX, PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX,
-    PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX, PROFILE_IDS,
-    ProfileAutomationConfig, ProfileEditSnapshot, ProfileId, ShortcutAction, TimerState,
-    WakatimeHeartbeatMetadata, adjust_daily_goal_minutes, adjust_daily_goal_pomodoros,
-    adjust_duration_minutes, compile_exception_dates, compile_one_time_windows, compile_windows,
-    profile_for_index, profile_index, profile_spec_for,
+    PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, PROFILE_EDIT_THEME_PRESET_INDEX,
+    PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX, PROFILE_EDIT_WAKATIME_PROJECT_INDEX,
+    PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX, PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX,
+    PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX, PROFILE_IDS, ProfileAutomationConfig,
+    ProfileEditSnapshot, ProfileId, ShortcutAction, TimerState, WakatimeHeartbeatMetadata,
+    adjust_daily_goal_minutes, adjust_daily_goal_pomodoros, adjust_duration_minutes,
+    compile_exception_dates, compile_one_time_windows, compile_windows, profile_for_index,
+    profile_index, profile_spec_for,
 };
 
 const PROFILE_MANAGER_SHORTCUT_ACTIONS: [ShortcutAction; 4] = [
@@ -222,6 +223,7 @@ impl App {
             weekly_goal: self.weekly_goal,
             monthly_goal: self.monthly_goal,
             goal_carry_over: self.goal_carry_over,
+            selected_theme_preset: self.selected_theme_preset,
             wakatime_metadata: self.wakatime_metadata.clone(),
         });
         self.profile_edit_active = true;
@@ -244,6 +246,7 @@ impl App {
             self.weekly_goal = snapshot.weekly_goal;
             self.monthly_goal = snapshot.monthly_goal;
             self.goal_carry_over = snapshot.goal_carry_over;
+            self.selected_theme_preset = snapshot.selected_theme_preset;
             self.wakatime_metadata = snapshot.wakatime_metadata;
             self.sync_wakatime_metadata_to_tracker();
             self.rebuild_notifier();
@@ -391,6 +394,13 @@ impl App {
             }
             PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX => {
                 self.goal_carry_over.monthly = increase;
+            }
+            PROFILE_EDIT_THEME_PRESET_INDEX => {
+                self.selected_theme_preset = if increase {
+                    self.selected_theme_preset.next()
+                } else {
+                    self.selected_theme_preset.previous()
+                };
             }
             PROFILE_EDIT_SCHEDULE_WINDOW_INDEX => {
                 self.cycle_schedule_window(increase);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -122,6 +122,7 @@ fn selected_builtin_profile_is_applied_on_startup() {
         weekly_goal: WeeklyGoalConfig::default(),
         monthly_goal: MonthlyGoalConfig::default(),
         goal_carry_over: GoalCarryOverConfig::default(),
+        selected_theme_preset: ThemePreset::Classic,
         wakatime: WakatimeMetadataConfig::default(),
         shortcuts: ShortcutConfig::default(),
     };
@@ -3326,6 +3327,7 @@ fn strict_mode_blocks_custom_profile_commit_during_active_focus() {
         weekly_goal: app.weekly_goal,
         monthly_goal: app.monthly_goal,
         goal_carry_over: app.goal_carry_over,
+        selected_theme_preset: app.selected_theme_preset,
         wakatime_metadata: app.wakatime_metadata.clone(),
     });
     let original_profile_automation = app
@@ -3379,6 +3381,7 @@ fn enabling_strict_mode_saves_during_active_focus_for_custom_profile_without_res
         weekly_goal: app.weekly_goal,
         monthly_goal: app.monthly_goal,
         goal_carry_over: app.goal_carry_over,
+        selected_theme_preset: app.selected_theme_preset,
         wakatime_metadata: app.wakatime_metadata.clone(),
     });
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ use crate::blocker::{BlockingPreviewAction, EditSiteResult, InvalidSiteInput, Si
 use crate::config::{
     AppConfig, BlocklistProfileConfig, BreakTemplateConfig, CustomProfileConfig, DailyGoalConfig,
     MonthlyGoalConfig, OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig,
-    RecurringScheduleConfig, WeeklyGoalConfig,
+    RecurringScheduleConfig, ThemePreset, WeeklyGoalConfig,
 };
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
@@ -49,19 +49,20 @@ use output::{
     print_goal_command_output, print_json, print_json_compact, print_profile_output,
     print_schedule_command_output, print_site_add_command_output, print_site_delete_command_output,
     print_site_edit_command_output, print_site_list_command_output, print_status_output,
-    print_strict_command_output, print_task_goal_command_output, print_timer_state_output,
+    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
+    print_timer_state_output,
 };
 use parsing::{
     finalize_cli_action, invalid_usage, parse_global_tokens, parse_goal_carry_value,
     parse_goal_value, parse_monthly_goal_value, parse_primary_command, parse_profile_id,
     parse_schedule_value, parse_site_edit_value, parse_strict_value, parse_task_goal_value,
-    parse_watch_interval_option, parse_watch_interval_secs, parse_weekly_goal_value,
-    require_nonempty_key_value,
+    parse_theme_preset, parse_watch_interval_option, parse_watch_interval_secs,
+    parse_weekly_goal_value, require_nonempty_key_value,
 };
 use status::{
-    available_break_template_views, build_status_output, build_task_goal_output,
-    mirror_metadata_from_task_label, profile_id, profile_view, selected_break_template_view,
-    timer_phase_id, timer_status_id,
+    available_break_template_views, available_theme_preset_views, build_status_output,
+    build_task_goal_output, mirror_metadata_from_task_label, profile_id, profile_view,
+    selected_break_template_view, theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 const USAGE_TEXT: &str = r#"Usage:
@@ -75,6 +76,7 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --task-goal [LABEL|LABEL:MINUTES,POMODOROS] [--json]
   focustime --task-goal=LABEL[:MINUTES,POMODOROS] [--json]
   focustime --profile [classic|deep-work|custom] [--json]
+  focustime --theme [classic|high-contrast|deuteranopia-friendly] [--json]
   focustime --goal [--json]
   focustime --goal=MINUTES,POMODOROS [--json]
   focustime --goal-weekly [--json]
@@ -117,6 +119,7 @@ Options:
   --task          Select task label (auto-creates unknown labels)
   --task-goal     Show or set per-task cumulative goal targets
   --profile       Show current profile, or set it when value is provided
+  --theme         Show current theme preset, or set it when value is provided
   --goal          Show current daily goal, or set minutes/pomodoros targets
   --goal-weekly   Show current weekly goal, or set minutes/pomodoros targets
   --goal-monthly  Show current monthly goal, or set minutes/pomodoros targets
@@ -208,6 +211,9 @@ pub enum CommandKind {
     Profile {
         profile: Option<ProfileId>,
     },
+    Theme {
+        preset: Option<ThemePreset>,
+    },
     Goal {
         goal: Option<DailyGoalConfig>,
     },
@@ -275,6 +281,7 @@ enum PrimaryCommand {
         goal: Option<DailyGoalConfig>,
     },
     Profile(Option<ProfileId>),
+    Theme(Option<ThemePreset>),
     Goal(Option<DailyGoalConfig>),
     GoalWeekly(Option<WeeklyGoalConfig>),
     GoalMonthly(Option<MonthlyGoalConfig>),
@@ -319,6 +326,7 @@ enum ParsedToken {
     Status,
     Watch(Option<u64>),
     Profile(Option<ProfileId>),
+    Theme(Option<ThemePreset>),
     Goal(Option<DailyGoalConfig>),
     GoalWeekly(Option<WeeklyGoalConfig>),
     GoalMonthly(Option<MonthlyGoalConfig>),
@@ -415,12 +423,20 @@ struct BreakTemplateView {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ThemePresetView {
+    id: &'static str,
+    label: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct ProfileOutput {
     updated: bool,
     selected: ProfileView,
     available: Vec<ProfileView>,
     selected_break_template: BreakTemplateView,
     available_break_templates: Vec<BreakTemplateView>,
+    selected_theme_preset: ThemePresetView,
+    available_theme_presets: Vec<ThemePresetView>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -485,6 +501,7 @@ struct StatusOutput {
     selected_profile: ProfileView,
     selected_break_template: BreakTemplateView,
     available_break_templates: Vec<BreakTemplateView>,
+    selected_theme_preset: ThemePresetView,
     selected_task_label: Option<String>,
     focus_intention: Option<String>,
     task_note: Option<String>,
@@ -565,6 +582,13 @@ struct GoalCarryCommandOutput {
 struct StrictCommandOutput {
     updated: bool,
     strict_mode: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ThemeCommandOutput {
+    updated: bool,
+    selected_theme_preset: ThemePresetView,
+    available_theme_presets: Vec<ThemePresetView>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,7 +2,8 @@ use crate::cli::{
     KeyValueParser, OsString, OutputMode, ParsedToken, PathBuf, ValueArgParser, invalid_usage,
     parse_goal_carry_value, parse_goal_value, parse_monthly_goal_value, parse_profile_id,
     parse_schedule_value, parse_site_edit_value, parse_strict_value, parse_task_goal_value,
-    parse_watch_interval_secs, parse_weekly_goal_value, require_nonempty_key_value,
+    parse_theme_preset, parse_watch_interval_secs, parse_weekly_goal_value,
+    require_nonempty_key_value,
 };
 
 pub(super) fn infer_output_mode_from_os_args(args: &[OsString]) -> OutputMode {
@@ -54,10 +55,11 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 22] = [
+    let parsers: [(&str, ValueArgParser); 23] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
         ("--profile", classify_profile_arg),
+        ("--theme", classify_theme_arg),
         ("--goal", classify_goal_arg),
         ("--goal-weekly", classify_goal_weekly_arg),
         ("--goal-monthly", classify_goal_monthly_arg),
@@ -166,6 +168,16 @@ fn classify_profile_arg(args: &[String], index: usize) -> Result<(ParsedToken, u
         return Ok((ParsedToken::Profile(Some(selected)), 2));
     }
     Ok((ParsedToken::Profile(None), 1))
+}
+
+fn classify_theme_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let selected = parse_theme_preset(next)?;
+        return Ok((ParsedToken::Theme(Some(selected)), 2));
+    }
+    Ok((ParsedToken::Theme(None), 1))
 }
 
 fn classify_export_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
@@ -442,10 +454,11 @@ fn classify_schedule_set_arg(
 }
 
 pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 22] = [
+    let parsers: [KeyValueParser; 23] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
         parse_profile_key_value_arg,
+        parse_theme_key_value_arg,
         parse_goal_key_value_arg,
         parse_goal_weekly_key_value_arg,
         parse_goal_monthly_key_value_arg,
@@ -503,6 +516,14 @@ fn parse_profile_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String>
     if let Some(value) = arg.strip_prefix("--profile=") {
         let value = require_nonempty_key_value(value, "`--profile=` requires a profile value.")?;
         return Ok(Some(ParsedToken::Profile(Some(parse_profile_id(value)?))));
+    }
+    Ok(None)
+}
+
+fn parse_theme_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--theme=") {
+        let value = require_nonempty_key_value(value, "`--theme=` requires a theme value.")?;
+        return Ok(Some(ParsedToken::Theme(Some(parse_theme_preset(value)?))));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -11,18 +11,20 @@ use crate::cli::{
     RecurringScheduleConfig, ScheduleCommandOutput, SiteAddCommandOutput, SiteBlocker,
     SiteDeleteCommandOutput, SiteEditCommandOutput, SiteEditValue, SiteListCommandOutput,
     SiteListTarget, StatusOutput, StrictCommandOutput, TaskCommandOutput, TaskGoalCommandOutput,
-    TaskGoalOutput, TimerCommandOutput, TimerStateOutput, WeeklyGoalConfig,
-    available_break_template_views, build_blocking_preview_command_output,
-    build_diagnostics_command_output, build_schedule_inspection_output, build_status_output,
-    build_task_goal_output, display_input_value, effective_blocked_sites_for_profile, flush_stdout,
+    TaskGoalOutput, ThemeCommandOutput, ThemePreset, TimerCommandOutput, TimerStateOutput,
+    WeeklyGoalConfig, available_break_template_views, available_theme_preset_views,
+    build_blocking_preview_command_output, build_diagnostics_command_output,
+    build_schedule_inspection_output, build_status_output, build_task_goal_output,
+    display_input_value, effective_blocked_sites_for_profile, flush_stdout,
     mirror_metadata_from_task_label, print_blocking_preview_command_output,
     print_blocklist_profile_command_output, print_diagnostics_command_output, print_export_output,
     print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
     print_profile_output, print_schedule_command_output, print_site_add_command_output,
     print_site_delete_command_output, print_site_edit_command_output,
     print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_timer_state_output, profile_id, profile_view,
-    selected_break_template_view, timer_phase_id, timer_status_id,
+    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
+    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
+    timer_status_id,
 };
 
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
@@ -36,6 +38,7 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
             execute_task_goal_command(label, goal, cli_command.output)
         }
         CommandKind::Profile { profile } => execute_profile_command(profile, cli_command.output),
+        CommandKind::Theme { preset } => execute_theme_command(preset, cli_command.output),
         CommandKind::Goal { goal } => execute_goal_command(goal, cli_command.output),
         CommandKind::GoalWeekly { goal } => execute_weekly_goal_command(goal, cli_command.output),
         CommandKind::GoalMonthly { goal } => execute_monthly_goal_command(goal, cli_command.output),
@@ -639,16 +642,44 @@ fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Re
         .collect();
     let selected_break_template = selected_break_template_view(&config);
     let available_break_templates = available_break_template_views(&config);
+    let selected_theme_preset = theme_preset_view(config.selected_theme_preset);
+    let available_theme_presets = available_theme_preset_views();
     let payload = ProfileOutput {
         updated,
         selected,
         available,
         selected_break_template,
         available_break_templates,
+        selected_theme_preset,
+        available_theme_presets,
     };
 
     match output {
         OutputMode::Text => print_profile_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_theme_command(preset: Option<ThemePreset>, output: OutputMode) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let mut updated = false;
+    if let Some(preset) = preset {
+        config.selected_theme_preset = preset;
+        config
+            .save()
+            .map_err(|error| format!("Failed to save theme preset: {error}"))?;
+        updated = true;
+    }
+
+    let payload = ThemeCommandOutput {
+        updated,
+        selected_theme_preset: theme_preset_view(config.selected_theme_preset),
+        available_theme_presets: available_theme_preset_views(),
+    };
+
+    match output {
+        OutputMode::Text => print_theme_command_output(&payload),
         OutputMode::Json => print_json(&payload)?,
     }
     Ok(())

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -7,8 +7,8 @@ use crate::cli::{
     ScheduleCommandOutput, ScheduleInspectionOutput, Serialize, SetupCheck, SetupCheckLevel,
     SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput,
     SiteEditCommandOutput, SiteListCommandOutput, StatusOutput, StrictCommandOutput,
-    TaskGoalCommandOutput, TaskGoalOutput, TimerStateOutput, Write, format_schedule_conflict,
-    inspect_schedule_conflicts_from_config, io,
+    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, TimerStateOutput, Write,
+    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -33,6 +33,10 @@ pub(super) fn print_profile_output(payload: &ProfileOutput) {
         format_duration(payload.selected_break_template.long_break_secs),
         payload.selected_break_template.long_break_interval
     );
+    println!(
+        "Selected theme preset: {} ({})",
+        payload.selected_theme_preset.label, payload.selected_theme_preset.id
+    );
     println!("Available break templates:");
     for template in &payload.available_break_templates {
         println!(
@@ -54,6 +58,24 @@ pub(super) fn print_profile_output(payload: &ProfileOutput) {
             format_duration(profile.long_break_secs),
             profile.long_break_interval
         );
+    }
+    println!("Available theme presets:");
+    for preset in &payload.available_theme_presets {
+        println!("  - {} ({})", preset.label, preset.id);
+    }
+}
+
+pub(super) fn print_theme_command_output(payload: &ThemeCommandOutput) {
+    if payload.updated {
+        println!("Theme preset updated.");
+    }
+    println!(
+        "Selected theme preset: {} ({})",
+        payload.selected_theme_preset.label, payload.selected_theme_preset.id
+    );
+    println!("Available theme presets:");
+    for preset in &payload.available_theme_presets {
+        println!("  - {} ({})", preset.label, preset.id);
     }
 }
 
@@ -195,6 +217,10 @@ pub(super) fn print_status_output(payload: &StatusOutput) {
         format_duration(payload.selected_break_template.short_break_secs),
         format_duration(payload.selected_break_template.long_break_secs),
         payload.selected_break_template.long_break_interval
+    );
+    println!(
+        "Selected theme preset: {} ({})",
+        payload.selected_theme_preset.label, payload.selected_theme_preset.id
     );
     println!(
         "Task label: {}",

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -2,8 +2,8 @@ use crate::cli::{
     BlocklistProfileCommandKind, BlocklistSiteCommandKind, CliAction, CliCommand, CommandKind,
     DEFAULT_WATCH_INTERVAL_SECS, DailyGoalConfig, MonthlyGoalConfig, NaiveDate,
     OneTimeFocusWindowConfig, OutputMode, ParsedToken, PrimaryCommand, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, SiteEditValue, SiteListTarget, USAGE_TEXT,
-    WeeklyGoalConfig,
+    RecurringFocusWindowConfig, RecurringScheduleConfig, SiteEditValue, SiteListTarget,
+    ThemePreset, USAGE_TEXT, WeeklyGoalConfig,
 };
 
 pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), String> {
@@ -37,6 +37,7 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::Status
             | ParsedToken::Watch(_)
             | ParsedToken::Profile(_)
+            | ParsedToken::Theme(_)
             | ParsedToken::Goal(_)
             | ParsedToken::GoalWeekly(_)
             | ParsedToken::GoalMonthly(_)
@@ -91,6 +92,9 @@ pub(super) fn parse_primary_command(
             ParsedToken::Watch(_) => {}
             ParsedToken::Profile(profile) => {
                 set_primary_command(&mut primary, PrimaryCommand::Profile(*profile))?
+            }
+            ParsedToken::Theme(preset) => {
+                set_primary_command(&mut primary, PrimaryCommand::Theme(*preset))?
             }
             ParsedToken::Goal(goal) => {
                 set_primary_command(&mut primary, PrimaryCommand::Goal(*goal))?
@@ -215,6 +219,10 @@ pub(super) fn finalize_cli_action(
         }
         Some(PrimaryCommand::Profile(profile)) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Profile { profile },
+            output,
+        })),
+        Some(PrimaryCommand::Theme(preset)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Theme { preset },
             output,
         })),
         Some(PrimaryCommand::Goal(goal)) => Ok(CliAction::RunCommand(CliCommand {
@@ -391,6 +399,22 @@ pub(super) fn parse_profile_id(value: &str) -> Result<ProfileId, String> {
         "custom" => Ok(ProfileId::Custom),
         _ => Err(invalid_usage(&format!(
             "Invalid profile `{value}`. Use `classic`, `deep-work`, or `custom`."
+        ))),
+    }
+}
+
+pub(super) fn parse_theme_preset(value: &str) -> Result<ThemePreset, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "classic" => Ok(ThemePreset::Classic),
+        "high-contrast" | "high_contrast" | "highcontrast" => Ok(ThemePreset::HighContrast),
+        "deuteranopia-friendly"
+        | "deuteranopia_friendly"
+        | "deuteranopiafriendly"
+        | "colorblind-friendly"
+        | "colorblind_friendly"
+        | "colorblindfriendly" => Ok(ThemePreset::DeuteranopiaFriendly),
+        _ => Err(invalid_usage(&format!(
+            "Invalid theme preset `{value}`. Use `classic`, `high-contrast`, or `deuteranopia-friendly`."
         ))),
     }
 }
@@ -656,6 +680,7 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Task(_) => "--task",
         PrimaryCommand::TaskGoal { .. } => "--task-goal",
         PrimaryCommand::Profile(_) => "--profile",
+        PrimaryCommand::Theme(_) => "--theme",
         PrimaryCommand::Goal(_) => "--goal",
         PrimaryCommand::GoalWeekly(_) => "--goal-weekly",
         PrimaryCommand::GoalMonthly(_) => "--goal-monthly",

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -3,8 +3,8 @@ use crate::cli::{
     DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS, DEFAULT_SHORT_BREAK_SECS,
     DailyGoalSnapshot, Datelike, FocusScoreOutput, FocusStats, GoalOutput, LiveStatusOutput,
     NaiveDate, ProfileId, ProfileSpec, ProfileView, SessionOutput, StatusOutput, TaskGoalOutput,
-    TimerPhase, TimerStatus, TodayOutput, carry_over_goal_target, current_day_key,
-    effective_blocked_sites_for_profile, session_recovery,
+    ThemePreset, ThemePresetView, TimerPhase, TimerStatus, TodayOutput, carry_over_goal_target,
+    current_day_key, effective_blocked_sites_for_profile, session_recovery,
 };
 
 pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
@@ -57,6 +57,7 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
         selected_profile: profile_view(config.selected_profile, &config.effective_custom_profile()),
         selected_break_template: selected_break_template_view(config),
         available_break_templates: available_break_template_views(config),
+        selected_theme_preset: theme_preset_view(config.selected_theme_preset),
         selected_task_label,
         focus_intention,
         task_note,
@@ -460,6 +461,24 @@ pub(super) fn available_break_template_views(config: &AppConfig) -> Vec<BreakTem
         .iter()
         .map(break_template_view)
         .collect()
+}
+
+pub(super) fn theme_preset_view(preset: ThemePreset) -> ThemePresetView {
+    ThemePresetView {
+        id: preset.id(),
+        label: preset.label(),
+    }
+}
+
+pub(super) fn available_theme_preset_views() -> Vec<ThemePresetView> {
+    [
+        ThemePreset::Classic,
+        ThemePreset::HighContrast,
+        ThemePreset::DeuteranopiaFriendly,
+    ]
+    .into_iter()
+    .map(theme_preset_view)
+    .collect()
 }
 
 pub(super) fn timer_phase_id(phase: TimerPhase) -> &'static str {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -248,6 +248,46 @@ fn parse_profile_with_equals_sets_profile() {
 }
 
 #[test]
+fn parse_theme_without_value_reads_current_theme() {
+    let parsed = parse(&["--theme"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Theme { preset: None },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_theme_with_value_sets_theme() {
+    let parsed = parse(&["--theme", "high-contrast"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Theme {
+                preset: Some(ThemePreset::HighContrast)
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_theme_with_equals_sets_theme() {
+    let parsed = parse(&["--theme=deuteranopia-friendly"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Theme {
+                preset: Some(ThemePreset::DeuteranopiaFriendly)
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
 fn parse_goal_without_value_reads_current_goal() {
     let parsed = parse(&["--goal"]).unwrap();
     assert_eq!(
@@ -681,6 +721,15 @@ fn classify_key_value_arg_accepts_profile_equals_value() {
 }
 
 #[test]
+fn classify_key_value_arg_accepts_theme_equals_value() {
+    let parsed = classify_key_value_arg("--theme=high_contrast").unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::Theme(Some(ThemePreset::HighContrast)))
+    );
+}
+
+#[test]
 fn classify_key_value_arg_accepts_task_equals_value() {
     let parsed = classify_key_value_arg("--task=Docs").unwrap();
     assert_eq!(parsed, Some(ParsedToken::Task("Docs".to_string())));
@@ -723,6 +772,12 @@ fn classify_key_value_arg_rejects_empty_task_equals_value() {
 fn classify_key_value_arg_rejects_empty_profile_equals_value() {
     let error = classify_key_value_arg("--profile=").unwrap_err();
     assert!(error.contains("`--profile=` requires a profile value."));
+}
+
+#[test]
+fn classify_key_value_arg_rejects_empty_theme_equals_value() {
+    let error = classify_key_value_arg("--theme=").unwrap_err();
+    assert!(error.contains("`--theme=` requires a theme value."));
 }
 
 #[test]
@@ -900,6 +955,12 @@ fn parse_rejects_task_goal_with_blank_label() {
 fn parse_rejects_task_goal_with_non_numeric_pomodoros_suffix() {
     let error = parse(&["--task-goal=Docs:120,abc"]).unwrap_err();
     assert!(error.contains("Invalid goal pomodoros"));
+}
+
+#[test]
+fn parse_rejects_theme_with_unknown_value() {
+    let error = parse(&["--theme=solarized"]).unwrap_err();
+    assert!(error.contains("Invalid theme preset"));
 }
 
 #[test]
@@ -1354,6 +1415,20 @@ fn build_status_output_trims_selected_break_template_name() {
     let output = build_status_output(&config, &stats);
 
     assert_eq!(output.selected_break_template.name, "Deep Work");
+}
+
+#[test]
+fn build_status_output_includes_selected_theme_preset() {
+    let config = AppConfig {
+        selected_theme_preset: ThemePreset::DeuteranopiaFriendly,
+        ..AppConfig::default()
+    };
+    let stats = FocusStats::default();
+
+    let output = build_status_output(&config, &stats);
+
+    assert_eq!(output.selected_theme_preset.id, "deuteranopia-friendly");
+    assert_eq!(output.selected_theme_preset.label, "Deuteranopia Friendly");
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,9 @@ pub struct AppConfig {
     /// Name of the active break template.
     #[serde(default)]
     pub selected_break_template: String,
+    /// Selected UI theme preset.
+    #[serde(default)]
+    pub selected_theme_preset: ThemePreset,
     /// Notification preferences for phase transitions.
     #[serde(default)]
     pub notifications: NotificationConfig,
@@ -953,6 +956,73 @@ impl<'de> Deserialize<'de> for ProfileId {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ThemePreset {
+    #[default]
+    Classic,
+    HighContrast,
+    DeuteranopiaFriendly,
+}
+
+impl ThemePreset {
+    fn from_config_value(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "classic" => Self::Classic,
+            "high-contrast" | "high_contrast" | "highcontrast" => Self::HighContrast,
+            "deuteranopia-friendly"
+            | "deuteranopia_friendly"
+            | "deuteranopiafriendly"
+            | "colorblind-friendly"
+            | "colorblind_friendly"
+            | "colorblindfriendly" => Self::DeuteranopiaFriendly,
+            _ => Self::Classic,
+        }
+    }
+
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Classic => "classic",
+            Self::HighContrast => "high-contrast",
+            Self::DeuteranopiaFriendly => "deuteranopia-friendly",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Classic => "Classic",
+            Self::HighContrast => "High Contrast",
+            Self::DeuteranopiaFriendly => "Deuteranopia Friendly",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Classic => Self::HighContrast,
+            Self::HighContrast => Self::DeuteranopiaFriendly,
+            Self::DeuteranopiaFriendly => Self::Classic,
+        }
+    }
+
+    pub fn previous(self) -> Self {
+        match self {
+            Self::Classic => Self::DeuteranopiaFriendly,
+            Self::HighContrast => Self::Classic,
+            Self::DeuteranopiaFriendly => Self::HighContrast,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ThemePreset {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::from_config_value(&value))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CustomProfileConfig {
     #[serde(default = "default_focus_secs")]
@@ -1066,6 +1136,7 @@ impl Default for AppConfig {
             custom_profile: None,
             break_templates: default_break_templates(),
             selected_break_template: default_break_template_name(),
+            selected_theme_preset: ThemePreset::default(),
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             recurring_schedule: RecurringScheduleConfig::default(),

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -17,6 +17,7 @@ fn default_values_are_canonical_pomodoro() {
     assert_eq!(cfg.selected_profile, ProfileId::Custom);
     assert!(cfg.custom_profile.is_none());
     assert_eq!(cfg.selected_break_template, "Classic");
+    assert_eq!(cfg.selected_theme_preset, ThemePreset::Classic);
     assert_eq!(cfg.break_templates.len(), 2);
     assert!(cfg.blocked_sites.is_empty());
     assert_eq!(cfg.selected_blocklist_profile, "Default");
@@ -81,6 +82,7 @@ fn round_trip_full_config() {
             },
         ],
         selected_break_template: "Recovery".to_string(),
+        selected_theme_preset: ThemePreset::HighContrast,
         notifications: NotificationConfig {
             enabled: true,
             sound: true,
@@ -197,6 +199,7 @@ fn round_trip_full_config() {
         parsed.selected_break_template,
         original.selected_break_template
     );
+    assert_eq!(parsed.selected_theme_preset, original.selected_theme_preset);
     assert_eq!(parsed.notifications, original.notifications);
     assert_eq!(parsed.auto_start, original.auto_start);
     assert_eq!(parsed.recurring_schedule, original.recurring_schedule);
@@ -225,6 +228,7 @@ fn missing_fields_fall_back_to_defaults() {
     assert_eq!(cfg.selected_profile, ProfileId::Custom);
     assert!(cfg.custom_profile.is_none());
     assert_eq!(cfg.selected_break_template, "");
+    assert_eq!(cfg.selected_theme_preset, ThemePreset::Classic);
     assert_eq!(cfg.break_templates.len(), 2);
     assert!(cfg.blocked_sites.is_empty());
     assert!(cfg.blocklist_profiles.is_empty());
@@ -381,6 +385,20 @@ fn normalize_selected_break_template_clears_unknown_when_no_template_matches_cus
     .normalize();
 
     assert_eq!(cfg.selected_break_template, "");
+}
+
+#[test]
+fn theme_preset_deserializes_aliases_and_falls_back_to_classic() {
+    let alias_cfg: AppConfig = toml::from_str("selected_theme_preset = \"colorblind-friendly\"")
+        .expect("theme alias should parse");
+    assert_eq!(
+        alias_cfg.selected_theme_preset,
+        ThemePreset::DeuteranopiaFriendly
+    );
+
+    let unknown_cfg: AppConfig =
+        toml::from_str("selected_theme_preset = \"unknown\"").expect("config should parse");
+    assert_eq!(unknown_cfg.selected_theme_preset, ThemePreset::Classic);
 }
 
 #[test]
@@ -606,6 +624,7 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
         }),
         break_templates: default_break_templates(),
         selected_break_template: default_break_template_name(),
+        selected_theme_preset: ThemePreset::Classic,
         notifications: NotificationConfig::default(),
         auto_start: AutoStartConfig::default(),
         recurring_schedule: RecurringScheduleConfig::default(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,6 +13,7 @@ use crate::app::{
     SetupCheckLevel, ShortcutAction, SiteFeedbackLevel, SiteInputMode, SiteListMode,
 };
 use crate::blocker::BlockingPreviewAction;
+use crate::config::ThemePreset;
 use crate::timer::{TimerPhase, TimerStatus};
 use crate::wakatime::WakatimeRuntimeState;
 
@@ -47,12 +48,14 @@ const PROFILE_EDIT_GROUP_GOALS: [usize; 9] = [9, 10, 11, 12, 13, 14, 15, 16, 17]
 const PROFILE_EDIT_GROUP_WAKATIME: [usize; 2] = [18, 19];
 const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 15] =
     [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34];
-const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 5] = [
+const PROFILE_EDIT_GROUP_APPEARANCE: [usize; 1] = [35];
+const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 6] = [
     ("Timer", &PROFILE_EDIT_GROUP_TIMER),
     ("Automation", &PROFILE_EDIT_GROUP_AUTOMATION),
     ("Goals", &PROFILE_EDIT_GROUP_GOALS),
     ("WakaTime", &PROFILE_EDIT_GROUP_WAKATIME),
     ("Schedule", &PROFILE_EDIT_GROUP_SCHEDULE),
+    ("Appearance", &PROFILE_EDIT_GROUP_APPEARANCE),
 ];
 
 pub fn render(frame: &mut Frame, app: &App) {
@@ -66,11 +69,11 @@ pub fn render(frame: &mut Frame, app: &App) {
     }
 }
 
-fn render_hint_lines(frame: &mut Frame, area: Rect, lines: Vec<Line<'static>>) {
+fn render_hint_lines(frame: &mut Frame, app: &App, area: Rect, lines: Vec<Line<'static>>) {
     frame.render_widget(
         Paragraph::new(lines)
             .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::DarkGray))
+            .style(Style::default().fg(app_color(app, Color::DarkGray)))
             .wrap(Wrap { trim: true }),
         area,
     );
@@ -131,11 +134,40 @@ fn format_timer_goal_streak_line(app: &App) -> String {
     }
 }
 
-fn render_centered_error(frame: &mut Frame, area: Rect, message: String) {
+fn render_centered_error(frame: &mut Frame, app: &App, area: Rect, message: String) {
     let err_widget = Paragraph::new(message)
         .alignment(Alignment::Center)
-        .style(Style::default().fg(Color::Red));
+        .style(Style::default().fg(app_color(app, Color::Red)));
     frame.render_widget(err_widget, area);
+}
+
+pub(super) fn app_color(app: &App, color: Color) -> Color {
+    themed_color(color, Some(app.selected_theme_preset()))
+}
+
+fn themed_color(color: Color, preset: Option<ThemePreset>) -> Color {
+    let preset = preset.unwrap_or(ThemePreset::Classic);
+    match preset {
+        ThemePreset::Classic => color,
+        ThemePreset::HighContrast => match color {
+            Color::DarkGray | Color::Gray => Color::White,
+            Color::Yellow => Color::LightYellow,
+            Color::Cyan => Color::LightCyan,
+            Color::Green => Color::LightGreen,
+            Color::Red => Color::LightRed,
+            Color::Black => Color::White,
+            _ => color,
+        },
+        ThemePreset::DeuteranopiaFriendly => match color {
+            Color::Red => Color::Blue,
+            Color::LightRed => Color::LightBlue,
+            Color::Green => Color::Cyan,
+            Color::LightGreen => Color::LightCyan,
+            Color::Cyan => Color::Magenta,
+            Color::LightYellow => Color::Yellow,
+            _ => color,
+        },
+    }
 }
 
 /// Returns a centered rectangle of given percentage of the parent rect.

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -1,7 +1,7 @@
 use crate::ui::{
     Alignment, App, Block, Borders, Color, Constraint, Direction, Frame, HistoryFeedbackLevel,
     Layout, Line, List, ListItem, Modifier, Paragraph, Rect, ShortcutAction, Span, Style, Wrap,
-    centered_rect, format_duration_label, format_goal_period_progress,
+    app_color, centered_rect, format_duration_label, format_goal_period_progress,
     format_wakatime_heartbeat_timestamp, render_hint_lines,
 };
 
@@ -13,7 +13,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .title(" Focus History ")
         .title_alignment(Alignment::Center)
-        .style(Style::default().fg(Color::Cyan));
+        .style(Style::default().fg(app_color(app, Color::Cyan)));
     frame.render_widget(block, outer);
 
     let inner = Layout::default()
@@ -47,16 +47,25 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
                 today_stats.focused_minutes()
             ),
             Style::default()
-                .fg(Color::White)
+                .fg(app_color(app, Color::White))
                 .add_modifier(Modifier::BOLD),
         ),
-        Line::styled(focus_score_line, Style::default().fg(Color::DarkGray)),
-        Line::styled(goals_line, Style::default().fg(Color::DarkGray)),
+        Line::styled(
+            focus_score_line,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
+        Line::styled(
+            goals_line,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
         Line::styled(
             format!("Active days (7d): {recent_active_days}"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         ),
-        Line::styled(interruption_line, Style::default().fg(Color::DarkGray)),
+        Line::styled(
+            interruption_line,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
     ])
     .block(Block::default().borders(Borders::ALL).title(" Overview "))
     .wrap(Wrap { trim: true });
@@ -104,6 +113,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .collect();
     render_history_panel(
         frame,
+        app,
         left_sections[0],
         " Task Totals ",
         task_total_items,
@@ -124,6 +134,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .collect();
     render_history_panel(
         frame,
+        app,
         left_sections[1],
         " Task Trends (7d vs prev 7d) ",
         task_trend_items,
@@ -144,6 +155,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .collect();
     render_history_panel(
         frame,
+        app,
         right_sections[0],
         " Profile Effect ",
         profile_items,
@@ -166,6 +178,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .collect();
     render_history_panel(
         frame,
+        app,
         left_sections[2],
         " Break-glass Audit ",
         override_items,
@@ -186,6 +199,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .collect();
     render_history_panel(
         frame,
+        app,
         right_sections[1],
         " Monthly Trend ",
         monthly_items,
@@ -196,8 +210,8 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
 
     if let Some(feedback) = app.history_feedback.as_ref() {
         let (prefix, color) = match feedback.level {
-            HistoryFeedbackLevel::Success => ("✓", Color::Green),
-            HistoryFeedbackLevel::Warning => ("⚠", Color::Yellow),
+            HistoryFeedbackLevel::Success => ("✓", app_color(app, Color::Green)),
+            HistoryFeedbackLevel::Warning => ("⚠", app_color(app, Color::Yellow)),
         };
         let message = format!("{prefix}  {}", feedback.message);
         let feedback_widget = Paragraph::new(message)
@@ -208,13 +222,14 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
     } else if let Some(err) = app.stats_error.as_ref() {
         let error_widget = Paragraph::new(format!("⚠  {err}"))
             .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::Red))
+            .style(Style::default().fg(app_color(app, Color::Red)))
             .wrap(Wrap { trim: true });
         frame.render_widget(error_widget, inner[2]);
     }
 
     render_hint_lines(
         frame,
+        app,
         inner[3],
         vec![
             Line::from(format!(
@@ -263,6 +278,7 @@ pub(super) fn readable_focus_score_text(text: &str) -> String {
 
 fn render_history_panel(
     frame: &mut Frame,
+    app: &App,
     area: Rect,
     title: &'static str,
     items: Vec<ListItem>,
@@ -270,13 +286,13 @@ fn render_history_panel(
 ) {
     if items.is_empty() {
         let empty = Paragraph::new(empty_message)
-            .style(Style::default().fg(Color::DarkGray))
+            .style(Style::default().fg(app_color(app, Color::DarkGray)))
             .block(Block::default().borders(Borders::ALL).title(title));
         frame.render_widget(empty, area);
     } else {
         let list = List::new(items)
             .block(Block::default().borders(Borders::ALL).title(title))
-            .style(Style::default().fg(Color::Gray));
+            .style(Style::default().fg(app_color(app, Color::Gray)));
         frame.render_widget(list, area);
     }
 }
@@ -289,7 +305,7 @@ fn render_monthly_heatmap_panel(frame: &mut Frame, area: Rect, app: &App) {
     );
     let mut lines: Vec<Line> = vec![Line::styled(
         "  Mo Tu We Th Fr Sa Su",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(app_color(app, Color::DarkGray)),
     )];
 
     let mut weekday = heatmap.first_weekday_monday0 as usize;
@@ -299,7 +315,7 @@ fn render_monthly_heatmap_panel(frame: &mut Frame, area: Rect, app: &App) {
     }
     for day in heatmap.days {
         let (symbol, color) =
-            heatmap_cell_symbol(day.focused_minutes(), heatmap.max_focused_minutes);
+            heatmap_cell_symbol(app, day.focused_minutes(), heatmap.max_focused_minutes);
         week_spans.push(Span::styled(
             format!("{symbol}  "),
             Style::default().fg(color),
@@ -321,12 +337,12 @@ fn render_monthly_heatmap_panel(frame: &mut Frame, area: Rect, app: &App) {
 
     lines.push(Line::styled(
         "  None  .   Low  :  *  O  #  High",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(app_color(app, Color::DarkGray)),
     ));
 
     let widget = Paragraph::new(lines)
         .block(Block::default().borders(Borders::ALL).title(title))
-        .style(Style::default().fg(Color::Gray))
+        .style(Style::default().fg(app_color(app, Color::Gray)))
         .wrap(Wrap { trim: false });
     frame.render_widget(widget, area);
 }
@@ -405,19 +421,19 @@ pub(super) fn format_task_goal_progress_summary(
     }
 }
 
-fn heatmap_cell_symbol(focused_minutes: u64, max_focused_minutes: u64) -> (char, Color) {
+fn heatmap_cell_symbol(app: &App, focused_minutes: u64, max_focused_minutes: u64) -> (char, Color) {
     if focused_minutes == 0 || max_focused_minutes == 0 {
-        return ('.', Color::DarkGray);
+        return ('.', app_color(app, Color::DarkGray));
     }
 
     let scaled = (focused_minutes.saturating_mul(4))
         .saturating_add(max_focused_minutes.saturating_sub(1))
         / max_focused_minutes;
     match scaled.clamp(1, 4) {
-        1 => (':', Color::Green),
-        2 => ('*', Color::Yellow),
-        3 => ('O', Color::LightRed),
-        _ => ('#', Color::Red),
+        1 => (':', app_color(app, Color::Green)),
+        2 => ('*', app_color(app, Color::Yellow)),
+        3 => ('O', app_color(app, Color::LightRed)),
+        _ => ('#', app_color(app, Color::Red)),
     }
 }
 

--- a/src/ui/profile_manager.rs
+++ b/src/ui/profile_manager.rs
@@ -1,7 +1,7 @@
 use crate::ui::{
     Alignment, App, Block, Borders, Color, Constraint, Direction, Frame, Layout, Line, List,
     ListItem, ListState, Modifier, PROFILE_EDIT_GROUPS, PROFILE_IDS, Paragraph, ShortcutAction,
-    Span, Style, Wrap, centered_rect, render_centered_error, render_hint_lines,
+    Span, Style, Wrap, app_color, centered_rect, render_centered_error, render_hint_lines,
 };
 
 pub(super) fn render_profile_manager(frame: &mut Frame, app: &App) {
@@ -13,7 +13,7 @@ pub(super) fn render_profile_manager(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .title(" Pomodoro Profiles ")
         .title_alignment(Alignment::Center)
-        .style(Style::default().fg(Color::Cyan));
+        .style(Style::default().fg(app_color(app, Color::Cyan)));
     frame.render_widget(block, outer);
 
     let inner = Layout::default()
@@ -37,7 +37,7 @@ pub(super) fn render_profile_manager(frame: &mut Frame, app: &App) {
     ))
     .style(
         Style::default()
-            .fg(Color::White)
+            .fg(app_color(app, Color::White))
             .add_modifier(Modifier::BOLD),
     )
     .wrap(Wrap { trim: true });
@@ -49,8 +49,8 @@ pub(super) fn render_profile_manager(frame: &mut Frame, app: &App) {
         .block(Block::default().borders(Borders::ALL).title(" Profiles "))
         .highlight_style(
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::White)
+                .fg(app_color(app, Color::Black))
+                .bg(app_color(app, Color::White))
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▶ ");
@@ -71,10 +71,10 @@ pub(super) fn render_profile_manager(frame: &mut Frame, app: &App) {
     frame.render_widget(Paragraph::new(lines).block(editor_block), inner[2]);
 
     if let Some(err) = app.config_error.as_ref() {
-        render_centered_error(frame, inner[4], format!("⚠  {err}"));
+        render_centered_error(frame, app, inner[4], format!("⚠  {err}"));
     }
 
-    render_hint_lines(frame, inner[5], profile_manager_hints(app));
+    render_hint_lines(frame, app, inner[5], profile_manager_hints(app));
 }
 
 fn profile_list_items(app: &App) -> Vec<ListItem<'static>> {
@@ -105,9 +105,9 @@ fn profile_editor_block(app: &App) -> Block<'static> {
         .borders(Borders::ALL)
         .title(editor_title)
         .style(if app.profile_edit_active {
-            Style::default().fg(Color::Yellow)
+            Style::default().fg(app_color(app, Color::Yellow))
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(app_color(app, Color::DarkGray))
         })
 }
 
@@ -115,7 +115,7 @@ fn profile_editor_lines(app: &App) -> Vec<Line<'static>> {
     if !app.profile_edit_active {
         return vec![
             Line::from("Press [e] to edit the selected profile."),
-            Line::from("Sections: Timer · Automation · Goals · WakaTime · Schedule"),
+            Line::from("Sections: Timer · Automation · Goals · WakaTime · Schedule · Appearance"),
             Line::from("Editor is compact for smaller terminals."),
         ];
     }
@@ -141,13 +141,13 @@ fn profile_editor_lines(app: &App) -> Vec<Line<'static>> {
             fields.len()
         ),
         Style::default()
-            .fg(Color::Cyan)
+            .fg(app_color(app, Color::Cyan))
             .add_modifier(Modifier::BOLD),
     ));
     if start > 0 {
         lines.push(Line::styled(
             "… ↑ more fields",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         ));
     }
     for index in &fields[start..end] {
@@ -156,11 +156,11 @@ fn profile_editor_lines(app: &App) -> Vec<Line<'static>> {
         let mut line = Line::from(format!("{label:<18} {value}"));
         if *index == app.profile_edit_field {
             line = Line::from(vec![
-                Span::styled("> ", Style::default().fg(Color::Yellow)),
+                Span::styled("> ", Style::default().fg(app_color(app, Color::Yellow))),
                 Span::styled(
                     format!("{label:<18} {value}"),
                     Style::default()
-                        .fg(Color::Yellow)
+                        .fg(app_color(app, Color::Yellow))
                         .add_modifier(Modifier::BOLD),
                 ),
             ]);
@@ -170,7 +170,7 @@ fn profile_editor_lines(app: &App) -> Vec<Line<'static>> {
     if end < fields.len() {
         lines.push(Line::styled(
             "… ↓ more fields",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         ));
     }
     lines
@@ -179,7 +179,7 @@ fn profile_editor_lines(app: &App) -> Vec<Line<'static>> {
 fn profile_manager_hints(app: &App) -> Vec<Line<'static>> {
     if app.profile_edit_active {
         vec![
-            Line::from("Sections: Timer · Automation · Goals · WakaTime · Schedule"),
+            Line::from("Sections: Timer · Automation · Goals · WakaTime · Schedule · Appearance"),
             Line::from("Edit: [↑/↓] Field  [←/→] Change value  [Type/Backspace] WakaTime text"),
             Line::from(if app.strict_mode_enforced_for_focus() {
                 format!(
@@ -265,6 +265,7 @@ fn profile_edit_field_display_label(field_index: usize) -> &'static str {
         32 => "One-time end",
         33 => "One-time add/remove",
         34 => "Conflict inspector",
+        35 => "Theme preset",
         _ => "",
     }
 }

--- a/src/ui/session_planner.rs
+++ b/src/ui/session_planner.rs
@@ -1,7 +1,8 @@
 use crate::ui::{
     Alignment, App, Block, Borders, Color, Constraint, Direction, Frame, Layout, Line, List,
     ListItem, ListState, Modifier, PLANNER_RECENT_LABEL_LIMIT, Paragraph, PlannerFeedbackLevel,
-    PlannerInputMode, Rect, ShortcutAction, Style, Wrap, centered_rect, render_hint_lines,
+    PlannerInputMode, Rect, ShortcutAction, Style, Wrap, app_color, centered_rect,
+    render_hint_lines,
 };
 
 pub(super) fn render_session_planner(frame: &mut Frame, app: &App) {
@@ -12,7 +13,7 @@ pub(super) fn render_session_planner(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .title(" Session Planner ")
         .title_alignment(Alignment::Center)
-        .style(Style::default().fg(Color::Cyan));
+        .style(Style::default().fg(app_color(app, Color::Cyan)));
     frame.render_widget(block, outer);
 
     let inner = Layout::default()
@@ -41,7 +42,7 @@ fn render_session_planner_selected_task(frame: &mut Frame, app: &App, area: Rect
     );
     frame.render_widget(
         Paragraph::new(Line::from(selected_text))
-            .style(Style::default().fg(Color::White))
+            .style(Style::default().fg(app_color(app, Color::White)))
             .wrap(Wrap { trim: true }),
         area,
     );
@@ -51,7 +52,7 @@ fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {
     if app.task_labels.is_empty() {
         frame.render_widget(
             Paragraph::new("No task labels yet. Press [a] to add one.")
-                .style(Style::default().fg(Color::DarkGray))
+                .style(Style::default().fg(app_color(app, Color::DarkGray)))
                 .block(
                     Block::default()
                         .borders(Borders::ALL)
@@ -98,8 +99,8 @@ fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {
         )
         .highlight_style(
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::White)
+                .fg(app_color(app, Color::Black))
+                .bg(app_color(app, Color::White))
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▶ ");
@@ -141,9 +142,9 @@ fn render_session_planner_input(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(
         Paragraph::new(input_text)
             .style(if app.planner_input_active {
-                Style::default().fg(Color::White)
+                Style::default().fg(app_color(app, Color::White))
             } else {
-                Style::default().fg(Color::DarkGray)
+                Style::default().fg(app_color(app, Color::DarkGray))
             })
             .block(Block::default().borders(Borders::ALL).title(input_title)),
         area,
@@ -153,8 +154,8 @@ fn render_session_planner_input(frame: &mut Frame, app: &App, area: Rect) {
 fn render_session_planner_feedback(frame: &mut Frame, app: &App, area: Rect) {
     if let Some(feedback) = app.planner_feedback.as_ref() {
         let (prefix, color) = match feedback.level {
-            PlannerFeedbackLevel::Success => ("✓", Color::Green),
-            PlannerFeedbackLevel::Warning => ("⚠", Color::Yellow),
+            PlannerFeedbackLevel::Success => ("✓", app_color(app, Color::Green)),
+            PlannerFeedbackLevel::Warning => ("⚠", app_color(app, Color::Yellow)),
         };
         frame.render_widget(
             Paragraph::new(format!("{prefix}  {}", feedback.message))
@@ -236,5 +237,5 @@ fn render_session_planner_hints(frame: &mut Frame, app: &App, area: Rect) {
             }),
         ]
     };
-    render_hint_lines(frame, area, hints);
+    render_hint_lines(frame, app, area, hints);
 }

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -1,7 +1,7 @@
 use crate::ui::{
     Alignment, App, Block, BlockingPreviewAction, Borders, Color, Constraint, Direction, Frame,
     Layout, Line, Modifier, Paragraph, Rect, SetupCheck, SetupCheckLevel, ShortcutAction, Span,
-    Style, Wrap, centered_rect, render_hint_lines,
+    Style, Wrap, app_color, centered_rect, render_hint_lines,
 };
 
 pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
@@ -12,7 +12,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .title(" Setup Diagnostics ")
         .title_alignment(Alignment::Center)
-        .style(Style::default().fg(Color::Cyan));
+        .style(Style::default().fg(app_color(app, Color::Cyan)));
     frame.render_widget(block, outer);
 
     let inner = Layout::default()
@@ -34,23 +34,26 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         "Hosts file: {}",
         app.setup_diagnostics.hosts_file_path
     ))
-    .style(Style::default().fg(Color::DarkGray));
+    .style(Style::default().fg(app_color(app, Color::DarkGray)));
     frame.render_widget(hosts_path, inner[0]);
 
     render_setup_check(
         frame,
+        app,
         inner[2],
         "Blocking permissions",
         &app.setup_diagnostics.blocking_permissions,
     );
     render_setup_check(
         frame,
+        app,
         inner[3],
         "Hosts write capability",
         &app.setup_diagnostics.hosts_write_capability,
     );
     render_setup_check(
         frame,
+        app,
         inner[4],
         "WakaTime config status",
         &app.setup_diagnostics.wakatime_config,
@@ -60,7 +63,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
     {
         (
             format!("Preview unavailable: {error}"),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(app_color(app, Color::Yellow)),
         )
     } else {
         let action = match app.blocking_preview.action {
@@ -78,7 +81,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
                 },
                 app.blocking_preview.effective_blocked_sites_count
             ),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         )
     };
     frame.render_widget(
@@ -102,13 +105,14 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
                     .borders(Borders::ALL)
                     .title(" Blocking preview (focustime section) "),
             )
-            .style(Style::default().fg(Color::Gray))
+            .style(Style::default().fg(app_color(app, Color::Gray)))
             .wrap(Wrap { trim: false }),
         inner[6],
     );
 
     render_hint_lines(
         frame,
+        app,
         inner[7],
         vec![
             Line::from(format!(
@@ -132,10 +136,16 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
     );
 }
 
-pub(super) fn render_setup_check(frame: &mut Frame, area: Rect, label: &str, check: &SetupCheck) {
+pub(super) fn render_setup_check(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    label: &str,
+    check: &SetupCheck,
+) {
     let (icon, status_color) = match check.level {
-        SetupCheckLevel::Ok => ("✓", Color::Green),
-        SetupCheckLevel::Warning => ("⚠", Color::Yellow),
+        SetupCheckLevel::Ok => ("✓", app_color(app, Color::Green)),
+        SetupCheckLevel::Warning => ("⚠", app_color(app, Color::Yellow)),
     };
     let line = Line::from(vec![
         Span::styled(
@@ -144,7 +154,10 @@ pub(super) fn render_setup_check(frame: &mut Frame, area: Rect, label: &str, che
                 .fg(status_color)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(check.message.as_str(), Style::default().fg(Color::Gray)),
+        Span::styled(
+            check.message.as_str(),
+            Style::default().fg(app_color(app, Color::Gray)),
+        ),
     ]);
     frame.render_widget(Paragraph::new(line).wrap(Wrap { trim: true }), area);
 }

--- a/src/ui/site_manager.rs
+++ b/src/ui/site_manager.rs
@@ -2,7 +2,7 @@ use crate::ui::{
     Alignment, App, Block, BlocklistProfileInputMode, Borders, Color, Constraint, Direction, Frame,
     Layout, Line, List, ListItem, ListState, Modifier, Paragraph, Rect, ShortcutAction,
     SiteFeedbackLevel, SiteInputMode, SiteListMode, Span, Style, TimerPhase, TimerStatus,
-    centered_rect, format_duration_label, render_centered_error, render_hint_lines,
+    app_color, centered_rect, format_duration_label, render_centered_error, render_hint_lines,
 };
 
 pub(super) fn render_site_manager(frame: &mut Frame, app: &App) {
@@ -10,9 +10,9 @@ pub(super) fn render_site_manager(frame: &mut Frame, app: &App) {
     let outer = centered_rect(70, 82, area);
 
     let block_color = if app.blocker.is_blocking {
-        Color::Red
+        app_color(app, Color::Red)
     } else {
-        Color::Green
+        app_color(app, Color::Green)
     };
 
     let title = if app.blocker.is_blocking {
@@ -60,7 +60,7 @@ pub(super) fn render_site_manager(frame: &mut Frame, app: &App) {
     frame.render_widget(
         Paragraph::new(profile_text)
             .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::Cyan)),
+            .style(Style::default().fg(app_color(app, Color::Cyan))),
         inner[1],
     );
 
@@ -81,6 +81,7 @@ pub(super) fn render_site_manager(frame: &mut Frame, app: &App) {
     render_site_manager_feedback_line(frame, app, inner[5]);
     render_hint_lines(
         frame,
+        app,
         inner[6],
         site_manager_hint_lines(app, site_list_mode, input_mode),
     );
@@ -92,7 +93,9 @@ fn site_manager_status_span(app: &App) -> Span<'static> {
     if app.blocker.is_blocking {
         return Span::styled(
             "Blocking is ACTIVE during this focus session",
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(app_color(app, Color::Red))
+                .add_modifier(Modifier::BOLD),
         );
     }
 
@@ -103,7 +106,7 @@ fn site_manager_status_span(app: &App) -> Span<'static> {
                 "Break-glass override active — blocking paused ({} left)",
                 format_duration_label(remaining_secs)
             ),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(app_color(app, Color::Yellow)),
         );
     }
 
@@ -114,13 +117,13 @@ fn site_manager_status_span(app: &App) -> Span<'static> {
                     "Focus session active — blocking unavailable (permission/setup issue; open {} Setup)",
                     app.shortcut_hint(ShortcutAction::OpenSetupDiagnostics)
                 ),
-                Style::default().fg(Color::Yellow),
+                Style::default().fg(app_color(app, Color::Yellow)),
             );
         }
         if app.effective_blocked_site_count() == 0 {
             return Span::styled(
                 "Focus session active — blocking inactive (effective blocked set is empty)",
-                Style::default().fg(Color::Yellow),
+                Style::default().fg(app_color(app, Color::Yellow)),
             );
         }
         return Span::styled(
@@ -128,13 +131,13 @@ fn site_manager_status_span(app: &App) -> Span<'static> {
                 "Focus session active — blocking unavailable (open {} Setup)",
                 app.shortcut_hint(ShortcutAction::OpenSetupDiagnostics)
             ),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(app_color(app, Color::Yellow)),
         );
     }
 
     Span::styled(
         "Blocking will activate when a focus session starts",
-        Style::default().fg(Color::Gray),
+        Style::default().fg(app_color(app, Color::Gray)),
     )
 }
 
@@ -182,11 +185,11 @@ fn render_site_manager_site_list(
     let list_block = Block::default()
         .borders(Borders::ALL)
         .title(list_title)
-        .style(Style::default().fg(Color::Gray));
+        .style(Style::default().fg(app_color(app, Color::Gray)));
 
     if app.active_policy_sites().is_empty() {
         let empty = Paragraph::new(empty_text)
-            .style(Style::default().fg(Color::DarkGray))
+            .style(Style::default().fg(app_color(app, Color::DarkGray)))
             .block(list_block);
         frame.render_widget(empty, area);
         return;
@@ -201,8 +204,8 @@ fn render_site_manager_site_list(
         .block(list_block)
         .highlight_style(
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::White)
+                .fg(app_color(app, Color::Black))
+                .bg(app_color(app, Color::White))
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▶ ");
@@ -230,9 +233,9 @@ fn render_site_manager_input(
         },
     };
     let active_style = if app.site_input_active {
-        Style::default().fg(Color::Yellow)
+        Style::default().fg(app_color(app, Color::Yellow))
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(app_color(app, Color::DarkGray))
     };
     let input_text = if app.site_input_active {
         format!("{}_", app.site_input)
@@ -265,9 +268,9 @@ fn render_site_manager_profile_input(
         None => " Blocklist Profiles ",
     };
     let active_style = if app.blocklist_profile_input_active {
-        Style::default().fg(Color::Yellow)
+        Style::default().fg(app_color(app, Color::Yellow))
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(app_color(app, Color::DarkGray))
     };
     let profile_input_text = if app.blocklist_profile_input_active {
         format!("{}_", app.blocklist_profile_input)
@@ -304,6 +307,7 @@ fn render_site_manager_feedback_line(frame: &mut Frame, app: &App, area: Rect) {
         };
         render_centered_error(
             frame,
+            app,
             area,
             format!(
                 "⚠  {err}{privilege_hint} · open {} Setup for remediation",
@@ -314,14 +318,14 @@ fn render_site_manager_feedback_line(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     if let Some(err) = app.config_error.as_ref() {
-        render_centered_error(frame, area, format!("⚠  {err}"));
+        render_centered_error(frame, app, area, format!("⚠  {err}"));
         return;
     }
 
     if let Some(feedback) = app.site_feedback.as_ref() {
         let (prefix, color) = match feedback.level {
-            SiteFeedbackLevel::Success => ("✓", Color::Green),
-            SiteFeedbackLevel::Warning => ("⚠", Color::Yellow),
+            SiteFeedbackLevel::Success => ("✓", app_color(app, Color::Green)),
+            SiteFeedbackLevel::Warning => ("⚠", app_color(app, Color::Yellow)),
         };
         let feedback_widget = Paragraph::new(format!("{prefix}  {}", feedback.message))
             .alignment(Alignment::Center)

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -1,6 +1,7 @@
-use crate::config::{AppConfig, ShortcutConfig};
+use crate::config::{AppConfig, ShortcutConfig, ThemePreset};
 use crate::ui::*;
 use chrono::{Datelike, Duration, NaiveDate};
+use ratatui::style::Color;
 use ratatui::{Terminal, backend::TestBackend};
 
 use crate::stats::current_day_key;
@@ -55,6 +56,28 @@ fn timer_primary_hint_includes_break_glass_shortcut() {
 fn timer_primary_hint_includes_note_shortcut() {
     let app = App::default();
     assert!(timer_primary_hint(&app).contains("[m] Note"));
+}
+
+#[test]
+fn app_color_uses_high_contrast_preset_mapping() {
+    let app = App::from_config_for_tests(AppConfig {
+        selected_theme_preset: ThemePreset::HighContrast,
+        ..AppConfig::default()
+    });
+
+    assert_eq!(app_color(&app, Color::DarkGray), Color::White);
+    assert_eq!(app_color(&app, Color::Cyan), Color::LightCyan);
+}
+
+#[test]
+fn app_color_uses_deuteranopia_friendly_mapping() {
+    let app = App::from_config_for_tests(AppConfig {
+        selected_theme_preset: ThemePreset::DeuteranopiaFriendly,
+        ..AppConfig::default()
+    });
+
+    assert_eq!(app_color(&app, Color::Red), Color::Blue);
+    assert_eq!(app_color(&app, Color::Green), Color::Cyan);
 }
 
 #[test]
@@ -343,9 +366,10 @@ fn render_setup_check_wraps_long_warning_message() {
         level: SetupCheckLevel::Warning,
         message: "wrapped output should include TAIL-END".to_string(),
     };
+    let app = App::default();
 
     terminal
-        .draw(|frame| render_setup_check(frame, frame.area(), "Check", &check))
+        .draw(|frame| render_setup_check(frame, &app, frame.area(), "Check", &check))
         .expect("render should succeed");
 
     let text = terminal_text(&terminal, width, height);

--- a/src/ui/timer.rs
+++ b/src/ui/timer.rs
@@ -1,7 +1,7 @@
 use crate::ui::{
     Alignment, App, Block, Borders, Color, Constraint, Direction, Frame, Gauge, Layout, Line,
     Local, Modifier, Paragraph, Rect, ShortcutAction, Style, TimeZone, TimerPhase, TimerStatus,
-    WakatimeRuntimeState, Wrap, centered_rect, format_timer_goal_streak_line,
+    WakatimeRuntimeState, Wrap, app_color, centered_rect, format_timer_goal_streak_line,
     readable_goal_streak_text, render_hint_lines,
 };
 
@@ -13,7 +13,7 @@ pub(super) fn render_timer(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .title(" focustime ")
         .title_alignment(Alignment::Center)
-        .style(Style::default().fg(phase_color(app.timer.phase)));
+        .style(Style::default().fg(phase_color(app, app.timer.phase)));
     frame.render_widget(block, outer);
 
     let inner = Layout::default()
@@ -50,7 +50,7 @@ fn render_timer_phase_header(frame: &mut Frame, app: &App, area: Rect) {
         .alignment(Alignment::Center)
         .style(
             Style::default()
-                .fg(phase_color(app.timer.phase))
+                .fg(phase_color(app, app.timer.phase))
                 .add_modifier(Modifier::BOLD),
         );
     frame.render_widget(phase_widget, area);
@@ -65,7 +65,7 @@ fn render_timer_countdown(frame: &mut Frame, app: &App, area: Rect) {
         .alignment(Alignment::Center)
         .style(
             Style::default()
-                .fg(Color::White)
+                .fg(app_color(app, Color::White))
                 .add_modifier(Modifier::BOLD),
         );
     frame.render_widget(time_widget, area);
@@ -102,7 +102,7 @@ fn render_timer_progress_bar(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(
         Paragraph::new("⏳ Progress")
             .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::DarkGray)),
+            .style(Style::default().fg(app_color(app, Color::DarkGray))),
         layout[0],
     );
 
@@ -111,8 +111,8 @@ fn render_timer_progress_bar(frame: &mut Frame, app: &App, area: Rect) {
         .block(Block::default().borders(Borders::NONE))
         .gauge_style(
             Style::default()
-                .fg(phase_color(app.timer.phase))
-                .bg(Color::DarkGray),
+                .fg(phase_color(app, app.timer.phase))
+                .bg(app_color(app, Color::DarkGray)),
         )
         .ratio(elapsed_ratio);
     frame.render_widget(gauge, layout[2]);
@@ -132,7 +132,7 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
     let (task_text, task_style) = if let Some(label) = app.current_task_label() {
         (
             format!("🎯 Task: {label}"),
-            Style::default().fg(Color::LightYellow),
+            Style::default().fg(app_color(app, Color::LightYellow)),
         )
     } else {
         (
@@ -140,24 +140,27 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
                 "🎯 Task: not selected ({} Planner)",
                 app.shortcut_hint(ShortcutAction::OpenSessionPlanner)
             ),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(app_color(app, Color::Yellow)),
         )
     };
     let can_edit_session_note = app.can_edit_session_note();
     let (note_text, note_style) = if let Some(note) = app.current_task_note() {
-        (format!("📝 Note: {note}"), Style::default().fg(Color::Cyan))
+        (
+            format!("📝 Note: {note}"),
+            Style::default().fg(app_color(app, Color::Cyan)),
+        )
     } else if can_edit_session_note {
         (
             format!(
                 "📝 Note: none yet ({} Edit note)",
                 app.shortcut_hint(ShortcutAction::TimerEditNote)
             ),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         )
     } else {
         (
             "📝 Note: unavailable (start or resume focus to edit)".to_string(),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         )
     };
     let (stats_text, stats_style) = timer_stats_line(app);
@@ -169,31 +172,43 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
     let mut lines = vec![
         Line::styled(task_text, task_style),
         Line::styled(note_text, note_style),
-        Line::styled(status_text, Style::default().fg(Color::Gray)),
-        Line::styled(profile_line, Style::default().fg(Color::DarkGray)),
-        Line::styled(schedule_next_text, Style::default().fg(Color::DarkGray)),
-        Line::styled(schedule_status_text, Style::default().fg(Color::DarkGray)),
+        Line::styled(
+            status_text,
+            Style::default().fg(app_color(app, Color::Gray)),
+        ),
+        Line::styled(
+            profile_line,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
+        Line::styled(
+            schedule_next_text,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
+        Line::styled(
+            schedule_status_text,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
         Line::styled(format!("📈 {stats_text}"), stats_style),
     ];
     if let Some((goals, streak)) = goal_text.split_once(" | Streak: ") {
         lines.push(Line::styled(
             format!("🔥 {goals}"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         ));
         lines.push(Line::styled(
             format!("🔥 Streak: {streak}"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         ));
     } else {
         lines.push(Line::styled(
             format!("🔥 {goal_text}"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         ));
     }
     lines.push(Line::styled(waka_text, Style::default().fg(waka_color)));
     lines.push(Line::styled(
         strict_and_break_glass,
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(app_color(app, Color::DarkGray)),
     ));
 
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
@@ -247,16 +262,19 @@ fn phase_notice_line(app: &App) -> (String, Style) {
         let draft = if draft.is_empty() { "<empty>" } else { draft };
         return (
             format!("📝 Note: {draft}   [Enter] Save   [Esc] Cancel"),
-            Style::default().fg(Color::Cyan),
+            Style::default().fg(app_color(app, Color::Cyan)),
         );
     }
 
     if let Some(message) = app.phase_notification.as_ref() {
-        (format!("🔔 {message}"), Style::default().fg(Color::Yellow))
+        (
+            format!("🔔 {message}"),
+            Style::default().fg(app_color(app, Color::Yellow)),
+        )
     } else {
         (
             "🔔 Waiting for next completed phase".to_string(),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         )
     }
 }
@@ -265,7 +283,7 @@ fn timer_stats_line(app: &App) -> (String, Style) {
     if let Some(err) = app.stats_error.as_ref() {
         (
             format!("⚠ Stats persistence warning: {err}"),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(app_color(app, Color::Yellow)),
         )
     } else {
         let session_stats = app.session_stats();
@@ -278,7 +296,7 @@ fn timer_stats_line(app: &App) -> (String, Style) {
                 today_stats.pomodoros_completed,
                 today_stats.focused_minutes()
             ),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(app_color(app, Color::DarkGray)),
         )
     }
 }
@@ -286,14 +304,22 @@ fn timer_stats_line(app: &App) -> (String, Style) {
 pub(super) fn wakatime_status_line(app: &App) -> (String, Color) {
     let runtime_state = app.wakatime.runtime_state();
     let (status_text, status_color) = match &runtime_state {
-        WakatimeRuntimeState::NotConfigured => {
-            ("⏱  WakaTime: not configured".to_string(), Color::DarkGray)
-        }
-        WakatimeRuntimeState::Idle => ("⏱  WakaTime: idle".to_string(), Color::DarkGray),
-        WakatimeRuntimeState::Tracking => ("⏱  WakaTime: tracking".to_string(), Color::Green),
-        WakatimeRuntimeState::Sending => {
-            ("⏱  WakaTime: sending heartbeat...".to_string(), Color::Cyan)
-        }
+        WakatimeRuntimeState::NotConfigured => (
+            "⏱  WakaTime: not configured".to_string(),
+            app_color(app, Color::DarkGray),
+        ),
+        WakatimeRuntimeState::Idle => (
+            "⏱  WakaTime: idle".to_string(),
+            app_color(app, Color::DarkGray),
+        ),
+        WakatimeRuntimeState::Tracking => (
+            "⏱  WakaTime: tracking".to_string(),
+            app_color(app, Color::Green),
+        ),
+        WakatimeRuntimeState::Sending => (
+            "⏱  WakaTime: sending heartbeat...".to_string(),
+            app_color(app, Color::Cyan),
+        ),
         WakatimeRuntimeState::Retrying {
             attempt,
             max_attempts,
@@ -303,9 +329,12 @@ pub(super) fn wakatime_status_line(app: &App) -> (String, Color) {
             format!(
                 "⏱  WakaTime: retrying ({attempt}/{max_attempts}) in {next_backoff_secs}s ({error})"
             ),
-            Color::Yellow,
+            app_color(app, Color::Yellow),
         ),
-        WakatimeRuntimeState::Error(error) => (format!("⏱  WakaTime: error ({error})"), Color::Red),
+        WakatimeRuntimeState::Error(error) => (
+            format!("⏱  WakaTime: error ({error})"),
+            app_color(app, Color::Red),
+        ),
     };
 
     if matches!(runtime_state, WakatimeRuntimeState::NotConfigured) {
@@ -349,6 +378,7 @@ pub(super) fn format_duration_label(duration_secs: u64) -> String {
 fn render_timer_hints(frame: &mut Frame, app: &App, area: Rect) {
     render_hint_lines(
         frame,
+        app,
         area,
         vec![
             Line::from(timer_primary_hint(app)),
@@ -422,10 +452,10 @@ pub(super) fn timer_tertiary_hint(app: &App) -> String {
     }
 }
 
-fn phase_color(phase: TimerPhase) -> Color {
+fn phase_color(app: &App, phase: TimerPhase) -> Color {
     match phase {
-        TimerPhase::Focus => Color::Red,
-        TimerPhase::ShortBreak => Color::Green,
-        TimerPhase::LongBreak => Color::Cyan,
+        TimerPhase::Focus => app_color(app, Color::Red),
+        TimerPhase::ShortBreak => app_color(app, Color::Green),
+        TimerPhase::LongBreak => app_color(app, Color::Cyan),
     }
 }


### PR DESCRIPTION
## What

Add global theme preset support with built-in accessibility-focused options across config, TUI, and CLI surfaces.

- Added a persisted `selected_theme_preset` config field and `ThemePreset` model (`classic`, `high-contrast`, `deuteranopia-friendly`) with tolerant parsing aliases.
- Wired theme preset state through app runtime, persistence, and profile editor workflows.
- Introduced centralized UI color mapping and applied it across timer/history/setup/planner/site/profile screens.
- Added `--theme` CLI command support (show/set) and included selected theme metadata in profile/status output contracts.
- Updated README and changelog, and expanded config/app/ui/cli test coverage.

## Why

The app previously used fixed colors and had no way to select a built-in theme. This change delivers issue #194 by adding global presets, including accessibility-oriented options, while keeping the default visual behavior intact.

Fixes: #194

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (no new dependencies or elevated trust boundaries introduced)
- [x] Breaking behavior changes are clearly described in this PR (none)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added three theme presets (Classic, High-Contrast, Deuteranopia-Friendly) for improved accessibility
* Theme selection available via CLI (`--theme` command) and in-app profile editor (←/→ keys)
* Selected theme persists to configuration
* UI colors now adapt based on the chosen theme across all interface sections

## Documentation
* Updated CLI help and in-app guidance with theme preset selection and keyboard navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->