### PR TITLE
Stats growth observability and retention policy design

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ cargo run -- --diagnostics --json
 cargo run -- --blocking-preview
 cargo run -- --blocking-preview --json
 
-# Show status (text or JSON, including live timer/session fields, latest interruption summary, and `selected_task_goal` in JSON)
+# Show status (text or JSON, including growth/retention signals, live timer/session fields, latest interruption summary, and `selected_task_goal` in JSON)
 cargo run -- --status
 cargo run -- --status --json
 
@@ -412,6 +412,9 @@ pomodoros = 20
 minutes = 2400
 pomodoros = 80
 
+[stats_retention]
+preset = "balanced" # keep_all | balanced | aggressive
+
 [wakatime]
 project = "focustime"
 language = "Pomodoro"
@@ -592,6 +595,15 @@ Override events are recorded for audit visibility in the History view and includ
 - per-task cumulative goals (minutes/pomodoros) with per-label progress and met/in-progress evaluation
 - structured interruption events for manual `stop/reset` and `skip/next` actions
 - current streak and best streak based on completed daily goals
+- growth indicators (`record` count + estimated `stats.toml` size + top high-volume sections)
+
+Current retention presets for historical records:
+
+- `keep_all`: no automatic pruning
+- `balanced` (default): keep daily aggregates, prune `focus_sessions` at 365 days, prune `session_interruptions` and `break_glass_overrides` at 180 days
+- `aggressive`: prune daily aggregates at 365 days, `focus_sessions` at 180 days, and `session_interruptions` / `break_glass_overrides` at 90 days
+
+Retention is enforced when stats are persisted. Existing data older than the selected windows is pruned on save.
 
 If daily, weekly, or monthly goals are configured, timer and history views also
 show live progress for each period:

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,8 +14,8 @@ use crate::config::{
     AppConfig, AutoStartConfig, BlocklistProfileConfig, BreakTemplateConfig, CustomProfileConfig,
     DailyGoalConfig, GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig,
     OneTimeFocusWindowConfig, ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, ThemePreset, WakatimeMetadataConfig,
-    WeeklyGoalConfig,
+    RecurringFocusWindowConfig, RecurringScheduleConfig, StatsRetentionConfig, ThemePreset,
+    WakatimeMetadataConfig, WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -28,8 +28,9 @@ use crate::stats::{
     BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles,
     FocusSessionMetadata, FocusStats, GoalStreak, MonthlyHeatmap, MonthlyStats,
     ProfileEffectiveness, ProfileTotals, SessionInterruptionEvent, SessionInterruptionReason,
-    SessionStats, TaskGoalProgress, TaskTotals, TaskTrend, WeeklyConsistency, WeeklyFocusScore,
-    WeeklyStats, carry_over_goal_target, current_day_key,
+    SessionStats, StatsGrowthSummary, StatsRetentionPruneResult, TaskGoalProgress, TaskTotals,
+    TaskTrend, WeeklyConsistency, WeeklyFocusScore, WeeklyStats, carry_over_goal_target,
+    current_day_key,
 };
 use crate::task_labels::{normalize_task_label, task_label_index};
 use crate::timer::{
@@ -555,6 +556,7 @@ pub struct App {
     weekly_goal: WeeklyGoalConfig,
     monthly_goal: MonthlyGoalConfig,
     goal_carry_over: GoalCarryOverConfig,
+    stats_retention: StatsRetentionConfig,
     wakatime_metadata: WakatimeMetadataConfig,
     pending_timer_action: Option<PendingTimerAction>,
     notifier: PhaseNotifier,
@@ -596,6 +598,7 @@ impl App {
         let weekly_goal = config.weekly_goal;
         let monthly_goal = config.monthly_goal;
         let goal_carry_over = config.goal_carry_over;
+        let stats_retention = config.stats_retention;
         let wakatime_metadata = config.wakatime;
         let blocklist_profiles = config.blocklist_profiles.clone();
         let active_blocklist_profile =
@@ -608,10 +611,11 @@ impl App {
             &custom_profile,
         );
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
-        let (stats, stats_error) = match FocusStats::load() {
+        let (mut stats, stats_error) = match FocusStats::load() {
             Ok(stats) => (stats, None),
             Err(e) => (FocusStats::default(), Some(e)),
         };
+        let retained = stats.apply_retention_policy(stats_retention, Local::now().date_naive());
         let (task_labels, selected_task_label) = stats.task_planner_state();
         let task_label_favorites = task_label_state_keys(stats.task_label_favorites());
         let task_label_archived = task_label_state_keys(stats.task_label_archived());
@@ -698,11 +702,12 @@ impl App {
             weekly_goal,
             monthly_goal,
             goal_carry_over,
+            stats_retention,
             wakatime_metadata,
             pending_timer_action: None,
             notifier: PhaseNotifier::new(notification_settings),
             stats,
-            stats_dirty: false,
+            stats_dirty: retained.any_removed(),
             stats_has_unsaved_elapsed: false,
             shortcuts,
         };
@@ -914,6 +919,19 @@ impl App {
 
     pub fn latest_monthly_heatmap(&self) -> MonthlyHeatmap {
         self.stats.latest_monthly_heatmap()
+    }
+
+    pub fn stats_growth_summary(&self) -> StatsGrowthSummary {
+        self.stats.growth_summary()
+    }
+
+    pub fn stats_retention_config(&self) -> StatsRetentionConfig {
+        self.stats_retention
+    }
+
+    pub fn stats_retention_preview(&self) -> StatsRetentionPruneResult {
+        self.stats
+            .retention_preview(self.stats_retention, Local::now().date_naive())
     }
 
     #[allow(dead_code)]

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -199,6 +199,7 @@ impl App {
             weekly_goal: self.weekly_goal,
             monthly_goal: self.monthly_goal,
             goal_carry_over: self.goal_carry_over,
+            stats_retention: self.stats_retention,
             wakatime: self.wakatime_metadata.clone(),
             shortcuts: self.shortcuts.to_config(),
         }
@@ -241,6 +242,13 @@ impl App {
             return;
         }
 
+        if self
+            .stats
+            .apply_retention_policy(self.stats_retention, Local::now().date_naive())
+            .any_removed()
+        {
+            self.stats_dirty = true;
+        }
         self.save_stats();
         if self.stats_error.is_none() {
             self.stats_dirty = false;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,6 +1,6 @@
 use crate::app::*;
 use crate::blocker;
-use crate::config::ShortcutConfig;
+use crate::config::{ShortcutConfig, StatsRetentionConfig};
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
 };
@@ -122,6 +122,7 @@ fn selected_builtin_profile_is_applied_on_startup() {
         weekly_goal: WeeklyGoalConfig::default(),
         monthly_goal: MonthlyGoalConfig::default(),
         goal_carry_over: GoalCarryOverConfig::default(),
+        stats_retention: StatsRetentionConfig::default(),
         selected_theme_preset: ThemePreset::Classic,
         wakatime: WakatimeMetadataConfig::default(),
         shortcuts: ShortcutConfig::default(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,8 +19,8 @@ use crate::config::{
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
 use crate::stats::{
-    DailyGoalSnapshot, FocusStats, SessionInterruptionEvent, carry_over_goal_target,
-    current_day_key,
+    DailyGoalSnapshot, FocusStats, SessionInterruptionEvent, StatsGrowthSummary,
+    StatsRetentionPruneResult, carry_over_goal_target, current_day_key,
 };
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
@@ -531,7 +531,19 @@ struct StatusOutput {
     today: TodayOutput,
     latest_interruption: Option<SessionInterruptionEvent>,
     focus_score: FocusScoreOutput,
+    stats_growth: StatsGrowthSummary,
+    stats_retention: StatsRetentionStatusOutput,
     live: LiveStatusOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct StatsRetentionStatusOutput {
+    preset: &'static str,
+    keep_daily_days: Option<u16>,
+    keep_focus_sessions_days: Option<u16>,
+    keep_session_interruptions_days: Option<u16>,
+    keep_break_glass_overrides_days: Option<u16>,
+    pending_prune: StatsRetentionPruneResult,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -7,8 +7,9 @@ use crate::cli::{
     RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, ScheduleInspectionOutput,
     Serialize, SetupCheck, SetupCheckLevel, SetupCheckOutput, SetupDiagnostics,
     SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput,
-    StatusOutput, StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
-    TimerStateOutput, Write, format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput, StrictCommandOutput,
+    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, TimerStateOutput, Write,
+    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -266,6 +267,8 @@ pub(super) fn print_status_output(payload: &StatusOutput) {
         println!("Last interruption: none");
     }
     print_status_focus_score_line(&payload.focus_score);
+    print_status_growth_line(&payload.stats_growth);
+    print_status_retention_line(&payload.stats_retention);
     println!(
         "Live timer: {} {} ({} remaining, source: {})",
         payload.live.phase,
@@ -339,6 +342,74 @@ fn print_status_focus_score_line(focus_score: &FocusScoreOutput) {
             "Focus score: n/a (weekly goal off; consistency {}%)",
             focus_score.consistency_score_pct
         );
+    }
+}
+
+fn print_status_growth_line(growth: &StatsGrowthSummary) {
+    println!(
+        "Stats growth: {} records, ~{}",
+        growth.total_record_count,
+        format_bytes(growth.estimated_bytes)
+    );
+    if growth.high_volume_sections.is_empty() {
+        println!("Stats growth top sections: none");
+        return;
+    }
+    let high_volume = growth
+        .high_volume_sections
+        .iter()
+        .map(|section| {
+            format!(
+                "{} ({}, ~{})",
+                section.name,
+                section.record_count,
+                format_bytes(section.estimated_bytes)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("Stats growth top sections: {high_volume}");
+}
+
+fn print_status_retention_line(retention: &StatsRetentionStatusOutput) {
+    println!("Stats retention preset: {}", retention.preset);
+    println!(
+        "Stats retention windows: daily {}, sessions {}, interruptions {}, overrides {}",
+        format_retention_window(retention.keep_daily_days),
+        format_retention_window(retention.keep_focus_sessions_days),
+        format_retention_window(retention.keep_session_interruptions_days),
+        format_retention_window(retention.keep_break_glass_overrides_days),
+    );
+    if retention.pending_prune.any_removed() {
+        println!(
+            "Stats retention pending prune: {} records (daily {}, sessions {}, interruptions {}, overrides {})",
+            retention.pending_prune.total_removed(),
+            retention.pending_prune.daily_removed,
+            retention.pending_prune.focus_sessions_removed,
+            retention.pending_prune.session_interruptions_removed,
+            retention.pending_prune.break_glass_overrides_removed
+        );
+    } else {
+        println!("Stats retention pending prune: none");
+    }
+}
+
+fn format_retention_window(days: Option<u16>) -> String {
+    match days {
+        Some(days) => format!("{days}d"),
+        None => "keep_all".to_string(),
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} B")
     }
 }
 

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -2,9 +2,10 @@ use crate::cli::{
     AppConfig, BreakTemplateConfig, BreakTemplateView, CustomProfileConfig, DEFAULT_FOCUS_SECS,
     DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS, DEFAULT_SHORT_BREAK_SECS,
     DailyGoalSnapshot, Datelike, FocusScoreOutput, FocusStats, GoalOutput, LiveStatusOutput,
-    NaiveDate, ProfileId, ProfileSpec, ProfileView, SessionOutput, StatusOutput, TaskGoalOutput,
-    ThemePreset, ThemePresetView, TimerPhase, TimerStatus, TodayOutput, carry_over_goal_target,
-    current_day_key, effective_blocked_sites_for_profile, session_recovery,
+    NaiveDate, ProfileId, ProfileSpec, ProfileView, SessionOutput, StatsRetentionStatusOutput,
+    StatusOutput, TaskGoalOutput, ThemePreset, ThemePresetView, TimerPhase, TimerStatus,
+    TodayOutput, carry_over_goal_target, current_day_key, effective_blocked_sites_for_profile,
+    session_recovery,
 };
 
 pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
@@ -51,6 +52,9 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
     let focus_score_pct = completion_score_pct.map(|completion| {
         (u16::from(consistency_score_pct) + u16::from(completion)).div_ceil(2) as u8
     });
+    let stats_growth = stats.growth_summary();
+    let retention_windows = config.stats_retention.windows();
+    let pending_prune = stats.retention_preview(config.stats_retention, day_date);
 
     StatusOutput {
         day,
@@ -102,6 +106,15 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
             focus_score_pct,
             consistency_score_pct,
             completion_score_pct,
+        },
+        stats_growth,
+        stats_retention: StatsRetentionStatusOutput {
+            preset: config.stats_retention.preset.id(),
+            keep_daily_days: retention_windows.keep_daily_days,
+            keep_focus_sessions_days: retention_windows.keep_focus_sessions_days,
+            keep_session_interruptions_days: retention_windows.keep_session_interruptions_days,
+            keep_break_glass_overrides_days: retention_windows.keep_break_glass_overrides_days,
+            pending_prune,
         },
         live,
     }

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1600,6 +1600,46 @@ fn build_status_output_excludes_allowlist_from_blocked_sites_count() {
 }
 
 #[test]
+fn build_status_output_includes_growth_and_retention_signals() {
+    let mut stats = FocusStats::default();
+    let goal = DailyGoalSnapshot {
+        minutes: 25,
+        pomodoros: 1,
+    };
+    let today = NaiveDate::parse_from_str(&current_day_key(), "%Y-%m-%d")
+        .expect("current day key should parse as a date");
+    let old_day = today
+        .checked_sub_signed(Duration::days(500))
+        .unwrap()
+        .format("%Y-%m-%d")
+        .to_string();
+    let recent_day = today.format("%Y-%m-%d").to_string();
+    stats.record_completed_pomodoro_with_task(&old_day, goal, Some("Docs"), 25 * 60, None);
+    stats.record_completed_pomodoro_with_task(&recent_day, goal, Some("Docs"), 25 * 60, None);
+
+    let config = AppConfig::default();
+    let output = build_status_output(&config, &stats);
+
+    assert!(output.stats_growth.total_record_count > 0);
+    assert!(output.stats_growth.estimated_bytes > 0);
+    assert_eq!(output.stats_retention.preset, "balanced");
+    assert_eq!(output.stats_retention.keep_daily_days, None);
+    assert_eq!(output.stats_retention.keep_focus_sessions_days, Some(365));
+    assert_eq!(
+        output.stats_retention.keep_session_interruptions_days,
+        Some(180)
+    );
+    assert_eq!(
+        output.stats_retention.keep_break_glass_overrides_days,
+        Some(180)
+    );
+    assert_eq!(
+        output.stats_retention.pending_prune.focus_sessions_removed,
+        1
+    );
+}
+
+#[test]
 fn build_status_output_reports_daily_weekly_monthly_goal_state() {
     let mut stats = FocusStats::default();
     let today = current_day_key();

--- a/src/config.rs
+++ b/src/config.rs
@@ -722,18 +722,24 @@ impl StatsRetentionConfig {
                 keep_focus_sessions_days: None,
                 keep_session_interruptions_days: None,
                 keep_break_glass_overrides_days: None,
+                keep_weekly_goal_snapshots_days: None,
+                keep_monthly_goal_snapshots_days: None,
             },
             StatsRetentionPreset::Balanced => StatsRetentionWindows {
                 keep_daily_days: None,
                 keep_focus_sessions_days: Some(365),
                 keep_session_interruptions_days: Some(180),
                 keep_break_glass_overrides_days: Some(180),
+                keep_weekly_goal_snapshots_days: Some(365),
+                keep_monthly_goal_snapshots_days: Some(365),
             },
             StatsRetentionPreset::Aggressive => StatsRetentionWindows {
                 keep_daily_days: Some(365),
                 keep_focus_sessions_days: Some(180),
                 keep_session_interruptions_days: Some(90),
                 keep_break_glass_overrides_days: Some(90),
+                keep_weekly_goal_snapshots_days: Some(180),
+                keep_monthly_goal_snapshots_days: Some(180),
             },
         }
     }
@@ -745,6 +751,8 @@ pub struct StatsRetentionWindows {
     pub keep_focus_sessions_days: Option<u16>,
     pub keep_session_interruptions_days: Option<u16>,
     pub keep_break_glass_overrides_days: Option<u16>,
+    pub keep_weekly_goal_snapshots_days: Option<u16>,
+    pub keep_monthly_goal_snapshots_days: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,6 +110,9 @@ pub struct AppConfig {
     /// Carry-over behavior for unmet daily/weekly/monthly targets.
     #[serde(default)]
     pub goal_carry_over: GoalCarryOverConfig,
+    /// Retention policy for persisted stats history.
+    #[serde(default)]
+    pub stats_retention: StatsRetentionConfig,
     /// WakaTime heartbeat metadata labels.
     #[serde(default)]
     pub wakatime: WakatimeMetadataConfig,
@@ -686,6 +689,64 @@ pub struct GoalCarryOverConfig {
     pub monthly: bool,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StatsRetentionPreset {
+    KeepAll,
+    Aggressive,
+    #[default]
+    Balanced,
+}
+
+impl StatsRetentionPreset {
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::KeepAll => "keep_all",
+            Self::Balanced => "balanced",
+            Self::Aggressive => "aggressive",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct StatsRetentionConfig {
+    #[serde(default)]
+    pub preset: StatsRetentionPreset,
+}
+
+impl StatsRetentionConfig {
+    pub fn windows(self) -> StatsRetentionWindows {
+        match self.preset {
+            StatsRetentionPreset::KeepAll => StatsRetentionWindows {
+                keep_daily_days: None,
+                keep_focus_sessions_days: None,
+                keep_session_interruptions_days: None,
+                keep_break_glass_overrides_days: None,
+            },
+            StatsRetentionPreset::Balanced => StatsRetentionWindows {
+                keep_daily_days: None,
+                keep_focus_sessions_days: Some(365),
+                keep_session_interruptions_days: Some(180),
+                keep_break_glass_overrides_days: Some(180),
+            },
+            StatsRetentionPreset::Aggressive => StatsRetentionWindows {
+                keep_daily_days: Some(365),
+                keep_focus_sessions_days: Some(180),
+                keep_session_interruptions_days: Some(90),
+                keep_break_glass_overrides_days: Some(90),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatsRetentionWindows {
+    pub keep_daily_days: Option<u16>,
+    pub keep_focus_sessions_days: Option<u16>,
+    pub keep_session_interruptions_days: Option<u16>,
+    pub keep_break_glass_overrides_days: Option<u16>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WakatimeTaskMappingConfig {
     #[serde(default)]
@@ -1216,6 +1277,7 @@ impl Default for AppConfig {
             weekly_goal: WeeklyGoalConfig::default(),
             monthly_goal: MonthlyGoalConfig::default(),
             goal_carry_over: GoalCarryOverConfig::default(),
+            stats_retention: StatsRetentionConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
             shortcuts: ShortcutConfig::default(),
         }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -60,6 +60,8 @@ fn stats_retention_defaults_to_balanced_windows() {
     assert_eq!(windows.keep_focus_sessions_days, Some(365));
     assert_eq!(windows.keep_session_interruptions_days, Some(180));
     assert_eq!(windows.keep_break_glass_overrides_days, Some(180));
+    assert_eq!(windows.keep_weekly_goal_snapshots_days, Some(365));
+    assert_eq!(windows.keep_monthly_goal_snapshots_days, Some(365));
 }
 
 #[test]
@@ -72,6 +74,8 @@ fn stats_retention_windows_change_by_preset() {
     assert_eq!(keep_all.keep_focus_sessions_days, None);
     assert_eq!(keep_all.keep_session_interruptions_days, None);
     assert_eq!(keep_all.keep_break_glass_overrides_days, None);
+    assert_eq!(keep_all.keep_weekly_goal_snapshots_days, None);
+    assert_eq!(keep_all.keep_monthly_goal_snapshots_days, None);
 
     let aggressive = StatsRetentionConfig {
         preset: StatsRetentionPreset::Aggressive,
@@ -81,6 +85,8 @@ fn stats_retention_windows_change_by_preset() {
     assert_eq!(aggressive.keep_focus_sessions_days, Some(180));
     assert_eq!(aggressive.keep_session_interruptions_days, Some(90));
     assert_eq!(aggressive.keep_break_glass_overrides_days, Some(90));
+    assert_eq!(aggressive.keep_weekly_goal_snapshots_days, Some(180));
+    assert_eq!(aggressive.keep_monthly_goal_snapshots_days, Some(180));
 }
 
 #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -46,8 +46,41 @@ fn default_values_are_canonical_pomodoro() {
     assert_eq!(cfg.weekly_goal, WeeklyGoalConfig::default());
     assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
     assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
+    assert_eq!(cfg.stats_retention, StatsRetentionConfig::default());
     assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     assert_eq!(cfg.shortcuts, ShortcutConfig::default());
+}
+
+#[test]
+fn stats_retention_defaults_to_balanced_windows() {
+    let cfg = AppConfig::default();
+    assert_eq!(cfg.stats_retention.preset, StatsRetentionPreset::Balanced);
+    let windows = cfg.stats_retention.windows();
+    assert_eq!(windows.keep_daily_days, None);
+    assert_eq!(windows.keep_focus_sessions_days, Some(365));
+    assert_eq!(windows.keep_session_interruptions_days, Some(180));
+    assert_eq!(windows.keep_break_glass_overrides_days, Some(180));
+}
+
+#[test]
+fn stats_retention_windows_change_by_preset() {
+    let keep_all = StatsRetentionConfig {
+        preset: StatsRetentionPreset::KeepAll,
+    }
+    .windows();
+    assert_eq!(keep_all.keep_daily_days, None);
+    assert_eq!(keep_all.keep_focus_sessions_days, None);
+    assert_eq!(keep_all.keep_session_interruptions_days, None);
+    assert_eq!(keep_all.keep_break_glass_overrides_days, None);
+
+    let aggressive = StatsRetentionConfig {
+        preset: StatsRetentionPreset::Aggressive,
+    }
+    .windows();
+    assert_eq!(aggressive.keep_daily_days, Some(365));
+    assert_eq!(aggressive.keep_focus_sessions_days, Some(180));
+    assert_eq!(aggressive.keep_session_interruptions_days, Some(90));
+    assert_eq!(aggressive.keep_break_glass_overrides_days, Some(90));
 }
 
 #[test]
@@ -178,6 +211,9 @@ fn round_trip_full_config() {
             weekly: false,
             monthly: true,
         },
+        stats_retention: StatsRetentionConfig {
+            preset: StatsRetentionPreset::Aggressive,
+        },
         wakatime: WakatimeMetadataConfig {
             project: "Team Focus".to_string(),
             language: "Focus Session".to_string(),
@@ -236,6 +272,7 @@ fn round_trip_full_config() {
     assert_eq!(parsed.weekly_goal, original.weekly_goal);
     assert_eq!(parsed.monthly_goal, original.monthly_goal);
     assert_eq!(parsed.goal_carry_over, original.goal_carry_over);
+    assert_eq!(parsed.stats_retention, original.stats_retention);
     assert_eq!(parsed.wakatime, original.wakatime);
     assert_eq!(parsed.shortcuts, original.shortcuts);
 }
@@ -658,6 +695,7 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
         weekly_goal: WeeklyGoalConfig::default(),
         monthly_goal: MonthlyGoalConfig::default(),
         goal_carry_over: GoalCarryOverConfig::default(),
+        stats_retention: StatsRetentionConfig::default(),
         wakatime: WakatimeMetadataConfig::default(),
         shortcuts: ShortcutConfig::default(),
     };

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -11,6 +11,7 @@ use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 
 use crate::config::ProfileId;
+use crate::config::StatsRetentionConfig;
 use crate::task_labels::{canonical_task_label, normalize_task_label, task_label_index};
 
 mod helpers;
@@ -197,6 +198,42 @@ impl DailyStats {
 pub struct ExportedStatsFiles {
     pub json_path: PathBuf,
     pub csv_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StatsGrowthSection {
+    pub name: String,
+    pub record_count: usize,
+    pub estimated_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StatsGrowthSummary {
+    pub total_record_count: usize,
+    pub estimated_bytes: u64,
+    pub sections: Vec<StatsGrowthSection>,
+    pub high_volume_sections: Vec<StatsGrowthSection>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct StatsRetentionPruneResult {
+    pub daily_removed: usize,
+    pub focus_sessions_removed: usize,
+    pub session_interruptions_removed: usize,
+    pub break_glass_overrides_removed: usize,
+}
+
+impl StatsRetentionPruneResult {
+    pub fn total_removed(self) -> usize {
+        self.daily_removed
+            .saturating_add(self.focus_sessions_removed)
+            .saturating_add(self.session_interruptions_removed)
+            .saturating_add(self.break_glass_overrides_removed)
+    }
+
+    pub fn any_removed(self) -> bool {
+        self.total_removed() > 0
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -221,6 +221,8 @@ pub struct StatsRetentionPruneResult {
     pub focus_sessions_removed: usize,
     pub session_interruptions_removed: usize,
     pub break_glass_overrides_removed: usize,
+    pub weekly_goal_snapshots_removed: usize,
+    pub monthly_goal_snapshots_removed: usize,
 }
 
 impl StatsRetentionPruneResult {
@@ -229,6 +231,8 @@ impl StatsRetentionPruneResult {
             .saturating_add(self.focus_sessions_removed)
             .saturating_add(self.session_interruptions_removed)
             .saturating_add(self.break_glass_overrides_removed)
+            .saturating_add(self.weekly_goal_snapshots_removed)
+            .saturating_add(self.monthly_goal_snapshots_removed)
     }
 
     pub fn any_removed(self) -> bool {

--- a/src/stats/analytics.rs
+++ b/src/stats/analytics.rs
@@ -503,6 +503,24 @@ impl FocusStats {
                 before.saturating_sub(self.break_glass_overrides.len());
         }
 
+        if let Some(keep_days) = windows.keep_weekly_goal_snapshots_days {
+            let cutoff_day = retention_cutoff_day(reference_day, keep_days);
+            let before = self.weekly_goal_snapshots.len();
+            self.weekly_goal_snapshots
+                .retain(|week_key, _| is_week_key_on_or_after(week_key, cutoff_day));
+            result.weekly_goal_snapshots_removed =
+                before.saturating_sub(self.weekly_goal_snapshots.len());
+        }
+
+        if let Some(keep_days) = windows.keep_monthly_goal_snapshots_days {
+            let cutoff_day = retention_cutoff_day(reference_day, keep_days);
+            let before = self.monthly_goal_snapshots.len();
+            self.monthly_goal_snapshots
+                .retain(|month_key, _| is_month_key_on_or_after(month_key, cutoff_day));
+            result.monthly_goal_snapshots_removed =
+                before.saturating_sub(self.monthly_goal_snapshots.len());
+        }
+
         result
     }
 
@@ -545,4 +563,37 @@ fn is_day_key_on_or_after(day_key: &str, cutoff_day: chrono::NaiveDate) -> bool 
     chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d")
         .map(|day| day >= cutoff_day)
         .unwrap_or(true)
+}
+
+fn is_week_key_on_or_after(week_key: &str, cutoff_day: chrono::NaiveDate) -> bool {
+    let Some((year, week)) = parse_week_label(week_key) else {
+        return true;
+    };
+    let Some(week_start) = chrono::NaiveDate::from_isoywd_opt(year, week, chrono::Weekday::Mon)
+    else {
+        return true;
+    };
+    let week_end = week_start
+        .checked_add_signed(chrono::Duration::days(6))
+        .unwrap_or(week_start);
+    week_end >= cutoff_day
+}
+
+fn is_month_key_on_or_after(month_key: &str, cutoff_day: chrono::NaiveDate) -> bool {
+    let Some((year_token, month_token)) = month_key.split_once('-') else {
+        return true;
+    };
+    let Ok(year) = year_token.parse::<i32>() else {
+        return true;
+    };
+    let Ok(month) = month_token.parse::<u32>() else {
+        return true;
+    };
+    let Some(month_start) = chrono::NaiveDate::from_ymd_opt(year, month, 1) else {
+        return true;
+    };
+    let month_end_day = days_in_month(year, month);
+    let month_end =
+        chrono::NaiveDate::from_ymd_opt(year, month, month_end_day).unwrap_or(month_start);
+    month_end >= cutoff_day
 }

--- a/src/stats/analytics.rs
+++ b/src/stats/analytics.rs
@@ -1,10 +1,11 @@
 use crate::stats::{
     BTreeMap, BTreeSet, DailyGoalSnapshot, Datelike, FocusStats, HeatmapDayStats, MonthlyHeatmap,
     MonthlyStats, ProfileBucket, ProfileEffectiveness, ProfileEffectivenessAccumulator,
-    ProfileTotals, WeeklyConsistency, WeeklyFocusScore, WeeklyStats, average_two_percentages,
-    consistency_score_from_active_days, daily_has_activity, days_in_month, format_week_label,
-    month_key_for_day, parse_week_label, percentage_round_nearest, profile_bucket_for,
-    week_key_for_day, weekly_completion_score_pct,
+    ProfileTotals, StatsGrowthSection, StatsGrowthSummary, StatsRetentionConfig,
+    StatsRetentionPruneResult, WeeklyConsistency, WeeklyFocusScore, WeeklyStats,
+    average_two_percentages, consistency_score_from_active_days, daily_has_activity, days_in_month,
+    format_week_label, month_key_for_day, parse_week_label, percentage_round_nearest,
+    profile_bucket_for, week_key_for_day, weekly_completion_score_pct,
 };
 
 impl FocusStats {
@@ -383,4 +384,165 @@ impl FocusStats {
             days,
         }
     }
+
+    pub fn growth_summary(&self) -> StatsGrowthSummary {
+        let mut sections = vec![
+            stats_growth_section("daily", self.daily.len(), &self.daily),
+            stats_growth_section(
+                "weekly_goal_snapshots",
+                self.weekly_goal_snapshots.len(),
+                &self.weekly_goal_snapshots,
+            ),
+            stats_growth_section(
+                "monthly_goal_snapshots",
+                self.monthly_goal_snapshots.len(),
+                &self.monthly_goal_snapshots,
+            ),
+            stats_growth_section("task_labels", self.task_labels.len(), &self.task_labels),
+            stats_growth_section(
+                "selected_task_label",
+                usize::from(self.selected_task_label.is_some()),
+                &self.selected_task_label,
+            ),
+            stats_growth_section(
+                "task_label_favorites",
+                self.task_label_favorites.len(),
+                &self.task_label_favorites,
+            ),
+            stats_growth_section(
+                "task_label_archived",
+                self.task_label_archived.len(),
+                &self.task_label_archived,
+            ),
+            stats_growth_section(
+                "focus_sessions",
+                self.focus_sessions.len(),
+                &self.focus_sessions,
+            ),
+            stats_growth_section(
+                "session_interruptions",
+                self.session_interruptions.len(),
+                &self.session_interruptions,
+            ),
+            stats_growth_section(
+                "break_glass_overrides",
+                self.break_glass_overrides.len(),
+                &self.break_glass_overrides,
+            ),
+            stats_growth_section(
+                "task_goal_targets",
+                self.task_goal_targets.len(),
+                &self.task_goal_targets,
+            ),
+        ];
+        sections.sort_by(|left, right| left.name.cmp(&right.name));
+        let total_record_count = sections.iter().fold(0_usize, |total, section| {
+            total.saturating_add(section.record_count)
+        });
+        let mut high_volume_sections: Vec<StatsGrowthSection> = sections
+            .iter()
+            .filter(|section| section.record_count > 0)
+            .cloned()
+            .collect();
+        high_volume_sections.sort_by(|left, right| {
+            right
+                .record_count
+                .cmp(&left.record_count)
+                .then_with(|| right.estimated_bytes.cmp(&left.estimated_bytes))
+                .then_with(|| left.name.cmp(&right.name))
+        });
+        high_volume_sections.truncate(3);
+
+        StatsGrowthSummary {
+            total_record_count,
+            estimated_bytes: estimated_serialized_bytes(&self.to_persisted()),
+            sections,
+            high_volume_sections,
+        }
+    }
+
+    pub fn apply_retention_policy(
+        &mut self,
+        retention: StatsRetentionConfig,
+        reference_day: chrono::NaiveDate,
+    ) -> StatsRetentionPruneResult {
+        let windows = retention.windows();
+        let mut result = StatsRetentionPruneResult::default();
+
+        if let Some(keep_days) = windows.keep_daily_days {
+            let cutoff_day = retention_cutoff_day(reference_day, keep_days);
+            let before = self.daily.len();
+            self.daily
+                .retain(|day_key, _| is_day_key_on_or_after(day_key, cutoff_day));
+            result.daily_removed = before.saturating_sub(self.daily.len());
+        }
+
+        if let Some(keep_days) = windows.keep_focus_sessions_days {
+            let cutoff_day = retention_cutoff_day(reference_day, keep_days);
+            let before = self.focus_sessions.len();
+            self.focus_sessions
+                .retain(|session| is_day_key_on_or_after(&session.date, cutoff_day));
+            result.focus_sessions_removed = before.saturating_sub(self.focus_sessions.len());
+        }
+
+        if let Some(keep_days) = windows.keep_session_interruptions_days {
+            let cutoff_day = retention_cutoff_day(reference_day, keep_days);
+            let before = self.session_interruptions.len();
+            self.session_interruptions
+                .retain(|event| is_day_key_on_or_after(&event.date, cutoff_day));
+            result.session_interruptions_removed =
+                before.saturating_sub(self.session_interruptions.len());
+        }
+
+        if let Some(keep_days) = windows.keep_break_glass_overrides_days {
+            let cutoff_day = retention_cutoff_day(reference_day, keep_days);
+            let before = self.break_glass_overrides.len();
+            self.break_glass_overrides
+                .retain(|event| is_day_key_on_or_after(&event.date, cutoff_day));
+            result.break_glass_overrides_removed =
+                before.saturating_sub(self.break_glass_overrides.len());
+        }
+
+        result
+    }
+
+    pub fn retention_preview(
+        &self,
+        retention: StatsRetentionConfig,
+        reference_day: chrono::NaiveDate,
+    ) -> StatsRetentionPruneResult {
+        let mut cloned = self.clone();
+        cloned.apply_retention_policy(retention, reference_day)
+    }
+}
+
+fn stats_growth_section(
+    name: &str,
+    record_count: usize,
+    value: &impl serde::Serialize,
+) -> StatsGrowthSection {
+    StatsGrowthSection {
+        name: name.to_string(),
+        record_count,
+        estimated_bytes: estimated_serialized_bytes(value),
+    }
+}
+
+fn estimated_serialized_bytes(value: &impl serde::Serialize) -> u64 {
+    toml::to_string(value)
+        .map(|serialized| serialized.len() as u64)
+        .unwrap_or(0)
+}
+
+fn retention_cutoff_day(reference_day: chrono::NaiveDate, keep_days: u16) -> chrono::NaiveDate {
+    let days_to_keep = i64::from(keep_days.max(1));
+    reference_day
+        .checked_sub_signed(chrono::Duration::days(days_to_keep.saturating_sub(1)))
+        .unwrap_or(reference_day)
+}
+
+fn is_day_key_on_or_after(day_key: &str, cutoff_day: chrono::NaiveDate) -> bool {
+    chrono::NaiveDate::parse_from_str(day_key, "%Y-%m-%d")
+        .map(|day| day >= cutoff_day)
+        .unwrap_or(true)
 }

--- a/src/stats/analytics.rs
+++ b/src/stats/analytics.rs
@@ -547,9 +547,14 @@ fn stats_growth_section(
 }
 
 fn estimated_serialized_bytes(value: &impl serde::Serialize) -> u64 {
-    toml::to_string(value)
-        .map(|serialized| serialized.len() as u64)
-        .unwrap_or(0)
+    #[derive(serde::Serialize)]
+    struct SizeProbe<'a, T: ?Sized + serde::Serialize> {
+        value: &'a T,
+    }
+
+    toml::to_string(&SizeProbe { value })
+        .expect("stats growth section should be serializable")
+        .len() as u64
 }
 
 fn retention_cutoff_day(reference_day: chrono::NaiveDate, keep_days: u16) -> chrono::NaiveDate {

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -1425,6 +1425,140 @@ fn export_to_dir_returns_error_when_target_is_not_directory() {
 }
 
 #[test]
+fn growth_summary_reports_sections_and_high_volume_groups() {
+    let mut stats = FocusStats::default();
+    let goal = DailyGoalSnapshot {
+        minutes: 25,
+        pomodoros: 1,
+    };
+    stats.record_focus_elapsed("2026-04-10", 25 * 60, goal);
+    stats.record_completed_pomodoro_with_task("2026-04-10", goal, Some("Docs"), 25 * 60, None);
+    stats.record_session_interruption_event(
+        "2026-04-10",
+        1_711_000_123,
+        SessionInterruptionReason::ManualStop,
+        FocusSessionMetadata {
+            task_label: Some("Docs"),
+            focus_intention: Some("Write docs"),
+            task_note: Some("API section"),
+        },
+        300,
+        None,
+    );
+
+    let summary = stats.growth_summary();
+    assert!(summary.total_record_count > 0);
+    assert!(summary.estimated_bytes > 0);
+    assert!(!summary.sections.is_empty());
+    assert!(!summary.high_volume_sections.is_empty());
+    assert!(
+        summary
+            .sections
+            .iter()
+            .any(|section| section.name == "focus_sessions" && section.record_count == 1)
+    );
+    assert!(
+        summary
+            .sections
+            .iter()
+            .any(|section| section.name == "session_interruptions" && section.record_count == 1)
+    );
+}
+
+#[test]
+fn apply_retention_policy_prunes_old_high_volume_entries() {
+    let mut stats = FocusStats::default();
+    let goal = DailyGoalSnapshot {
+        minutes: 25,
+        pomodoros: 1,
+    };
+    let today = chrono::NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+    let old_day = today
+        .checked_sub_signed(chrono::Duration::days(500))
+        .unwrap()
+        .format("%Y-%m-%d")
+        .to_string();
+    let recent_day = today
+        .checked_sub_signed(chrono::Duration::days(10))
+        .unwrap()
+        .format("%Y-%m-%d")
+        .to_string();
+
+    stats.record_completed_pomodoro_with_task(&old_day, goal, Some("Docs"), 25 * 60, None);
+    stats.record_completed_pomodoro_with_task(&recent_day, goal, Some("Docs"), 25 * 60, None);
+    stats.record_session_interruption_event(
+        &old_day,
+        1_711_000_000,
+        SessionInterruptionReason::ManualStop,
+        FocusSessionMetadata {
+            task_label: Some("Docs"),
+            focus_intention: Some("Old interruption"),
+            task_note: Some("Old note"),
+        },
+        600,
+        None,
+    );
+    stats.record_session_interruption_event(
+        &recent_day,
+        1_711_000_111,
+        SessionInterruptionReason::ManualSkip,
+        FocusSessionMetadata {
+            task_label: Some("Docs"),
+            focus_intention: Some("Recent interruption"),
+            task_note: Some("Recent note"),
+        },
+        600,
+        None,
+    );
+    stats.record_break_glass_override_event(&old_day, 1_711_000_222, Some("Docs"), 120);
+    stats.record_break_glass_override_event(&recent_day, 1_711_000_333, Some("Docs"), 120);
+
+    let result = stats.apply_retention_policy(
+        crate::config::StatsRetentionConfig {
+            preset: crate::config::StatsRetentionPreset::Balanced,
+        },
+        today,
+    );
+    assert_eq!(result.daily_removed, 0);
+    assert_eq!(result.focus_sessions_removed, 1);
+    assert_eq!(result.session_interruptions_removed, 1);
+    assert_eq!(result.break_glass_overrides_removed, 1);
+    assert_eq!(result.total_removed(), 3);
+    assert!(result.any_removed());
+    assert_eq!(stats.task_totals(10)[0].pomodoros_completed, 1);
+    assert_eq!(stats.recent_break_glass_overrides(10).len(), 1);
+    assert_eq!(stats.recent_session_interruptions(10).len(), 1);
+}
+
+#[test]
+fn retention_preview_reports_changes_without_mutating_stats() {
+    let mut stats = FocusStats::default();
+    let goal = DailyGoalSnapshot {
+        minutes: 25,
+        pomodoros: 1,
+    };
+    stats.record_completed_pomodoro_with_task("2024-01-01", goal, Some("Docs"), 25 * 60, None);
+    let today = chrono::NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
+
+    let preview = stats.retention_preview(
+        crate::config::StatsRetentionConfig {
+            preset: crate::config::StatsRetentionPreset::Aggressive,
+        },
+        today,
+    );
+    assert_eq!(preview.focus_sessions_removed, 1);
+    assert!(preview.any_removed());
+
+    let summary = stats.growth_summary();
+    assert!(
+        summary
+            .sections
+            .iter()
+            .any(|section| section.name == "focus_sessions" && section.record_count == 1)
+    );
+}
+
+#[test]
 fn create_unique_temp_path_changes_between_calls() {
     let target = Path::new("focustime-stats.json");
     let first = create_unique_temp_path(target);

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -1461,7 +1461,25 @@ fn growth_summary_reports_sections_and_high_volume_groups() {
         summary
             .sections
             .iter()
+            .any(|section| section.name == "focus_sessions" && section.estimated_bytes > 0)
+    );
+    assert!(
+        summary
+            .sections
+            .iter()
+            .any(|section| section.name == "task_labels" && section.estimated_bytes > 0)
+    );
+    assert!(
+        summary
+            .sections
+            .iter()
             .any(|section| section.name == "session_interruptions" && section.record_count == 1)
+    );
+    assert!(
+        summary
+            .sections
+            .iter()
+            .any(|section| section.name == "session_interruptions" && section.estimated_bytes > 0)
     );
 }
 

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -1473,19 +1473,21 @@ fn apply_retention_policy_prunes_old_high_volume_entries() {
         pomodoros: 1,
     };
     let today = chrono::NaiveDate::from_ymd_opt(2026, 4, 10).unwrap();
-    let old_day = today
+    let old_day_date = today
         .checked_sub_signed(chrono::Duration::days(500))
-        .unwrap()
-        .format("%Y-%m-%d")
-        .to_string();
-    let recent_day = today
+        .unwrap();
+    let recent_day_date = today
         .checked_sub_signed(chrono::Duration::days(10))
-        .unwrap()
-        .format("%Y-%m-%d")
-        .to_string();
+        .unwrap();
+    let old_day = old_day_date.format("%Y-%m-%d").to_string();
+    let recent_day = recent_day_date.format("%Y-%m-%d").to_string();
 
     stats.record_completed_pomodoro_with_task(&old_day, goal, Some("Docs"), 25 * 60, None);
     stats.record_completed_pomodoro_with_task(&recent_day, goal, Some("Docs"), 25 * 60, None);
+    stats.sync_weekly_goal_snapshot(old_day_date, goal);
+    stats.sync_weekly_goal_snapshot(recent_day_date, goal);
+    stats.sync_monthly_goal_snapshot(old_day_date, goal);
+    stats.sync_monthly_goal_snapshot(recent_day_date, goal);
     stats.record_session_interruption_event(
         &old_day,
         1_711_000_000,
@@ -1523,7 +1525,9 @@ fn apply_retention_policy_prunes_old_high_volume_entries() {
     assert_eq!(result.focus_sessions_removed, 1);
     assert_eq!(result.session_interruptions_removed, 1);
     assert_eq!(result.break_glass_overrides_removed, 1);
-    assert_eq!(result.total_removed(), 3);
+    assert_eq!(result.weekly_goal_snapshots_removed, 1);
+    assert_eq!(result.monthly_goal_snapshots_removed, 1);
+    assert_eq!(result.total_removed(), 5);
     assert!(result.any_removed());
     assert_eq!(stats.task_totals(10)[0].pomodoros_completed, 1);
     assert_eq!(stats.recent_break_glass_overrides(10).len(), 1);

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -37,6 +37,24 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
     let focus_score_line = readable_focus_score_text(&format_history_focus_score_line(app));
     let goals_line = readable_goal_streak_text(&format_history_goal_streak_line(app));
     let interruption_line = format_history_interruption_line(app);
+    let growth_summary = app.stats_growth_summary();
+    let retention_preview = app.stats_retention_preview();
+    let retention = app.stats_retention_config();
+    let growth_line = format!(
+        "Stats growth: {} records · ~{} · {}",
+        growth_summary.total_record_count,
+        format_bytes(growth_summary.estimated_bytes),
+        format_top_sections(&growth_summary.high_volume_sections)
+    );
+    let retention_line = if retention_preview.any_removed() {
+        format!(
+            "Retention: {} · prunes {} old record(s) on next save",
+            retention.preset.id(),
+            retention_preview.total_removed()
+        )
+    } else {
+        format!("Retention: {} · no pending prune", retention.preset.id())
+    };
     let overview = Paragraph::new(vec![
         Line::styled(
             format!(
@@ -64,6 +82,14 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         ),
         Line::styled(
             interruption_line,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
+        Line::styled(
+            growth_line,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
+        Line::styled(
+            retention_line,
             Style::default().fg(app_color(app, Color::DarkGray)),
         ),
     ])
@@ -439,4 +465,27 @@ fn heatmap_cell_symbol(app: &App, focused_minutes: u64, max_focused_minutes: u64
 
 pub(super) fn format_month_label(year: i32, month: u32) -> String {
     format!("{year:04}-{month:02}")
+}
+
+fn format_top_sections(sections: &[crate::stats::StatsGrowthSection]) -> String {
+    if sections.is_empty() {
+        return "top: none".to_string();
+    }
+    let labels: Vec<String> = sections
+        .iter()
+        .map(|section| format!("{} {}", section.name, section.record_count))
+        .collect();
+    format!("top: {}", labels.join(", "))
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} B")
+    }
 }


### PR DESCRIPTION
## What

- Add a stats growth summary model that reports total record count, estimated `stats.toml` size, per-section volume, and top high-volume sections.
- Introduce `stats_retention` presets (`keep_all`, `balanced`, `aggressive`) and apply retention pruning during stats persistence.
- Surface growth and retention signals in both supported user surfaces: CLI `--status` (text + JSON) and TUI History overview.
- Add focused tests for growth computation, retention pruning/preview behavior, status payloads, and config defaults/round-trip behavior.
- Update README with retention presets/defaults and observability behavior.

## Why

Stats history can grow significantly over time, but users currently have limited visibility into growth pressure and no explicit retention policy controls. This change makes growth observable in day-to-day surfaces and defines a practical default retention strategy, while keeping behavior configurable and documented.

Closes #257.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable stats retention presets (`balanced`, `aggressive`, `keep_all`) with per-category windows and automatic pruning applied on save
  * CLI status now shows stats growth (record counts, estimated storage), active retention config, and a pending-prune preview
  * UI Overview shows stats growth summary and retention/pending-prune info

* **Documentation**
  * README updated with `[stats_retention]` config docs and `--status` command JSON examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->