### PR TITLE
Feature flags for multi-version rollout safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Feature flags for rollout-safe compatibility paths (#258):** added centralized `[feature_flags]` config defaults plus diagnostics visibility to gate legacy automation/blocklist mirrors and task-label metadata fallback behavior across config, CLI, recovery, and stats loading paths.
+
 ## [0.9.0] - 2026-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ selected_blocklist_profile = "Work"
 strict_mode = false
 break_glass_duration_secs = 300
 
+[feature_flags]
+# Preserve per-profile automation values in legacy top-level fields.
+legacy_automation_mirror = true
+# Preserve active blocklist profile values in legacy blocked_sites.
+legacy_blocked_sites_mirror = true
+# Backfill legacy metadata from task_label when missing.
+metadata_task_label_fallback = true
+
 [shortcuts]
 timer_toggle_pause = "space"
 timer_stop_reset = "s"

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,10 +12,11 @@ use crate::blocker::{
 };
 use crate::config::{
     AppConfig, AutoStartConfig, BlocklistProfileConfig, BreakTemplateConfig, CustomProfileConfig,
-    DailyGoalConfig, GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig,
-    OneTimeFocusWindowConfig, ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, StatsRetentionConfig, ThemePreset,
-    WakatimeMetadataConfig, WeeklyGoalConfig,
+    DailyGoalConfig, FeatureFlagsConfig, GoalCarryOverConfig, MonthlyGoalConfig,
+    NotificationConfig, OneTimeFocusWindowConfig, ProfileAutomationConfig,
+    ProfileAutomationSettingsConfig, ProfileId, RecurringFocusWindowConfig,
+    RecurringScheduleConfig, StatsRetentionConfig, ThemePreset, WakatimeMetadataConfig,
+    WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -431,10 +432,11 @@ pub struct SetupDiagnostics {
     pub blocking_permissions: SetupCheck,
     pub hosts_write_capability: SetupCheck,
     pub wakatime_config: SetupCheck,
+    pub feature_flags: FeatureFlagsConfig,
 }
 
 impl SetupDiagnostics {
-    fn collect(blocker: &SiteBlocker) -> Self {
+    fn collect(blocker: &SiteBlocker, feature_flags: FeatureFlagsConfig) -> Self {
         let hosts_diagnostics = blocker.hosts_file_diagnostics();
         let blocking_permissions = blocking_permissions_check(&hosts_diagnostics);
         let hosts_write_capability = hosts_write_capability_check(&hosts_diagnostics);
@@ -454,6 +456,7 @@ impl SetupDiagnostics {
             blocking_permissions,
             hosts_write_capability,
             wakatime_config,
+            feature_flags,
         }
     }
 }
@@ -528,6 +531,8 @@ pub struct App {
     pub wakatime: WakatimeTracker,
     pub selected_profile: ProfileId,
     selected_theme_preset: ThemePreset,
+    feature_flags: FeatureFlagsConfig,
+    legacy_blocked_sites: Vec<String>,
     profile_automation: ProfileAutomationSettingsConfig,
     pub custom_profile: CustomProfileConfig,
     pub profile_selection_index: usize,
@@ -582,6 +587,8 @@ impl App {
         let config = config.normalized();
         let selected_profile = config.selected_profile;
         let selected_theme_preset = config.selected_theme_preset;
+        let feature_flags = config.feature_flags;
+        let legacy_blocked_sites = config.blocked_sites.clone();
         let custom_profile = config.effective_custom_profile();
         let profile_automation = config.profile_automation.clone().unwrap_or_default();
         let selected_automation = config.profile_automation_for(selected_profile);
@@ -611,10 +618,13 @@ impl App {
             &custom_profile,
         );
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
-        let (mut stats, stats_error) = match FocusStats::load() {
-            Ok(stats) => (stats, None),
-            Err(e) => (FocusStats::default(), Some(e)),
-        };
+        let (mut stats, stats_error) =
+            match FocusStats::load_with_options(crate::stats::StatsLoadOptions {
+                metadata_task_label_fallback: feature_flags.metadata_task_label_fallback,
+            }) {
+                Ok(stats) => (stats, None),
+                Err(e) => (FocusStats::default(), Some(e)),
+            };
         let retained = stats.apply_retention_policy(stats_retention, Local::now().date_naive());
         let (task_labels, selected_task_label) = stats.task_planner_state();
         let task_label_favorites = task_label_state_keys(stats.task_label_favorites());
@@ -627,7 +637,7 @@ impl App {
             profile_spec.long_break_interval,
         );
         let blocker = SiteBlocker::new();
-        let setup_diagnostics = SetupDiagnostics::collect(&blocker);
+        let setup_diagnostics = SetupDiagnostics::collect(&blocker, feature_flags);
         let mut app = Self {
             timer,
             should_quit: false,
@@ -674,6 +684,8 @@ impl App {
             }),
             selected_profile,
             selected_theme_preset,
+            feature_flags,
+            legacy_blocked_sites,
             profile_automation,
             custom_profile,
             profile_selection_index: profile_index(selected_profile),

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -106,6 +106,10 @@ impl App {
         self.selected_task_label.clone()
     }
 
+    pub fn metadata_task_label_fallback_enabled_for_cli(&self) -> bool {
+        self.feature_flags.metadata_task_label_fallback
+    }
+
     pub fn timer_state_for_cli(&self) -> (TimerPhase, TimerStatus, u64, u32) {
         (
             self.timer.phase,

--- a/src/app/feedback_diagnostics.rs
+++ b/src/app/feedback_diagnostics.rs
@@ -105,7 +105,7 @@ impl App {
     }
 
     pub(super) fn refresh_setup_diagnostics(&mut self) {
-        self.setup_diagnostics = SetupDiagnostics::collect(&self.blocker);
+        self.setup_diagnostics = SetupDiagnostics::collect(&self.blocker, self.feature_flags);
         self.refresh_blocking_preview();
     }
 

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -103,45 +103,60 @@ impl App {
         Ok(())
     }
 
+    fn recovery_snapshot_task_label_fallback(
+        recovery_task_label: &Option<String>,
+        metadata_fallback_enabled: bool,
+    ) -> Option<String> {
+        if metadata_fallback_enabled {
+            recovery_task_label.clone()
+        } else {
+            None
+        }
+    }
+
+    fn recovery_snapshot_metadata_value(
+        focus_active: bool,
+        active_value: Option<String>,
+        recovery_task_label: &Option<String>,
+        metadata_fallback_enabled: bool,
+    ) -> Option<String> {
+        if focus_active {
+            active_value.or_else(|| {
+                Self::recovery_snapshot_task_label_fallback(
+                    recovery_task_label,
+                    metadata_fallback_enabled,
+                )
+            })
+        } else {
+            Self::recovery_snapshot_task_label_fallback(
+                recovery_task_label,
+                metadata_fallback_enabled,
+            )
+        }
+    }
+
     pub(super) fn sync_recovery_snapshot(&mut self) {
+        let focus_active = self.focus_session_active_for_current_state();
         let metadata_fallback_enabled = self.feature_flags.metadata_task_label_fallback;
-        let recovery_task_label = if self.focus_session_active_for_current_state() {
+        let recovery_task_label = if focus_active {
             self.active_focus_task_label
                 .clone()
                 .or_else(|| self.selected_task_label.clone())
         } else {
             self.selected_task_label.clone()
         };
-        let recovery_focus_intention = if self.focus_session_active_for_current_state() {
-            self.active_focus_intention.clone().or_else(|| {
-                if metadata_fallback_enabled {
-                    recovery_task_label.clone()
-                } else {
-                    None
-                }
-            })
-        } else {
-            if metadata_fallback_enabled {
-                recovery_task_label.clone()
-            } else {
-                None
-            }
-        };
-        let recovery_task_note = if self.focus_session_active_for_current_state() {
-            self.active_focus_task_note.clone().or_else(|| {
-                if metadata_fallback_enabled {
-                    recovery_task_label.clone()
-                } else {
-                    None
-                }
-            })
-        } else {
-            if metadata_fallback_enabled {
-                recovery_task_label.clone()
-            } else {
-                None
-            }
-        };
+        let recovery_focus_intention = Self::recovery_snapshot_metadata_value(
+            focus_active,
+            self.active_focus_intention.clone(),
+            &recovery_task_label,
+            metadata_fallback_enabled,
+        );
+        let recovery_task_note = Self::recovery_snapshot_metadata_value(
+            focus_active,
+            self.active_focus_task_note.clone(),
+            &recovery_task_label,
+            metadata_fallback_enabled,
+        );
 
         let snapshot = InProgressSessionSnapshot::from_timer_state_with_metadata_with_fallback(
             &self.timer,

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -104,6 +104,7 @@ impl App {
     }
 
     pub(super) fn sync_recovery_snapshot(&mut self) {
+        let metadata_fallback_enabled = self.feature_flags.metadata_task_label_fallback;
         let recovery_task_label = if self.focus_session_active_for_current_state() {
             self.active_focus_task_label
                 .clone()
@@ -112,26 +113,43 @@ impl App {
             self.selected_task_label.clone()
         };
         let recovery_focus_intention = if self.focus_session_active_for_current_state() {
-            self.active_focus_intention
-                .clone()
-                .or_else(|| recovery_task_label.clone())
+            self.active_focus_intention.clone().or_else(|| {
+                if metadata_fallback_enabled {
+                    recovery_task_label.clone()
+                } else {
+                    None
+                }
+            })
         } else {
-            recovery_task_label.clone()
+            if metadata_fallback_enabled {
+                recovery_task_label.clone()
+            } else {
+                None
+            }
         };
         let recovery_task_note = if self.focus_session_active_for_current_state() {
-            self.active_focus_task_note
-                .clone()
-                .or_else(|| recovery_task_label.clone())
+            self.active_focus_task_note.clone().or_else(|| {
+                if metadata_fallback_enabled {
+                    recovery_task_label.clone()
+                } else {
+                    None
+                }
+            })
         } else {
-            recovery_task_label.clone()
+            if metadata_fallback_enabled {
+                recovery_task_label.clone()
+            } else {
+                None
+            }
         };
 
-        let snapshot = InProgressSessionSnapshot::from_timer_state_with_metadata(
+        let snapshot = InProgressSessionSnapshot::from_timer_state_with_metadata_with_fallback(
             &self.timer,
             recovery_task_label,
             recovery_focus_intention,
             recovery_task_note,
             self.selected_profile,
+            metadata_fallback_enabled,
         );
 
         match snapshot {

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -57,7 +57,8 @@ impl App {
         recovered_timer.status = snapshot.status();
         recovered_timer.remaining_secs = snapshot.remaining_secs;
         recovered_timer.pomodoros_completed = snapshot.pomodoros_completed;
-        snapshot.validate_for_timer(&recovered_timer)?;
+        let metadata_fallback_enabled = self.feature_flags.metadata_task_label_fallback;
+        snapshot.validate_for_timer_with_fallback(&recovered_timer, metadata_fallback_enabled)?;
 
         let task_label = snapshot
             .normalized_task_label()
@@ -84,12 +85,12 @@ impl App {
             None
         };
         self.active_focus_intention = if self.timer.phase == TimerPhase::Focus {
-            snapshot.normalized_focus_intention()
+            snapshot.normalized_focus_intention_with_fallback(metadata_fallback_enabled)
         } else {
             None
         };
         self.active_focus_task_note = if self.timer.phase == TimerPhase::Focus {
-            snapshot.normalized_task_note()
+            snapshot.normalized_task_note_with_fallback(metadata_fallback_enabled)
         } else {
             None
         };
@@ -167,10 +168,15 @@ impl App {
             .or_else(|| blocklist_profiles.first())
             .map(|profile| profile.name.clone())
             .unwrap_or_else(|| DEFAULT_BLOCKLIST_PROFILE_NAME.to_string());
-        let blocked_sites = blocklist_profiles
+        let mirrored_blocked_sites = blocklist_profiles
             .get(active_index)
             .map(effective_blocked_sites_for_profile)
             .unwrap_or_default();
+        let blocked_sites = if self.feature_flags.legacy_blocked_sites_mirror {
+            mirrored_blocked_sites
+        } else {
+            self.legacy_blocked_sites.clone()
+        };
         let mut profile_automation = self.profile_automation.clone();
         profile_automation
             .set_for_profile(self.selected_profile, self.selected_profile_automation());
@@ -201,6 +207,7 @@ impl App {
             goal_carry_over: self.goal_carry_over,
             stats_retention: self.stats_retention,
             wakatime: self.wakatime_metadata.clone(),
+            feature_flags: self.feature_flags,
             shortcuts: self.shortcuts.to_config(),
         }
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4784,6 +4784,35 @@ fn planner_label_change_during_running_break_updates_recovery_snapshot() {
 }
 
 #[test]
+fn planner_label_change_during_running_break_does_not_backfill_metadata_when_disabled() {
+    let mut app = App::from_config(AppConfig {
+        feature_flags: FeatureFlagsConfig {
+            metadata_task_label_fallback: false,
+            ..FeatureFlagsConfig::default()
+        },
+        ..AppConfig::default()
+    });
+    app.task_labels = vec!["Task A".to_string(), "Task B".to_string()];
+    app.selected_task_label = Some("Task A".to_string());
+    app.sync_task_planner_state();
+
+    app.handle_key(key(KeyCode::Char(' '))); // focus running
+    app.handle_key(key(KeyCode::Char('n'))); // short break idle
+    app.handle_key(key(KeyCode::Char(' '))); // short break running
+    assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
+    assert_eq!(app.timer.status, TimerStatus::Running);
+
+    app.open_session_planner();
+    app.planner_selection_index = 1;
+    app.select_planner_label();
+
+    let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
+    assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task B"));
+    assert_eq!(snapshot.focus_intention, None);
+    assert_eq!(snapshot.task_note, None);
+}
+
+#[test]
 fn prevent_double_input_on_windows() {
     let mut press_event = KeyEvent::from(KeyCode::Char('a'));
     press_event.kind = KeyEventKind::Press;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,6 +1,6 @@
 use crate::app::*;
 use crate::blocker;
-use crate::config::{ShortcutConfig, StatsRetentionConfig};
+use crate::config::{FeatureFlagsConfig, ShortcutConfig, StatsRetentionConfig};
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
 };
@@ -125,6 +125,7 @@ fn selected_builtin_profile_is_applied_on_startup() {
         stats_retention: StatsRetentionConfig::default(),
         selected_theme_preset: ThemePreset::Classic,
         wakatime: WakatimeMetadataConfig::default(),
+        feature_flags: FeatureFlagsConfig::default(),
         shortcuts: ShortcutConfig::default(),
     };
     let app = App::from_config(config);
@@ -2352,6 +2353,27 @@ fn persisted_config_mirrors_active_profile_sites_to_legacy_blocked_sites() {
         persisted.blocklist_profiles[0].sites,
         vec!["example.com".to_string()]
     );
+}
+
+#[test]
+fn persisted_config_keeps_legacy_blocked_sites_when_mirror_flag_is_disabled() {
+    let mut app = App::from_config(AppConfig {
+        blocked_sites: vec!["legacy-only.com".to_string()],
+        feature_flags: FeatureFlagsConfig {
+            legacy_blocked_sites_mirror: false,
+            ..FeatureFlagsConfig::default()
+        },
+        ..AppConfig::default()
+    });
+    app.handle_key(key(KeyCode::Char('b')));
+    app.handle_key(key(KeyCode::Char('a')));
+    for c in "example.com".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+
+    let persisted = app.persisted_config();
+    assert_eq!(persisted.blocked_sites, vec!["legacy-only.com".to_string()]);
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2374,6 +2374,11 @@ fn persisted_config_keeps_legacy_blocked_sites_when_mirror_flag_is_disabled() {
 
     let persisted = app.persisted_config();
     assert_eq!(persisted.blocked_sites, vec!["legacy-only.com".to_string()]);
+    assert!(
+        persisted.blocklist_profiles[0]
+            .sites
+            .contains(&"example.com".to_string())
+    );
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -651,12 +651,20 @@ struct SetupCheckOutput {
     message: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+struct FeatureFlagsOutput {
+    legacy_automation_mirror: bool,
+    legacy_blocked_sites_mirror: bool,
+    metadata_task_label_fallback: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct DiagnosticsCommandOutput {
     hosts_file_path: String,
     blocking_permissions: SetupCheckOutput,
     hosts_write_capability: SetupCheckOutput,
     wakatime_config: SetupCheckOutput,
+    feature_flags: FeatureFlagsOutput,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -134,7 +134,10 @@ fn execute_task_goal_command(
     goal: Option<DailyGoalConfig>,
     output: OutputMode,
 ) -> Result<(), String> {
-    let mut stats = FocusStats::load()?;
+    let config = AppConfig::load().normalized();
+    let mut stats = FocusStats::load_with_options(crate::stats::StatsLoadOptions {
+        metadata_task_label_fallback: config.feature_flags.metadata_task_label_fallback,
+    })?;
     let selected_task_label = stats.task_planner_state().1;
     let requested_label = label.or(selected_task_label).ok_or_else(|| {
         "No task label selected. Use `--task LABEL` first or pass `--task-goal LABEL`.".to_string()
@@ -554,7 +557,10 @@ fn sync_legacy_blocked_sites(config: &mut AppConfig) {
     ensure_blocklist_profiles(config);
     let index = selected_blocklist_profile_index(config);
     config.selected_blocklist_profile = config.blocklist_profiles[index].name.clone();
-    config.blocked_sites = effective_blocked_sites_for_profile(&config.blocklist_profiles[index]);
+    if config.feature_flags.legacy_blocked_sites_mirror {
+        config.blocked_sites =
+            effective_blocked_sites_for_profile(&config.blocklist_profiles[index]);
+    }
 }
 
 fn build_blocklist_profile_command_output(
@@ -950,7 +956,10 @@ fn execute_status_watch_command(output: OutputMode, interval_secs: u64) -> Resul
 
 fn load_status_output() -> Result<StatusOutput, String> {
     let config = AppConfig::load().normalized();
-    let stats = FocusStats::load().map_err(|error| format!("Failed to load stats: {error}"))?;
+    let stats = FocusStats::load_with_options(crate::stats::StatsLoadOptions {
+        metadata_task_label_fallback: config.feature_flags.metadata_task_label_fallback,
+    })
+    .map_err(|error| format!("Failed to load stats: {error}"))?;
     Ok(build_status_output(&config, &stats))
 }
 
@@ -978,7 +987,11 @@ fn emit_status_output(
 }
 
 fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
-    let stats = FocusStats::load().map_err(|error| format!("Failed to load stats: {error}"))?;
+    let config = AppConfig::load().normalized();
+    let stats = FocusStats::load_with_options(crate::stats::StatsLoadOptions {
+        metadata_task_label_fallback: config.feature_flags.metadata_task_label_fallback,
+    })
+    .map_err(|error| format!("Failed to load stats: {error}"))?;
     let target_dir = match dir {
         Some(path) => path,
         None => env::current_dir()
@@ -1292,8 +1305,10 @@ fn build_timer_state_output(app: &App) -> TimerStateOutput {
     let profile = app.selected_profile_id();
     let (focus_secs, short_break_secs, long_break_secs, long_break_interval) =
         app.profile_values(profile);
-    let (selected_task_label, focus_intention, task_note) =
-        mirror_metadata_from_task_label(app.selected_task_label_for_cli());
+    let (selected_task_label, focus_intention, task_note) = mirror_metadata_from_task_label(
+        app.selected_task_label_for_cli(),
+        app.metadata_task_label_fallback_enabled_for_cli(),
+    );
 
     TimerStateOutput {
         phase: timer_phase_id(phase),

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -3,13 +3,13 @@ use std::collections::HashSet;
 use crate::cli::{
     BackupOutput, BlockingPreviewAction, BlockingPreviewCommandOutput,
     BlocklistProfileCommandOutput, BlocklistProfileConfig, DiagnosticsCommandOutput, ExportOutput,
-    FocusScoreOutput, GoalCarryCommandOutput, GoalCommandOutput, GoalOutput, ProfileOutput,
-    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, ScheduleInspectionOutput,
-    Serialize, SetupCheck, SetupCheckLevel, SetupCheckOutput, SetupDiagnostics,
-    SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput,
-    StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput, StrictCommandOutput,
-    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, TimerStateOutput, Write,
-    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    FeatureFlagsOutput, FocusScoreOutput, GoalCarryCommandOutput, GoalCommandOutput, GoalOutput,
+    ProfileOutput, RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput,
+    ScheduleInspectionOutput, Serialize, SetupCheck, SetupCheckLevel, SetupCheckOutput,
+    SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput,
+    SiteListCommandOutput, StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput,
+    StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
+    TimerStateOutput, Write, format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -576,6 +576,12 @@ pub(super) fn print_diagnostics_command_output(payload: &DiagnosticsCommandOutpu
     print_diagnostics_check("Blocking permissions", &payload.blocking_permissions);
     print_diagnostics_check("Hosts write capability", &payload.hosts_write_capability);
     print_diagnostics_check("WakaTime config", &payload.wakatime_config);
+    println!(
+        "Feature flags: automation-mirror={}, blocked-sites-mirror={}, metadata-fallback={}",
+        bool_label(payload.feature_flags.legacy_automation_mirror),
+        bool_label(payload.feature_flags.legacy_blocked_sites_mirror),
+        bool_label(payload.feature_flags.metadata_task_label_fallback),
+    );
 }
 
 fn print_diagnostics_check(label: &str, check: &SetupCheckOutput) {
@@ -590,6 +596,11 @@ pub(super) fn build_diagnostics_command_output(
         blocking_permissions: setup_check_output(&diagnostics.blocking_permissions),
         hosts_write_capability: setup_check_output(&diagnostics.hosts_write_capability),
         wakatime_config: setup_check_output(&diagnostics.wakatime_config),
+        feature_flags: FeatureFlagsOutput {
+            legacy_automation_mirror: diagnostics.feature_flags.legacy_automation_mirror,
+            legacy_blocked_sites_mirror: diagnostics.feature_flags.legacy_blocked_sites_mirror,
+            metadata_task_label_fallback: diagnostics.feature_flags.metadata_task_label_fallback,
+        },
     }
 }
 
@@ -645,6 +656,10 @@ fn setup_check_level_id(level: SetupCheckLevel) -> &'static str {
         SetupCheckLevel::Ok => "ok",
         SetupCheckLevel::Warning => "warning",
     }
+}
+
+fn bool_label(enabled: bool) -> &'static str {
+    if enabled { "on" } else { "off" }
 }
 
 pub(super) fn print_json<T: Serialize>(payload: &T) -> Result<(), String> {

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -16,8 +16,10 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
     let week = stats.weekly_for_day(day_date);
     let month = stats.monthly_for_day(day_date);
     let (_, selected_task_label) = stats.task_planner_state();
-    let (selected_task_label, focus_intention, task_note) =
-        mirror_metadata_from_task_label(selected_task_label);
+    let (selected_task_label, focus_intention, task_note) = mirror_metadata_from_task_label(
+        selected_task_label,
+        config.feature_flags.metadata_task_label_fallback,
+    );
     let goal_snapshot = effective_daily_goal_snapshot_for_day(config, stats, day_date);
     let weekly_goal_snapshot = effective_weekly_goal_snapshot(config, stats, day_date);
     let monthly_goal_snapshot = effective_monthly_goal_snapshot(config, stats, day_date);
@@ -34,6 +36,7 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
         })
         .map(|profile| effective_blocked_sites_for_profile(profile).len())
         .unwrap_or_default();
+    let selected_automation = config.profile_automation_for(config.selected_profile);
     let live = build_live_status_output(config, selected_task_label.clone());
     let session = build_session_output(&live);
     let latest_interruption = stats.latest_session_interruption();
@@ -67,7 +70,7 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
         task_note,
         selected_blocklist_profile: config.selected_blocklist_profile.clone(),
         blocked_sites_count: active_sites_count,
-        strict_mode: config.strict_mode,
+        strict_mode: selected_automation.strict_mode,
         goal: GoalOutput {
             configured: goal_snapshot.has_any_target(),
             minutes_target: goal_snapshot.minutes,
@@ -290,8 +293,12 @@ fn build_live_status_output(
     fallback_task_label: Option<String>,
 ) -> LiveStatusOutput {
     let custom = config.effective_custom_profile();
+    let strict_mode_enabled = config
+        .profile_automation_for(config.selected_profile)
+        .strict_mode;
+    let metadata_fallback = config.feature_flags.metadata_task_label_fallback;
     let (fallback_task_label, fallback_focus_intention, fallback_task_note) =
-        mirror_metadata_from_task_label(fallback_task_label);
+        mirror_metadata_from_task_label(fallback_task_label, metadata_fallback);
     match session_recovery::load() {
         Ok(Some(snapshot)) => {
             let phase = snapshot.phase();
@@ -306,9 +313,10 @@ fn build_live_status_output(
                 pomodoros_completed: snapshot.pomodoros_completed,
                 selected_profile: profile_view(snapshot.selected_profile, &custom),
                 selected_task_label: snapshot.normalized_task_label(),
-                focus_intention: snapshot.normalized_focus_intention(),
-                task_note: snapshot.normalized_task_note(),
-                strict_mode_enforced: config.strict_mode
+                focus_intention: snapshot
+                    .normalized_focus_intention_with_fallback(metadata_fallback),
+                task_note: snapshot.normalized_task_note_with_fallback(metadata_fallback),
+                strict_mode_enforced: strict_mode_enabled
                     && phase == TimerPhase::Focus
                     && status != TimerStatus::Idle,
             }
@@ -352,12 +360,16 @@ fn build_live_status_output(
 
 pub(super) fn mirror_metadata_from_task_label(
     task_label: Option<String>,
+    metadata_fallback: bool,
 ) -> (Option<String>, Option<String>, Option<String>) {
     let task_label = task_label
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    let focus_intention = task_label.clone();
-    let task_note = task_label.clone();
+    let (focus_intention, task_note) = if metadata_fallback {
+        (task_label.clone(), task_label.clone())
+    } else {
+        (None, None)
+    };
     (task_label, focus_intention, task_note)
 }
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,4 +1,5 @@
 use crate::cli::*;
+use crate::config::FeatureFlagsConfig;
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
 };
@@ -555,6 +556,16 @@ fn parse_diagnostics_supports_json_mode() {
             output: OutputMode::Json
         })
     );
+}
+
+#[test]
+fn diagnostics_output_includes_effective_feature_flags() {
+    let app = App::default();
+    let payload = build_diagnostics_command_output(&app.setup_diagnostics);
+
+    assert!(payload.feature_flags.legacy_automation_mirror);
+    assert!(payload.feature_flags.legacy_blocked_sites_mirror);
+    assert!(payload.feature_flags.metadata_task_label_fallback);
 }
 
 #[test]
@@ -1777,6 +1788,29 @@ fn build_status_output_includes_unconfigured_selected_task_goal() {
     assert!(!selected_task_goal.met);
     assert!(!output.focus_score.available);
     assert!(output.focus_score.focus_score_pct.is_none());
+}
+
+#[test]
+fn build_status_output_disables_task_label_metadata_mirror_when_flag_disabled() {
+    let mut stats = FocusStats::default();
+    let changed =
+        stats.update_task_planner_state(vec!["Docs".to_string()], Some("Docs".to_string()));
+    assert!(changed);
+    let config = AppConfig {
+        feature_flags: FeatureFlagsConfig {
+            metadata_task_label_fallback: false,
+            ..FeatureFlagsConfig::default()
+        },
+        ..AppConfig::default()
+    };
+
+    let output = build_status_output(&config, &stats);
+
+    assert_eq!(output.selected_task_label.as_deref(), Some("Docs"));
+    assert!(output.focus_intention.is_none());
+    assert!(output.task_note.is_none());
+    assert!(output.live.focus_intention.is_none());
+    assert!(output.live.task_note.is_none());
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,9 @@ pub struct AppConfig {
     /// WakaTime heartbeat metadata labels.
     #[serde(default)]
     pub wakatime: WakatimeMetadataConfig,
+    /// Feature flags used to safely gate compatibility-sensitive behavior.
+    #[serde(default)]
+    pub feature_flags: FeatureFlagsConfig,
     /// User-configurable keyboard shortcuts for core TUI command actions.
     #[serde(default)]
     pub shortcuts: ShortcutConfig,
@@ -134,6 +137,35 @@ impl AppConfigDisk {
         Self {
             schema_version: CURRENT_CONFIG_SCHEMA_VERSION,
             config,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeatureFlagsConfig {
+    /// Keep selected profile automation mirrored into legacy top-level automation fields.
+    #[serde(default = "default_true")]
+    pub legacy_automation_mirror: bool,
+    /// Keep selected blocklist profile mirrored into legacy `blocked_sites`.
+    #[serde(default = "default_true")]
+    pub legacy_blocked_sites_mirror: bool,
+    /// Backfill missing metadata fields from task labels for legacy records/snapshots.
+    #[serde(default = "default_true")]
+    pub metadata_task_label_fallback: bool,
+}
+
+impl FeatureFlagsConfig {
+    pub fn normalized(&self) -> Self {
+        *self
+    }
+}
+
+impl Default for FeatureFlagsConfig {
+    fn default() -> Self {
+        Self {
+            legacy_automation_mirror: true,
+            legacy_blocked_sites_mirror: true,
+            metadata_task_label_fallback: true,
         }
     }
 }
@@ -1260,6 +1292,10 @@ fn default_legacy_config_schema_version() -> u32 {
     LEGACY_CONFIG_SCHEMA_VERSION
 }
 
+fn default_true() -> bool {
+    true
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
@@ -1287,6 +1323,7 @@ impl Default for AppConfig {
             goal_carry_over: GoalCarryOverConfig::default(),
             stats_retention: StatsRetentionConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
+            feature_flags: FeatureFlagsConfig::default(),
             shortcuts: ShortcutConfig::default(),
         }
     }
@@ -1356,6 +1393,9 @@ impl AppConfig {
     }
 
     pub(crate) fn align_legacy_automation_with_selected_profile(&mut self) {
+        if !self.feature_flags.legacy_automation_mirror {
+            return;
+        }
         let selected = self.profile_automation_for(self.selected_profile);
         self.notifications = selected.notifications;
         self.auto_start = selected.auto_start;
@@ -1443,6 +1483,7 @@ impl AppConfig {
             self.break_glass_duration_secs,
             default_break_glass_duration_secs(),
         );
+        self.feature_flags = self.feature_flags.normalized();
         self.custom_profile = self.custom_profile.map(|profile| profile.normalized());
         self.break_templates = normalize_break_templates(&self.break_templates);
         let effective_custom_profile = self.effective_custom_profile();
@@ -1468,12 +1509,14 @@ impl AppConfig {
             &self.selected_blocklist_profile,
             &self.blocklist_profiles,
         );
-        self.blocked_sites = self
-            .blocklist_profiles
-            .iter()
-            .find(|profile| profile.name == self.selected_blocklist_profile)
-            .map(effective_blocked_sites_for_profile)
-            .unwrap_or_default();
+        if self.feature_flags.legacy_blocked_sites_mirror {
+            self.blocked_sites = self
+                .blocklist_profiles
+                .iter()
+                .find(|profile| profile.name == self.selected_blocklist_profile)
+                .map(effective_blocked_sites_for_profile)
+                .unwrap_or_default();
+        }
         self.wakatime = self.wakatime.normalized();
         self.shortcuts = self.shortcuts.normalized();
         self

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -48,6 +48,7 @@ fn default_values_are_canonical_pomodoro() {
     assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
     assert_eq!(cfg.stats_retention, StatsRetentionConfig::default());
     assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
+    assert_eq!(cfg.feature_flags, FeatureFlagsConfig::default());
     assert_eq!(cfg.shortcuts, ShortcutConfig::default());
 }
 
@@ -236,6 +237,11 @@ fn round_trip_full_config() {
                 },
             ],
         },
+        feature_flags: FeatureFlagsConfig {
+            legacy_automation_mirror: true,
+            legacy_blocked_sites_mirror: true,
+            metadata_task_label_fallback: true,
+        },
         shortcuts: ShortcutConfig {
             timer_toggle_pause: "space".to_string(),
             timer_stop_reset: "x".to_string(),
@@ -313,6 +319,7 @@ fn missing_fields_fall_back_to_defaults() {
     assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
     assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
     assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
+    assert_eq!(cfg.feature_flags, FeatureFlagsConfig::default());
     assert_eq!(cfg.shortcuts, ShortcutConfig::default());
 }
 
@@ -703,6 +710,7 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
         goal_carry_over: GoalCarryOverConfig::default(),
         stats_retention: StatsRetentionConfig::default(),
         wakatime: WakatimeMetadataConfig::default(),
+        feature_flags: FeatureFlagsConfig::default(),
         shortcuts: ShortcutConfig::default(),
     };
     let custom = cfg.effective_custom_profile();
@@ -1226,4 +1234,92 @@ fn normalize_selected_profile_automation_updates_legacy_view() {
     assert_eq!(cfg.auto_start, deep_work.auto_start);
     assert_eq!(cfg.strict_mode, deep_work.strict_mode);
     assert_eq!(cfg.recurring_schedule, deep_work.recurring_schedule);
+}
+
+#[test]
+fn normalize_keeps_legacy_automation_fields_when_mirror_flag_is_disabled() {
+    let deep_work = ProfileAutomationConfig {
+        notifications: NotificationConfig {
+            enabled: true,
+            sound: true,
+        },
+        auto_start: AutoStartConfig {
+            focus_to_break: true,
+            break_to_focus: true,
+        },
+        strict_mode: true,
+        recurring_schedule: RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec!["fri".to_string()],
+                start: "13:00".to_string(),
+                end: "15:00".to_string(),
+            }],
+            exception_dates: Vec::new(),
+            one_time_windows: Vec::new(),
+        },
+    };
+    let cfg = AppConfig {
+        selected_profile: ProfileId::DeepWork,
+        notifications: NotificationConfig {
+            enabled: false,
+            sound: false,
+        },
+        auto_start: AutoStartConfig {
+            focus_to_break: false,
+            break_to_focus: false,
+        },
+        strict_mode: false,
+        recurring_schedule: RecurringScheduleConfig::default(),
+        profile_automation: Some(ProfileAutomationSettingsConfig {
+            classic: None,
+            deep_work: Some(deep_work.clone()),
+            custom: None,
+        }),
+        feature_flags: FeatureFlagsConfig {
+            legacy_automation_mirror: false,
+            ..FeatureFlagsConfig::default()
+        },
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    assert_eq!(
+        cfg.notifications,
+        NotificationConfig {
+            enabled: false,
+            sound: false,
+        }
+    );
+    assert_eq!(
+        cfg.auto_start,
+        AutoStartConfig {
+            focus_to_break: false,
+            break_to_focus: false,
+        }
+    );
+    assert!(!cfg.strict_mode);
+    assert_eq!(cfg.recurring_schedule, RecurringScheduleConfig::default());
+    assert_eq!(cfg.profile_automation_for(ProfileId::DeepWork), deep_work);
+}
+
+#[test]
+fn normalize_keeps_legacy_blocked_sites_when_mirror_flag_is_disabled() {
+    let cfg = AppConfig {
+        blocked_sites: vec!["legacy-only.com".to_string()],
+        blocklist_profiles: vec![BlocklistProfileConfig {
+            name: "Work".to_string(),
+            sites: vec!["a.com".to_string(), "b.com".to_string()],
+            allowlist_sites: vec!["b.com".to_string()],
+        }],
+        selected_blocklist_profile: "Work".to_string(),
+        feature_flags: FeatureFlagsConfig {
+            legacy_blocked_sites_mirror: false,
+            ..FeatureFlagsConfig::default()
+        },
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    assert_eq!(cfg.selected_blocklist_profile, "Work");
+    assert_eq!(cfg.blocked_sites, vec!["legacy-only.com".to_string()]);
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -286,6 +286,7 @@ fn round_trip_full_config() {
     assert_eq!(parsed.goal_carry_over, original.goal_carry_over);
     assert_eq!(parsed.stats_retention, original.stats_retention);
     assert_eq!(parsed.wakatime, original.wakatime);
+    assert_eq!(parsed.feature_flags, original.feature_flags);
     assert_eq!(parsed.shortcuts, original.shortcuts);
 }
 

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -88,7 +88,7 @@ pub struct InProgressSessionSnapshot {
 }
 
 impl InProgressSessionSnapshot {
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[allow(dead_code)]
     pub fn from_timer_state_with_metadata(
         timer: &TimerState,
         selected_task_label: Option<String>,

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -88,12 +88,31 @@ pub struct InProgressSessionSnapshot {
 }
 
 impl InProgressSessionSnapshot {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn from_timer_state_with_metadata(
         timer: &TimerState,
         selected_task_label: Option<String>,
         focus_intention: Option<String>,
         task_note: Option<String>,
         selected_profile: ProfileId,
+    ) -> Option<Self> {
+        Self::from_timer_state_with_metadata_with_fallback(
+            timer,
+            selected_task_label,
+            focus_intention,
+            task_note,
+            selected_profile,
+            true,
+        )
+    }
+
+    pub fn from_timer_state_with_metadata_with_fallback(
+        timer: &TimerState,
+        selected_task_label: Option<String>,
+        focus_intention: Option<String>,
+        task_note: Option<String>,
+        selected_profile: ProfileId,
+        metadata_fallback_to_task_label: bool,
     ) -> Option<Self> {
         if timer.status == TimerStatus::Idle {
             return None;
@@ -102,14 +121,18 @@ impl InProgressSessionSnapshot {
         let selected_task_label = selected_task_label
             .as_deref()
             .and_then(normalize_task_label)?;
-        let focus_intention = focus_intention
-            .as_deref()
-            .and_then(normalize_metadata_text)
-            .unwrap_or_else(|| selected_task_label.clone());
-        let task_note = task_note
-            .as_deref()
-            .and_then(normalize_metadata_text)
-            .unwrap_or_else(|| selected_task_label.clone());
+        let focus_intention = focus_intention.as_deref().and_then(normalize_metadata_text);
+        let task_note = task_note.as_deref().and_then(normalize_metadata_text);
+        let focus_intention = if focus_intention.is_some() || !metadata_fallback_to_task_label {
+            focus_intention
+        } else {
+            Some(selected_task_label.clone())
+        };
+        let task_note = if task_note.is_some() || !metadata_fallback_to_task_label {
+            task_note
+        } else {
+            Some(selected_task_label.clone())
+        };
 
         Some(Self {
             phase: RecoveryTimerPhase::from_timer_phase(timer.phase),
@@ -117,8 +140,8 @@ impl InProgressSessionSnapshot {
             remaining_secs: timer.remaining_secs,
             pomodoros_completed: timer.pomodoros_completed,
             selected_task_label: Some(selected_task_label),
-            focus_intention: Some(focus_intention),
-            task_note: Some(task_note),
+            focus_intention,
+            task_note,
             selected_profile,
         })
     }

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -137,21 +137,53 @@ impl InProgressSessionSnapshot {
             .and_then(normalize_task_label)
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn normalized_focus_intention(&self) -> Option<String> {
-        self.focus_intention
-            .as_deref()
-            .and_then(normalize_metadata_text)
-            .or_else(|| self.normalized_task_label())
+        self.normalized_focus_intention_with_fallback(true)
     }
 
+    pub fn normalized_focus_intention_with_fallback(
+        &self,
+        fallback_to_task_label: bool,
+    ) -> Option<String> {
+        let normalized = self
+            .focus_intention
+            .as_deref()
+            .and_then(normalize_metadata_text);
+        if normalized.is_some() || !fallback_to_task_label {
+            normalized
+        } else {
+            self.normalized_task_label()
+        }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn normalized_task_note(&self) -> Option<String> {
-        self.task_note
-            .as_deref()
-            .and_then(normalize_metadata_text)
-            .or_else(|| self.normalized_task_label())
+        self.normalized_task_note_with_fallback(true)
     }
 
+    pub fn normalized_task_note_with_fallback(
+        &self,
+        fallback_to_task_label: bool,
+    ) -> Option<String> {
+        let normalized = self.task_note.as_deref().and_then(normalize_metadata_text);
+        if normalized.is_some() || !fallback_to_task_label {
+            normalized
+        } else {
+            self.normalized_task_label()
+        }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn validate_for_timer(&self, timer: &TimerState) -> Result<(), String> {
+        self.validate_for_timer_with_fallback(timer, true)
+    }
+
+    pub fn validate_for_timer_with_fallback(
+        &self,
+        timer: &TimerState,
+        fallback_to_task_label: bool,
+    ) -> Result<(), String> {
         if !matches!(
             self.status,
             RecoveryTimerStatus::Running | RecoveryTimerStatus::Paused
@@ -162,10 +194,16 @@ impl InProgressSessionSnapshot {
         if self.normalized_task_label().is_none() {
             return Err("saved task label is missing or invalid".to_string());
         }
-        if self.normalized_focus_intention().is_none() {
+        if self
+            .normalized_focus_intention_with_fallback(fallback_to_task_label)
+            .is_none()
+        {
             return Err("saved focus intention is missing or invalid".to_string());
         }
-        if self.normalized_task_note().is_none() {
+        if self
+            .normalized_task_note_with_fallback(fallback_to_task_label)
+            .is_none()
+        {
             return Err("saved task note is missing or invalid".to_string());
         }
 
@@ -426,5 +464,38 @@ mod tests {
         );
         assert_eq!(snapshot.normalized_task_note().as_deref(), Some("Docs"));
         assert!(snapshot.validate_for_timer(&timer).is_ok());
+    }
+
+    #[test]
+    fn metadata_fallback_can_be_disabled_for_legacy_snapshots() {
+        let timer = TimerState::with_profile(60, 30, 90, 4);
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Running,
+            remaining_secs: 60,
+            pomodoros_completed: 1,
+            selected_task_label: Some("Docs".to_string()),
+            focus_intention: None,
+            task_note: None,
+            selected_profile: ProfileId::Classic,
+        };
+
+        assert_eq!(
+            snapshot
+                .normalized_focus_intention_with_fallback(false)
+                .as_deref(),
+            None
+        );
+        assert_eq!(
+            snapshot
+                .normalized_task_note_with_fallback(false)
+                .as_deref(),
+            None
+        );
+        assert!(
+            snapshot
+                .validate_for_timer_with_fallback(&timer, false)
+                .is_err()
+        );
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -38,6 +38,19 @@ const CSV_EXPORT_FILE_NAME: &str = "focustime-stats.csv";
 const EXPORT_SCHEMA_VERSION: u32 = 5;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatsLoadOptions {
+    pub metadata_task_label_fallback: bool,
+}
+
+impl Default for StatsLoadOptions {
+    fn default() -> Self {
+        Self {
+            metadata_task_label_fallback: true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SessionStats {
     pub pomodoros_completed: u32,

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -2,40 +2,60 @@
 use crate::stats::fs;
 use crate::stats::{
     BreakGlassOverrideEvent, FocusSessionRecord, FocusStats, PersistedStats, STATS_FILE_NAME,
-    SessionInterruptionEvent, SessionStats, io, normalize_session_metadata_text,
+    SessionInterruptionEvent, SessionStats, StatsLoadOptions, io, normalize_session_metadata_text,
     normalize_task_goal_targets, normalize_task_label, normalize_task_planner_state,
     planner_state_labels_for_keys, write_atomic_bytes,
 };
 
 impl FocusStats {
     #[cfg(test)]
+    #[allow(dead_code)]
     pub fn load() -> Result<Self, String> {
+        Self::load_with_options(StatsLoadOptions::default())
+    }
+
+    #[cfg(test)]
+    pub fn load_with_options(_options: StatsLoadOptions) -> Result<Self, String> {
         Ok(Self::default())
     }
 
     #[cfg(not(test))]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn load() -> Result<Self, String> {
-        Self::try_load()
+        Self::load_with_options(StatsLoadOptions::default())
     }
 
     #[cfg(not(test))]
-    fn try_load() -> Result<Self, String> {
+    pub fn load_with_options(options: StatsLoadOptions) -> Result<Self, String> {
+        Self::try_load(options)
+    }
+
+    #[cfg(not(test))]
+    fn try_load(options: StatsLoadOptions) -> Result<Self, String> {
         let path = crate::config::app_data_path(STATS_FILE_NAME)
             .ok_or_else(|| "cannot determine stats directory".to_string())?;
         match fs::read_to_string(path) {
-            Ok(content) => Self::try_from_toml(&content),
+            Ok(content) => Self::try_from_toml_with_options(&content, options),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
             Err(e) => Err(format!("stats read failed: {e}")),
         }
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn try_from_toml(content: &str) -> Result<Self, String> {
-        let persisted: PersistedStats =
-            toml::from_str(content).map_err(|e| format!("stats parse failed: {e}"))?;
-        Ok(Self::from_persisted(persisted))
+        Self::try_from_toml_with_options(content, StatsLoadOptions::default())
     }
 
-    fn from_persisted(persisted: PersistedStats) -> Self {
+    pub(super) fn try_from_toml_with_options(
+        content: &str,
+        options: StatsLoadOptions,
+    ) -> Result<Self, String> {
+        let persisted: PersistedStats =
+            toml::from_str(content).map_err(|e| format!("stats parse failed: {e}"))?;
+        Ok(Self::from_persisted(persisted, options))
+    }
+
+    fn from_persisted(persisted: PersistedStats, options: StatsLoadOptions) -> Self {
         let (task_labels, selected_task_label, task_label_favorites, task_label_archived) =
             normalize_task_planner_state(
                 persisted.task_labels,
@@ -47,10 +67,18 @@ impl FocusStats {
         let mut focus_sessions = Vec::new();
         for session in persisted.focus_sessions {
             if let Some(task_label) = normalize_task_label(&session.task_label) {
-                let focus_intention = normalize_session_metadata_text(&session.focus_intention)
-                    .unwrap_or_else(|| task_label.clone());
-                let task_note = normalize_session_metadata_text(&session.task_note)
-                    .unwrap_or_else(|| task_label.clone());
+                let focus_intention = normalize_session_metadata_text(&session.focus_intention);
+                let task_note = normalize_session_metadata_text(&session.task_note);
+                let focus_intention = if options.metadata_task_label_fallback {
+                    focus_intention.unwrap_or_else(|| task_label.clone())
+                } else {
+                    focus_intention.unwrap_or_default()
+                };
+                let task_note = if options.metadata_task_label_fallback {
+                    task_note.unwrap_or_else(|| task_label.clone())
+                } else {
+                    task_note.unwrap_or_default()
+                };
                 focus_sessions.push(FocusSessionRecord {
                     date: session.date.trim().to_string(),
                     task_label,

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -894,6 +894,29 @@ fn legacy_focus_sessions_default_metadata_from_task_label() {
 }
 
 #[test]
+fn legacy_focus_sessions_keep_empty_metadata_when_fallback_is_disabled() {
+    let legacy_toml = r#"
+            [[focus_sessions]]
+            date = "2026-04-09"
+            task_label = "Project A"
+            focused_seconds = 1500
+        "#;
+    let restored = FocusStats::try_from_toml_with_options(
+        legacy_toml,
+        StatsLoadOptions {
+            metadata_task_label_fallback: false,
+        },
+    )
+    .unwrap();
+
+    let export = restored.export_data();
+    assert_eq!(export.sessions.len(), 1);
+    assert_eq!(export.sessions[0].task_label, "Project A");
+    assert!(export.sessions[0].focus_intention.is_empty());
+    assert!(export.sessions[0].task_note.is_empty());
+}
+
+#[test]
 fn session_export_preserves_persisted_metadata_fields() {
     let mut stats = FocusStats::default();
     let goal = DailyGoalSnapshot {

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -24,6 +24,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             Constraint::Length(2), // blocking permissions
             Constraint::Length(2), // hosts write capability
             Constraint::Length(2), // wakatime config status
+            Constraint::Length(2), // feature flags
             Constraint::Length(1), // preview summary
             Constraint::Min(0),    // preview section
             Constraint::Length(2), // key hints
@@ -58,6 +59,25 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         "WakaTime config status",
         &app.setup_diagnostics.wakatime_config,
     );
+    frame.render_widget(
+        Paragraph::new(format!(
+            "Feature flags: automation-mirror={} · blocked-sites-mirror={} · metadata-fallback={}",
+            bool_label(app.setup_diagnostics.feature_flags.legacy_automation_mirror),
+            bool_label(
+                app.setup_diagnostics
+                    .feature_flags
+                    .legacy_blocked_sites_mirror
+            ),
+            bool_label(
+                app.setup_diagnostics
+                    .feature_flags
+                    .metadata_task_label_fallback
+            )
+        ))
+        .style(Style::default().fg(app_color(app, Color::DarkGray)))
+        .wrap(Wrap { trim: true }),
+        inner[5],
+    );
 
     let (preview_summary, preview_style) = if let Some(error) = app.blocking_preview.error.as_ref()
     {
@@ -88,7 +108,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         Paragraph::new(preview_summary)
             .alignment(Alignment::Left)
             .style(preview_style),
-        inner[5],
+        inner[6],
     );
 
     let preview_section_text = if app.blocking_preview.error.is_some() {
@@ -107,13 +127,13 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             )
             .style(Style::default().fg(app_color(app, Color::Gray)))
             .wrap(Wrap { trim: false }),
-        inner[6],
+        inner[7],
     );
 
     render_hint_lines(
         frame,
         app,
-        inner[7],
+        inner[8],
         vec![
             Line::from(format!(
                 "Diagnostics: {} Refresh checks + preview",
@@ -134,6 +154,10 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             }),
         ],
     );
+}
+
+fn bool_label(enabled: bool) -> &'static str {
+    if enabled { "on" } else { "off" }
 }
 
 pub(super) fn render_setup_check(


### PR DESCRIPTION
## What

- Adds a centralized `feature_flags` configuration model with safe default-on values.
- Gates compatibility-sensitive behavior across config/runtime paths:
  - legacy automation mirror
  - legacy `blocked_sites` mirror
  - metadata fallback from `task_label`
- Exposes effective feature flag state in CLI diagnostics output and Setup Diagnostics UI.
- Adds regression coverage for default-on and disabled-flag behavior.
- Updates README config docs and CHANGELOG.

## Why

This change enables safer multi-version rollout of behavior changes. It preserves current behavior by default for existing users, while letting compatibility fallbacks be turned off deliberately and independently.

Closes #258.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable feature flags to toggle legacy automation mirroring, legacy blocked-sites mirroring, and metadata task-label fallback; flags are visible in setup UI and CLI diagnostics and influence status output, stats loading, session recovery, and persisted config.
* **Documentation**
  * README and changelog updated with the new feature_flags section and default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->