### PR TITLE
Config schema/versioning groundwork for upcoming migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ and interruption/completed-session history export fields.
 ### Example config
 
 ```toml
+schema_version = 1
 selected_profile = "custom"
 selected_break_template = "Classic"
 selected_theme_preset = "classic"
@@ -424,6 +425,11 @@ language = "Markdown"
 task_label = "Review"
 language = "Code Review"
 ```
+
+`schema_version` is managed by focustime when writing `config.toml`. Files
+without this key are treated as legacy and migrated automatically. If a file
+declares a newer schema version than the running binary supports, focustime
+attempts a best-effort load of known fields.
 
 `[wakatime]` is optional. If omitted (or set to blank values), `focustime` uses
 the defaults above for heartbeat metadata labels.

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,9 @@ use paths::config_dir_from_env;
 #[cfg(all(test, not(target_os = "windows")))]
 use paths::env_path_from_value;
 
+const CURRENT_CONFIG_SCHEMA_VERSION: u32 = 1;
+const LEGACY_CONFIG_SCHEMA_VERSION: u32 = 0;
+
 /// Persistent application configuration stored as TOML.
 ///
 /// File locations:
@@ -113,6 +116,23 @@ pub struct AppConfig {
     /// User-configurable keyboard shortcuts for core TUI command actions.
     #[serde(default)]
     pub shortcuts: ShortcutConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AppConfigDisk {
+    #[serde(default = "default_legacy_config_schema_version")]
+    schema_version: u32,
+    #[serde(flatten)]
+    config: AppConfig,
+}
+
+impl AppConfigDisk {
+    fn from_config(config: AppConfig) -> Self {
+        Self {
+            schema_version: CURRENT_CONFIG_SCHEMA_VERSION,
+            config,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1167,6 +1187,9 @@ fn default_long_break_secs() -> u64 {
 fn default_long_break_interval() -> u32 {
     crate::timer::DEFAULT_LONG_BREAK_INTERVAL
 }
+fn default_legacy_config_schema_version() -> u32 {
+    LEGACY_CONFIG_SCHEMA_VERSION
+}
 
 impl Default for AppConfig {
     fn default() -> Self {
@@ -1283,7 +1306,10 @@ impl AppConfig {
     fn try_load_with_env(get_var: impl FnMut(&str) -> Option<OsString>) -> Option<Self> {
         let path = Self::config_path_with_env(get_var)?;
         let content = fs::read_to_string(path).ok()?;
-        toml::from_str(&content).ok().map(Self::normalize)
+        let config_toml: toml::Value = toml::from_str(&content).ok()?;
+        let migrated_toml = migrate_config_toml_to_current(config_toml)?;
+        let disk: AppConfigDisk = migrated_toml.try_into().ok()?;
+        Some(disk.config.normalize())
     }
 
     /// Persist the current config to disk.
@@ -1293,12 +1319,23 @@ impl AppConfig {
         let path = Self::config_path().ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, "cannot determine config directory")
         })?;
+        self.save_to_path(path)
+    }
 
+    #[cfg(test)]
+    fn save_with_env(&self, get_var: impl FnMut(&str) -> Option<OsString>) -> io::Result<()> {
+        let path = Self::config_path_with_env(get_var).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotFound, "cannot determine config directory")
+        })?;
+        self.save_to_path(path)
+    }
+
+    fn save_to_path(&self, path: PathBuf) -> io::Result<()> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
 
-        let content = toml::to_string_pretty(self)
+        let content = toml::to_string_pretty(&AppConfigDisk::from_config(self.clone()))
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         // Best-effort atomic write: temp file + rename.
@@ -1381,6 +1418,48 @@ impl AppConfig {
         let app_dir = app_dir_with_env(get_var)?;
         Some(app_dir.join("config.toml"))
     }
+}
+
+fn migrate_config_toml_to_current(mut config_toml: toml::Value) -> Option<toml::Value> {
+    let schema_version = detect_config_schema_version(&config_toml)?;
+    if schema_version > CURRENT_CONFIG_SCHEMA_VERSION {
+        // Forward-compatibility mode: try best-effort deserialization with known fields.
+        return Some(config_toml);
+    }
+
+    let mut from_schema_version = schema_version;
+    while from_schema_version < CURRENT_CONFIG_SCHEMA_VERSION {
+        config_toml = migrate_config_toml_step(config_toml, from_schema_version)?;
+        from_schema_version += 1;
+    }
+    Some(config_toml)
+}
+
+fn detect_config_schema_version(config_toml: &toml::Value) -> Option<u32> {
+    let table = config_toml.as_table()?;
+    table
+        .get("schema_version")
+        .map(|value| value.as_integer().and_then(|raw| u32::try_from(raw).ok()))
+        .unwrap_or(Some(LEGACY_CONFIG_SCHEMA_VERSION))
+}
+
+fn migrate_config_toml_step(
+    config_toml: toml::Value,
+    from_schema_version: u32,
+) -> Option<toml::Value> {
+    match from_schema_version {
+        LEGACY_CONFIG_SCHEMA_VERSION => migrate_config_toml_legacy_to_v1(config_toml),
+        _ => None,
+    }
+}
+
+fn migrate_config_toml_legacy_to_v1(mut config_toml: toml::Value) -> Option<toml::Value> {
+    let table = config_toml.as_table_mut()?;
+    table.insert(
+        "schema_version".to_string(),
+        toml::Value::Integer(i64::from(CURRENT_CONFIG_SCHEMA_VERSION)),
+    );
+    Some(config_toml)
 }
 
 #[cfg_attr(test, allow(dead_code))]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -7,6 +7,17 @@ const CONFIG_DIR_ENV: &str = "APPDATA";
 #[cfg(not(target_os = "windows"))]
 const CONFIG_DIR_ENV: &str = "XDG_CONFIG_HOME";
 
+fn unique_temp_base(test_name: &str) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "focustime-config-test-{test_name}-{}-{now}",
+        std::process::id()
+    ))
+}
+
 #[test]
 fn default_values_are_canonical_pomodoro() {
     let cfg = AppConfig::default();
@@ -659,14 +670,7 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
 
 #[test]
 fn load_returns_default_when_config_file_is_corrupt() {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let temp_base = std::env::temp_dir().join(format!(
-        "focustime-config-test-{}-{now}",
-        std::process::id()
-    ));
+    let temp_base = unique_temp_base("corrupt");
     let app_dir = temp_base.join("focustime");
     fs::create_dir_all(&app_dir).unwrap();
     fs::write(app_dir.join("config.toml"), "this is not valid toml !!!").unwrap();
@@ -707,6 +711,111 @@ fn load_returns_default_when_config_file_is_corrupt() {
     assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
     assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
     assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
+}
+
+#[test]
+fn load_with_env_migrates_legacy_config_without_schema_version() {
+    let temp_base = unique_temp_base("legacy-no-version");
+    let app_dir = temp_base.join("focustime");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("config.toml"),
+        "focus_secs = 1800\nshort_break_secs = 360\n",
+    )
+    .unwrap();
+
+    let cfg = AppConfig::load_with_env(|key| {
+        if key == CONFIG_DIR_ENV {
+            Some(temp_base.clone().into_os_string())
+        } else {
+            None
+        }
+    });
+    let _ = fs::remove_dir_all(&temp_base);
+
+    assert_eq!(cfg.focus_secs, 1800);
+    assert_eq!(cfg.short_break_secs, 360);
+}
+
+#[test]
+fn load_with_env_migrates_explicit_legacy_schema_version() {
+    let temp_base = unique_temp_base("legacy-version-zero");
+    let app_dir = temp_base.join("focustime");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("config.toml"),
+        "schema_version = 0\nfocus_secs = 1950\n",
+    )
+    .unwrap();
+
+    let cfg = AppConfig::load_with_env(|key| {
+        if key == CONFIG_DIR_ENV {
+            Some(temp_base.clone().into_os_string())
+        } else {
+            None
+        }
+    });
+    let _ = fs::remove_dir_all(&temp_base);
+
+    assert_eq!(cfg.focus_secs, 1950);
+}
+
+#[test]
+fn load_with_env_leniently_parses_newer_schema_version() {
+    let temp_base = unique_temp_base("future-version");
+    let app_dir = temp_base.join("focustime");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("config.toml"),
+        "schema_version = 99\nfocus_secs = 2100\nfuture_only = \"ignored\"\n",
+    )
+    .unwrap();
+
+    let cfg = AppConfig::load_with_env(|key| {
+        if key == CONFIG_DIR_ENV {
+            Some(temp_base.clone().into_os_string())
+        } else {
+            None
+        }
+    });
+    let _ = fs::remove_dir_all(&temp_base);
+
+    assert_eq!(cfg.focus_secs, 2100);
+}
+
+#[test]
+fn save_with_env_writes_current_schema_version() {
+    let temp_base = unique_temp_base("save-schema-version");
+    let cfg = AppConfig {
+        focus_secs: 2100,
+        ..AppConfig::default()
+    };
+    cfg.save_with_env(|key| {
+        if key == CONFIG_DIR_ENV {
+            Some(temp_base.clone().into_os_string())
+        } else {
+            None
+        }
+    })
+    .unwrap();
+
+    let app_dir = temp_base.join("focustime");
+    let saved = fs::read_to_string(app_dir.join("config.toml")).unwrap();
+    let saved_toml: toml::Value = toml::from_str(&saved).unwrap();
+    let _ = fs::remove_dir_all(&temp_base);
+
+    assert_eq!(
+        saved_toml
+            .get("schema_version")
+            .and_then(toml::Value::as_integer),
+        Some(i64::from(CURRENT_CONFIG_SCHEMA_VERSION))
+    );
+    assert_eq!(
+        saved_toml
+            .get("focus_secs")
+            .and_then(toml::Value::as_integer),
+        Some(2100)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

- Add explicit config schema metadata through a disk-facing `AppConfigDisk` envelope with top-level `schema_version`.
- Refactor config load/save to use version-aware pathways: detect schema version, run migration dispatch scaffolding, and normalize into runtime `AppConfig`.
- Add migration groundwork for legacy config (`schema_version` missing or `0`) and lenient forward-compat behavior for newer schema versions.
- Extend config tests to cover legacy migration, future-version lenient loading, and persistence of current schema version.
- Update README config docs and example to document `schema_version` behavior.

## Why

Upcoming config migrations need a safe, explicit versioning contract so existing users can upgrade without manual intervention while preserving forward-compatible parsing behavior.

Closes #256.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration schema versioning is now automatically managed
  * Legacy configurations are automatically migrated to the current format
  * Graceful handling of configurations from newer app versions

* **Documentation**
  * Added information on configuration schema management and auto-migration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->