### PR TITLE
Map task labels to WakaTime metadata overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **WakaTime task-label metadata mapping (#195):** added optional `[[wakatime.task_mappings]]` config entries to override heartbeat `project`/`language` per task label with case-insensitive matching and per-field fallback to global `[wakatime]` defaults across runtime tracking.
+
 ## [0.8.1] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -400,10 +400,29 @@ pomodoros = 80
 [wakatime]
 project = "focustime"
 language = "Pomodoro"
+
+[[wakatime.task_mappings]]
+task_label = "Docs"
+project = "Documentation"
+language = "Markdown"
+
+[[wakatime.task_mappings]]
+task_label = "Review"
+language = "Code Review"
 ```
 
 `[wakatime]` is optional. If omitted (or set to blank values), `focustime` uses
 the defaults above for heartbeat metadata labels.
+
+`[[wakatime.task_mappings]]` is also optional. When present, focustime matches
+the active task label case-insensitively and overrides WakaTime metadata per
+field:
+
+- `project`: task-mapped value if provided, otherwise `[wakatime].project`
+- `language`: task-mapped value if provided, otherwise `[wakatime].language`
+
+Mappings with blank `task_label` or blank override values are ignored. If
+duplicate task labels are configured, the first valid mapping is used.
 
 ## Site manager workflow
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1181,6 +1181,7 @@ impl App {
             self.blocker.unblock()
         };
         self.set_block_error_from_result(block_result);
+        self.sync_wakatime_metadata_to_tracker();
         self.sync_wakatime_tracking_for_state();
     }
 

--- a/src/app/profile_management.rs
+++ b/src/app/profile_management.rs
@@ -449,12 +449,12 @@ impl App {
         }
     }
 
-    fn sync_wakatime_metadata_to_tracker(&mut self) {
+    pub(super) fn sync_wakatime_metadata_to_tracker(&mut self) {
+        let (project, language) = self
+            .wakatime_metadata
+            .resolved_project_language_for_task_label(self.current_task_label());
         self.wakatime
-            .set_heartbeat_metadata(WakatimeHeartbeatMetadata {
-                project: self.wakatime_metadata.project.clone(),
-                language: self.wakatime_metadata.language.clone(),
-            });
+            .set_heartbeat_metadata(WakatimeHeartbeatMetadata { project, language });
     }
 
     pub(super) fn clamp_break_template_selection(&mut self) {

--- a/src/app/session_planner.rs
+++ b/src/app/session_planner.rs
@@ -475,6 +475,7 @@ impl App {
     }
 
     pub(super) fn sync_task_planner_state(&mut self) {
+        self.sync_wakatime_metadata_to_tracker();
         if self.stats.update_task_planner_state_with_label_states(
             self.task_labels.clone(),
             self.selected_task_label.clone(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -544,6 +544,7 @@ fn persisted_config_preserves_wakatime_metadata() {
         wakatime: WakatimeMetadataConfig {
             project: "Team Focus".to_string(),
             language: "Deep Work".to_string(),
+            ..WakatimeMetadataConfig::default()
         },
         ..AppConfig::default()
     };
@@ -555,6 +556,7 @@ fn persisted_config_preserves_wakatime_metadata() {
         WakatimeMetadataConfig {
             project: "Team Focus".to_string(),
             language: "Deep Work".to_string(),
+            ..WakatimeMetadataConfig::default()
         }
     );
 }
@@ -922,6 +924,7 @@ fn editing_wakatime_metadata_fields_updates_and_persists_settings() {
         wakatime: WakatimeMetadataConfig {
             project: "A".to_string(),
             language: "B".to_string(),
+            ..WakatimeMetadataConfig::default()
         },
         ..AppConfig::default()
     };
@@ -949,6 +952,7 @@ fn editing_wakatime_metadata_fields_updates_and_persists_settings() {
         WakatimeMetadataConfig {
             project: "Team Focus".to_string(),
             language: "Deep Work".to_string(),
+            ..WakatimeMetadataConfig::default()
         }
     );
     assert_eq!(
@@ -966,6 +970,7 @@ fn editing_wakatime_metadata_blank_values_fall_back_to_defaults() {
         wakatime: WakatimeMetadataConfig {
             project: "A".to_string(),
             language: "B".to_string(),
+            ..WakatimeMetadataConfig::default()
         },
         ..AppConfig::default()
     };
@@ -987,6 +992,114 @@ fn editing_wakatime_metadata_blank_values_fall_back_to_defaults() {
     assert_eq!(
         app.wakatime.heartbeat_metadata_for_tests(),
         WakatimeHeartbeatMetadata::default()
+    );
+}
+
+#[test]
+fn selecting_task_label_applies_wakatime_mapping_override() {
+    let config = AppConfig {
+        wakatime: WakatimeMetadataConfig {
+            project: "Global Project".to_string(),
+            language: "Global Language".to_string(),
+            task_mappings: vec![crate::config::WakatimeTaskMappingConfig {
+                task_label: "Docs".to_string(),
+                project: Some("Documentation".to_string()),
+                language: Some("Markdown".to_string()),
+            }],
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+
+    app.select_task_label_for_cli("Docs").unwrap();
+
+    assert_eq!(
+        app.wakatime.heartbeat_metadata_for_tests(),
+        WakatimeHeartbeatMetadata {
+            project: "Documentation".to_string(),
+            language: "Markdown".to_string(),
+        }
+    );
+}
+
+#[test]
+fn selecting_unmapped_task_label_uses_global_wakatime_metadata() {
+    let config = AppConfig {
+        wakatime: WakatimeMetadataConfig {
+            project: "Global Project".to_string(),
+            language: "Global Language".to_string(),
+            task_mappings: vec![crate::config::WakatimeTaskMappingConfig {
+                task_label: "Docs".to_string(),
+                project: Some("Documentation".to_string()),
+                language: Some("Markdown".to_string()),
+            }],
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+
+    app.select_task_label_for_cli("Planning").unwrap();
+
+    assert_eq!(
+        app.wakatime.heartbeat_metadata_for_tests(),
+        WakatimeHeartbeatMetadata {
+            project: "Global Project".to_string(),
+            language: "Global Language".to_string(),
+        }
+    );
+}
+
+#[test]
+fn selecting_task_label_uses_partial_wakatime_mapping_fallback() {
+    let config = AppConfig {
+        wakatime: WakatimeMetadataConfig {
+            project: "Global Project".to_string(),
+            language: "Global Language".to_string(),
+            task_mappings: vec![crate::config::WakatimeTaskMappingConfig {
+                task_label: "Docs".to_string(),
+                project: Some("Documentation".to_string()),
+                language: None,
+            }],
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+
+    app.select_task_label_for_cli("Docs").unwrap();
+
+    assert_eq!(
+        app.wakatime.heartbeat_metadata_for_tests(),
+        WakatimeHeartbeatMetadata {
+            project: "Documentation".to_string(),
+            language: "Global Language".to_string(),
+        }
+    );
+}
+
+#[test]
+fn selecting_task_label_matches_wakatime_mapping_case_insensitively() {
+    let config = AppConfig {
+        wakatime: WakatimeMetadataConfig {
+            project: "Global Project".to_string(),
+            language: "Global Language".to_string(),
+            task_mappings: vec![crate::config::WakatimeTaskMappingConfig {
+                task_label: "Deep Work".to_string(),
+                project: None,
+                language: Some("Rust".to_string()),
+            }],
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+
+    app.select_task_label_for_cli("deep work").unwrap();
+
+    assert_eq!(
+        app.wakatime.heartbeat_metadata_for_tests(),
+        WakatimeHeartbeatMetadata {
+            project: "Global Project".to_string(),
+            language: "Rust".to_string(),
+        }
     );
 }
 
@@ -1803,6 +1916,7 @@ fn cancelling_profile_edit_restores_wakatime_metadata() {
         wakatime: WakatimeMetadataConfig {
             project: "Team Focus".to_string(),
             language: "Deep Work".to_string(),
+            ..WakatimeMetadataConfig::default()
         },
         ..AppConfig::default()
     };
@@ -1821,6 +1935,7 @@ fn cancelling_profile_edit_restores_wakatime_metadata() {
         WakatimeMetadataConfig {
             project: "Team Focus".to_string(),
             language: "Deep Work".to_string(),
+            ..WakatimeMetadataConfig::default()
         }
     );
     assert_eq!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -667,11 +667,23 @@ pub struct GoalCarryOverConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WakatimeTaskMappingConfig {
+    #[serde(default)]
+    pub task_label: String,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WakatimeMetadataConfig {
     #[serde(default = "default_wakatime_project")]
     pub project: String,
     #[serde(default = "default_wakatime_language")]
     pub language: String,
+    #[serde(default)]
+    pub task_mappings: Vec<WakatimeTaskMappingConfig>,
 }
 
 impl WakatimeMetadataConfig {
@@ -685,7 +697,40 @@ impl WakatimeMetadataConfig {
                 &self.language,
                 &default_wakatime_language(),
             ),
+            task_mappings: normalize_wakatime_task_mappings(&self.task_mappings),
         }
+    }
+
+    pub fn task_mapping_for_label(&self, task_label: &str) -> Option<&WakatimeTaskMappingConfig> {
+        let task_label = task_label.trim();
+        if task_label.is_empty() {
+            return None;
+        }
+        self.task_mappings
+            .iter()
+            .find(|mapping| mapping.task_label.eq_ignore_ascii_case(task_label))
+    }
+
+    pub fn resolved_project_language_for_task_label(
+        &self,
+        task_label: Option<&str>,
+    ) -> (String, String) {
+        let Some(task_label) = task_label.map(str::trim).filter(|label| !label.is_empty()) else {
+            return (self.project.clone(), self.language.clone());
+        };
+        let Some(mapping) = self.task_mapping_for_label(task_label) else {
+            return (self.project.clone(), self.language.clone());
+        };
+        (
+            mapping
+                .project
+                .clone()
+                .unwrap_or_else(|| self.project.clone()),
+            mapping
+                .language
+                .clone()
+                .unwrap_or_else(|| self.language.clone()),
+        )
     }
 }
 
@@ -694,6 +739,7 @@ impl Default for WakatimeMetadataConfig {
         Self {
             project: default_wakatime_project(),
             language: default_wakatime_language(),
+            task_mappings: Vec::new(),
         }
     }
 }
@@ -1362,6 +1408,41 @@ fn normalize_nonempty_or_default_string(value: &str, default: &str) -> String {
     } else {
         trimmed.to_string()
     }
+}
+
+fn normalize_optional_nonempty_string(value: Option<&str>) -> Option<String> {
+    let trimmed = value?.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn normalize_wakatime_task_mappings(
+    mappings: &[WakatimeTaskMappingConfig],
+) -> Vec<WakatimeTaskMappingConfig> {
+    let mut normalized = Vec::new();
+    let mut seen_labels = HashSet::new();
+    for mapping in mappings {
+        let Some(task_label) = normalize_optional_nonempty_string(Some(&mapping.task_label)) else {
+            continue;
+        };
+        let project = normalize_optional_nonempty_string(mapping.project.as_deref());
+        let language = normalize_optional_nonempty_string(mapping.language.as_deref());
+        if project.is_none() && language.is_none() {
+            continue;
+        }
+        let key = task_label.to_ascii_lowercase();
+        if seen_labels.insert(key) {
+            normalized.push(WakatimeTaskMappingConfig {
+                task_label,
+                project,
+                language,
+            });
+        }
+    }
+    normalized
 }
 
 fn parse_shortcut_char(value: &str) -> Option<char> {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -170,6 +170,18 @@ fn round_trip_full_config() {
         wakatime: WakatimeMetadataConfig {
             project: "Team Focus".to_string(),
             language: "Focus Session".to_string(),
+            task_mappings: vec![
+                WakatimeTaskMappingConfig {
+                    task_label: "Docs".to_string(),
+                    project: Some("Documentation".to_string()),
+                    language: Some("Markdown".to_string()),
+                },
+                WakatimeTaskMappingConfig {
+                    task_label: "Code".to_string(),
+                    project: Some("Engineering".to_string()),
+                    language: None,
+                },
+            ],
         },
         shortcuts: ShortcutConfig {
             timer_toggle_pause: "space".to_string(),
@@ -709,6 +721,86 @@ language = ""
     .unwrap();
     let normalized = cfg.normalize();
     assert_eq!(normalized.wakatime, WakatimeMetadataConfig::default());
+}
+
+#[test]
+fn wakatime_task_mappings_normalize_filter_and_deduplicate() {
+    let cfg: AppConfig = toml::from_str(
+        r#"
+[wakatime]
+project = " Team Focus "
+language = " Focus Session "
+
+[[wakatime.task_mappings]]
+task_label = " Docs "
+project = " Documentation "
+
+[[wakatime.task_mappings]]
+task_label = "docs"
+language = "Rust"
+
+[[wakatime.task_mappings]]
+task_label = "Planning"
+project = "   "
+language = ""
+
+[[wakatime.task_mappings]]
+task_label = "   "
+project = "Ignored"
+"#,
+    )
+    .unwrap();
+
+    let normalized = cfg.normalize();
+    assert_eq!(normalized.wakatime.project, "Team Focus");
+    assert_eq!(normalized.wakatime.language, "Focus Session");
+    assert_eq!(
+        normalized.wakatime.task_mappings,
+        vec![WakatimeTaskMappingConfig {
+            task_label: "Docs".to_string(),
+            project: Some("Documentation".to_string()),
+            language: None,
+        }]
+    );
+}
+
+#[test]
+fn wakatime_task_mappings_resolve_with_per_field_fallback() {
+    let metadata = WakatimeMetadataConfig {
+        project: "Global Project".to_string(),
+        language: "Global Language".to_string(),
+        task_mappings: vec![
+            WakatimeTaskMappingConfig {
+                task_label: "Docs".to_string(),
+                project: Some("Documentation".to_string()),
+                language: None,
+            },
+            WakatimeTaskMappingConfig {
+                task_label: "Review".to_string(),
+                project: None,
+                language: Some("PR Review".to_string()),
+            },
+        ],
+    };
+
+    let (docs_project, docs_language) =
+        metadata.resolved_project_language_for_task_label(Some(" docs "));
+    assert_eq!(docs_project, "Documentation");
+    assert_eq!(docs_language, "Global Language");
+
+    let (review_project, review_language) =
+        metadata.resolved_project_language_for_task_label(Some("REVIEW"));
+    assert_eq!(review_project, "Global Project");
+    assert_eq!(review_language, "PR Review");
+
+    let (fallback_project, fallback_language) =
+        metadata.resolved_project_language_for_task_label(Some("Unknown"));
+    assert_eq!(fallback_project, "Global Project");
+    assert_eq!(fallback_language, "Global Language");
+
+    let (none_project, none_language) = metadata.resolved_project_language_for_task_label(None);
+    assert_eq!(none_project, "Global Project");
+    assert_eq!(none_language, "Global Language");
 }
 
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## What

- Added config support for `[[wakatime.task_mappings]]` entries keyed by task label with optional `project`/`language` overrides.
- Added runtime metadata resolution so heartbeats use task-aware overrides with per-field fallback to global `[wakatime]` values.
- Wired metadata synchronization into planner/task state changes and focus tracking transitions.
- Added config and app tests for normalization, fallback behavior, and case-insensitive matching.
- Updated `README.md` and `CHANGELOG.md` with the new mapping behavior.

## Why

Issue #195 asks for richer WakaTime tracking by mapping task labels to metadata overrides rather than only using one global project/language pair.

Closes #195.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `[[wakatime.task_mappings]]` configuration section to set custom heartbeat project and language per task label. Supports case-insensitive matching and fallback to global WakaTime settings.

* **Documentation**
  * Expanded WakaTime configuration documentation with task-mapping configuration examples and behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->