### PR TITLE
Prepare v0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-04
+
 ### Added
 
-- **Theme presets with accessibility options (#194):** added global theme preset selection (`classic`, `high-contrast`, `deuteranopia-friendly`) across config persistence, TUI appearance rendering, profile editor controls, and CLI `--theme` management/status outputs.
+- **Keyboard shortcut customization for command actions (#243):** added configurable `[shortcuts]` bindings for timer controls, view switching, manager actions, export/refresh, and quit command routing across config, runtime action dispatch, and UI command legends.
+- **Theme presets with accessibility options (#244):** added global theme preset selection (`classic`, `high-contrast`, `deuteranopia-friendly`) across config persistence, TUI appearance rendering, profile editor controls, and CLI `--theme` management/status outputs.
+
+### Changed
+
+- **Shortcut input handling hardening (#243):** prevented quit-key collisions and preserved `Ctrl-C` fallback behavior during text-entry workflows, including site manager editing.
 
 ## [0.8.0] - 2026-05-03
 
@@ -213,7 +220,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/utilForever/focustime/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/utilForever/focustime/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/utilForever/focustime/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/utilForever/focustime/compare/v0.6.2...v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -630,12 +630,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.8.0`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.8.1`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.8.0](https://github.com/utilForever/focustime/releases/tag/v0.8.0).
+The latest stable release is [v0.8.1](https://github.com/utilForever/focustime/releases/tag/v0.8.1).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Finalize the v0.8.1 release metadata and changelog entries, including a correction pass for missing PR coverage in the 0.8.1 notes.

## Why

Issue #245 requested the v0.8.1 release updates across Cargo metadata, README release references, and CHANGELOG content. During follow-up review, the 0.8.1 changelog section was missing merged PRs from the v0.8.0..HEAD range, so this PR adds those entries and fixes the PR reference mismatch.

Fixes: #245

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes (currently stalls in this environment)
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR (N/A - no breaking behavior changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcut customization for timer, view, manager, actions, export, refresh, and quit functions.
  * Theme presets with accessibility options.

* **Bug Fixes**
  * Enhanced shortcut input handling to prevent quit-key collisions while preserving Ctrl-C fallback during text entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->