### PR TITLE
CLI parity for session metadata (focus_intention, task_note)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Feature flags for rollout-safe compatibility paths (#258):** added centralized `[feature_flags]` config defaults plus diagnostics visibility to gate legacy automation/blocklist mirrors and task-label metadata fallback behavior across config, CLI, recovery, and stats loading paths.
+- **CLI parity for session metadata commands (#259):** added non-interactive `--focus-intention` and `--task-note` read/set workflows so in-progress session metadata can be inspected and updated from CLI output contracts without entering TUI mode.
 
 ## [0.9.0] - 2026-05-05
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ cargo run -- --task-goal "Write docs"
 cargo run -- --task-goal "Write docs:120,4"
 cargo run -- --task-goal=Write-docs:120,4 --json
 
+# Show session metadata, or set it while focus is running/paused
+cargo run -- --focus-intention
+cargo run -- --focus-intention "Review PR feedback"
+cargo run -- --task-note
+cargo run -- --task-note="Capture blockers for retro" --json
+
 # Show or set the active profile
 cargo run -- --profile
 cargo run -- --profile deep-work
@@ -333,6 +339,9 @@ quick session note.
 
 Saved notes are reflected in live status metadata (`task_note`), recovery state,
 and interruption/completed-session history export fields.
+
+CLI parity is available via `--focus-intention` and `--task-note` for non-interactive
+inspection and in-session updates (updates require an active or paused focus session).
 
 ### Example config
 

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -106,8 +106,42 @@ impl App {
         self.selected_task_label.clone()
     }
 
-    pub fn metadata_task_label_fallback_enabled_for_cli(&self) -> bool {
-        self.feature_flags.metadata_task_label_fallback
+    pub fn focus_intention_for_cli(&self) -> Option<String> {
+        if self.focus_session_active_for_current_state() {
+            return self
+                .active_focus_intention
+                .clone()
+                .or_else(|| self.active_focus_task_label.clone())
+                .or_else(|| self.selected_task_label.clone());
+        }
+        self.cli_metadata_fallback_value()
+    }
+
+    pub fn task_note_for_cli(&self) -> Option<String> {
+        if self.focus_session_active_for_current_state() {
+            return self
+                .active_focus_task_note
+                .clone()
+                .or_else(|| self.active_focus_task_label.clone())
+                .or_else(|| self.selected_task_label.clone());
+        }
+        self.cli_metadata_fallback_value()
+    }
+
+    pub fn set_focus_intention_for_cli(&mut self, value: &str) -> Result<(), String> {
+        self.ensure_focus_active_for_cli_metadata_update("--focus-intention")?;
+        let value = self.resolve_cli_metadata_value(value)?;
+        self.active_focus_intention = Some(value);
+        self.sync_recovery_snapshot();
+        Ok(())
+    }
+
+    pub fn set_task_note_for_cli(&mut self, value: &str) -> Result<(), String> {
+        self.ensure_focus_active_for_cli_metadata_update("--task-note")?;
+        let value = self.resolve_cli_metadata_value(value)?;
+        self.active_focus_task_note = Some(value);
+        self.sync_recovery_snapshot();
+        Ok(())
     }
 
     pub fn timer_state_for_cli(&self) -> (TimerPhase, TimerStatus, u64, u32) {
@@ -117,5 +151,30 @@ impl App {
             self.timer.remaining_secs,
             self.timer.pomodoros_completed,
         )
+    }
+
+    fn cli_metadata_fallback_value(&self) -> Option<String> {
+        if self.feature_flags.metadata_task_label_fallback {
+            self.selected_task_label.clone()
+        } else {
+            None
+        }
+    }
+
+    fn ensure_focus_active_for_cli_metadata_update(&self, command: &str) -> Result<(), String> {
+        if self.focus_session_active_for_current_state() {
+            Ok(())
+        } else {
+            Err(format!(
+                "Cannot set session metadata with `{command}`: focus session is not active or paused."
+            ))
+        }
+    }
+
+    fn resolve_cli_metadata_value(&self, value: &str) -> Result<String, String> {
+        normalize_task_label(value)
+            .or_else(|| self.active_focus_task_label.clone())
+            .or_else(|| self.selected_task_label.clone())
+            .ok_or_else(|| "Cannot set session metadata: no task label is selected.".to_string())
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4108,6 +4108,42 @@ fn cli_start_begins_focus_when_task_label_exists() {
 }
 
 #[test]
+fn cli_metadata_update_requires_active_or_paused_focus() {
+    let mut app = App::default();
+
+    let focus_error = app.set_focus_intention_for_cli("Write docs").unwrap_err();
+    assert_eq!(
+        focus_error,
+        "Cannot set session metadata with `--focus-intention`: focus session is not active or paused."
+    );
+
+    let note_error = app.set_task_note_for_cli("Capture blockers").unwrap_err();
+    assert_eq!(
+        note_error,
+        "Cannot set session metadata with `--task-note`: focus session is not active or paused."
+    );
+}
+
+#[test]
+fn cli_metadata_update_syncs_active_state_and_recovery_snapshot() {
+    let mut app = App::default();
+    app.selected_task_label = Some("Docs".to_string());
+    app.start_focus_for_cli().unwrap();
+
+    app.set_focus_intention_for_cli("Write API docs").unwrap();
+    app.set_task_note_for_cli("Capture blockers").unwrap();
+
+    assert_eq!(
+        app.focus_intention_for_cli().as_deref(),
+        Some("Write API docs")
+    );
+    assert_eq!(app.task_note_for_cli().as_deref(), Some("Capture blockers"));
+    let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
+    assert_eq!(snapshot.focus_intention.as_deref(), Some("Write API docs"));
+    assert_eq!(snapshot.task_note.as_deref(), Some("Capture blockers"));
+}
+
+#[test]
 fn cli_pause_and_resume_transitions_timer_state() {
     let mut app = App::default();
     app.selected_task_label = Some("Docs".to_string());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,10 +48,10 @@ use output::{
     print_blocklist_profile_command_output, print_diagnostics_command_output, print_export_output,
     print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
     print_profile_output, print_restore_output, print_schedule_command_output,
-    print_site_add_command_output, print_site_delete_command_output,
-    print_site_edit_command_output, print_site_list_command_output, print_status_output,
-    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
-    print_timer_state_output,
+    print_session_metadata_command_output, print_site_add_command_output,
+    print_site_delete_command_output, print_site_edit_command_output,
+    print_site_list_command_output, print_status_output, print_strict_command_output,
+    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
 };
 use parsing::{
     finalize_cli_action, invalid_usage, parse_global_tokens, parse_goal_carry_value,
@@ -62,8 +62,8 @@ use parsing::{
 };
 use status::{
     available_break_template_views, available_theme_preset_views, build_status_output,
-    build_task_goal_output, mirror_metadata_from_task_label, profile_id, profile_view,
-    selected_break_template_view, theme_preset_view, timer_phase_id, timer_status_id,
+    build_task_goal_output, profile_id, profile_view, selected_break_template_view,
+    theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 const USAGE_TEXT: &str = r#"Usage:
@@ -76,6 +76,10 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --task=LABEL [--json]
   focustime --task-goal [LABEL|LABEL:MINUTES,POMODOROS] [--json]
   focustime --task-goal=LABEL[:MINUTES,POMODOROS] [--json]
+  focustime --focus-intention [TEXT] [--json]
+  focustime --focus-intention=TEXT [--json]
+  focustime --task-note [TEXT] [--json]
+  focustime --task-note=TEXT [--json]
   focustime --profile [classic|deep-work|custom] [--json]
   focustime --theme [classic|high-contrast|deuteranopia-friendly] [--json]
   focustime --goal [--json]
@@ -121,6 +125,8 @@ Options:
   --next          Skip to the next phase
   --task          Select task label (auto-creates unknown labels)
   --task-goal     Show or set per-task cumulative goal targets
+  --focus-intention  Show current focus intention, or set it for the active/paused focus session
+  --task-note        Show current task note, or set it for the active/paused focus session
   --profile       Show current profile, or set it when value is provided
   --theme         Show current theme preset, or set it when value is provided
   --goal          Show current daily goal, or set minutes/pomodoros targets
@@ -213,6 +219,12 @@ pub enum CommandKind {
         label: Option<String>,
         goal: Option<DailyGoalConfig>,
     },
+    FocusIntention {
+        value: Option<String>,
+    },
+    TaskNote {
+        value: Option<String>,
+    },
     Profile {
         profile: Option<ProfileId>,
     },
@@ -291,6 +303,8 @@ enum PrimaryCommand {
         label: Option<String>,
         goal: Option<DailyGoalConfig>,
     },
+    FocusIntention(Option<String>),
+    TaskNote(Option<String>),
     Profile(Option<ProfileId>),
     Theme(Option<ThemePreset>),
     Goal(Option<DailyGoalConfig>),
@@ -336,6 +350,8 @@ enum ParsedToken {
         label: Option<String>,
         goal: Option<DailyGoalConfig>,
     },
+    FocusIntention(Option<String>),
+    TaskNote(Option<String>),
     Status,
     Watch(Option<u64>),
     Profile(Option<ProfileId>),
@@ -603,6 +619,15 @@ struct TaskGoalCommandOutput {
     focused_minutes: u64,
     pomodoros_completed: u32,
     met: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SessionMetadataCommandOutput {
+    action: &'static str,
+    updated: bool,
+    focus_intention: Option<String>,
+    task_note: Option<String>,
+    timer: TimerStateOutput,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -55,9 +55,11 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 25] = [
+    let parsers: [(&str, ValueArgParser); 27] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
+        ("--focus-intention", classify_focus_intention_arg),
+        ("--task-note", classify_task_note_arg),
         ("--profile", classify_profile_arg),
         ("--theme", classify_theme_arg),
         ("--goal", classify_goal_arg),
@@ -180,6 +182,35 @@ fn classify_theme_arg(args: &[String], index: usize) -> Result<(ParsedToken, usi
         return Ok((ParsedToken::Theme(Some(selected)), 2));
     }
     Ok((ParsedToken::Theme(None), 1))
+}
+
+fn classify_focus_intention_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value = require_nonempty_key_value(
+            next,
+            "`--focus-intention` requires a value when one is provided.",
+        )?;
+        return Ok((ParsedToken::FocusIntention(Some(value.to_string())), 2));
+    }
+    Ok((ParsedToken::FocusIntention(None), 1))
+}
+
+fn classify_task_note_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value = require_nonempty_key_value(
+            next,
+            "`--task-note` requires a value when one is provided.",
+        )?;
+        return Ok((ParsedToken::TaskNote(Some(value.to_string())), 2));
+    }
+    Ok((ParsedToken::TaskNote(None), 1))
 }
 
 fn classify_export_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
@@ -476,9 +507,11 @@ fn classify_schedule_set_arg(
 }
 
 pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 25] = [
+    let parsers: [KeyValueParser; 27] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
+        parse_focus_intention_key_value_arg,
+        parse_task_note_key_value_arg,
         parse_profile_key_value_arg,
         parse_theme_key_value_arg,
         parse_goal_key_value_arg,
@@ -532,6 +565,24 @@ fn parse_task_goal_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, Strin
             label: Some(label),
             goal,
         }));
+    }
+    Ok(None)
+}
+
+fn parse_focus_intention_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--focus-intention=") {
+        let value =
+            require_nonempty_key_value(value, "`--focus-intention=` requires a non-empty value.")?;
+        return Ok(Some(ParsedToken::FocusIntention(Some(value.to_string()))));
+    }
+    Ok(None)
+}
+
+fn parse_task_note_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--task-note=") {
+        let value =
+            require_nonempty_key_value(value, "`--task-note=` requires a non-empty value.")?;
+        return Ok(Some(ParsedToken::TaskNote(Some(value.to_string()))));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -8,23 +8,24 @@ use crate::cli::{
     CommandKind, DailyGoalConfig, DailyGoalSnapshot, EditSiteResult, ExportOutput, FocusStats,
     GoalCarryCommandOutput, GoalCommandOutput, InvalidSiteEntryOutput, InvalidSiteInput,
     MonthlyGoalConfig, OutputMode, PathBuf, ProfileId, ProfileOutput, ProfileView,
-    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, SiteAddCommandOutput,
-    SiteBlocker, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteEditValue,
-    SiteListCommandOutput, SiteListTarget, StatusOutput, StrictCommandOutput, TaskCommandOutput,
-    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, ThemePreset, TimerCommandOutput,
-    TimerStateOutput, WeeklyGoalConfig, available_break_template_views,
+    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, SessionMetadataCommandOutput,
+    SiteAddCommandOutput, SiteBlocker, SiteDeleteCommandOutput, SiteEditCommandOutput,
+    SiteEditValue, SiteListCommandOutput, SiteListTarget, StatusOutput, StrictCommandOutput,
+    TaskCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, ThemePreset,
+    TimerCommandOutput, TimerStateOutput, WeeklyGoalConfig, available_break_template_views,
     available_theme_preset_views, build_blocking_preview_command_output,
     build_diagnostics_command_output, build_schedule_inspection_output, build_status_output,
     build_task_goal_output, display_input_value, effective_blocked_sites_for_profile, flush_stdout,
-    mirror_metadata_from_task_label, print_backup_output, print_blocking_preview_command_output,
+    print_backup_output, print_blocking_preview_command_output,
     print_blocklist_profile_command_output, print_diagnostics_command_output, print_export_output,
     print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
     print_profile_output, print_restore_output, print_schedule_command_output,
-    print_site_add_command_output, print_site_delete_command_output,
-    print_site_edit_command_output, print_site_list_command_output, print_status_output,
-    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
-    print_timer_state_output, profile_id, profile_view, selected_break_template_view,
-    theme_preset_view, timer_phase_id, timer_status_id,
+    print_session_metadata_command_output, print_site_add_command_output,
+    print_site_delete_command_output, print_site_edit_command_output,
+    print_site_list_command_output, print_status_output, print_strict_command_output,
+    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
+    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
+    timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
@@ -40,6 +41,10 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         CommandKind::TaskGoal { label, goal } => {
             execute_task_goal_command(label, goal, cli_command.output)
         }
+        CommandKind::FocusIntention { value } => {
+            execute_focus_intention_command(value, cli_command.output)
+        }
+        CommandKind::TaskNote { value } => execute_task_note_command(value, cli_command.output),
         CommandKind::Profile { profile } => execute_profile_command(profile, cli_command.output),
         CommandKind::Theme { preset } => execute_theme_command(preset, cli_command.output),
         CommandKind::Goal { goal } => execute_goal_command(goal, cli_command.output),
@@ -184,6 +189,29 @@ fn execute_task_goal_command(
         OutputMode::Json => print_json(&payload)?,
     }
     Ok(())
+}
+
+fn execute_focus_intention_command(
+    value: Option<String>,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut app = App::new();
+    let mut updated = false;
+    if let Some(value) = value {
+        app.set_focus_intention_for_cli(&value)?;
+        updated = true;
+    }
+    emit_session_metadata_command_output("focus-intention", updated, &app, output)
+}
+
+fn execute_task_note_command(value: Option<String>, output: OutputMode) -> Result<(), String> {
+    let mut app = App::new();
+    let mut updated = false;
+    if let Some(value) = value {
+        app.set_task_note_for_cli(&value)?;
+        updated = true;
+    }
+    emit_session_metadata_command_output("task-note", updated, &app, output)
 }
 
 fn execute_blocklist_profile_command(
@@ -1300,15 +1328,34 @@ fn emit_timer_command_output(
     Ok(())
 }
 
+fn emit_session_metadata_command_output(
+    action: &'static str,
+    updated: bool,
+    app: &App,
+    output: OutputMode,
+) -> Result<(), String> {
+    let payload = SessionMetadataCommandOutput {
+        action,
+        updated,
+        focus_intention: app.focus_intention_for_cli(),
+        task_note: app.task_note_for_cli(),
+        timer: build_timer_state_output(app),
+    };
+    match output {
+        OutputMode::Text => print_session_metadata_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
 fn build_timer_state_output(app: &App) -> TimerStateOutput {
     let (phase, status, remaining_secs, pomodoros_completed) = app.timer_state_for_cli();
     let profile = app.selected_profile_id();
     let (focus_secs, short_break_secs, long_break_secs, long_break_interval) =
         app.profile_values(profile);
-    let (selected_task_label, focus_intention, task_note) = mirror_metadata_from_task_label(
-        app.selected_task_label_for_cli(),
-        app.metadata_task_label_fallback_enabled_for_cli(),
-    );
+    let selected_task_label = app.selected_task_label_for_cli();
+    let focus_intention = app.focus_intention_for_cli();
+    let task_note = app.task_note_for_cli();
 
     TimerStateOutput {
         phase: timer_phase_id(phase),

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -5,10 +5,10 @@ use crate::cli::{
     BlocklistProfileCommandOutput, BlocklistProfileConfig, DiagnosticsCommandOutput, ExportOutput,
     FeatureFlagsOutput, FocusScoreOutput, GoalCarryCommandOutput, GoalCommandOutput, GoalOutput,
     ProfileOutput, RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput,
-    ScheduleInspectionOutput, Serialize, SetupCheck, SetupCheckLevel, SetupCheckOutput,
-    SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput,
-    SiteListCommandOutput, StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput,
-    StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
+    ScheduleInspectionOutput, Serialize, SessionMetadataCommandOutput, SetupCheck, SetupCheckLevel,
+    SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput,
+    SiteEditCommandOutput, SiteListCommandOutput, StatsGrowthSummary, StatsRetentionStatusOutput,
+    StatusOutput, StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
     TimerStateOutput, Write, format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
 };
 
@@ -204,6 +204,23 @@ pub(super) fn print_site_delete_command_output(payload: &SiteDeleteCommandOutput
         "Effective blocked sites: {}",
         payload.effective_blocked_sites_count
     );
+}
+
+pub(super) fn print_session_metadata_command_output(payload: &SessionMetadataCommandOutput) {
+    if payload.updated {
+        println!("Session metadata updated: {}.", payload.action);
+    } else {
+        println!("Session metadata: {}.", payload.action);
+    }
+    println!(
+        "Focus intention: {}",
+        payload.focus_intention.as_deref().unwrap_or("none")
+    );
+    println!(
+        "Task note: {}",
+        payload.task_note.as_deref().unwrap_or("none")
+    );
+    print_timer_state_output(&payload.timer);
 }
 
 pub(super) fn print_status_output(payload: &StatusOutput) {

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -34,6 +34,8 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::Next
             | ParsedToken::Task(_)
             | ParsedToken::TaskGoal { .. }
+            | ParsedToken::FocusIntention(_)
+            | ParsedToken::TaskNote(_)
             | ParsedToken::Status
             | ParsedToken::Watch(_)
             | ParsedToken::Profile(_)
@@ -90,6 +92,12 @@ pub(super) fn parse_primary_command(
                     goal: *goal,
                 },
             )?,
+            ParsedToken::FocusIntention(value) => {
+                set_primary_command(&mut primary, PrimaryCommand::FocusIntention(value.clone()))?
+            }
+            ParsedToken::TaskNote(value) => {
+                set_primary_command(&mut primary, PrimaryCommand::TaskNote(value.clone()))?
+            }
             ParsedToken::Status => set_primary_command(&mut primary, PrimaryCommand::Status)?,
             ParsedToken::Watch(_) => {}
             ParsedToken::Profile(profile) => {
@@ -301,6 +309,14 @@ pub(super) fn finalize_cli_action(
         })),
         Some(PrimaryCommand::TaskGoal { label, goal }) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::TaskGoal { label, goal },
+            output,
+        })),
+        Some(PrimaryCommand::FocusIntention(value)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::FocusIntention { value },
+            output,
+        })),
+        Some(PrimaryCommand::TaskNote(value)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::TaskNote { value },
             output,
         })),
         Some(PrimaryCommand::Status) => Ok(CliAction::RunCommand(CliCommand {
@@ -695,6 +711,8 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Next => "--next",
         PrimaryCommand::Task(_) => "--task",
         PrimaryCommand::TaskGoal { .. } => "--task-goal",
+        PrimaryCommand::FocusIntention(_) => "--focus-intention",
+        PrimaryCommand::TaskNote(_) => "--task-note",
         PrimaryCommand::Profile(_) => "--profile",
         PrimaryCommand::Theme(_) => "--theme",
         PrimaryCommand::Goal(_) => "--goal",

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -197,6 +197,58 @@ fn parse_task_goal_with_colon_in_label_reads_specific_goal() {
 }
 
 #[test]
+fn parse_focus_intention_without_value_reads_current_metadata() {
+    let parsed = parse(&["--focus-intention"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::FocusIntention { value: None },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_focus_intention_with_equals_sets_metadata() {
+    let parsed = parse(&["--focus-intention=Write docs"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::FocusIntention {
+                value: Some("Write docs".to_string())
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_task_note_without_value_reads_current_metadata() {
+    let parsed = parse(&["--task-note"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::TaskNote { value: None },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_task_note_with_value_sets_metadata() {
+    let parsed = parse(&["--task-note", "Capture blockers"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::TaskNote {
+                value: Some("Capture blockers".to_string())
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
 fn parse_profile_supports_json_mode() {
     let parsed = parse(&["--profile", "--json"]).unwrap();
     assert_eq!(
@@ -1064,6 +1116,18 @@ fn parse_rejects_task_without_value() {
 fn parse_rejects_task_with_blank_value() {
     let error = parse(&["--task", "   "]).unwrap_err();
     assert!(error.contains("`--task` requires a task label"));
+}
+
+#[test]
+fn parse_rejects_focus_intention_with_blank_value() {
+    let error = parse(&["--focus-intention", "   "]).unwrap_err();
+    assert!(error.contains("`--focus-intention` requires a value"));
+}
+
+#[test]
+fn parse_rejects_task_note_with_blank_equals_value() {
+    let error = parse(&["--task-note="]).unwrap_err();
+    assert!(error.contains("`--task-note=` requires a non-empty value."));
 }
 
 #[test]

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -83,6 +83,13 @@ fn stderr_text(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).to_string()
 }
 
+fn write_recovery_snapshot(env: &TestEnv, content: &str) {
+    let app_data_dir = env.root.join("focustime");
+    fs::create_dir_all(&app_data_dir).expect("failed to create app data directory");
+    fs::write(app_data_dir.join("session-recovery.toml"), content)
+        .expect("failed to write recovery snapshot");
+}
+
 #[test]
 fn status_json_success_emits_payload_on_stdout() {
     let env = TestEnv::new("status-json-success");
@@ -170,6 +177,92 @@ fn task_goal_json_reads_unconfigured_selected_task_goal() {
     assert_eq!(read_payload["focused_minutes"], 0);
     assert_eq!(read_payload["pomodoros_completed"], 0);
     assert_eq!(read_payload["met"], false);
+}
+
+#[test]
+fn session_metadata_json_reads_fallback_from_selected_task_label() {
+    let env = TestEnv::new("metadata-json-read-fallback");
+
+    let select_output = env.run(&["--task", "Docs", "--json"]);
+    assert_eq!(select_output.status.code(), Some(0));
+    assert!(stderr_text(&select_output).trim().is_empty());
+
+    let read_output = env.run(&["--focus-intention", "--json"]);
+    assert_eq!(read_output.status.code(), Some(0));
+    assert!(stderr_text(&read_output).trim().is_empty());
+
+    let payload: Value =
+        serde_json::from_slice(&read_output.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["action"], "focus-intention");
+    assert_eq!(payload["updated"], false);
+    assert_eq!(payload["focus_intention"], "Docs");
+    assert_eq!(payload["task_note"], "Docs");
+    assert_eq!(payload["timer"]["selected_task_label"], "Docs");
+}
+
+#[test]
+fn session_metadata_json_set_and_read_updates_recovery_backed_state() {
+    let env = TestEnv::new("metadata-json-set-read");
+    write_recovery_snapshot(
+        &env,
+        r#"phase = "focus"
+status = "running"
+remaining_secs = 1200
+pomodoros_completed = 2
+selected_task_label = "Docs"
+focus_intention = "Write docs"
+task_note = "Draft outline"
+selected_profile = "classic"
+"#,
+    );
+
+    let set_note_output = env.run(&["--task-note", "Capture blockers", "--json"]);
+    assert_eq!(set_note_output.status.code(), Some(0));
+    assert!(stderr_text(&set_note_output).trim().is_empty());
+    let set_note_payload: Value =
+        serde_json::from_slice(&set_note_output.stdout).expect("stdout should be JSON");
+    assert_eq!(set_note_payload["action"], "task-note");
+    assert_eq!(set_note_payload["updated"], true);
+    assert_eq!(set_note_payload["focus_intention"], "Write docs");
+    assert_eq!(set_note_payload["task_note"], "Capture blockers");
+
+    let set_focus_output = env.run(&["--focus-intention=Deep Work", "--json"]);
+    assert_eq!(set_focus_output.status.code(), Some(0));
+    assert!(stderr_text(&set_focus_output).trim().is_empty());
+    let set_focus_payload: Value =
+        serde_json::from_slice(&set_focus_output.stdout).expect("stdout should be JSON");
+    assert_eq!(set_focus_payload["action"], "focus-intention");
+    assert_eq!(set_focus_payload["updated"], true);
+    assert_eq!(set_focus_payload["focus_intention"], "Deep Work");
+    assert_eq!(set_focus_payload["task_note"], "Capture blockers");
+
+    let read_output = env.run(&["--task-note", "--json"]);
+    assert_eq!(read_output.status.code(), Some(0));
+    assert!(stderr_text(&read_output).trim().is_empty());
+    let read_payload: Value = serde_json::from_slice(&read_output.stdout).expect("stdout JSON");
+    assert_eq!(read_payload["action"], "task-note");
+    assert_eq!(read_payload["updated"], false);
+    assert_eq!(read_payload["focus_intention"], "Deep Work");
+    assert_eq!(read_payload["task_note"], "Capture blockers");
+}
+
+#[test]
+fn session_metadata_set_json_requires_active_focus_session() {
+    let env = TestEnv::new("metadata-json-set-requires-active-session");
+    let output = env.run(&["--focus-intention", "Write docs", "--json"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr_text(&output).trim().is_empty());
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"]["kind"], "runtime");
+    assert_eq!(payload["error"]["exit_code"], 1);
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .expect("error message should be a string")
+            .contains("focus session is not active or paused")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

- Adds first-class CLI commands for session metadata: `--focus-intention` and `--task-note`.
- Supports both read (no value) and set (`--flag value` / `--flag=value`) flows, with text/JSON output parity.
- Wires command parsing, routing, execution, app-level metadata mutation, and recovery sync so CLI updates are reflected in live timer/status metadata.
- Adds parser/app/contract tests for the new behavior and updates README/CHANGELOG documentation.

## Why

CLI users could see `focus_intention` and `task_note` in status/timer outputs but could not manage those fields without entering TUI mode. This change provides non-interactive parity for managing session metadata while preserving existing persistence and contract behavior.

Closes #259.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI commands `--focus-intention` and `--task-note` for non-interactive reading and updating of session metadata without entering the full application interface.
  * Implemented feature flags rollout mechanism with centralized configuration and diagnostics.

* **Documentation**
  * Updated CHANGELOG and README with new CLI command examples and usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->