### PR TITLE
Add CLI backup/restore commands for config and stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **WakaTime task-label metadata mapping (#195):** added optional `[[wakatime.task_mappings]]` config entries to override heartbeat `project`/`language` per task label with case-insensitive matching and per-field fallback to global `[wakatime]` defaults across runtime tracking.
+- **CLI backup/restore commands (#197):** added `--backup[=DIR]` and `--restore[=DIR]` automation commands to copy `config.toml` and `stats.toml`, including strict restore validation that requires both files in the restore source directory.
 
 ## [0.8.1] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ cargo run -- --status --json
 cargo run -- --status --watch
 cargo run -- --status --watch=2 --json
 
+# Back up config.toml and stats.toml to current directory or a target directory
+cargo run -- --backup
+cargo run -- --backup=./reports --json
+
+# Restore config.toml and stats.toml from current directory or a source directory
+# (restore requires both files to be present in the source directory)
+cargo run -- --restore
+cargo run -- --restore=./reports --json
+
 # Export stats to current directory or a target directory
 cargo run -- --export
 cargo run -- --export=./reports --json

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,10 +44,11 @@ use execute::{
 use output::{
     build_blocking_preview_command_output, build_diagnostics_command_output,
     build_schedule_inspection_output, display_input_value, effective_blocked_sites_for_profile,
-    flush_stdout, print_blocking_preview_command_output, print_blocklist_profile_command_output,
-    print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
-    print_goal_command_output, print_json, print_json_compact, print_profile_output,
-    print_schedule_command_output, print_site_add_command_output, print_site_delete_command_output,
+    flush_stdout, print_backup_output, print_blocking_preview_command_output,
+    print_blocklist_profile_command_output, print_diagnostics_command_output, print_export_output,
+    print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
+    print_profile_output, print_restore_output, print_schedule_command_output,
+    print_site_add_command_output, print_site_delete_command_output,
     print_site_edit_command_output, print_site_list_command_output, print_status_output,
     print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
     print_timer_state_output,
@@ -108,6 +109,8 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --diagnostics [--json]
   focustime --blocking-preview [--json]
   focustime --status [--watch[=SECONDS]] [--json]
+  focustime --backup[=DIR] [--json]
+  focustime --restore[=DIR] [--json]
   focustime --export[=DIR] [--json]
 
 Options:
@@ -145,6 +148,8 @@ Options:
   --blocking-preview  Preview focustime hosts-section changes without writing
   --status        Print status summary (includes live timer/session fields and latest interruption)
   --watch         Stream periodic status updates (status command only; default 1s)
+  --backup        Back up config.toml and stats.toml to current directory or DIR
+  --restore       Restore config.toml and stats.toml from current directory or DIR
   --export        Export stats to current directory or DIR
   --json          Emit machine-readable JSON output
   -h, --help      Show this help"#;
@@ -243,6 +248,12 @@ pub enum CommandKind {
     Status {
         watch_interval_secs: Option<u64>,
     },
+    Backup {
+        dir: Option<PathBuf>,
+    },
+    Restore {
+        dir: Option<PathBuf>,
+    },
     Export {
         dir: Option<PathBuf>,
     },
@@ -294,6 +305,8 @@ enum PrimaryCommand {
     Diagnostics,
     BlockingPreview,
     Status,
+    Backup(Option<PathBuf>),
+    Restore(Option<PathBuf>),
     Export(Option<PathBuf>),
     BlocklistProfile(Option<String>),
     BlocklistProfileCreate(String),
@@ -338,6 +351,8 @@ enum ParsedToken {
     ScheduleSet(RecurringScheduleConfig),
     Diagnostics,
     BlockingPreview,
+    Backup(Option<PathBuf>),
+    Restore(Option<PathBuf>),
     Export(Option<PathBuf>),
     BlocklistProfile(Option<String>),
     BlocklistProfileCreate(String),
@@ -524,6 +539,20 @@ struct ExportOutput {
     export_dir: PathBuf,
     json_path: PathBuf,
     csv_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct BackupOutput {
+    backup_dir: PathBuf,
+    config_backup_path: PathBuf,
+    stats_backup_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct RestoreOutput {
+    restore_dir: PathBuf,
+    config_restored_path: PathBuf,
+    stats_restored_path: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -55,7 +55,7 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 23] = [
+    let parsers: [(&str, ValueArgParser); 25] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
         ("--profile", classify_profile_arg),
@@ -69,6 +69,8 @@ fn classify_value_arg(
         ("--strict", classify_strict_arg),
         ("--schedule-set", classify_schedule_set_arg),
         ("--watch", classify_watch_arg),
+        ("--backup", classify_backup_arg),
+        ("--restore", classify_restore_arg),
         ("--export", classify_export_arg),
         ("--blocklist-profile", classify_blocklist_profile_arg),
         (
@@ -187,6 +189,24 @@ fn classify_export_arg(args: &[String], index: usize) -> Result<(ParsedToken, us
         return Ok((ParsedToken::Export(Some(PathBuf::from(next))), 2));
     }
     Ok((ParsedToken::Export(None), 1))
+}
+
+fn classify_backup_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((ParsedToken::Backup(Some(PathBuf::from(next))), 2));
+    }
+    Ok((ParsedToken::Backup(None), 1))
+}
+
+fn classify_restore_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((ParsedToken::Restore(Some(PathBuf::from(next))), 2));
+    }
+    Ok((ParsedToken::Restore(None), 1))
 }
 
 fn classify_watch_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
@@ -454,7 +474,7 @@ fn classify_schedule_set_arg(
 }
 
 pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 23] = [
+    let parsers: [KeyValueParser; 25] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
         parse_profile_key_value_arg,
@@ -468,6 +488,8 @@ pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, S
         parse_strict_key_value_arg,
         parse_schedule_set_key_value_arg,
         parse_watch_key_value_arg,
+        parse_backup_key_value_arg,
+        parse_restore_key_value_arg,
         parse_export_key_value_arg,
         parse_blocklist_profile_key_value_arg,
         parse_blocklist_profile_create_key_value_arg,
@@ -618,6 +640,22 @@ fn parse_export_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> 
     if let Some(value) = arg.strip_prefix("--export=") {
         let value = require_nonempty_key_value(value, "`--export=` requires a target directory.")?;
         return Ok(Some(ParsedToken::Export(Some(PathBuf::from(value)))));
+    }
+    Ok(None)
+}
+
+fn parse_backup_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--backup=") {
+        let value = require_nonempty_key_value(value, "`--backup=` requires a target directory.")?;
+        return Ok(Some(ParsedToken::Backup(Some(PathBuf::from(value)))));
+    }
+    Ok(None)
+}
+
+fn parse_restore_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--restore=") {
+        let value = require_nonempty_key_value(value, "`--restore=` requires a source directory.")?;
+        return Ok(Some(ParsedToken::Restore(Some(PathBuf::from(value)))));
     }
     Ok(None)
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -195,7 +195,9 @@ fn classify_backup_arg(args: &[String], index: usize) -> Result<(ParsedToken, us
     if let Some(next) = args.get(index + 1)
         && !next.starts_with('-')
     {
-        return Ok((ParsedToken::Backup(Some(PathBuf::from(next))), 2));
+        let value =
+            require_nonempty_key_value(next, "`--backup` requires a target directory.")?;
+        return Ok((ParsedToken::Backup(Some(PathBuf::from(value))), 2));
     }
     Ok((ParsedToken::Backup(None), 1))
 }
@@ -204,7 +206,9 @@ fn classify_restore_arg(args: &[String], index: usize) -> Result<(ParsedToken, u
     if let Some(next) = args.get(index + 1)
         && !next.starts_with('-')
     {
-        return Ok((ParsedToken::Restore(Some(PathBuf::from(next))), 2));
+        let value =
+            require_nonempty_key_value(next, "`--restore` requires a source directory.")?;
+        return Ok((ParsedToken::Restore(Some(PathBuf::from(value))), 2));
     }
     Ok((ParsedToken::Restore(None), 1))
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -195,8 +195,7 @@ fn classify_backup_arg(args: &[String], index: usize) -> Result<(ParsedToken, us
     if let Some(next) = args.get(index + 1)
         && !next.starts_with('-')
     {
-        let value =
-            require_nonempty_key_value(next, "`--backup` requires a target directory.")?;
+        let value = require_nonempty_key_value(next, "`--backup` requires a target directory.")?;
         return Ok((ParsedToken::Backup(Some(PathBuf::from(value))), 2));
     }
     Ok((ParsedToken::Backup(None), 1))
@@ -206,8 +205,7 @@ fn classify_restore_arg(args: &[String], index: usize) -> Result<(ParsedToken, u
     if let Some(next) = args.get(index + 1)
         && !next.starts_with('-')
     {
-        let value =
-            require_nonempty_key_value(next, "`--restore` requires a source directory.")?;
+        let value = require_nonempty_key_value(next, "`--restore` requires a source directory.")?;
         return Ok((ParsedToken::Restore(Some(PathBuf::from(value))), 2));
     }
     Ok((ParsedToken::Restore(None), 1))

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1001,15 +1001,6 @@ fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
 }
 
 fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
-    let config = AppConfig::load().normalized();
-    config
-        .save()
-        .map_err(|error| format!("Backup failed: could not persist config.toml: {error}"))?;
-    let stats = FocusStats::load().map_err(|error| format!("Backup failed: {error}"))?;
-    stats
-        .save()
-        .map_err(|error| format!("Backup failed: could not persist stats.toml: {error}"))?;
-
     let backup_dir = match dir {
         Some(path) => path,
         None => env::current_dir().map_err(|error| {
@@ -1021,6 +1012,8 @@ fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
 
     let source_config = app_data_file_path(CONFIG_FILE_NAME)?;
     let source_stats = app_data_file_path(STATS_FILE_NAME)?;
+    ensure_backup_source_file(&source_config, CONFIG_FILE_NAME)?;
+    ensure_backup_source_file(&source_stats, STATS_FILE_NAME)?;
     let config_backup_path = backup_dir.join(CONFIG_FILE_NAME);
     let stats_backup_path = backup_dir.join(STATS_FILE_NAME);
 
@@ -1081,6 +1074,24 @@ fn ensure_restore_source_file(path: &Path, file_name: &str) -> Result<(), String
     if !path.is_file() {
         return Err(format!(
             "Restore failed: `{}` is not a regular file.",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_backup_source_file(path: &Path, file_name: &str) -> Result<(), String> {
+    if !path.exists() {
+        return Err(format!(
+            "Backup failed: missing `{file_name}` in `{}`.",
+            path.parent()
+                .map(|parent| parent.display().to_string())
+                .unwrap_or_else(|| ".".to_string())
+        ));
+    }
+    if !path.is_file() {
+        return Err(format!(
+            "Backup failed: `{}` is not a regular file.",
             path.display()
         ));
     }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, io, path::Path, thread, time::Duration};
+use std::{env, fs, path::Path, thread, time::Duration};
 
 use crate::app::App;
 
@@ -1188,7 +1188,7 @@ fn replace_file_atomically(
     {
         match fs::rename(staged_path, destination) {
             Ok(()) => Ok(()),
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                 fs::remove_file(destination).map_err(|remove_error| {
                     format!(
                         "Failed to {context}: could not replace `{}`: {remove_error}",

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1087,10 +1087,16 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
         } else {
             let _ = remove_file_if_exists(&config_restored_path);
         }
-        let _ = remove_file_if_exists(&staged_stats_path);
         if let Some(snapshot) = original_stats_snapshot.as_deref() {
-            let _ = remove_file_if_exists(snapshot);
+            let _ = replace_file_atomically(
+                snapshot,
+                &stats_restored_path,
+                "roll back restored stats.toml",
+            );
+        } else {
+            let _ = remove_file_if_exists(&stats_restored_path);
         }
+        let _ = remove_file_if_exists(&staged_stats_path);
         return Err(error);
     }
     if let Some(snapshot) = original_config_snapshot.as_deref() {

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1,31 +1,34 @@
-use std::{env, thread, time::Duration};
+use std::{env, fs, path::Path, thread, time::Duration};
 
 use crate::app::App;
 
 use crate::cli::{
-    AppConfig, BlocklistProfileCommandKind, BlocklistProfileCommandOutput, BlocklistProfileConfig,
-    BlocklistProfileSummaryOutput, BlocklistSiteCommandKind, CliCommand, CommandKind,
-    DailyGoalConfig, DailyGoalSnapshot, EditSiteResult, ExportOutput, FocusStats,
+    AppConfig, BackupOutput, BlocklistProfileCommandKind, BlocklistProfileCommandOutput,
+    BlocklistProfileConfig, BlocklistProfileSummaryOutput, BlocklistSiteCommandKind, CliCommand,
+    CommandKind, DailyGoalConfig, DailyGoalSnapshot, EditSiteResult, ExportOutput, FocusStats,
     GoalCarryCommandOutput, GoalCommandOutput, InvalidSiteEntryOutput, InvalidSiteInput,
     MonthlyGoalConfig, OutputMode, PathBuf, ProfileId, ProfileOutput, ProfileView,
-    RecurringScheduleConfig, ScheduleCommandOutput, SiteAddCommandOutput, SiteBlocker,
-    SiteDeleteCommandOutput, SiteEditCommandOutput, SiteEditValue, SiteListCommandOutput,
-    SiteListTarget, StatusOutput, StrictCommandOutput, TaskCommandOutput, TaskGoalCommandOutput,
-    TaskGoalOutput, ThemeCommandOutput, ThemePreset, TimerCommandOutput, TimerStateOutput,
-    WeeklyGoalConfig, available_break_template_views, available_theme_preset_views,
-    build_blocking_preview_command_output, build_diagnostics_command_output,
-    build_schedule_inspection_output, build_status_output, build_task_goal_output,
-    display_input_value, effective_blocked_sites_for_profile, flush_stdout,
-    mirror_metadata_from_task_label, print_blocking_preview_command_output,
+    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, SiteAddCommandOutput,
+    SiteBlocker, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteEditValue,
+    SiteListCommandOutput, SiteListTarget, StatusOutput, StrictCommandOutput, TaskCommandOutput,
+    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, ThemePreset, TimerCommandOutput,
+    TimerStateOutput, WeeklyGoalConfig, available_break_template_views,
+    available_theme_preset_views, build_blocking_preview_command_output,
+    build_diagnostics_command_output, build_schedule_inspection_output, build_status_output,
+    build_task_goal_output, display_input_value, effective_blocked_sites_for_profile, flush_stdout,
+    mirror_metadata_from_task_label, print_backup_output, print_blocking_preview_command_output,
     print_blocklist_profile_command_output, print_diagnostics_command_output, print_export_output,
     print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
-    print_profile_output, print_schedule_command_output, print_site_add_command_output,
-    print_site_delete_command_output, print_site_edit_command_output,
-    print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
-    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
-    timer_status_id,
+    print_profile_output, print_restore_output, print_schedule_command_output,
+    print_site_add_command_output, print_site_delete_command_output,
+    print_site_edit_command_output, print_site_list_command_output, print_status_output,
+    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
+    print_timer_state_output, profile_id, profile_view, selected_break_template_view,
+    theme_preset_view, timer_phase_id, timer_status_id,
 };
+
+const CONFIG_FILE_NAME: &str = "config.toml";
+const STATS_FILE_NAME: &str = "stats.toml";
 
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
     match cli_command.kind {
@@ -60,6 +63,8 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         CommandKind::Status {
             watch_interval_secs,
         } => execute_status_command(cli_command.output, watch_interval_secs),
+        CommandKind::Backup { dir } => execute_backup_command(dir, cli_command.output),
+        CommandKind::Restore { dir } => execute_restore_command(dir, cli_command.output),
         CommandKind::Export { dir } => execute_export_command(dir, cli_command.output),
         CommandKind::BlocklistProfile { command } => {
             execute_blocklist_profile_command(command, cli_command.output)
@@ -992,6 +997,120 @@ fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
         OutputMode::Text => print_export_output(&payload),
         OutputMode::Json => print_json(&payload)?,
     }
+    Ok(())
+}
+
+fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
+    let config = AppConfig::load().normalized();
+    config
+        .save()
+        .map_err(|error| format!("Backup failed: could not persist config.toml: {error}"))?;
+    let stats = FocusStats::load().map_err(|error| format!("Backup failed: {error}"))?;
+    stats
+        .save()
+        .map_err(|error| format!("Backup failed: could not persist stats.toml: {error}"))?;
+
+    let backup_dir = match dir {
+        Some(path) => path,
+        None => env::current_dir().map_err(|error| {
+            format!("Backup failed: could not determine current directory: {error}")
+        })?,
+    };
+    fs::create_dir_all(&backup_dir)
+        .map_err(|error| format!("Backup failed: could not create backup directory: {error}"))?;
+
+    let source_config = app_data_file_path(CONFIG_FILE_NAME)?;
+    let source_stats = app_data_file_path(STATS_FILE_NAME)?;
+    let config_backup_path = backup_dir.join(CONFIG_FILE_NAME);
+    let stats_backup_path = backup_dir.join(STATS_FILE_NAME);
+
+    copy_file_with_context(&source_config, &config_backup_path, "backup config.toml")?;
+    copy_file_with_context(&source_stats, &stats_backup_path, "backup stats.toml")?;
+
+    let payload = BackupOutput {
+        backup_dir,
+        config_backup_path,
+        stats_backup_path,
+    };
+    match output {
+        OutputMode::Text => print_backup_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
+    let restore_dir = match dir {
+        Some(path) => path,
+        None => env::current_dir().map_err(|error| {
+            format!("Restore failed: could not determine current directory: {error}")
+        })?,
+    };
+    let source_config = restore_dir.join(CONFIG_FILE_NAME);
+    let source_stats = restore_dir.join(STATS_FILE_NAME);
+    ensure_restore_source_file(&source_config, CONFIG_FILE_NAME)?;
+    ensure_restore_source_file(&source_stats, STATS_FILE_NAME)?;
+
+    let config_restored_path = app_data_file_path(CONFIG_FILE_NAME)?;
+    let stats_restored_path = app_data_file_path(STATS_FILE_NAME)?;
+
+    copy_file_with_context(&source_config, &config_restored_path, "restore config.toml")?;
+    copy_file_with_context(&source_stats, &stats_restored_path, "restore stats.toml")?;
+
+    let payload = RestoreOutput {
+        restore_dir,
+        config_restored_path,
+        stats_restored_path,
+    };
+    match output {
+        OutputMode::Text => print_restore_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn ensure_restore_source_file(path: &Path, file_name: &str) -> Result<(), String> {
+    if !path.exists() {
+        return Err(format!(
+            "Restore failed: missing `{file_name}` in `{}`.",
+            path.parent()
+                .map(|parent| parent.display().to_string())
+                .unwrap_or_else(|| ".".to_string())
+        ));
+    }
+    if !path.is_file() {
+        return Err(format!(
+            "Restore failed: `{}` is not a regular file.",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn app_data_file_path(file_name: &str) -> Result<PathBuf, String> {
+    crate::config::app_data_path(file_name).ok_or_else(|| {
+        format!(
+            "could not determine application data path for `{file_name}` (environment is not configured)"
+        )
+    })
+}
+
+fn copy_file_with_context(source: &Path, destination: &Path, context: &str) -> Result<(), String> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "Failed to {context}: could not create `{}`: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    fs::copy(source, destination).map_err(|error| {
+        format!(
+            "Failed to {context}: `{}` -> `{}`: {error}",
+            source.display(),
+            destination.display()
+        )
+    })?;
     Ok(())
 }
 

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1100,10 +1100,10 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
         return Err(error);
     }
     if let Some(snapshot) = original_config_snapshot.as_deref() {
-        remove_file_if_exists(snapshot)?;
+        let _ = remove_file_if_exists(snapshot);
     }
     if let Some(snapshot) = original_stats_snapshot.as_deref() {
-        remove_file_if_exists(snapshot)?;
+        let _ = remove_file_if_exists(snapshot);
     }
 
     let payload = RestoreOutput {

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::Path, thread, time::Duration};
+use std::{env, fs, io, path::Path, thread, time::Duration};
 
 use crate::app::App;
 
@@ -1046,9 +1046,59 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
 
     let config_restored_path = app_data_file_path(CONFIG_FILE_NAME)?;
     let stats_restored_path = app_data_file_path(STATS_FILE_NAME)?;
+    let staged_config_path = temp_restore_path(&config_restored_path, "staged");
+    let staged_stats_path = temp_restore_path(&stats_restored_path, "staged");
+    copy_file_with_context(
+        &source_config,
+        &staged_config_path,
+        "stage restore config.toml",
+    )?;
+    copy_file_with_context(
+        &source_stats,
+        &staged_stats_path,
+        "stage restore stats.toml",
+    )?;
 
-    copy_file_with_context(&source_config, &config_restored_path, "restore config.toml")?;
-    copy_file_with_context(&source_stats, &stats_restored_path, "restore stats.toml")?;
+    let original_config_snapshot = snapshot_existing_file(
+        &config_restored_path,
+        "snapshot existing config.toml for rollback",
+    )?;
+    let original_stats_snapshot = snapshot_existing_file(
+        &stats_restored_path,
+        "snapshot existing stats.toml for rollback",
+    )?;
+
+    replace_file_atomically(
+        &staged_config_path,
+        &config_restored_path,
+        "restore config.toml",
+    )?;
+    if let Err(error) = replace_file_atomically(
+        &staged_stats_path,
+        &stats_restored_path,
+        "restore stats.toml",
+    ) {
+        if let Some(snapshot) = original_config_snapshot.as_deref() {
+            let _ = replace_file_atomically(
+                snapshot,
+                &config_restored_path,
+                "roll back restored config.toml",
+            );
+        } else {
+            let _ = remove_file_if_exists(&config_restored_path);
+        }
+        let _ = remove_file_if_exists(&staged_stats_path);
+        if let Some(snapshot) = original_stats_snapshot.as_deref() {
+            let _ = remove_file_if_exists(snapshot);
+        }
+        return Err(error);
+    }
+    if let Some(snapshot) = original_config_snapshot.as_deref() {
+        remove_file_if_exists(snapshot)?;
+    }
+    if let Some(snapshot) = original_stats_snapshot.as_deref() {
+        remove_file_if_exists(snapshot)?;
+    }
 
     let payload = RestoreOutput {
         restore_dir,
@@ -1096,6 +1146,92 @@ fn ensure_backup_source_file(path: &Path, file_name: &str) -> Result<(), String>
         ));
     }
     Ok(())
+}
+
+fn snapshot_existing_file(path: &Path, context: &str) -> Result<Option<PathBuf>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    if !path.is_file() {
+        return Err(format!(
+            "Failed to {context}: `{}` is not a regular file.",
+            path.display()
+        ));
+    }
+    let snapshot = temp_restore_path(path, "original");
+    fs::copy(path, &snapshot).map_err(|error| {
+        format!(
+            "Failed to {context}: `{}` -> `{}`: {error}",
+            path.display(),
+            snapshot.display()
+        )
+    })?;
+    Ok(Some(snapshot))
+}
+
+fn temp_restore_path(path: &Path, marker: &str) -> PathBuf {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let target_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("focustime-restore");
+    let pid = std::process::id();
+    parent.join(format!(".{target_name}.{pid}.{marker}.tmp"))
+}
+
+fn replace_file_atomically(
+    staged_path: &Path,
+    destination: &Path,
+    context: &str,
+) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        match fs::rename(staged_path, destination) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                fs::remove_file(destination).map_err(|remove_error| {
+                    format!(
+                        "Failed to {context}: could not replace `{}`: {remove_error}",
+                        destination.display()
+                    )
+                })?;
+                fs::rename(staged_path, destination).map_err(|rename_error| {
+                    format!(
+                        "Failed to {context}: `{}` -> `{}`: {rename_error}",
+                        staged_path.display(),
+                        destination.display()
+                    )
+                })
+            }
+            Err(error) => {
+                let _ = remove_file_if_exists(staged_path);
+                Err(format!(
+                    "Failed to {context}: `{}` -> `{}`: {error}",
+                    staged_path.display(),
+                    destination.display()
+                ))
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        fs::rename(staged_path, destination).map_err(|error| {
+            let _ = remove_file_if_exists(staged_path);
+            format!(
+                "Failed to {context}: `{}` -> `{}`: {error}",
+                staged_path.display(),
+                destination.display()
+            )
+        })
+    }
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    fs::remove_file(path).map_err(|error| format!("Failed to remove `{}`: {error}", path.display()))
 }
 
 fn app_data_file_path(file_name: &str) -> Result<PathBuf, String> {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,14 +1,14 @@
 use std::collections::HashSet;
 
 use crate::cli::{
-    BlockingPreviewAction, BlockingPreviewCommandOutput, BlocklistProfileCommandOutput,
-    BlocklistProfileConfig, DiagnosticsCommandOutput, ExportOutput, FocusScoreOutput,
-    GoalCarryCommandOutput, GoalCommandOutput, GoalOutput, ProfileOutput, RecurringScheduleConfig,
-    ScheduleCommandOutput, ScheduleInspectionOutput, Serialize, SetupCheck, SetupCheckLevel,
-    SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput,
-    SiteEditCommandOutput, SiteListCommandOutput, StatusOutput, StrictCommandOutput,
-    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, TimerStateOutput, Write,
-    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    BackupOutput, BlockingPreviewAction, BlockingPreviewCommandOutput,
+    BlocklistProfileCommandOutput, BlocklistProfileConfig, DiagnosticsCommandOutput, ExportOutput,
+    FocusScoreOutput, GoalCarryCommandOutput, GoalCommandOutput, GoalOutput, ProfileOutput,
+    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, ScheduleInspectionOutput,
+    Serialize, SetupCheck, SetupCheckLevel, SetupCheckOutput, SetupDiagnostics,
+    SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput,
+    StatusOutput, StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
+    TimerStateOutput, Write, format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -372,6 +372,18 @@ pub(super) fn print_export_output(payload: &ExportOutput) {
     println!("Exported stats to {}", payload.export_dir.display());
     println!("JSON: {}", payload.json_path.display());
     println!("CSV: {}", payload.csv_path.display());
+}
+
+pub(super) fn print_backup_output(payload: &BackupOutput) {
+    println!("Backed up app data to {}", payload.backup_dir.display());
+    println!("Config: {}", payload.config_backup_path.display());
+    println!("Stats: {}", payload.stats_backup_path.display());
+}
+
+pub(super) fn print_restore_output(payload: &RestoreOutput) {
+    println!("Restored app data from {}", payload.restore_dir.display());
+    println!("Config: {}", payload.config_restored_path.display());
+    println!("Stats: {}", payload.stats_restored_path.display());
 }
 
 pub(super) fn print_goal_command_output(label: &str, payload: &GoalCommandOutput) {

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -49,6 +49,8 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::ScheduleSet(_)
             | ParsedToken::Diagnostics
             | ParsedToken::BlockingPreview
+            | ParsedToken::Backup(_)
+            | ParsedToken::Restore(_)
             | ParsedToken::Export(_)
             | ParsedToken::BlocklistProfile(_)
             | ParsedToken::BlocklistProfileCreate(_)
@@ -126,6 +128,12 @@ pub(super) fn parse_primary_command(
             }
             ParsedToken::BlockingPreview => {
                 set_primary_command(&mut primary, PrimaryCommand::BlockingPreview)?
+            }
+            ParsedToken::Backup(dir) => {
+                set_primary_command(&mut primary, PrimaryCommand::Backup(dir.clone()))?
+            }
+            ParsedToken::Restore(dir) => {
+                set_primary_command(&mut primary, PrimaryCommand::Restore(dir.clone()))?
             }
             ParsedToken::Export(dir) => {
                 set_primary_command(&mut primary, PrimaryCommand::Export(dir.clone()))?
@@ -299,6 +307,14 @@ pub(super) fn finalize_cli_action(
             kind: CommandKind::Status {
                 watch_interval_secs,
             },
+            output,
+        })),
+        Some(PrimaryCommand::Backup(dir)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Backup { dir },
+            output,
+        })),
+        Some(PrimaryCommand::Restore(dir)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Restore { dir },
             output,
         })),
         Some(PrimaryCommand::Export(dir)) => Ok(CliAction::RunCommand(CliCommand {
@@ -693,6 +709,8 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Diagnostics => "--diagnostics",
         PrimaryCommand::BlockingPreview => "--blocking-preview",
         PrimaryCommand::Status => "--status",
+        PrimaryCommand::Backup(_) => "--backup",
+        PrimaryCommand::Restore(_) => "--restore",
         PrimaryCommand::Export(_) => "--export",
         PrimaryCommand::BlocklistProfile(_) => "--blocklist-profile",
         PrimaryCommand::BlocklistProfileCreate(_) => "--blocklist-profile-create",

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -598,6 +598,18 @@ fn parse_backup_accepts_optional_directory() {
 }
 
 #[test]
+fn parse_backup_without_value_uses_default_directory() {
+    let parsed = parse(&["--backup"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Backup { dir: None },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
 fn parse_backup_with_equals_accepts_directory() {
     let parsed = parse(&["--backup=reports"]).unwrap();
     assert_eq!(
@@ -620,6 +632,18 @@ fn parse_restore_accepts_optional_directory() {
             kind: CommandKind::Restore {
                 dir: Some(PathBuf::from("reports"))
             },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_restore_without_value_uses_default_directory() {
+    let parsed = parse(&["--restore"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Restore { dir: None },
             output: OutputMode::Text
         })
     );
@@ -1168,6 +1192,18 @@ fn parse_rejects_watch_without_status() {
 fn parse_rejects_watch_with_non_status_command() {
     let error = parse(&["--export", "--watch"]).unwrap_err();
     assert!(error.contains("`--watch` is only valid with `--status`"));
+}
+
+#[test]
+fn parse_rejects_backup_with_blank_positional_value() {
+    let error = parse(&["--backup", "   "]).unwrap_err();
+    assert!(error.contains("`--backup` requires a target directory."));
+}
+
+#[test]
+fn parse_rejects_restore_with_blank_positional_value() {
+    let error = parse(&["--restore", "   "]).unwrap_err();
+    assert!(error.contains("`--restore` requires a source directory."));
 }
 
 #[test]

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -584,6 +584,62 @@ fn parse_export_accepts_optional_directory() {
 }
 
 #[test]
+fn parse_backup_accepts_optional_directory() {
+    let parsed = parse(&["--backup", "reports"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Backup {
+                dir: Some(PathBuf::from("reports"))
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_backup_with_equals_accepts_directory() {
+    let parsed = parse(&["--backup=reports"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Backup {
+                dir: Some(PathBuf::from("reports"))
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_restore_accepts_optional_directory() {
+    let parsed = parse(&["--restore", "reports"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Restore {
+                dir: Some(PathBuf::from("reports"))
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_restore_with_equals_accepts_directory() {
+    let parsed = parse(&["--restore=reports"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Restore {
+                dir: Some(PathBuf::from("reports"))
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
 fn parse_export_with_equals_accepts_directory() {
     let parsed = parse(&["--export=reports"]).unwrap();
     assert_eq!(
@@ -790,6 +846,24 @@ fn classify_key_value_arg_accepts_export_equals_value() {
 }
 
 #[test]
+fn classify_key_value_arg_accepts_backup_equals_value() {
+    let parsed = classify_key_value_arg("--backup=reports").unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::Backup(Some(PathBuf::from("reports"))))
+    );
+}
+
+#[test]
+fn classify_key_value_arg_accepts_restore_equals_value() {
+    let parsed = classify_key_value_arg("--restore=reports").unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::Restore(Some(PathBuf::from("reports"))))
+    );
+}
+
+#[test]
 fn classify_key_value_arg_accepts_goal_equals_value() {
     let parsed = classify_key_value_arg("--goal=90,3").unwrap();
     assert_eq!(
@@ -871,6 +945,18 @@ fn classify_key_value_arg_accepts_schedule_set_equals_value() {
 fn classify_key_value_arg_rejects_empty_export_equals_value() {
     let error = classify_key_value_arg("--export=").unwrap_err();
     assert!(error.contains("`--export=` requires a target directory."));
+}
+
+#[test]
+fn classify_key_value_arg_rejects_empty_backup_equals_value() {
+    let error = classify_key_value_arg("--backup=").unwrap_err();
+    assert!(error.contains("`--backup=` requires a target directory."));
+}
+
+#[test]
+fn classify_key_value_arg_rejects_empty_restore_equals_value() {
+    let error = classify_key_value_arg("--restore=").unwrap_err();
+    assert!(error.contains("`--restore=` requires a source directory."));
 }
 
 #[test]
@@ -1045,6 +1131,12 @@ fn parse_rejects_schedule_set_with_invalid_one_time_date() {
 #[test]
 fn parse_rejects_multiple_primary_commands() {
     let error = parse(&["--status", "--export"]).unwrap_err();
+    assert!(error.contains("Multiple primary commands"));
+}
+
+#[test]
+fn parse_rejects_multiple_primary_commands_for_backup_and_restore() {
+    let error = parse(&["--backup", "--restore"]).unwrap_err();
     assert!(error.contains("Multiple primary commands"));
 }
 

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -204,6 +204,87 @@ fn status_watch_json_streams_multiple_snapshots() {
 }
 
 #[test]
+fn backup_and_restore_json_round_trip_config_and_stats_files() {
+    let env = TestEnv::new("backup-restore-json");
+    let backup_dir = env.root.join("backup");
+    let backup_arg = format!("--backup={}", backup_dir.display());
+    let restore_arg = format!("--restore={}", backup_dir.display());
+
+    let set_goal_output = env.run(&["--goal=120,4", "--json"]);
+    assert_eq!(set_goal_output.status.code(), Some(0));
+    assert!(stderr_text(&set_goal_output).trim().is_empty());
+
+    let set_task_goal_output = env.run(&["--task-goal=Docs:90,3", "--json"]);
+    assert_eq!(set_task_goal_output.status.code(), Some(0));
+    assert!(stderr_text(&set_task_goal_output).trim().is_empty());
+
+    let backup_output = env.run(&[backup_arg.as_str(), "--json"]);
+    assert_eq!(backup_output.status.code(), Some(0));
+    assert!(stderr_text(&backup_output).trim().is_empty());
+    let backup_payload: Value =
+        serde_json::from_slice(&backup_output.stdout).expect("stdout should be JSON");
+    assert!(backup_payload.get("backup_dir").is_some());
+    assert!(backup_payload.get("config_backup_path").is_some());
+    assert!(backup_payload.get("stats_backup_path").is_some());
+    assert!(backup_dir.join("config.toml").is_file());
+    assert!(backup_dir.join("stats.toml").is_file());
+
+    let mutate_goal_output = env.run(&["--goal=15,1", "--json"]);
+    assert_eq!(mutate_goal_output.status.code(), Some(0));
+    assert!(stderr_text(&mutate_goal_output).trim().is_empty());
+
+    let mutate_task_goal_output = env.run(&["--task-goal=Docs:30,1", "--json"]);
+    assert_eq!(mutate_task_goal_output.status.code(), Some(0));
+    assert!(stderr_text(&mutate_task_goal_output).trim().is_empty());
+
+    let restore_output = env.run(&[restore_arg.as_str(), "--json"]);
+    assert_eq!(restore_output.status.code(), Some(0));
+    assert!(stderr_text(&restore_output).trim().is_empty());
+    let restore_payload: Value =
+        serde_json::from_slice(&restore_output.stdout).expect("stdout should be JSON");
+    assert!(restore_payload.get("restore_dir").is_some());
+    assert!(restore_payload.get("config_restored_path").is_some());
+    assert!(restore_payload.get("stats_restored_path").is_some());
+
+    let goal_output = env.run(&["--goal", "--json"]);
+    assert_eq!(goal_output.status.code(), Some(0));
+    let goal_payload: Value = serde_json::from_slice(&goal_output.stdout).unwrap();
+    assert_eq!(goal_payload["minutes_target"], 120);
+    assert_eq!(goal_payload["pomodoros_target"], 4);
+
+    let task_goal_output = env.run(&["--task-goal", "Docs", "--json"]);
+    assert_eq!(task_goal_output.status.code(), Some(0));
+    let task_goal_payload: Value = serde_json::from_slice(&task_goal_output.stdout).unwrap();
+    assert_eq!(task_goal_payload["minutes_target"], 90);
+    assert_eq!(task_goal_payload["pomodoros_target"], 3);
+}
+
+#[test]
+fn restore_json_fails_when_backup_is_missing_stats_file() {
+    let env = TestEnv::new("restore-missing-stats");
+    let backup_dir = env.root.join("broken-backup");
+    fs::create_dir_all(&backup_dir).expect("failed to create backup directory");
+    fs::write(backup_dir.join("config.toml"), "focus_secs = 1500\n")
+        .expect("failed to write config backup file");
+    let restore_arg = format!("--restore={}", backup_dir.display());
+
+    let output = env.run(&[restore_arg.as_str(), "--json"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"]["kind"], "runtime");
+    assert_eq!(payload["error"]["exit_code"], 1);
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .expect("error message should be a string")
+            .contains("missing `stats.toml`")
+    );
+}
+
+#[test]
 fn parse_errors_in_json_mode_emit_usage_envelope() {
     let env = TestEnv::new("json-parse-error");
     let output = env.run(&["--status", "--unknown", "--json"]);

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -260,6 +260,33 @@ fn backup_and_restore_json_round_trip_config_and_stats_files() {
 }
 
 #[test]
+fn backup_json_copies_raw_files_even_when_malformed() {
+    let env = TestEnv::new("backup-raw-malformed");
+    let app_data_dir = env.root.join("focustime");
+    fs::create_dir_all(&app_data_dir).expect("failed to create app data directory");
+    let seed_output = env.run(&["--task", "Docs", "--json"]);
+    assert_eq!(seed_output.status.code(), Some(0));
+    assert!(stderr_text(&seed_output).trim().is_empty());
+
+    let malformed_config = "this is not valid toml !!!\n";
+    fs::write(app_data_dir.join("config.toml"), malformed_config).expect("failed to write config");
+
+    let backup_dir = env.root.join("backup");
+    let backup_arg = format!("--backup={}", backup_dir.display());
+    let output = env.run(&[backup_arg.as_str(), "--json"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert!(payload.get("backup_dir").is_some());
+    assert_eq!(
+        fs::read_to_string(backup_dir.join("config.toml")).unwrap(),
+        malformed_config
+    );
+    assert!(backup_dir.join("stats.toml").is_file());
+}
+
+#[test]
 fn restore_json_fails_when_backup_is_missing_stats_file() {
     let env = TestEnv::new("restore-missing-stats");
     let backup_dir = env.root.join("broken-backup");


### PR DESCRIPTION
## What

- Adds `--backup[=DIR]` and `--restore[=DIR]` CLI commands to copy `config.toml` and `stats.toml`.
- Implements strict restore behavior: both files must exist in the restore source directory.
- Extends CLI surface/parsing/execution/output, plus parser and JSON contract test coverage.
- Updates README examples and changelog notes for the new commands.

## Why

Issue #197 requests first-class backup and restore commands for persistent app data so users can automate migration/recovery workflows without manual file handling.

Fixes: #197

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable) (N/A - CLI-only data file command changes)
- [x] Site blocking behavior was verified for this change (if applicable) (N/A - no blocking logic changes)
- [x] WakaTime integration behavior was verified for this change (if applicable) (N/A - no WakaTime logic changes)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A - no new dependencies/config)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) (N/A - no dependency or security model changes)
- [x] Breaking behavior changes are clearly described in this PR (N/A - no breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands --backup[=DIR] and --restore[=DIR] to copy/restore configuration and stats to/from a chosen directory; supports JSON output.
  * Restore requires both config and stats files in the source and validates/atomically replaces files with rollback on failure.
  * Added optional task-label mapping to override project/language assignments per task (case-insensitive, per-field fallback).

* **Documentation**
  * README and changelog updated with backup/restore usage and options.

* **Tests**
  * Added CLI parsing and JSON integration tests for backup/restore flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->