### PR TITLE
Opt-in runtime knobs for schedule granularity and WakaTime retry/queue behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,10 @@ date = "2026-05-02"
 start = "14:00"
 end = "16:00"
 
+[schedule_runtime]
+time_step_minutes = 15
+delay_secs = 600
+
 [daily_goal]
 minutes = 120
 pomodoros = 4
@@ -443,6 +447,11 @@ preset = "balanced" # keep_all | balanced | aggressive
 [wakatime]
 project = "focustime"
 language = "Pomodoro"
+
+[wakatime_runtime]
+retry_backoff_secs = [1, 2]
+queue_capacity = 256
+queue_retry_delay_secs = 10
 
 [[wakatime.task_mappings]]
 task_label = "Docs"
@@ -471,6 +480,18 @@ field:
 
 Mappings with blank `task_label` or blank override values are ignored. If
 duplicate task labels are configured, the first valid mapping is used.
+
+`[schedule_runtime]` is optional. When omitted, focustime keeps existing
+schedule runtime defaults (`time_step_minutes = 15`, `delay_secs = 600`).
+`time_step_minutes` is clamped to `1..60`; `delay_secs` is clamped to
+`60..43200`.
+
+`[wakatime_runtime]` is optional. When omitted, focustime keeps existing
+WakaTime runtime defaults (`retry_backoff_secs = [1, 2]`,
+`queue_capacity = 256`, `queue_retry_delay_secs = 10`). Backoff entries are
+bounded to `1..300` seconds (up to 8 entries, empty/invalid falls back to
+defaults), queue capacity is clamped to `1..4096`, and queue replay delay is
+clamped to `0..3600`.
 
 ## Site manager workflow
 
@@ -543,7 +564,7 @@ Recurring schedule windows can also trigger focus behavior at wall-clock times:
 - `profile_automation.<profile>.recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
 - `profile_automation.<profile>.recurring_schedule.one_time_windows[]` accepts one-time date windows with `date` (`YYYY-MM-DD`) plus `start`/`end` (`HH:MM`)
 - when a window begins, focus auto-starts if possible; otherwise schedule mode arms and shows a reminder until you manually start focus
-- while a schedule window is active and focus is not already running, press `z` to delay the scheduled start by 10 minutes
+- while a schedule window is active and focus is not already running, press `z` to delay the scheduled start (default `10m`, configurable via `[schedule_runtime].delay_secs`)
 - recurring exception dates only skip recurring windows; one-time windows still apply on their configured date
 - if multiple windows overlap, the most recently started active window takes precedence; windows with the same start time are resolved deterministically
 - `--schedule` (text and JSON) reports detected schedule conflicts/overlaps without rejecting the schedule
@@ -691,10 +712,14 @@ When WakaTime is configured, heartbeats are still best-effort and non-blocking.
 The timer never waits on network calls.
 
 - transient heartbeat failures (`429`, `5xx`, and connectivity/timeout errors)
-  retry with bounded backoff (`1s`, then `2s`)
+  retry with bounded backoff (default `1s`, then `2s`, configurable via
+  `[wakatime_runtime].retry_backoff_secs`)
 - retryable failures that still cannot be delivered are queued in a durable local
-  backlog (bounded, drop-oldest at capacity) and replayed oldest-first after
-  restart and when connectivity recovers
+  backlog (bounded, drop-oldest at capacity; default `256`, configurable via
+  `[wakatime_runtime].queue_capacity`) and replayed oldest-first after restart
+  and when connectivity recovers
+- queued heartbeat replay delay after retryable failure defaults to `10s` and is
+  configurable via `[wakatime_runtime].queue_retry_delay_secs`
 - invalid/corrupt persisted queue snapshots are dropped on startup and surfaced
   as a runtime warning in WakaTime status
 - non-retryable failures are surfaced in the timer view status line

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ WakaTime runtime defaults (`retry_backoff_secs = [1, 2]`,
 `queue_capacity = 256`, `queue_retry_delay_secs = 10`). Backoff entries are
 bounded to `1..300` seconds (up to 8 entries, empty/invalid falls back to
 defaults), queue capacity is clamped to `1..4096`, and queue replay delay is
-clamped to `0..3600`.
+clamped to `1..3600`.
 
 ## Site manager workflow
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ Recurring schedule windows can also trigger focus behavior at wall-clock times:
 - `profile_automation.<profile>.recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
 - `profile_automation.<profile>.recurring_schedule.one_time_windows[]` accepts one-time date windows with `date` (`YYYY-MM-DD`) plus `start`/`end` (`HH:MM`)
 - when a window begins, focus auto-starts if possible; otherwise schedule mode arms and shows a reminder until you manually start focus
-- while a schedule window is active and focus is not already running, press `z` to delay the scheduled start (default `10m`, configurable via `[schedule_runtime].delay_secs`)
+- while a schedule window is active and focus is not already running, press `z` to delay the scheduled start (configurable via `[schedule_runtime].delay_secs`, default `10m`, clamped `60..43200` seconds)
 - recurring exception dates only skip recurring windows; one-time windows still apply on their configured date
 - if multiple windows overlap, the most recently started active window takes precedence; windows with the same start time are resolved deterministically
 - `--schedule` (text and JSON) reports detected schedule conflicts/overlaps without rejecting the schedule
@@ -582,13 +582,13 @@ You can configure notification and auto-start settings directly from the TUI:
   - **Schedule add/remove**: `→` adds a window, `←` removes selected window
   - **Schedule window**: `←/→` changes which window is selected
   - **Schedule day** + **Schedule day enabled**: choose day cursor and toggle it `Off/On`
-  - **Schedule start/end**: adjust times in 15-minute steps
+  - **Schedule start/end**: adjust times in `[schedule_runtime].time_step_minutes` steps (default `15`, clamped `1..60`)
   - **Schedule exception**: `←/→` changes which exception date is selected
   - **Exception date**: `←/→` moves selected exception date backward/forward by 1 day
   - **Exception add/remove**: `→` adds a date (starting from today), `←` removes selected date
   - **One-time window**: `←/→` changes which one-time window is selected
   - **One-time date**: `←/→` moves selected one-time window date backward/forward by 1 day
-  - **One-time start/end**: adjust one-time window times in 15-minute steps
+  - **One-time start/end**: adjust one-time window times in `[schedule_runtime].time_step_minutes` steps (default `15`, clamped `1..60`)
   - **One-time add/remove**: `→` adds a one-time window (starting from today), `←` removes selected window
   - **Conflict inspector**: read-only summary of detected schedule overlaps/conflicts
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,8 +15,8 @@ use crate::config::{
     DailyGoalConfig, FeatureFlagsConfig, GoalCarryOverConfig, MonthlyGoalConfig,
     NotificationConfig, OneTimeFocusWindowConfig, ProfileAutomationConfig,
     ProfileAutomationSettingsConfig, ProfileId, RecurringFocusWindowConfig,
-    RecurringScheduleConfig, StatsRetentionConfig, ThemePreset, WakatimeMetadataConfig,
-    WeeklyGoalConfig,
+    RecurringScheduleConfig, ScheduleRuntimeConfig, StatsRetentionConfig, ThemePreset,
+    WakatimeMetadataConfig, WakatimeRuntimeConfig, WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -38,7 +38,9 @@ use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
     DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerState, TimerStatus,
 };
-use crate::wakatime::{WakatimeConfigStatus, WakatimeHeartbeatMetadata, WakatimeTracker};
+use crate::wakatime::{
+    WakatimeConfigStatus, WakatimeHeartbeatMetadata, WakatimeRuntimeOptions, WakatimeTracker,
+};
 
 mod break_glass;
 mod cli_api;
@@ -129,10 +131,8 @@ const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
 const UNLINKED_BREAK_TEMPLATE_NAME: &str = "Custom";
 pub(crate) const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
-const SCHEDULE_TIME_STEP_MINUTES: u16 = 15;
 const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
 const SCHEDULE_DAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const SCHEDULE_DELAY_SECS: u64 = 10 * 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppMode {
@@ -546,6 +546,7 @@ pub struct App {
     notification_settings: NotificationConfig,
     auto_start: AutoStartConfig,
     recurring_schedule: RecurringScheduleConfig,
+    schedule_runtime: ScheduleRuntimeConfig,
     recurring_windows: Vec<RecurringWindow>,
     recurring_exception_dates: HashSet<NaiveDate>,
     one_time_windows: Vec<OneTimeWindow>,
@@ -563,6 +564,7 @@ pub struct App {
     goal_carry_over: GoalCarryOverConfig,
     stats_retention: StatsRetentionConfig,
     wakatime_metadata: WakatimeMetadataConfig,
+    wakatime_runtime: WakatimeRuntimeConfig,
     pending_timer_action: Option<PendingTimerAction>,
     notifier: PhaseNotifier,
     stats: FocusStats,
@@ -600,6 +602,7 @@ impl App {
             compile_exception_dates(&recurring_schedule.exception_dates);
         let one_time_windows = compile_one_time_windows(&recurring_schedule.one_time_windows);
         let strict_mode = selected_automation.strict_mode;
+        let schedule_runtime = config.schedule_runtime;
         let break_glass_duration_secs = config.break_glass_duration_secs;
         let daily_goal = config.daily_goal;
         let weekly_goal = config.weekly_goal;
@@ -607,6 +610,7 @@ impl App {
         let goal_carry_over = config.goal_carry_over;
         let stats_retention = config.stats_retention;
         let wakatime_metadata = config.wakatime;
+        let wakatime_runtime = config.wakatime_runtime;
         let blocklist_profiles = config.blocklist_profiles.clone();
         let active_blocklist_profile =
             blocklist_profile_index(&blocklist_profiles, &config.selected_blocklist_profile);
@@ -678,10 +682,17 @@ impl App {
             stats_error,
             history_feedback: None,
             phase_notification: None,
-            wakatime: WakatimeTracker::new_with_metadata(WakatimeHeartbeatMetadata {
-                project: wakatime_metadata.project.clone(),
-                language: wakatime_metadata.language.clone(),
-            }),
+            wakatime: WakatimeTracker::new_with_settings(
+                WakatimeHeartbeatMetadata {
+                    project: wakatime_metadata.project.clone(),
+                    language: wakatime_metadata.language.clone(),
+                },
+                WakatimeRuntimeOptions {
+                    retry_backoff_secs: wakatime_runtime.retry_backoff_secs.clone(),
+                    queue_capacity: wakatime_runtime.queue_capacity,
+                    queue_retry_delay_secs: wakatime_runtime.queue_retry_delay_secs,
+                },
+            ),
             selected_profile,
             selected_theme_preset,
             feature_flags,
@@ -699,6 +710,7 @@ impl App {
             notification_settings,
             auto_start,
             recurring_schedule,
+            schedule_runtime,
             recurring_windows,
             recurring_exception_dates,
             one_time_windows,
@@ -716,6 +728,7 @@ impl App {
             goal_carry_over,
             stats_retention,
             wakatime_metadata,
+            wakatime_runtime,
             pending_timer_action: None,
             notifier: PhaseNotifier::new(notification_settings),
             stats,

--- a/src/app/mode_keys.rs
+++ b/src/app/mode_keys.rs
@@ -1,7 +1,6 @@
 use crate::app::{
-    App, AppMode, KeyCode, KeyEvent, KeyModifiers, PendingTimerAction, SCHEDULE_DELAY_SECS,
-    SessionInterruptionReason, ShortcutAction, TimerPhase, TimerState, TimerStatus,
-    format_duration_label,
+    App, AppMode, KeyCode, KeyEvent, KeyModifiers, PendingTimerAction, SessionInterruptionReason,
+    ShortcutAction, TimerPhase, TimerState, TimerStatus, format_duration_label,
 };
 
 const TIMER_SHORTCUT_ACTIONS: [ShortcutAction; 11] = [
@@ -201,7 +200,7 @@ impl App {
             Ok(delayed_until) => {
                 self.phase_notification = Some(format!(
                     "Scheduled start delayed for {} (until {}).",
-                    format_duration_label(SCHEDULE_DELAY_SECS),
+                    format_duration_label(self.schedule_runtime.delay_secs),
                     delayed_until.format("%H:%M")
                 ));
             }

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -331,6 +331,7 @@ impl App {
             notifications: self.notification_settings,
             auto_start: self.auto_start,
             recurring_schedule: self.recurring_schedule.clone(),
+            schedule_runtime: self.schedule_runtime,
             profile_automation: Some(profile_automation),
             strict_mode: self.strict_mode,
             break_glass_duration_secs: self.break_glass_duration_secs,
@@ -340,6 +341,7 @@ impl App {
             goal_carry_over: self.goal_carry_over,
             stats_retention: self.stats_retention,
             wakatime: self.wakatime_metadata.clone(),
+            wakatime_runtime: self.wakatime_runtime.clone(),
             feature_flags: self.feature_flags,
             shortcuts: self.shortcuts.to_config(),
         }

--- a/src/app/schedule_editor.rs
+++ b/src/app/schedule_editor.rs
@@ -7,11 +7,10 @@ use crate::app::{
     PROFILE_EDIT_SCHEDULE_END_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX,
     PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX,
     PROFILE_EDIT_SCHEDULE_START_INDEX, PROFILE_EDIT_SCHEDULE_WINDOW_INDEX,
-    RecurringFocusWindowConfig, SCHEDULE_DAY_LABELS, SCHEDULE_DAY_TOKENS,
-    SCHEDULE_TIME_STEP_MINUTES, bool_label, format_hhmm, format_schedule_conflict,
-    format_schedule_days_for_display, inspect_schedule_conflicts_from_config, parse_hhmm_minutes,
-    parse_schedule_exception_date, sort_one_time_windows, sort_schedule_days,
-    sort_schedule_exception_dates,
+    RecurringFocusWindowConfig, SCHEDULE_DAY_LABELS, SCHEDULE_DAY_TOKENS, bool_label, format_hhmm,
+    format_schedule_conflict, format_schedule_days_for_display,
+    inspect_schedule_conflicts_from_config, parse_hhmm_minutes, parse_schedule_exception_date,
+    sort_one_time_windows, sort_schedule_days, sort_schedule_exception_dates,
 };
 
 impl App {
@@ -309,6 +308,7 @@ impl App {
     }
 
     pub(super) fn adjust_selected_schedule_time(&mut self, is_start: bool, increase: bool) {
+        let step_minutes = self.schedule_runtime.time_step_minutes;
         let Some(window) = self.selected_schedule_window_mut() else {
             return;
         };
@@ -322,19 +322,19 @@ impl App {
         if is_start {
             if increase {
                 start = start
-                    .saturating_add(SCHEDULE_TIME_STEP_MINUTES)
+                    .saturating_add(step_minutes)
                     .min(end.saturating_sub(1));
             } else {
-                start = start.saturating_sub(SCHEDULE_TIME_STEP_MINUTES);
+                start = start.saturating_sub(step_minutes);
             }
         } else if increase {
             end = end
-                .saturating_add(SCHEDULE_TIME_STEP_MINUTES)
+                .saturating_add(step_minutes)
                 .min(23 * 60 + 59)
                 .max(start.saturating_add(1));
         } else {
             end = end
-                .saturating_sub(SCHEDULE_TIME_STEP_MINUTES)
+                .saturating_sub(step_minutes)
                 .max(start.saturating_add(1));
         }
 
@@ -453,6 +453,7 @@ impl App {
         let Some(current_window) = self.selected_one_time_window().cloned() else {
             return;
         };
+        let step_minutes = self.schedule_runtime.time_step_minutes;
 
         let mut start = parse_hhmm_minutes(&current_window.start).unwrap_or(9 * 60);
         let mut end = parse_hhmm_minutes(&current_window.end).unwrap_or(10 * 60);
@@ -463,19 +464,19 @@ impl App {
         if is_start {
             if increase {
                 start = start
-                    .saturating_add(SCHEDULE_TIME_STEP_MINUTES)
+                    .saturating_add(step_minutes)
                     .min(end.saturating_sub(1));
             } else {
-                start = start.saturating_sub(SCHEDULE_TIME_STEP_MINUTES);
+                start = start.saturating_sub(step_minutes);
             }
         } else if increase {
             end = end
-                .saturating_add(SCHEDULE_TIME_STEP_MINUTES)
+                .saturating_add(step_minutes)
                 .min(23 * 60 + 59)
                 .max(start.saturating_add(1));
         } else {
             end = end
-                .saturating_sub(SCHEDULE_TIME_STEP_MINUTES)
+                .saturating_sub(step_minutes)
                 .max(start.saturating_add(1));
         }
 

--- a/src/app/schedule_runtime.rs
+++ b/src/app/schedule_runtime.rs
@@ -1,8 +1,8 @@
 use crate::app::{
-    App, DateTime, Local, SCHEDULE_DELAY_SECS, ScheduleDisplayState, ShortcutAction, TimerPhase,
-    TimerState, TimerStatus, WindowOccurrence, active_occurrence, active_one_time_occurrence,
-    next_occurrence_after, next_one_time_occurrence_after, occurrence_key, pick_active_occurrence,
-    pick_next_occurrence,
+    App, DateTime, Local, ScheduleDisplayState, ShortcutAction, TimerPhase, TimerState,
+    TimerStatus, WindowOccurrence, active_occurrence, active_one_time_occurrence,
+    format_duration_label, next_occurrence_after, next_one_time_occurrence_after, occurrence_key,
+    pick_active_occurrence, pick_next_occurrence,
 };
 
 struct ScheduleShortcutLabels {
@@ -19,6 +19,7 @@ impl App {
 
     pub(super) fn recurring_schedule_texts_at(&self, now: DateTime<Local>) -> (String, String) {
         let state = self.schedule_display_state_at(now);
+        let delay_label = format_duration_label(self.schedule_runtime.delay_secs);
         let labels = ScheduleShortcutLabels {
             planner: self.shortcut_hint(ShortcutAction::OpenSessionPlanner),
             toggle_pause: self.shortcut_hint(ShortcutAction::TimerTogglePause),
@@ -27,7 +28,7 @@ impl App {
         };
         (
             schedule_next_window_text_from_state(&state, now),
-            schedule_status_text_from_state(&state, &labels),
+            schedule_status_text_from_state(&state, &labels, &delay_label),
         )
     }
 
@@ -127,7 +128,8 @@ impl App {
             }
             _ => now,
         };
-        let requested_until = delayed_from + chrono::Duration::seconds(SCHEDULE_DELAY_SECS as i64);
+        let requested_until =
+            delayed_from + chrono::Duration::seconds(self.schedule_runtime.delay_secs as i64);
         let delayed_until = requested_until.min(active_window.end);
 
         self.schedule_armed_occurrence_key = None;
@@ -210,18 +212,21 @@ impl App {
     }
 
     fn schedule_arm_notification(&self) -> String {
+        let delay_label = format_duration_label(self.schedule_runtime.delay_secs);
         if !self.has_selectable_task_label_for_focus() {
             format!(
-                "Scheduled window started. Select a task label with {}, then press {} to start focus or {} to delay 10m.",
+                "Scheduled window started. Select a task label with {}, then press {} to start focus or {} to delay {}.",
                 self.shortcut_hint(ShortcutAction::OpenSessionPlanner),
                 self.shortcut_hint(ShortcutAction::TimerTogglePause),
                 self.shortcut_hint(ShortcutAction::DelayScheduleStart),
+                delay_label,
             )
         } else {
             format!(
-                "Scheduled window started. Press {} to start focus or {} to delay 10m.",
+                "Scheduled window started. Press {} to start focus or {} to delay {}.",
                 self.shortcut_hint(ShortcutAction::TimerTogglePause),
                 self.shortcut_hint(ShortcutAction::DelayScheduleStart),
+                delay_label,
             )
         }
     }
@@ -262,13 +267,19 @@ fn schedule_next_window_text_from_state(
 fn schedule_status_text_from_state(
     state: &ScheduleDisplayState,
     labels: &ScheduleShortcutLabels,
+    delay_label: &str,
 ) -> String {
     if !state.has_schedule_windows {
         return "⚙  Schedule status: off".to_string();
     }
 
     if let Some(delayed_until) = state.delayed_until.as_ref() {
-        return schedule_delayed_status_text(*delayed_until, state.has_selected_task, labels);
+        return schedule_delayed_status_text(
+            *delayed_until,
+            state.has_selected_task,
+            labels,
+            delay_label,
+        );
     }
 
     if state.active_window.is_some() {
@@ -313,21 +324,24 @@ fn schedule_delayed_status_text(
     delayed_until: DateTime<Local>,
     has_selected_task: bool,
     labels: &ScheduleShortcutLabels,
+    delay_label: &str,
 ) -> String {
     if has_selected_task {
         format!(
-            "⚙  Schedule status: delayed until {}; press {} to start now or {} to delay 10m",
+            "⚙  Schedule status: delayed until {}; press {} to start now or {} to delay {}",
             delayed_until.format("%H:%M"),
             labels.toggle_pause,
             labels.delay,
+            delay_label,
         )
     } else {
         format!(
-            "⚙  Schedule status: delayed until {}; select {} then {}, or press {} to delay 10m",
+            "⚙  Schedule status: delayed until {}; select {} then {}, or press {} to delay {}",
             delayed_until.format("%H:%M"),
             labels.planner,
             labels.toggle_pause,
             labels.delay,
+            delay_label,
         )
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -115,6 +115,7 @@ fn selected_builtin_profile_is_applied_on_startup() {
         notifications: NotificationConfig::default(),
         auto_start: AutoStartConfig::default(),
         recurring_schedule: RecurringScheduleConfig::default(),
+        schedule_runtime: ScheduleRuntimeConfig::default(),
         profile_automation: None,
         strict_mode: false,
         break_glass_duration_secs: 5 * 60,
@@ -125,6 +126,7 @@ fn selected_builtin_profile_is_applied_on_startup() {
         stats_retention: StatsRetentionConfig::default(),
         selected_theme_preset: ThemePreset::Classic,
         wakatime: WakatimeMetadataConfig::default(),
+        wakatime_runtime: WakatimeRuntimeConfig::default(),
         feature_flags: FeatureFlagsConfig::default(),
         shortcuts: ShortcutConfig::default(),
     };
@@ -134,6 +136,27 @@ fn selected_builtin_profile_is_applied_on_startup() {
     assert_eq!(app.timer.short_break_secs, DEFAULT_SHORT_BREAK_SECS);
     assert_eq!(app.timer.long_break_secs, DEFAULT_LONG_BREAK_SECS);
     assert_eq!(app.timer.long_break_interval, DEFAULT_LONG_BREAK_INTERVAL);
+}
+
+#[test]
+fn app_from_config_applies_wakatime_runtime_knobs() {
+    let app = App::from_config(AppConfig {
+        wakatime_runtime: WakatimeRuntimeConfig {
+            retry_backoff_secs: vec![2, 4, 8],
+            queue_capacity: 512,
+            queue_retry_delay_secs: 25,
+        },
+        ..AppConfig::default()
+    });
+
+    assert_eq!(
+        app.wakatime.runtime_options_for_tests(),
+        crate::wakatime::WakatimeRuntimeOptions {
+            retry_backoff_secs: vec![2, 4, 8],
+            queue_capacity: 512,
+            queue_retry_delay_secs: 25,
+        }
+    );
 }
 
 #[test]
@@ -3071,6 +3094,46 @@ fn schedule_delay_key_sets_delay_for_active_window() {
 }
 
 #[test]
+fn schedule_delay_key_uses_configured_runtime_delay_duration() {
+    let now = local_datetime_today(10, 15);
+    let config = AppConfig {
+        recurring_schedule: RecurringScheduleConfig {
+            windows: vec![crate::config::RecurringFocusWindowConfig {
+                days: vec![weekday_token(now.weekday()).to_string()],
+                start: "10:00".to_string(),
+                end: "11:00".to_string(),
+            }],
+            ..RecurringScheduleConfig::default()
+        },
+        schedule_runtime: ScheduleRuntimeConfig {
+            time_step_minutes: 15,
+            delay_secs: 90,
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+    app.sync_recurring_schedule(now);
+    app.current_frame_now = now;
+
+    app.handle_key(key(KeyCode::Char('z')));
+
+    assert_eq!(
+        app.schedule_delay_until,
+        Some(now + ChronoDuration::seconds(90))
+    );
+    assert!(
+        app.phase_notification
+            .as_deref()
+            .is_some_and(|message| message.contains("delayed for 1:30"))
+    );
+    assert!(
+        app.recurring_schedule_texts_at(now + ChronoDuration::seconds(30))
+            .1
+            .contains("delay 1:30")
+    );
+}
+
+#[test]
 fn schedule_delay_clamps_until_active_window_end() {
     let now = local_datetime_today(10, 15);
     let config = AppConfig {
@@ -3173,6 +3236,30 @@ fn recurring_schedule_status_text_shows_delayed_state() {
         .1;
     assert!(status.contains("Schedule status: delayed until"));
     assert!(status.contains("[z] to delay 10m"));
+}
+
+#[test]
+fn schedule_editor_uses_configured_runtime_step_minutes() {
+    let config = AppConfig {
+        recurring_schedule: RecurringScheduleConfig {
+            windows: vec![crate::config::RecurringFocusWindowConfig {
+                days: vec!["mon".to_string()],
+                start: "09:00".to_string(),
+                end: "11:00".to_string(),
+            }],
+            ..RecurringScheduleConfig::default()
+        },
+        schedule_runtime: ScheduleRuntimeConfig {
+            time_step_minutes: 30,
+            delay_secs: 10 * 60,
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+
+    app.adjust_selected_schedule_time(true, true);
+
+    assert_eq!(app.recurring_schedule.windows[0].start, "09:30");
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1746,7 +1746,6 @@ fn normalize_wakatime_task_mappings(
 fn normalize_wakatime_retry_backoff_secs(backoff_secs: &[u64]) -> Vec<u64> {
     let normalized = backoff_secs
         .iter()
-        .take(WAKATIME_RETRY_BACKOFF_MAX_ENTRIES)
         .filter_map(|secs| {
             if *secs == 0 {
                 None
@@ -1757,6 +1756,7 @@ fn normalize_wakatime_retry_backoff_secs(backoff_secs: &[u64]) -> Vec<u64> {
                 ))
             }
         })
+        .take(WAKATIME_RETRY_BACKOFF_MAX_ENTRIES)
         .collect::<Vec<_>>();
     if normalized.is_empty() {
         default_wakatime_retry_backoff_secs()

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,16 @@ use paths::env_path_from_value;
 
 const CURRENT_CONFIG_SCHEMA_VERSION: u32 = 1;
 const LEGACY_CONFIG_SCHEMA_VERSION: u32 = 0;
+const SCHEDULE_TIME_STEP_MIN_MINUTES: u16 = 1;
+const SCHEDULE_TIME_STEP_MAX_MINUTES: u16 = 60;
+const SCHEDULE_DELAY_MIN_SECS: u64 = 60;
+const SCHEDULE_DELAY_MAX_SECS: u64 = 12 * 60 * 60;
+const WAKATIME_QUEUE_CAPACITY_MIN: usize = 1;
+const WAKATIME_QUEUE_CAPACITY_MAX: usize = 4096;
+const WAKATIME_RETRY_DELAY_MAX_SECS: u64 = 60 * 60;
+const WAKATIME_RETRY_BACKOFF_MIN_SECS: u64 = 1;
+const WAKATIME_RETRY_BACKOFF_MAX_SECS: u64 = 300;
+const WAKATIME_RETRY_BACKOFF_MAX_ENTRIES: usize = 8;
 
 /// Persistent application configuration stored as TOML.
 ///
@@ -75,6 +85,9 @@ pub struct AppConfig {
     /// Recurring schedule windows for automatic focus startup.
     #[serde(default)]
     pub recurring_schedule: RecurringScheduleConfig,
+    /// Runtime tuning knobs for schedule editing and delay behavior.
+    #[serde(default)]
+    pub schedule_runtime: ScheduleRuntimeConfig,
     /// Profile-scoped automation settings.
     ///
     /// When absent, legacy global automation fields are used as shared defaults
@@ -116,6 +129,9 @@ pub struct AppConfig {
     /// WakaTime heartbeat metadata labels.
     #[serde(default)]
     pub wakatime: WakatimeMetadataConfig,
+    /// Runtime tuning knobs for WakaTime retry/queue behavior.
+    #[serde(default)]
+    pub wakatime_runtime: WakatimeRuntimeConfig,
     /// Feature flags used to safely gate compatibility-sensitive behavior.
     #[serde(default)]
     pub feature_flags: FeatureFlagsConfig,
@@ -529,6 +545,37 @@ impl RecurringScheduleConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScheduleRuntimeConfig {
+    #[serde(default = "default_schedule_time_step_minutes")]
+    pub time_step_minutes: u16,
+    #[serde(default = "default_schedule_delay_secs")]
+    pub delay_secs: u64,
+}
+
+impl ScheduleRuntimeConfig {
+    pub fn normalized(&self) -> Self {
+        Self {
+            time_step_minutes: self.time_step_minutes.clamp(
+                SCHEDULE_TIME_STEP_MIN_MINUTES,
+                SCHEDULE_TIME_STEP_MAX_MINUTES,
+            ),
+            delay_secs: self
+                .delay_secs
+                .clamp(SCHEDULE_DELAY_MIN_SECS, SCHEDULE_DELAY_MAX_SECS),
+        }
+    }
+}
+
+impl Default for ScheduleRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            time_step_minutes: default_schedule_time_step_minutes(),
+            delay_secs: default_schedule_delay_secs(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ProfileAutomationConfig {
     #[serde(default)]
@@ -798,6 +845,40 @@ pub struct WakatimeTaskMappingConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WakatimeRuntimeConfig {
+    #[serde(default = "default_wakatime_retry_backoff_secs")]
+    pub retry_backoff_secs: Vec<u64>,
+    #[serde(default = "default_wakatime_queue_capacity")]
+    pub queue_capacity: usize,
+    #[serde(default = "default_wakatime_queue_retry_delay_secs")]
+    pub queue_retry_delay_secs: u64,
+}
+
+impl WakatimeRuntimeConfig {
+    pub fn normalized(&self) -> Self {
+        Self {
+            retry_backoff_secs: normalize_wakatime_retry_backoff_secs(&self.retry_backoff_secs),
+            queue_capacity: self
+                .queue_capacity
+                .clamp(WAKATIME_QUEUE_CAPACITY_MIN, WAKATIME_QUEUE_CAPACITY_MAX),
+            queue_retry_delay_secs: self
+                .queue_retry_delay_secs
+                .clamp(0, WAKATIME_RETRY_DELAY_MAX_SECS),
+        }
+    }
+}
+
+impl Default for WakatimeRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            retry_backoff_secs: default_wakatime_retry_backoff_secs(),
+            queue_capacity: default_wakatime_queue_capacity(),
+            queue_retry_delay_secs: default_wakatime_queue_retry_delay_secs(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WakatimeMetadataConfig {
     #[serde(default = "default_wakatime_project")]
     pub project: String,
@@ -884,6 +965,26 @@ fn default_wakatime_project() -> String {
 
 fn default_wakatime_language() -> String {
     "Pomodoro".to_string()
+}
+
+fn default_wakatime_retry_backoff_secs() -> Vec<u64> {
+    vec![1, 2]
+}
+
+fn default_wakatime_queue_capacity() -> usize {
+    256
+}
+
+fn default_wakatime_queue_retry_delay_secs() -> u64 {
+    10
+}
+
+fn default_schedule_time_step_minutes() -> u16 {
+    15
+}
+
+fn default_schedule_delay_secs() -> u64 {
+    10 * 60
 }
 
 fn default_schedule_window_days() -> Vec<String> {
@@ -1314,6 +1415,7 @@ impl Default for AppConfig {
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
             recurring_schedule: RecurringScheduleConfig::default(),
+            schedule_runtime: ScheduleRuntimeConfig::default(),
             profile_automation: None,
             strict_mode: false,
             break_glass_duration_secs: default_break_glass_duration_secs(),
@@ -1323,6 +1425,7 @@ impl Default for AppConfig {
             goal_carry_over: GoalCarryOverConfig::default(),
             stats_retention: StatsRetentionConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
+            wakatime_runtime: WakatimeRuntimeConfig::default(),
             feature_flags: FeatureFlagsConfig::default(),
             shortcuts: ShortcutConfig::default(),
         }
@@ -1517,7 +1620,9 @@ impl AppConfig {
                 .map(effective_blocked_sites_for_profile)
                 .unwrap_or_default();
         }
+        self.schedule_runtime = self.schedule_runtime.normalized();
         self.wakatime = self.wakatime.normalized();
+        self.wakatime_runtime = self.wakatime_runtime.normalized();
         self.shortcuts = self.shortcuts.normalized();
         self
     }
@@ -1635,6 +1740,28 @@ fn normalize_wakatime_task_mappings(
         }
     }
     normalized
+}
+
+fn normalize_wakatime_retry_backoff_secs(backoff_secs: &[u64]) -> Vec<u64> {
+    let normalized = backoff_secs
+        .iter()
+        .take(WAKATIME_RETRY_BACKOFF_MAX_ENTRIES)
+        .filter_map(|secs| {
+            if *secs == 0 {
+                None
+            } else {
+                Some((*secs).clamp(
+                    WAKATIME_RETRY_BACKOFF_MIN_SECS,
+                    WAKATIME_RETRY_BACKOFF_MAX_SECS,
+                ))
+            }
+        })
+        .collect::<Vec<_>>();
+    if normalized.is_empty() {
+        default_wakatime_retry_backoff_secs()
+    } else {
+        normalized
+    }
 }
 
 fn parse_shortcut_char(value: &str) -> Option<char> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ const SCHEDULE_DELAY_MIN_SECS: u64 = 60;
 const SCHEDULE_DELAY_MAX_SECS: u64 = 12 * 60 * 60;
 const WAKATIME_QUEUE_CAPACITY_MIN: usize = 1;
 const WAKATIME_QUEUE_CAPACITY_MAX: usize = 4096;
+const WAKATIME_RETRY_DELAY_MIN_SECS: u64 = 1;
 const WAKATIME_RETRY_DELAY_MAX_SECS: u64 = 60 * 60;
 const WAKATIME_RETRY_BACKOFF_MIN_SECS: u64 = 1;
 const WAKATIME_RETRY_BACKOFF_MAX_SECS: u64 = 300;
@@ -863,7 +864,7 @@ impl WakatimeRuntimeConfig {
                 .clamp(WAKATIME_QUEUE_CAPACITY_MIN, WAKATIME_QUEUE_CAPACITY_MAX),
             queue_retry_delay_secs: self
                 .queue_retry_delay_secs
-                .clamp(0, WAKATIME_RETRY_DELAY_MAX_SECS),
+                .clamp(WAKATIME_RETRY_DELAY_MIN_SECS, WAKATIME_RETRY_DELAY_MAX_SECS),
         }
     }
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -36,6 +36,7 @@ fn default_values_are_canonical_pomodoro() {
     assert_eq!(cfg.notifications, NotificationConfig::default());
     assert_eq!(cfg.auto_start, AutoStartConfig::default());
     assert_eq!(cfg.recurring_schedule, RecurringScheduleConfig::default());
+    assert_eq!(cfg.schedule_runtime, ScheduleRuntimeConfig::default());
     assert!(cfg.profile_automation.is_none());
     assert!(!cfg.strict_mode);
     assert_eq!(
@@ -48,6 +49,7 @@ fn default_values_are_canonical_pomodoro() {
     assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
     assert_eq!(cfg.stats_retention, StatsRetentionConfig::default());
     assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
+    assert_eq!(cfg.wakatime_runtime, WakatimeRuntimeConfig::default());
     assert_eq!(cfg.feature_flags, FeatureFlagsConfig::default());
     assert_eq!(cfg.shortcuts, ShortcutConfig::default());
 }
@@ -155,6 +157,10 @@ fn round_trip_full_config() {
                 end: "15:00".to_string(),
             }],
         },
+        schedule_runtime: ScheduleRuntimeConfig {
+            time_step_minutes: 20,
+            delay_secs: 15 * 60,
+        },
         profile_automation: Some(ProfileAutomationSettingsConfig {
             classic: Some(ProfileAutomationConfig {
                 notifications: NotificationConfig {
@@ -237,6 +243,11 @@ fn round_trip_full_config() {
                 },
             ],
         },
+        wakatime_runtime: WakatimeRuntimeConfig {
+            retry_backoff_secs: vec![2, 5, 10],
+            queue_capacity: 512,
+            queue_retry_delay_secs: 30,
+        },
         feature_flags: FeatureFlagsConfig {
             legacy_automation_mirror: true,
             legacy_blocked_sites_mirror: true,
@@ -274,6 +285,7 @@ fn round_trip_full_config() {
     assert_eq!(parsed.notifications, original.notifications);
     assert_eq!(parsed.auto_start, original.auto_start);
     assert_eq!(parsed.recurring_schedule, original.recurring_schedule);
+    assert_eq!(parsed.schedule_runtime, original.schedule_runtime);
     assert_eq!(parsed.profile_automation, original.profile_automation);
     assert_eq!(parsed.strict_mode, original.strict_mode);
     assert_eq!(
@@ -286,6 +298,7 @@ fn round_trip_full_config() {
     assert_eq!(parsed.goal_carry_over, original.goal_carry_over);
     assert_eq!(parsed.stats_retention, original.stats_retention);
     assert_eq!(parsed.wakatime, original.wakatime);
+    assert_eq!(parsed.wakatime_runtime, original.wakatime_runtime);
     assert_eq!(parsed.feature_flags, original.feature_flags);
     assert_eq!(parsed.shortcuts, original.shortcuts);
 }
@@ -635,6 +648,70 @@ fn normalize_drops_one_time_windows_with_invalid_entries() {
 }
 
 #[test]
+fn normalize_clamps_schedule_runtime_knobs_to_safe_bounds() {
+    let cfg = AppConfig {
+        schedule_runtime: ScheduleRuntimeConfig {
+            time_step_minutes: 0,
+            delay_secs: 0,
+        },
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    assert_eq!(
+        cfg.schedule_runtime,
+        ScheduleRuntimeConfig {
+            time_step_minutes: 1,
+            delay_secs: 60,
+        }
+    );
+
+    let cfg = AppConfig {
+        schedule_runtime: ScheduleRuntimeConfig {
+            time_step_minutes: 200,
+            delay_secs: 24 * 60 * 60,
+        },
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    assert_eq!(
+        cfg.schedule_runtime,
+        ScheduleRuntimeConfig {
+            time_step_minutes: 60,
+            delay_secs: 12 * 60 * 60,
+        }
+    );
+}
+
+#[test]
+fn normalize_clamps_wakatime_runtime_knobs_and_falls_back_for_invalid_backoff() {
+    let cfg = AppConfig {
+        wakatime_runtime: WakatimeRuntimeConfig {
+            retry_backoff_secs: vec![0, 900, 2, 0],
+            queue_capacity: 0,
+            queue_retry_delay_secs: 24 * 60 * 60,
+        },
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    assert_eq!(cfg.wakatime_runtime.retry_backoff_secs, vec![300, 2]);
+    assert_eq!(cfg.wakatime_runtime.queue_capacity, 1);
+    assert_eq!(cfg.wakatime_runtime.queue_retry_delay_secs, 60 * 60);
+
+    let cfg = AppConfig {
+        wakatime_runtime: WakatimeRuntimeConfig {
+            retry_backoff_secs: vec![0, 0],
+            ..WakatimeRuntimeConfig::default()
+        },
+        ..AppConfig::default()
+    }
+    .normalize();
+    assert_eq!(cfg.wakatime_runtime.retry_backoff_secs, vec![1, 2]);
+}
+
+#[test]
 fn unknown_selected_profile_falls_back_to_custom_without_dropping_config() {
     let config = r#"
 focus_secs = 1500
@@ -702,6 +779,7 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
         notifications: NotificationConfig::default(),
         auto_start: AutoStartConfig::default(),
         recurring_schedule: RecurringScheduleConfig::default(),
+        schedule_runtime: ScheduleRuntimeConfig::default(),
         profile_automation: None,
         strict_mode: false,
         break_glass_duration_secs: default_break_glass_duration_secs(),
@@ -711,6 +789,7 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
         goal_carry_over: GoalCarryOverConfig::default(),
         stats_retention: StatsRetentionConfig::default(),
         wakatime: WakatimeMetadataConfig::default(),
+        wakatime_runtime: WakatimeRuntimeConfig::default(),
         feature_flags: FeatureFlagsConfig::default(),
         shortcuts: ShortcutConfig::default(),
     };

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -703,12 +703,15 @@ fn normalize_clamps_wakatime_runtime_knobs_and_falls_back_for_invalid_backoff() 
     let cfg = AppConfig {
         wakatime_runtime: WakatimeRuntimeConfig {
             retry_backoff_secs: vec![0, 0],
+            queue_retry_delay_secs: 0,
             ..WakatimeRuntimeConfig::default()
         },
         ..AppConfig::default()
     }
     .normalize();
     assert_eq!(cfg.wakatime_runtime.retry_backoff_secs, vec![1, 2]);
+    assert_eq!(cfg.wakatime_runtime.queue_retry_delay_secs, 1);
+
 }
 
 #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -712,6 +712,15 @@ fn normalize_clamps_wakatime_runtime_knobs_and_falls_back_for_invalid_backoff() 
     assert_eq!(cfg.wakatime_runtime.retry_backoff_secs, vec![1, 2]);
     assert_eq!(cfg.wakatime_runtime.queue_retry_delay_secs, 1);
 
+    let cfg = AppConfig {
+        wakatime_runtime: WakatimeRuntimeConfig {
+            retry_backoff_secs: vec![0, 0, 0, 0, 0, 0, 0, 0, 5],
+            ..WakatimeRuntimeConfig::default()
+        },
+        ..AppConfig::default()
+    }
+    .normalize();
+    assert_eq!(cfg.wakatime_runtime.retry_backoff_secs, vec![5]);
 }
 
 #[test]

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -10,15 +10,15 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::{Deserialize, Serialize};
 
 const HEARTBEAT_INTERVAL_SECS: u64 = 120;
-const HEARTBEAT_RETRY_BACKOFF_SECS: [u64; 2] = [1, 2];
-const HEARTBEAT_MAX_ATTEMPTS: u8 = 3;
-const HEARTBEAT_QUEUE_CAPACITY: usize = 256;
+const DEFAULT_HEARTBEAT_RETRY_BACKOFF_SECS: [u64; 2] = [1, 2];
+const DEFAULT_HEARTBEAT_QUEUE_CAPACITY: usize = 256;
+const DEFAULT_HEARTBEAT_QUEUE_RETRY_DELAY_SECS: u64 = 10;
+const MAX_HEARTBEAT_RETRY_BACKOFF_ENTRIES: usize = 8;
+const MAX_HEARTBEAT_RETRY_BACKOFF_SECS: u64 = 300;
+const MAX_HEARTBEAT_QUEUE_CAPACITY: usize = 4096;
+const MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS: u64 = 3600;
 const HEARTBEAT_QUEUE_SNAPSHOT_FILE_NAME: &str = "wakatime-queue.toml";
 const HEARTBEAT_QUEUE_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
-#[cfg(not(test))]
-const HEARTBEAT_QUEUE_RETRY_DELAY_SECS: u64 = 10;
-#[cfg(test)]
-const HEARTBEAT_QUEUE_RETRY_DELAY_SECS: u64 = 0;
 const DEFAULT_API_URL: &str = "https://wakatime.com";
 const DEFAULT_HEARTBEAT_ENTITY: &str = "focustime";
 const DEFAULT_HEARTBEAT_PROJECT: &str = "focustime";
@@ -101,6 +101,56 @@ impl Default for WakatimeHeartbeatMetadata {
         Self {
             project: DEFAULT_HEARTBEAT_PROJECT.to_string(),
             language: DEFAULT_HEARTBEAT_LANGUAGE.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WakatimeRuntimeOptions {
+    pub retry_backoff_secs: Vec<u64>,
+    pub queue_capacity: usize,
+    pub queue_retry_delay_secs: u64,
+}
+
+impl WakatimeRuntimeOptions {
+    pub fn normalized(&self) -> Self {
+        let retry_backoff_secs = self
+            .retry_backoff_secs
+            .iter()
+            .take(MAX_HEARTBEAT_RETRY_BACKOFF_ENTRIES)
+            .filter_map(|secs| {
+                if *secs == 0 {
+                    None
+                } else {
+                    Some((*secs).clamp(1, MAX_HEARTBEAT_RETRY_BACKOFF_SECS))
+                }
+            })
+            .collect::<Vec<_>>();
+        Self {
+            retry_backoff_secs: if retry_backoff_secs.is_empty() {
+                DEFAULT_HEARTBEAT_RETRY_BACKOFF_SECS.to_vec()
+            } else {
+                retry_backoff_secs
+            },
+            queue_capacity: self.queue_capacity.clamp(1, MAX_HEARTBEAT_QUEUE_CAPACITY),
+            queue_retry_delay_secs: self
+                .queue_retry_delay_secs
+                .clamp(0, MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS),
+        }
+    }
+
+    fn max_attempts(&self) -> u8 {
+        let attempts = self.retry_backoff_secs.len().saturating_add(1);
+        attempts.min(u8::MAX as usize) as u8
+    }
+}
+
+impl Default for WakatimeRuntimeOptions {
+    fn default() -> Self {
+        Self {
+            retry_backoff_secs: DEFAULT_HEARTBEAT_RETRY_BACKOFF_SECS.to_vec(),
+            queue_capacity: DEFAULT_HEARTBEAT_QUEUE_CAPACITY,
+            queue_retry_delay_secs: DEFAULT_HEARTBEAT_QUEUE_RETRY_DELAY_SECS,
         }
     }
 }
@@ -258,6 +308,7 @@ pub struct WakatimeTracker {
     /// Latches an immediate heartbeat request while another worker is in flight.
     pending_immediate_heartbeat: bool,
     heartbeat_metadata: WakatimeHeartbeatMetadata,
+    runtime: WakatimeRuntimeOptions,
     /// Startup-only warning (for example, invalid persisted queue state).
     startup_warning: Option<String>,
     /// Last queue snapshot persistence failure message.
@@ -268,10 +319,16 @@ pub struct WakatimeTracker {
 
 impl WakatimeTracker {
     pub fn new() -> Self {
-        Self::new_with_metadata(WakatimeHeartbeatMetadata::default())
+        Self::new_with_settings(
+            WakatimeHeartbeatMetadata::default(),
+            WakatimeRuntimeOptions::default(),
+        )
     }
 
-    pub fn new_with_metadata(metadata: WakatimeHeartbeatMetadata) -> Self {
+    pub fn new_with_settings(
+        metadata: WakatimeHeartbeatMetadata,
+        runtime: WakatimeRuntimeOptions,
+    ) -> Self {
         let config = WakatimeConfig::load();
         let (result_tx, result_rx) = mpsc::channel();
         let mut tracker = Self {
@@ -292,6 +349,7 @@ impl WakatimeTracker {
             queue_snapshot_path: heartbeat_queue_snapshot_path(),
             pending_immediate_heartbeat: false,
             heartbeat_metadata: metadata.normalized(),
+            runtime: runtime.normalized(),
             startup_warning: None,
             queue_persistence_error: None,
             #[cfg(test)]
@@ -370,18 +428,27 @@ impl WakatimeTracker {
         };
         match read_heartbeat_queue_snapshot(path) {
             Ok(Some(snapshot)) => {
+                let queue_capacity = self.runtime.queue_capacity;
                 self.queued_heartbeats = snapshot.queued_heartbeats.into_iter().fold(
                     VecDeque::new(),
                     |mut queue, heartbeat| {
-                        push_back_with_capacity(&mut queue, heartbeat);
+                        push_back_with_capacity(&mut queue, heartbeat, queue_capacity);
                         queue
                     },
                 );
                 if let Some(in_flight) = snapshot.in_flight_heartbeat {
                     if snapshot.in_flight_from_queue {
-                        push_front_with_capacity(&mut self.queued_heartbeats, in_flight);
+                        push_front_with_capacity(
+                            &mut self.queued_heartbeats,
+                            in_flight,
+                            queue_capacity,
+                        );
                     } else {
-                        push_back_with_capacity(&mut self.queued_heartbeats, in_flight);
+                        push_back_with_capacity(
+                            &mut self.queued_heartbeats,
+                            in_flight,
+                            queue_capacity,
+                        );
                     }
                 }
                 self.heartbeat_in_flight = false;
@@ -479,7 +546,7 @@ impl WakatimeTracker {
                         self.requeue_in_flight_heartbeat();
                         self.queue_retry_not_before_epoch_secs = Some(
                             current_unix_epoch_secs()
-                                .saturating_add(HEARTBEAT_QUEUE_RETRY_DELAY_SECS),
+                                .saturating_add(self.runtime.queue_retry_delay_secs),
                         );
                     } else {
                         self.in_flight_heartbeat = None;
@@ -574,7 +641,11 @@ impl WakatimeTracker {
     }
 
     fn enqueue_heartbeat(&mut self, heartbeat: Heartbeat) {
-        push_back_with_capacity(&mut self.queued_heartbeats, heartbeat);
+        push_back_with_capacity(
+            &mut self.queued_heartbeats,
+            heartbeat,
+            self.runtime.queue_capacity,
+        );
         self.sync_queue_snapshot();
     }
 
@@ -582,7 +653,11 @@ impl WakatimeTracker {
         let Some(in_flight_heartbeat) = self.in_flight_heartbeat.take() else {
             return;
         };
-        push_front_with_capacity(&mut self.queued_heartbeats, in_flight_heartbeat);
+        push_front_with_capacity(
+            &mut self.queued_heartbeats,
+            in_flight_heartbeat,
+            self.runtime.queue_capacity,
+        );
     }
 
     fn queue_retry_is_due(&self) -> bool {
@@ -644,9 +719,12 @@ impl WakatimeTracker {
         );
         let hostname = get_hostname();
         let result_tx = self.result_tx.clone();
+        let runtime = self.runtime.clone();
 
         std::thread::spawn(move || {
-            send_heartbeat_with_retries(result_tx, url, auth, user_agent, hostname, heartbeat);
+            send_heartbeat_with_retries(
+                result_tx, url, auth, user_agent, hostname, heartbeat, runtime,
+            );
         });
     }
 
@@ -678,6 +756,10 @@ impl WakatimeTracker {
             queue_snapshot_path: None,
             pending_immediate_heartbeat: false,
             heartbeat_metadata: WakatimeHeartbeatMetadata::default(),
+            runtime: WakatimeRuntimeOptions {
+                queue_retry_delay_secs: 0,
+                ..WakatimeRuntimeOptions::default()
+            },
             startup_warning: None,
             queue_persistence_error: None,
             disable_network_io: true,
@@ -705,6 +787,10 @@ impl WakatimeTracker {
             queue_snapshot_path: None,
             pending_immediate_heartbeat: false,
             heartbeat_metadata: WakatimeHeartbeatMetadata::default(),
+            runtime: WakatimeRuntimeOptions {
+                queue_retry_delay_secs: 0,
+                ..WakatimeRuntimeOptions::default()
+            },
             startup_warning: None,
             queue_persistence_error: None,
             disable_network_io: true,
@@ -727,6 +813,11 @@ impl WakatimeTracker {
     #[cfg(test)]
     pub(crate) fn heartbeat_metadata_for_tests(&self) -> WakatimeHeartbeatMetadata {
         self.heartbeat_metadata.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn runtime_options_for_tests(&self) -> WakatimeRuntimeOptions {
+        self.runtime.clone()
     }
 
     #[cfg(test)]
@@ -771,6 +862,7 @@ fn send_heartbeat_with_retries(
     user_agent: String,
     hostname: String,
     heartbeat: Heartbeat,
+    runtime: WakatimeRuntimeOptions,
 ) {
     let agent: ureq::Agent = ureq::Agent::config_builder()
         .timeout_global(Some(Duration::from_secs(10)))
@@ -797,11 +889,11 @@ fn send_heartbeat_with_retries(
                 let retryable = is_retryable_error(&error);
                 let backoff_index = attempt.saturating_sub(1) as usize;
                 if retryable
-                    && let Some(backoff_secs) = HEARTBEAT_RETRY_BACKOFF_SECS.get(backoff_index)
+                    && let Some(backoff_secs) = runtime.retry_backoff_secs.get(backoff_index)
                 {
                     let _ = result_tx.send(HeartbeatEvent::Retrying {
                         attempt,
-                        max_attempts: HEARTBEAT_MAX_ATTEMPTS,
+                        max_attempts: runtime.max_attempts(),
                         next_backoff_secs: *backoff_secs,
                         error: error_message.clone(),
                     });
@@ -951,15 +1043,19 @@ fn sync_parent_dir_to_disk(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn push_back_with_capacity(queue: &mut VecDeque<Heartbeat>, heartbeat: Heartbeat) {
-    if queue.len() >= HEARTBEAT_QUEUE_CAPACITY {
+fn push_back_with_capacity(queue: &mut VecDeque<Heartbeat>, heartbeat: Heartbeat, capacity: usize) {
+    if queue.len() >= capacity {
         let _ = queue.pop_front();
     }
     queue.push_back(heartbeat);
 }
 
-fn push_front_with_capacity(queue: &mut VecDeque<Heartbeat>, heartbeat: Heartbeat) {
-    if queue.len() >= HEARTBEAT_QUEUE_CAPACITY {
+fn push_front_with_capacity(
+    queue: &mut VecDeque<Heartbeat>,
+    heartbeat: Heartbeat,
+    capacity: usize,
+) {
+    if queue.len() >= capacity {
         let _ = queue.pop_front();
     }
     queue.push_front(heartbeat);
@@ -1085,6 +1181,10 @@ mod tests {
             queue_snapshot_path: None,
             pending_immediate_heartbeat: false,
             heartbeat_metadata: WakatimeHeartbeatMetadata::default(),
+            runtime: WakatimeRuntimeOptions {
+                queue_retry_delay_secs: 0,
+                ..WakatimeRuntimeOptions::default()
+            },
             startup_warning: None,
             queue_persistence_error: None,
             disable_network_io: true,
@@ -1260,7 +1360,7 @@ mod tests {
         tracker.heartbeat_in_flight = true;
         tracker.retry_state = Some(RetryState {
             attempt: 1,
-            max_attempts: HEARTBEAT_MAX_ATTEMPTS,
+            max_attempts: tracker.runtime.max_attempts(),
             next_backoff_secs: 1,
             error: "HTTP 503".to_string(),
         });
@@ -1349,13 +1449,14 @@ mod tests {
     #[test]
     fn queue_capacity_drops_oldest_entries_when_full() {
         let mut tracker = tracker_with(Some("test-key"), true, 0);
-        for index in 0..(HEARTBEAT_QUEUE_CAPACITY + 5) {
+        let queue_capacity = tracker.runtime.queue_capacity;
+        for index in 0..(queue_capacity + 5) {
             tracker.enqueue_heartbeat(build_heartbeat_payload(
                 index as f64,
                 &tracker.heartbeat_metadata,
             ));
         }
-        assert_eq!(tracker.queued_heartbeats.len(), HEARTBEAT_QUEUE_CAPACITY);
+        assert_eq!(tracker.queued_heartbeats.len(), queue_capacity);
         let oldest = tracker
             .queued_heartbeats
             .front()
@@ -1366,7 +1467,8 @@ mod tests {
     #[test]
     fn requeue_overflow_drops_oldest_queued_heartbeat() {
         let mut tracker = tracker_with(Some("test-key"), true, 0);
-        tracker.queued_heartbeats = (0..HEARTBEAT_QUEUE_CAPACITY)
+        let queue_capacity = tracker.runtime.queue_capacity;
+        tracker.queued_heartbeats = (0..queue_capacity)
             .map(|index| build_heartbeat_payload(index as f64, &tracker.heartbeat_metadata))
             .collect();
         tracker.in_flight_heartbeat =
@@ -1374,7 +1476,7 @@ mod tests {
 
         tracker.requeue_in_flight_heartbeat();
 
-        assert_eq!(tracker.queued_heartbeats.len(), HEARTBEAT_QUEUE_CAPACITY);
+        assert_eq!(tracker.queued_heartbeats.len(), queue_capacity);
         assert_eq!(
             tracker
                 .queued_heartbeats
@@ -1397,7 +1499,7 @@ mod tests {
                 .back()
                 .expect("latest queued heartbeat should remain")
                 .time,
-            (HEARTBEAT_QUEUE_CAPACITY - 1) as f64
+            (queue_capacity - 1) as f64
         );
     }
 
@@ -1415,7 +1517,7 @@ mod tests {
             .result_tx
             .send(HeartbeatEvent::Retrying {
                 attempt: 1,
-                max_attempts: HEARTBEAT_MAX_ATTEMPTS,
+                max_attempts: tracker.runtime.max_attempts(),
                 next_backoff_secs: 1,
                 error: "HTTP 503".to_string(),
             })
@@ -1427,7 +1529,7 @@ mod tests {
             tracker.runtime_state(),
             WakatimeRuntimeState::Retrying {
                 attempt: 1,
-                max_attempts: HEARTBEAT_MAX_ATTEMPTS,
+                max_attempts: tracker.runtime.max_attempts(),
                 next_backoff_secs: 1,
                 error: "HTTP 503".to_string(),
             }
@@ -1586,9 +1688,10 @@ mod tests {
     #[test]
     fn queue_snapshot_restore_is_bounded_by_queue_capacity() {
         let snapshot_path = unique_temp_queue_snapshot_path("restore-capacity");
+        let queue_capacity = WakatimeRuntimeOptions::default().queue_capacity;
         let oversized = HeartbeatQueueSnapshot {
             schema_version: HEARTBEAT_QUEUE_SNAPSHOT_SCHEMA_VERSION,
-            queued_heartbeats: (0..(HEARTBEAT_QUEUE_CAPACITY + 5))
+            queued_heartbeats: (0..(queue_capacity + 5))
                 .map(|index| {
                     build_heartbeat_payload(index as f64, &WakatimeHeartbeatMetadata::default())
                 })
@@ -1604,7 +1707,7 @@ mod tests {
         restored.queue_snapshot_path = Some(snapshot_path.clone());
         restored.restore_persisted_queue_state();
 
-        assert_eq!(restored.queued_heartbeats.len(), HEARTBEAT_QUEUE_CAPACITY);
+        assert_eq!(restored.queued_heartbeats.len(), queue_capacity);
         assert_eq!(
             restored
                 .queued_heartbeats

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -118,7 +118,6 @@ impl WakatimeRuntimeOptions {
         let retry_backoff_secs = self
             .retry_backoff_secs
             .iter()
-            .take(MAX_HEARTBEAT_RETRY_BACKOFF_ENTRIES)
             .filter_map(|secs| {
                 if *secs == 0 {
                     None
@@ -126,6 +125,7 @@ impl WakatimeRuntimeOptions {
                     Some((*secs).clamp(1, MAX_HEARTBEAT_RETRY_BACKOFF_SECS))
                 }
             })
+            .take(MAX_HEARTBEAT_RETRY_BACKOFF_ENTRIES)
             .collect::<Vec<_>>();
         Self {
             retry_backoff_secs: if retry_backoff_secs.is_empty() {
@@ -1356,6 +1356,13 @@ mod tests {
             normalized.queue_retry_delay_secs,
             MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS
         );
+
+        let normalized = WakatimeRuntimeOptions {
+            retry_backoff_secs: vec![0, 0, 0, 0, 0, 0, 0, 0, 5],
+            ..WakatimeRuntimeOptions::default()
+        }
+        .normalized();
+        assert_eq!(normalized.retry_backoff_secs, vec![5]);
 
     }
 

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -16,6 +16,7 @@ const DEFAULT_HEARTBEAT_QUEUE_RETRY_DELAY_SECS: u64 = 10;
 const MAX_HEARTBEAT_RETRY_BACKOFF_ENTRIES: usize = 8;
 const MAX_HEARTBEAT_RETRY_BACKOFF_SECS: u64 = 300;
 const MAX_HEARTBEAT_QUEUE_CAPACITY: usize = 4096;
+const MIN_HEARTBEAT_QUEUE_RETRY_DELAY_SECS: u64 = 1;
 const MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS: u64 = 3600;
 const HEARTBEAT_QUEUE_SNAPSHOT_FILE_NAME: &str = "wakatime-queue.toml";
 const HEARTBEAT_QUEUE_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
@@ -135,7 +136,10 @@ impl WakatimeRuntimeOptions {
             queue_capacity: self.queue_capacity.clamp(1, MAX_HEARTBEAT_QUEUE_CAPACITY),
             queue_retry_delay_secs: self
                 .queue_retry_delay_secs
-                .clamp(0, MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS),
+                .clamp(
+                    MIN_HEARTBEAT_QUEUE_RETRY_DELAY_SECS,
+                    MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS,
+                ),
         }
     }
 
@@ -1329,6 +1333,30 @@ mod tests {
                 language: DEFAULT_HEARTBEAT_LANGUAGE.to_string(),
             }
         );
+    }
+
+    #[test]
+    fn runtime_options_normalization_clamps_queue_retry_delay_to_positive_bounds() {
+        let normalized = WakatimeRuntimeOptions {
+            queue_retry_delay_secs: 0,
+            ..WakatimeRuntimeOptions::default()
+        }
+        .normalized();
+        assert_eq!(
+            normalized.queue_retry_delay_secs,
+            MIN_HEARTBEAT_QUEUE_RETRY_DELAY_SECS
+        );
+
+        let normalized = WakatimeRuntimeOptions {
+            queue_retry_delay_secs: u64::MAX,
+            ..WakatimeRuntimeOptions::default()
+        }
+        .normalized();
+        assert_eq!(
+            normalized.queue_retry_delay_secs,
+            MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS
+        );
+
     }
 
     #[test]

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -134,12 +134,10 @@ impl WakatimeRuntimeOptions {
                 retry_backoff_secs
             },
             queue_capacity: self.queue_capacity.clamp(1, MAX_HEARTBEAT_QUEUE_CAPACITY),
-            queue_retry_delay_secs: self
-                .queue_retry_delay_secs
-                .clamp(
-                    MIN_HEARTBEAT_QUEUE_RETRY_DELAY_SECS,
-                    MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS,
-                ),
+            queue_retry_delay_secs: self.queue_retry_delay_secs.clamp(
+                MIN_HEARTBEAT_QUEUE_RETRY_DELAY_SECS,
+                MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS,
+            ),
         }
     }
 
@@ -1363,7 +1361,6 @@ mod tests {
         }
         .normalized();
         assert_eq!(normalized.retry_backoff_secs, vec![5]);
-
     }
 
     #[test]


### PR DESCRIPTION
## What

Add optional runtime tuning knobs for schedule granularity/delay behavior and WakaTime retry/queue behavior, while preserving current defaults when these knobs are not configured.

## Why

Issue #261 requested safer opt-in runtime controls for schedule and WakaTime reliability behavior without changing behavior for existing installs.

Closes #261.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule timing is now configurable: adjust time-step increments and delay duration for postponed starts via [schedule_runtime].
  * WakaTime reliability is now configurable: tune retry backoff intervals, queue capacity, and queue retry delay via [wakatime_runtime].
  * All new settings include sensible defaults and automatic bounds-checking.

* **Documentation**
  * README updated with examples and guidance for the new runtime tuning options.

* **Tests**
  * Added tests covering schedule timing and WakaTime runtime configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/283)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->