### PR TITLE
True headless start command with JSON contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ cargo run
 
 `focustime` supports non-interactive CLI commands for scripting and automation.
 
+Before running `--start`, select a task label first (with `--task` or in the TUI).
+
 ```sh
 # Start focus timer without entering TUI
 cargo run -- --start

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ cargo run
 `focustime` supports non-interactive CLI commands for scripting and automation.
 
 ```sh
-# Launch TUI with focus timer already started
+# Start focus timer without entering TUI
 cargo run -- --start
+cargo run -- --start --json
 
 # Control timer flow without entering TUI
 cargo run -- --pause

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,7 +69,7 @@ use status::{
 
 const USAGE_TEXT: &str = r#"Usage:
   focustime
-  focustime --start
+  focustime --start [--json]
   focustime --pause [--json]
   focustime --resume [--json]
   focustime --stop [--json]
@@ -122,7 +122,7 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --export[=DIR] [--json]
 
 Options:
-  --start         Launch TUI with focus timer already started
+  --start         Start a focus timer without launching TUI
   --pause         Pause a running timer
   --resume        Resume a paused timer
   --stop          Stop/reset the current phase
@@ -215,6 +215,7 @@ struct CliErrorPayload {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommandKind {
+    Start,
     Pause,
     Resume,
     Stop,
@@ -296,7 +297,7 @@ pub struct CliCommand {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CliAction {
-    RunTui { start_immediately: bool },
+    RunTui,
     RunCommand(CliCommand),
     ShowHelp,
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -34,6 +34,7 @@ const STATS_FILE_NAME: &str = "stats.toml";
 
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
     match cli_command.kind {
+        CommandKind::Start => execute_start_command(cli_command.output),
         CommandKind::Pause => execute_pause_command(cli_command.output),
         CommandKind::Resume => execute_resume_command(cli_command.output),
         CommandKind::Stop => execute_stop_command(cli_command.output),
@@ -82,6 +83,12 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
             execute_blocklist_sites_command(target, command, cli_command.output)
         }
     }
+}
+
+fn execute_start_command(output: OutputMode) -> Result<(), String> {
+    let mut app = App::new();
+    app.start_focus_for_cli()?;
+    emit_timer_command_output("start", &app, output)
 }
 
 fn execute_pause_command(output: OutputMode) -> Result<(), String> {

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -233,18 +233,12 @@ pub(super) fn finalize_cli_action(
                     "`--json` is only valid with non-interactive commands.",
                 ));
             }
-            Ok(CliAction::RunTui {
-                start_immediately: false,
-            })
+            Ok(CliAction::RunTui)
         }
-        Some(PrimaryCommand::Start) => {
-            if output == OutputMode::Json {
-                return Err(invalid_usage("`--json` is not supported with `--start`."));
-            }
-            Ok(CliAction::RunTui {
-                start_immediately: true,
-            })
-        }
+        Some(PrimaryCommand::Start) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Start,
+            output,
+        })),
         Some(PrimaryCommand::Profile(profile)) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Profile { profile },
             output,

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -18,22 +18,18 @@ fn parse_with_contract(values: &[&str]) -> Result<CliAction, CliError> {
 #[test]
 fn parse_without_arguments_runs_default_tui() {
     let parsed = parse(&[]).unwrap();
-    assert_eq!(
-        parsed,
-        CliAction::RunTui {
-            start_immediately: false
-        }
-    );
+    assert_eq!(parsed, CliAction::RunTui);
 }
 
 #[test]
-fn parse_start_runs_tui_immediately() {
+fn parse_start_runs_as_noninteractive_command() {
     let parsed = parse(&["--start"]).unwrap();
     assert_eq!(
         parsed,
-        CliAction::RunTui {
-            start_immediately: true
-        }
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Start,
+            output: OutputMode::Text
+        })
     );
 }
 
@@ -1294,9 +1290,15 @@ fn parse_rejects_json_without_noninteractive_command() {
 }
 
 #[test]
-fn parse_rejects_json_with_start() {
-    let error = parse(&["--start", "--json"]).unwrap_err();
-    assert!(error.contains("not supported with `--start`"));
+fn parse_start_supports_json_mode() {
+    let parsed = parse(&["--start", "--json"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Start,
+            output: OutputMode::Json
+        })
+    );
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,7 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 use app::App;
 use app::should_handle_key;
 use cli::{
-    CliAction, OutputMode, emit_cli_error, execute_command, parse_args_with_contract,
-    runtime_error, usage_text,
+    CliAction, emit_cli_error, execute_command, parse_args_with_contract, runtime_error, usage_text,
 };
 
 /// RAII guard that restores the terminal on drop, ensuring cleanup on any exit path.
@@ -95,7 +94,6 @@ fn main() -> io::Result<()> {
         }
     };
 
-    let mut app = App::new();
     match cli_action {
         CliAction::ShowHelp => {
             println!("{}", usage_text());
@@ -112,19 +110,11 @@ fn main() -> io::Result<()> {
             }
             return Ok(());
         }
-        CliAction::RunTui { start_immediately } => {
-            if start_immediately && let Err(error) = app.start_focus_for_cli() {
-                let cli_error = runtime_error(OutputMode::Text, error);
-                if let Err(render_error) = emit_cli_error(&cli_error) {
-                    eprintln!("{render_error}");
-                }
-                process::exit(cli_error.exit_code());
-            }
-        }
+        CliAction::RunTui => {}
     }
 
     let mut guard = TerminalGuard::new()?;
-    run_app(&mut guard.terminal, app)
+    run_app(&mut guard.terminal, App::new())
 }
 
 fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) -> io::Result<()> {

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -405,6 +405,44 @@ fn restore_json_fails_when_backup_is_missing_stats_file() {
 }
 
 #[test]
+fn start_json_success_emits_timer_payload_on_stdout() {
+    let env = TestEnv::new("start-json-success");
+    let select_output = env.run(&["--task", "Docs", "--json"]);
+    assert_eq!(select_output.status.code(), Some(0));
+    assert!(stderr_text(&select_output).trim().is_empty());
+
+    let output = env.run(&["--start", "--json"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["action"], "start");
+    assert_eq!(payload["timer"]["phase"], "focus");
+    assert_eq!(payload["timer"]["status"], "running");
+    assert_eq!(payload["timer"]["selected_task_label"], "Docs");
+}
+
+#[test]
+fn start_json_requires_selected_task_label() {
+    let env = TestEnv::new("start-json-requires-task");
+    let output = env.run(&["--start", "--json"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"]["kind"], "runtime");
+    assert_eq!(payload["error"]["exit_code"], 1);
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .expect("error message should be a string")
+            .contains("select a task label first")
+    );
+}
+
+#[test]
 fn parse_errors_in_json_mode_emit_usage_envelope() {
     let env = TestEnv::new("json-parse-error");
     let output = env.run(&["--status", "--unknown", "--json"]);

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -423,6 +423,35 @@ fn start_json_success_emits_timer_payload_on_stdout() {
 }
 
 #[test]
+fn start_then_status_json_reports_running_recovery_state_across_processes() {
+    let env = TestEnv::new("start-status-cross-process");
+    let select_output = env.run(&["--task", "Docs", "--json"]);
+    assert_eq!(select_output.status.code(), Some(0));
+    assert!(stderr_text(&select_output).trim().is_empty());
+
+    let start_output = env.run(&["--start", "--json"]);
+    assert_eq!(start_output.status.code(), Some(0));
+    assert!(stderr_text(&start_output).trim().is_empty());
+
+    let status_output = env.run(&["--status", "--json"]);
+    assert_eq!(status_output.status.code(), Some(0));
+    assert!(stderr_text(&status_output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&status_output.stdout).expect("stdout JSON");
+    assert_eq!(payload["live"]["state_source"], "recovery");
+    assert_eq!(payload["live"]["in_progress"], true);
+    assert_eq!(payload["live"]["phase"], "focus");
+    assert_eq!(payload["live"]["status"], "running");
+    assert_eq!(payload["live"]["selected_task_label"], "Docs");
+    assert!(
+        payload["live"]["remaining_secs"]
+            .as_u64()
+            .expect("remaining secs should be u64")
+            > 0
+    );
+}
+
+#[test]
 fn start_json_requires_selected_task_label() {
     let env = TestEnv::new("start-json-requires-task");
     let output = env.run(&["--start", "--json"]);


### PR DESCRIPTION
## What

Convert `--start` into a true non-interactive CLI command path that supports both text and JSON output contracts, while keeping plain `focustime` as the interactive TUI entry point.

This PR:
- routes `--start` through `RunCommand(CommandKind::Start)` instead of TUI boot coupling,
- executes start via the same timer command envelope used by other CLI timer actions,
- updates parser/unit/integration coverage for `--start --json` success and runtime error envelopes,
- updates usage/docs to describe headless `--start` semantics.

## Why

Automation workflows need a machine-readable way to start focus sessions without entering the TUI. Before this change, `--start` was tied to TUI launch and rejected `--json`, which blocked that contract.

Closes #269.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable) (N/A)
- [ ] WakaTime integration behavior was verified for this change (if applicable) (N/A)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable) (N/A)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified README examples for `--start`, showing it starts the focus timer non-interactively and demonstrating `--json` usage.

* **New Features**
  * `--start` now starts the focus timer directly (no terminal UI entry).
  * `--start --json` is supported for automated timer operations with JSON output.

* **Tests**
  * Added and updated tests verifying `--start` behavior, JSON output, and error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/284)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->