### PR TITLE
Dual-read/dual-write compatibility path for config and stats migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dual-read/dual-write stats persistence compatibility path (#262):** added canonical data/state stats persistence with legacy-path read fallback and dual-write mirroring controls, including CLI backup/restore and diagnostics visibility updates for migration windows.
+
 ## [0.10.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -383,6 +383,10 @@ legacy_automation_mirror = true
 legacy_blocked_sites_mirror = true
 # Backfill legacy metadata from task_label when missing.
 metadata_task_label_fallback = true
+# Read stats from legacy config-dir path when canonical stats path is missing.
+stats_legacy_path_read_fallback = true
+# Mirror stats writes to legacy config-dir path during migration window.
+stats_legacy_path_dual_write = true
 
 [shortcuts]
 timer_toggle_pause = "space"
@@ -647,7 +651,7 @@ Override events are recorded for audit visibility in the History view and includ
 
 - completed pomodoros for the current app session
 - focused minutes for the current app session
-- daily aggregates persisted in `stats.toml` (in the same config directory as `config.toml`)
+- daily aggregates persisted in `stats.toml` (canonical data/state directory with optional legacy config-dir mirror during migration)
 - weekly totals derived from daily aggregates in the History view
 - weekly consistency score (`active_days / 7`, rounded to `%`) derived from daily activity
 - weekly focus score KPI (50/50 blend of consistency and weekly goal completion; `n/a` when weekly goal is off)

--- a/src/app.rs
+++ b/src/app.rs
@@ -634,6 +634,10 @@ impl App {
         let (mut stats, stats_error) =
             match FocusStats::load_with_options(crate::stats::StatsLoadOptions {
                 metadata_task_label_fallback: feature_flags.metadata_task_label_fallback,
+                path_compatibility: crate::stats::StatsPathCompatibilityOptions {
+                    legacy_path_read_fallback: feature_flags.stats_legacy_path_read_fallback,
+                    legacy_path_dual_write: feature_flags.stats_legacy_path_dual_write,
+                },
             }) {
                 Ok(stats) => (stats, None),
                 Err(e) => (FocusStats::default(), Some(e)),

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -367,7 +367,15 @@ impl App {
 
     #[cfg(not(test))]
     fn save_stats(&mut self) {
-        if let Err(e) = self.stats.save() {
+        if let Err(e) = self
+            .stats
+            .save_with_options(crate::stats::StatsSaveOptions {
+                path_compatibility: crate::stats::StatsPathCompatibilityOptions {
+                    legacy_path_read_fallback: self.feature_flags.stats_legacy_path_read_fallback,
+                    legacy_path_dual_write: self.feature_flags.stats_legacy_path_dual_write,
+                },
+            })
+        {
             self.stats_error = Some(format!("stats save failed: {e}"));
         } else {
             self.stats_error = None;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -714,6 +714,8 @@ struct FeatureFlagsOutput {
     legacy_automation_mirror: bool,
     legacy_blocked_sites_mirror: bool,
     metadata_task_label_fallback: bool,
+    stats_legacy_path_read_fallback: bool,
+    stats_legacy_path_dual_write: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1202,31 +1202,15 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
         }
         return Err(error);
     }
-    if let (Some(legacy_stats_path), Some(staged_legacy_stats_path)) = (
+    restore_legacy_stats_mirror_if_enabled(
         stats_legacy_restored_path.as_deref(),
         staged_legacy_stats_path.as_deref(),
-    ) && let Err(error) = replace_file_atomically(
-        staged_legacy_stats_path,
-        legacy_stats_path,
-        "restore legacy stats.toml mirror",
-    ) {
-        rollback_restored_file(
-            original_config_snapshot.as_deref(),
-            &config_restored_path,
-            "roll back restored config.toml",
-        );
-        rollback_restored_file(
-            original_stats_snapshot.as_deref(),
-            &stats_restored_path,
-            "roll back restored stats.toml",
-        );
-        rollback_restored_file(
-            original_legacy_stats_snapshot.as_deref(),
-            legacy_stats_path,
-            "roll back restored legacy stats.toml",
-        );
-        return Err(error);
-    }
+        original_legacy_stats_snapshot.as_deref(),
+        original_config_snapshot.as_deref(),
+        &config_restored_path,
+        original_stats_snapshot.as_deref(),
+        &stats_restored_path,
+    )?;
     if let Some(snapshot) = original_config_snapshot.as_deref() {
         let _ = remove_file_if_exists(snapshot);
     }
@@ -1377,6 +1361,45 @@ fn rollback_restored_file(snapshot: Option<&Path>, destination: &Path, rollback_
     } else {
         let _ = remove_file_if_exists(destination);
     }
+}
+
+fn restore_legacy_stats_mirror_if_enabled(
+    legacy_stats_path: Option<&Path>,
+    staged_legacy_stats_path: Option<&Path>,
+    original_legacy_stats_snapshot: Option<&Path>,
+    original_config_snapshot: Option<&Path>,
+    config_restored_path: &Path,
+    original_stats_snapshot: Option<&Path>,
+    stats_restored_path: &Path,
+) -> Result<(), String> {
+    let (Some(legacy_stats_path), Some(staged_legacy_stats_path)) =
+        (legacy_stats_path, staged_legacy_stats_path)
+    else {
+        return Ok(());
+    };
+    if let Err(error) = replace_file_atomically(
+        staged_legacy_stats_path,
+        legacy_stats_path,
+        "restore legacy stats.toml mirror",
+    ) {
+        rollback_restored_file(
+            original_config_snapshot,
+            config_restored_path,
+            "roll back restored config.toml",
+        );
+        rollback_restored_file(
+            original_stats_snapshot,
+            stats_restored_path,
+            "roll back restored stats.toml",
+        );
+        rollback_restored_file(
+            original_legacy_stats_snapshot,
+            legacy_stats_path,
+            "roll back restored legacy stats.toml",
+        );
+        return Err(error);
+    }
+    Ok(())
 }
 
 fn config_file_path() -> Result<PathBuf, String> {

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -32,6 +32,12 @@ use crate::cli::{
 const CONFIG_FILE_NAME: &str = "config.toml";
 const STATS_FILE_NAME: &str = "stats.toml";
 
+#[derive(Debug, Clone)]
+struct StatsPersistencePaths {
+    canonical: PathBuf,
+    legacy: Option<PathBuf>,
+}
+
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
     match cli_command.kind {
         CommandKind::Start => execute_start_command(cli_command.output),
@@ -151,9 +157,7 @@ fn execute_task_goal_command(
     output: OutputMode,
 ) -> Result<(), String> {
     let config = AppConfig::load().normalized();
-    let mut stats = FocusStats::load_with_options(crate::stats::StatsLoadOptions {
-        metadata_task_label_fallback: config.feature_flags.metadata_task_label_fallback,
-    })?;
+    let mut stats = FocusStats::load_with_options(stats_load_options(&config))?;
     let selected_task_label = stats.task_planner_state().1;
     let requested_label = label.or(selected_task_label).ok_or_else(|| {
         "No task label selected. Use `--task LABEL` first or pass `--task-goal LABEL`.".to_string()
@@ -167,7 +171,7 @@ fn execute_task_goal_command(
         };
         let canonical = stats.set_task_goal_target(&requested_label, target)?;
         stats
-            .save()
+            .save_with_options(stats_save_options(&config))
             .map_err(|error| format!("Failed to save task goals: {error}"))?;
         updated = true;
         canonical
@@ -1013,10 +1017,8 @@ fn execute_status_watch_command(output: OutputMode, interval_secs: u64) -> Resul
 
 fn load_status_output() -> Result<StatusOutput, String> {
     let config = AppConfig::load().normalized();
-    let stats = FocusStats::load_with_options(crate::stats::StatsLoadOptions {
-        metadata_task_label_fallback: config.feature_flags.metadata_task_label_fallback,
-    })
-    .map_err(|error| format!("Failed to load stats: {error}"))?;
+    let stats = FocusStats::load_with_options(stats_load_options(&config))
+        .map_err(|error| format!("Failed to load stats: {error}"))?;
     Ok(build_status_output(&config, &stats))
 }
 
@@ -1045,10 +1047,8 @@ fn emit_status_output(
 
 fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
     let config = AppConfig::load().normalized();
-    let stats = FocusStats::load_with_options(crate::stats::StatsLoadOptions {
-        metadata_task_label_fallback: config.feature_flags.metadata_task_label_fallback,
-    })
-    .map_err(|error| format!("Failed to load stats: {error}"))?;
+    let stats = FocusStats::load_with_options(stats_load_options(&config))
+        .map_err(|error| format!("Failed to load stats: {error}"))?;
     let target_dir = match dir {
         Some(path) => path,
         None => env::current_dir()
@@ -1071,6 +1071,7 @@ fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
 }
 
 fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
+    let config = AppConfig::load().normalized();
     let backup_dir = match dir {
         Some(path) => path,
         None => env::current_dir().map_err(|error| {
@@ -1080,8 +1081,12 @@ fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
     fs::create_dir_all(&backup_dir)
         .map_err(|error| format!("Backup failed: could not create backup directory: {error}"))?;
 
-    let source_config = app_data_file_path(CONFIG_FILE_NAME)?;
-    let source_stats = app_data_file_path(STATS_FILE_NAME)?;
+    let source_config = config_file_path()?;
+    let stats_paths = stats_persistence_paths()?;
+    let source_stats = resolve_stats_backup_source_path(
+        &stats_paths,
+        config.feature_flags.stats_legacy_path_read_fallback,
+    );
     ensure_backup_source_file(&source_config, CONFIG_FILE_NAME)?;
     ensure_backup_source_file(&source_stats, STATS_FILE_NAME)?;
     let config_backup_path = backup_dir.join(CONFIG_FILE_NAME);
@@ -1103,6 +1108,7 @@ fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
 }
 
 fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
+    let config = AppConfig::load().normalized();
     let restore_dir = match dir {
         Some(path) => path,
         None => env::current_dir().map_err(|error| {
@@ -1114,10 +1120,19 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
     ensure_restore_source_file(&source_config, CONFIG_FILE_NAME)?;
     ensure_restore_source_file(&source_stats, STATS_FILE_NAME)?;
 
-    let config_restored_path = app_data_file_path(CONFIG_FILE_NAME)?;
-    let stats_restored_path = app_data_file_path(STATS_FILE_NAME)?;
+    let config_restored_path = config_file_path()?;
+    let stats_paths = stats_persistence_paths()?;
+    let stats_restored_path = stats_paths.canonical.clone();
+    let stats_legacy_restored_path = if config.feature_flags.stats_legacy_path_dual_write {
+        stats_paths.legacy.clone()
+    } else {
+        None
+    };
     let staged_config_path = temp_restore_path(&config_restored_path, "staged");
     let staged_stats_path = temp_restore_path(&stats_restored_path, "staged");
+    let staged_legacy_stats_path = stats_legacy_restored_path
+        .as_ref()
+        .map(|path| temp_restore_path(path, "staged"));
     copy_file_with_context(
         &source_config,
         &staged_config_path,
@@ -1128,6 +1143,13 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
         &staged_stats_path,
         "stage restore stats.toml",
     )?;
+    if let Some(staged_legacy) = staged_legacy_stats_path.as_deref() {
+        copy_file_with_context(
+            &source_stats,
+            staged_legacy,
+            "stage restore legacy stats.toml mirror",
+        )?;
+    }
 
     let original_config_snapshot = snapshot_existing_file(
         &config_restored_path,
@@ -1137,6 +1159,15 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
         &stats_restored_path,
         "snapshot existing stats.toml for rollback",
     )?;
+    let original_legacy_stats_snapshot =
+        if let Some(legacy_stats_path) = stats_legacy_restored_path.as_deref() {
+            snapshot_existing_file(
+                legacy_stats_path,
+                "snapshot existing legacy stats.toml for rollback",
+            )?
+        } else {
+            None
+        };
 
     replace_file_atomically(
         &staged_config_path,
@@ -1148,31 +1179,61 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
         &stats_restored_path,
         "restore stats.toml",
     ) {
-        if let Some(snapshot) = original_config_snapshot.as_deref() {
-            let _ = replace_file_atomically(
-                snapshot,
-                &config_restored_path,
-                "roll back restored config.toml",
+        rollback_restored_file(
+            original_config_snapshot.as_deref(),
+            &config_restored_path,
+            "roll back restored config.toml",
+        );
+        rollback_restored_file(
+            original_stats_snapshot.as_deref(),
+            &stats_restored_path,
+            "roll back restored stats.toml",
+        );
+        if let Some(legacy_stats_path) = stats_legacy_restored_path.as_deref() {
+            rollback_restored_file(
+                original_legacy_stats_snapshot.as_deref(),
+                legacy_stats_path,
+                "roll back restored legacy stats.toml",
             );
-        } else {
-            let _ = remove_file_if_exists(&config_restored_path);
-        }
-        if let Some(snapshot) = original_stats_snapshot.as_deref() {
-            let _ = replace_file_atomically(
-                snapshot,
-                &stats_restored_path,
-                "roll back restored stats.toml",
-            );
-        } else {
-            let _ = remove_file_if_exists(&stats_restored_path);
         }
         let _ = remove_file_if_exists(&staged_stats_path);
+        if let Some(staged_legacy) = staged_legacy_stats_path.as_deref() {
+            let _ = remove_file_if_exists(staged_legacy);
+        }
+        return Err(error);
+    }
+    if let (Some(legacy_stats_path), Some(staged_legacy_stats_path)) = (
+        stats_legacy_restored_path.as_deref(),
+        staged_legacy_stats_path.as_deref(),
+    ) && let Err(error) = replace_file_atomically(
+        staged_legacy_stats_path,
+        legacy_stats_path,
+        "restore legacy stats.toml mirror",
+    ) {
+        rollback_restored_file(
+            original_config_snapshot.as_deref(),
+            &config_restored_path,
+            "roll back restored config.toml",
+        );
+        rollback_restored_file(
+            original_stats_snapshot.as_deref(),
+            &stats_restored_path,
+            "roll back restored stats.toml",
+        );
+        rollback_restored_file(
+            original_legacy_stats_snapshot.as_deref(),
+            legacy_stats_path,
+            "roll back restored legacy stats.toml",
+        );
         return Err(error);
     }
     if let Some(snapshot) = original_config_snapshot.as_deref() {
         let _ = remove_file_if_exists(snapshot);
     }
     if let Some(snapshot) = original_stats_snapshot.as_deref() {
+        let _ = remove_file_if_exists(snapshot);
+    }
+    if let Some(snapshot) = original_legacy_stats_snapshot.as_deref() {
         let _ = remove_file_if_exists(snapshot);
     }
 
@@ -1310,12 +1371,66 @@ fn remove_file_if_exists(path: &Path) -> Result<(), String> {
     fs::remove_file(path).map_err(|error| format!("Failed to remove `{}`: {error}", path.display()))
 }
 
-fn app_data_file_path(file_name: &str) -> Result<PathBuf, String> {
-    crate::config::app_data_path(file_name).ok_or_else(|| {
+fn rollback_restored_file(snapshot: Option<&Path>, destination: &Path, rollback_context: &str) {
+    if let Some(snapshot) = snapshot {
+        let _ = replace_file_atomically(snapshot, destination, rollback_context);
+    } else {
+        let _ = remove_file_if_exists(destination);
+    }
+}
+
+fn config_file_path() -> Result<PathBuf, String> {
+    crate::config::app_data_path(CONFIG_FILE_NAME).ok_or_else(|| {
         format!(
-            "could not determine application data path for `{file_name}` (environment is not configured)"
+            "could not determine application data path for `{CONFIG_FILE_NAME}` (environment is not configured)"
         )
     })
+}
+
+fn stats_persistence_paths() -> Result<StatsPersistencePaths, String> {
+    let canonical = crate::config::stats_data_path(STATS_FILE_NAME).ok_or_else(|| {
+        format!(
+            "could not determine application data path for `{STATS_FILE_NAME}` (environment is not configured)"
+        )
+    })?;
+    let legacy = crate::config::app_data_path(STATS_FILE_NAME).filter(|path| path != &canonical);
+    Ok(StatsPersistencePaths { canonical, legacy })
+}
+
+fn resolve_stats_backup_source_path(
+    paths: &StatsPersistencePaths,
+    legacy_read_fallback: bool,
+) -> PathBuf {
+    if paths.canonical.exists() {
+        return paths.canonical.clone();
+    }
+    if legacy_read_fallback
+        && let Some(legacy) = paths.legacy.as_ref()
+        && legacy.exists()
+    {
+        return legacy.clone();
+    }
+    paths.canonical.clone()
+}
+
+fn stats_path_compatibility(config: &AppConfig) -> crate::stats::StatsPathCompatibilityOptions {
+    crate::stats::StatsPathCompatibilityOptions {
+        legacy_path_read_fallback: config.feature_flags.stats_legacy_path_read_fallback,
+        legacy_path_dual_write: config.feature_flags.stats_legacy_path_dual_write,
+    }
+}
+
+fn stats_load_options(config: &AppConfig) -> crate::stats::StatsLoadOptions {
+    crate::stats::StatsLoadOptions {
+        metadata_task_label_fallback: config.feature_flags.metadata_task_label_fallback,
+        path_compatibility: stats_path_compatibility(config),
+    }
+}
+
+fn stats_save_options(config: &AppConfig) -> crate::stats::StatsSaveOptions {
+    crate::stats::StatsSaveOptions {
+        path_compatibility: stats_path_compatibility(config),
+    }
 }
 
 fn copy_file_with_context(source: &Path, destination: &Path, context: &str) -> Result<(), String> {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -623,10 +623,12 @@ pub(super) fn print_diagnostics_command_output(payload: &DiagnosticsCommandOutpu
     print_diagnostics_check("Hosts write capability", &payload.hosts_write_capability);
     print_diagnostics_check("WakaTime config", &payload.wakatime_config);
     println!(
-        "Feature flags: automation-mirror={}, blocked-sites-mirror={}, metadata-fallback={}",
+        "Feature flags: automation-mirror={}, blocked-sites-mirror={}, metadata-fallback={}, stats-read-fallback={}, stats-dual-write={}",
         bool_label(payload.feature_flags.legacy_automation_mirror),
         bool_label(payload.feature_flags.legacy_blocked_sites_mirror),
         bool_label(payload.feature_flags.metadata_task_label_fallback),
+        bool_label(payload.feature_flags.stats_legacy_path_read_fallback),
+        bool_label(payload.feature_flags.stats_legacy_path_dual_write),
     );
 }
 
@@ -646,6 +648,10 @@ pub(super) fn build_diagnostics_command_output(
             legacy_automation_mirror: diagnostics.feature_flags.legacy_automation_mirror,
             legacy_blocked_sites_mirror: diagnostics.feature_flags.legacy_blocked_sites_mirror,
             metadata_task_label_fallback: diagnostics.feature_flags.metadata_task_label_fallback,
+            stats_legacy_path_read_fallback: diagnostics
+                .feature_flags
+                .stats_legacy_path_read_fallback,
+            stats_legacy_path_dual_write: diagnostics.feature_flags.stats_legacy_path_dual_write,
         },
     }
 }

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -650,6 +650,8 @@ fn diagnostics_output_includes_effective_feature_flags() {
     assert!(payload.feature_flags.legacy_automation_mirror);
     assert!(payload.feature_flags.legacy_blocked_sites_mirror);
     assert!(payload.feature_flags.metadata_task_label_fallback);
+    assert!(payload.feature_flags.stats_legacy_path_read_fallback);
+    assert!(payload.feature_flags.stats_legacy_path_dual_write);
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,11 +8,11 @@ use chrono::{Local, NaiveDate};
 use serde::{Deserialize, Deserializer, Serialize};
 
 mod paths;
-use paths::app_dir_with_env;
-#[cfg(test)]
-use paths::config_dir_from_env;
 #[cfg(all(test, not(target_os = "windows")))]
 use paths::env_path_from_value;
+use paths::{app_dir_with_env, stats_app_dir_with_env};
+#[cfg(test)]
+use paths::{config_dir_from_env, stats_state_dir_from_env};
 
 const CURRENT_CONFIG_SCHEMA_VERSION: u32 = 1;
 const LEGACY_CONFIG_SCHEMA_VERSION: u32 = 0;
@@ -169,6 +169,12 @@ pub struct FeatureFlagsConfig {
     /// Backfill missing metadata fields from task labels for legacy records/snapshots.
     #[serde(default = "default_true")]
     pub metadata_task_label_fallback: bool,
+    /// Allow stats loading to fall back to legacy config-directory persistence path.
+    #[serde(default = "default_true")]
+    pub stats_legacy_path_read_fallback: bool,
+    /// Mirror stats writes to legacy config-directory persistence path.
+    #[serde(default = "default_true")]
+    pub stats_legacy_path_dual_write: bool,
 }
 
 impl FeatureFlagsConfig {
@@ -183,6 +189,8 @@ impl Default for FeatureFlagsConfig {
             legacy_automation_mirror: true,
             legacy_blocked_sites_mirror: true,
             metadata_task_label_fallback: true,
+            stats_legacy_path_read_fallback: true,
+            stats_legacy_path_dual_write: true,
         }
     }
 }
@@ -1769,8 +1777,18 @@ pub(crate) fn app_data_path(file_name: &str) -> Option<PathBuf> {
     Some(app_dir.join(file_name))
 }
 
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) fn stats_data_path(file_name: &str) -> Option<PathBuf> {
+    let app_dir = stats_app_dir()?;
+    Some(app_dir.join(file_name))
+}
+
 fn app_dir() -> Option<PathBuf> {
     app_dir_with_env(|key| std::env::var_os(key))
+}
+
+fn stats_app_dir() -> Option<PathBuf> {
+    stats_app_dir_with_env(|key| std::env::var_os(key))
 }
 
 fn nonzero_or_default_u64(value: u64, default: u64) -> u64 {

--- a/src/config/paths.rs
+++ b/src/config/paths.rs
@@ -5,6 +5,13 @@ pub(super) fn app_dir_with_env(get_var: impl FnMut(&str) -> Option<OsString>) ->
     Some(config_dir.join("focustime"))
 }
 
+pub(super) fn stats_app_dir_with_env(
+    get_var: impl FnMut(&str) -> Option<OsString>,
+) -> Option<PathBuf> {
+    let state_dir = stats_state_dir_from_env(get_var)?;
+    Some(state_dir.join("focustime"))
+}
+
 pub(super) fn config_dir_from_env(
     mut get_var: impl FnMut(&str) -> Option<OsString>,
 ) -> Option<PathBuf> {
@@ -30,6 +37,44 @@ pub(super) fn config_dir_from_env(
             return None;
         }
         Some(home.join(".config"))
+    }
+}
+
+pub(super) fn stats_state_dir_from_env(
+    mut get_var: impl FnMut(&str) -> Option<OsString>,
+) -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(local_app_data) = get_var("LOCALAPPDATA").and_then(env_path_from_value)
+            && local_app_data.is_absolute()
+        {
+            return Some(local_app_data);
+        }
+        let appdata = env_path_from_value(get_var("APPDATA")?)?;
+        if appdata.is_absolute() {
+            Some(appdata)
+        } else {
+            None
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Honour XDG_STATE_HOME first, then XDG_DATA_HOME, then ~/.local/state.
+        if let Some(xdg_state) = get_var("XDG_STATE_HOME").and_then(env_path_from_value) {
+            if xdg_state.is_absolute() {
+                return Some(xdg_state);
+            }
+        }
+        if let Some(xdg_data) = get_var("XDG_DATA_HOME").and_then(env_path_from_value) {
+            if xdg_data.is_absolute() {
+                return Some(xdg_data);
+            }
+        }
+        let home = get_var("HOME").and_then(env_path_from_value)?;
+        if !home.is_absolute() {
+            return None;
+        }
+        Some(home.join(".local").join("state"))
     }
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -252,6 +252,8 @@ fn round_trip_full_config() {
             legacy_automation_mirror: true,
             legacy_blocked_sites_mirror: true,
             metadata_task_label_fallback: true,
+            stats_legacy_path_read_fallback: true,
+            stats_legacy_path_dual_write: true,
         },
         shortcuts: ShortcutConfig {
             timer_toggle_pause: "space".to_string(),
@@ -1128,6 +1130,71 @@ fn config_dir_uses_absolute_appdata_when_set() {
         _ => None,
     });
     assert_eq!(dir, Some(PathBuf::from(r"C:\Users\test\AppData\Roaming")));
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn stats_state_dir_uses_absolute_xdg_state_home_when_set() {
+    let dir = stats_state_dir_from_env(|key| match key {
+        "XDG_STATE_HOME" => Some(OsString::from("/tmp/state")),
+        _ => None,
+    });
+    assert_eq!(dir, Some(PathBuf::from("/tmp/state")));
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn stats_state_dir_falls_back_to_absolute_xdg_data_home() {
+    let dir = stats_state_dir_from_env(|key| match key {
+        "XDG_STATE_HOME" => Some(OsString::from("relative-state")),
+        "XDG_DATA_HOME" => Some(OsString::from("/tmp/data")),
+        _ => None,
+    });
+    assert_eq!(dir, Some(PathBuf::from("/tmp/data")));
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn stats_state_dir_falls_back_to_home_local_state() {
+    let dir = stats_state_dir_from_env(|key| match key {
+        "XDG_STATE_HOME" => None,
+        "XDG_DATA_HOME" => None,
+        "HOME" => Some(OsString::from("/tmp/home")),
+        _ => None,
+    });
+    assert_eq!(dir, Some(PathBuf::from("/tmp/home/.local/state")));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn stats_state_dir_uses_absolute_localappdata_when_set() {
+    let dir = stats_state_dir_from_env(|key| match key {
+        "LOCALAPPDATA" => Some(OsString::from(r"C:\Users\test\AppData\Local")),
+        _ => None,
+    });
+    assert_eq!(dir, Some(PathBuf::from(r"C:\Users\test\AppData\Local")));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn stats_state_dir_falls_back_to_absolute_appdata_when_localappdata_missing() {
+    let dir = stats_state_dir_from_env(|key| match key {
+        "LOCALAPPDATA" => None,
+        "APPDATA" => Some(OsString::from(r"C:\Users\test\AppData\Roaming")),
+        _ => None,
+    });
+    assert_eq!(dir, Some(PathBuf::from(r"C:\Users\test\AppData\Roaming")));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn stats_state_dir_returns_none_when_all_candidates_are_relative() {
+    let dir = stats_state_dir_from_env(|key| match key {
+        "LOCALAPPDATA" => Some(OsString::from("AppData\\Local")),
+        "APPDATA" => Some(OsString::from("AppData\\Roaming")),
+        _ => None,
+    });
+    assert!(dir.is_none());
 }
 
 #[cfg(unix)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -39,16 +39,38 @@ const EXPORT_SCHEMA_VERSION: u32 = 5;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatsPathCompatibilityOptions {
+    pub legacy_path_read_fallback: bool,
+    pub legacy_path_dual_write: bool,
+}
+
+impl Default for StatsPathCompatibilityOptions {
+    fn default() -> Self {
+        Self {
+            legacy_path_read_fallback: true,
+            legacy_path_dual_write: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StatsLoadOptions {
     pub metadata_task_label_fallback: bool,
+    pub path_compatibility: StatsPathCompatibilityOptions,
 }
 
 impl Default for StatsLoadOptions {
     fn default() -> Self {
         Self {
             metadata_task_label_fallback: true,
+            path_compatibility: StatsPathCompatibilityOptions::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StatsSaveOptions {
+    pub path_compatibility: StatsPathCompatibilityOptions,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -1,10 +1,12 @@
-#[cfg(not(test))]
+use std::path::{Path, PathBuf};
+
 use crate::stats::fs;
 use crate::stats::{
     BreakGlassOverrideEvent, FocusSessionRecord, FocusStats, PersistedStats, STATS_FILE_NAME,
-    SessionInterruptionEvent, SessionStats, StatsLoadOptions, io, normalize_session_metadata_text,
-    normalize_task_goal_targets, normalize_task_label, normalize_task_planner_state,
-    planner_state_labels_for_keys, write_atomic_bytes,
+    SessionInterruptionEvent, SessionStats, StatsLoadOptions, StatsPathCompatibilityOptions,
+    StatsSaveOptions, io, normalize_session_metadata_text, normalize_task_goal_targets,
+    normalize_task_label, normalize_task_planner_state, planner_state_labels_for_keys,
+    write_atomic_bytes,
 };
 
 impl FocusStats {
@@ -32,12 +34,29 @@ impl FocusStats {
 
     #[cfg(not(test))]
     fn try_load(options: StatsLoadOptions) -> Result<Self, String> {
-        let path = crate::config::app_data_path(STATS_FILE_NAME)
+        let read_paths = stats_read_paths(options.path_compatibility)
             .ok_or_else(|| "cannot determine stats directory".to_string())?;
-        match fs::read_to_string(path) {
-            Ok(content) => Self::try_from_toml_with_options(&content, options),
-            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
-            Err(e) => Err(format!("stats read failed: {e}")),
+        let mut failures = Vec::new();
+        for path in &read_paths {
+            match fs::read_to_string(path) {
+                Ok(content) => match Self::try_from_toml_with_options(&content, options) {
+                    Ok(stats) => return Ok(stats),
+                    Err(error) => failures.push(format!(
+                        "stats parse failed at `{}`: {error}",
+                        path.display()
+                    )),
+                },
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => failures.push(format!(
+                    "stats read failed at `{}`: {error}",
+                    path.display()
+                )),
+            }
+        }
+        if failures.is_empty() {
+            Ok(Self::default())
+        } else {
+            Err(failures.join(" | "))
         }
     }
 
@@ -160,14 +179,104 @@ impl FocusStats {
         }
     }
 
-    #[cfg_attr(test, allow(dead_code))]
-    pub fn save(&self) -> io::Result<()> {
-        let path = crate::config::app_data_path(STATS_FILE_NAME).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::NotFound, "cannot determine stats directory")
-        })?;
-
+    pub fn save_with_options(&self, options: StatsSaveOptions) -> io::Result<()> {
+        let (canonical_path, legacy_path) = stats_write_paths(options.path_compatibility)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "cannot determine stats directory")
+            })?;
         let content = toml::to_string_pretty(&self.to_persisted())
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        write_atomic_bytes(&path, content.as_bytes())
+        write_stats_with_rollback(&canonical_path, legacy_path.as_deref(), content.as_bytes())
+    }
+}
+
+fn stats_paths() -> Option<(PathBuf, Option<PathBuf>)> {
+    let canonical_path = crate::config::stats_data_path(STATS_FILE_NAME)?;
+    let legacy_path =
+        crate::config::app_data_path(STATS_FILE_NAME).filter(|path| path != &canonical_path);
+    Some((canonical_path, legacy_path))
+}
+
+#[cfg(not(test))]
+fn stats_read_paths(path_compatibility: StatsPathCompatibilityOptions) -> Option<Vec<PathBuf>> {
+    let (canonical_path, legacy_path) = stats_paths()?;
+    let mut read_paths = vec![canonical_path];
+    if path_compatibility.legacy_path_read_fallback
+        && let Some(legacy_path) = legacy_path
+    {
+        read_paths.push(legacy_path);
+    }
+    Some(read_paths)
+}
+
+fn stats_write_paths(
+    path_compatibility: StatsPathCompatibilityOptions,
+) -> Option<(PathBuf, Option<PathBuf>)> {
+    let (canonical_path, legacy_path) = stats_paths()?;
+    let legacy_path = if path_compatibility.legacy_path_dual_write {
+        legacy_path
+    } else {
+        None
+    };
+    Some((canonical_path, legacy_path))
+}
+
+fn write_stats_with_rollback(
+    canonical_path: &Path,
+    legacy_path: Option<&Path>,
+    content: &[u8],
+) -> io::Result<()> {
+    let canonical_snapshot = read_existing_bytes(canonical_path)?;
+    let legacy_snapshot = if let Some(path) = legacy_path {
+        Some(read_existing_bytes(path)?)
+    } else {
+        None
+    };
+
+    write_atomic_bytes(canonical_path, content)?;
+    if let Some(path) = legacy_path
+        && let Err(error) = write_atomic_bytes(path, content)
+    {
+        let mut rollback_errors = Vec::new();
+        if let Err(rollback_error) = restore_existing_bytes(canonical_path, canonical_snapshot) {
+            rollback_errors.push(format!(
+                "rollback failed for `{}`: {rollback_error}",
+                canonical_path.display()
+            ));
+        }
+        if let Some(snapshot) = legacy_snapshot
+            && let Err(rollback_error) = restore_existing_bytes(path, snapshot)
+        {
+            rollback_errors.push(format!(
+                "rollback failed for `{}`: {rollback_error}",
+                path.display()
+            ));
+        }
+        let mut detail = format!("stats mirror write failed at `{}`: {error}", path.display());
+        if !rollback_errors.is_empty() {
+            detail.push_str("; ");
+            detail.push_str(&rollback_errors.join("; "));
+        }
+        return Err(io::Error::other(detail));
+    }
+    Ok(())
+}
+
+fn read_existing_bytes(path: &Path) -> io::Result<Option<Vec<u8>>> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn restore_existing_bytes(path: &Path, snapshot: Option<Vec<u8>>) -> io::Result<()> {
+    if let Some(bytes) = snapshot {
+        return write_atomic_bytes(path, &bytes);
+    }
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
     }
 }

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -905,6 +905,7 @@ fn legacy_focus_sessions_keep_empty_metadata_when_fallback_is_disabled() {
         legacy_toml,
         StatsLoadOptions {
             metadata_task_label_fallback: false,
+            ..StatsLoadOptions::default()
         },
     )
     .unwrap();

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -61,7 +61,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
     );
     frame.render_widget(
         Paragraph::new(format!(
-            "Feature flags: automation-mirror={} · blocked-sites-mirror={} · metadata-fallback={}",
+            "Feature flags: automation-mirror={} · blocked-sites-mirror={} · metadata-fallback={} · stats-read-fallback={} · stats-dual-write={}",
             bool_label(app.setup_diagnostics.feature_flags.legacy_automation_mirror),
             bool_label(
                 app.setup_diagnostics
@@ -72,6 +72,16 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
                 app.setup_diagnostics
                     .feature_flags
                     .metadata_task_label_fallback
+            ),
+            bool_label(
+                app.setup_diagnostics
+                    .feature_flags
+                    .stats_legacy_path_read_fallback
+            ),
+            bool_label(
+                app.setup_diagnostics
+                    .feature_flags
+                    .stats_legacy_path_dual_write
             )
         ))
         .style(Style::default().fg(app_color(app, Color::DarkGray)))

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -24,7 +24,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             Constraint::Length(2), // blocking permissions
             Constraint::Length(2), // hosts write capability
             Constraint::Length(2), // wakatime config status
-            Constraint::Length(2), // feature flags
+            Constraint::Length(3), // feature flags
             Constraint::Length(1), // preview summary
             Constraint::Min(0),    // preview section
             Constraint::Length(2), // key hints
@@ -59,9 +59,9 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         "WakaTime config status",
         &app.setup_diagnostics.wakatime_config,
     );
-    frame.render_widget(
-        Paragraph::new(format!(
-            "Feature flags: automation-mirror={} · blocked-sites-mirror={} · metadata-fallback={} · stats-read-fallback={} · stats-dual-write={}",
+    let feature_flags_lines = vec![
+        Line::from(format!(
+            "Feature flags: automation-mirror={} · blocked-sites-mirror={} · metadata-fallback={}",
             bool_label(app.setup_diagnostics.feature_flags.legacy_automation_mirror),
             bool_label(
                 app.setup_diagnostics
@@ -73,6 +73,9 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
                     .feature_flags
                     .metadata_task_label_fallback
             ),
+        )),
+        Line::from(format!(
+            "               stats-read-fallback={} · stats-dual-write={}",
             bool_label(
                 app.setup_diagnostics
                     .feature_flags
@@ -83,9 +86,12 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
                     .feature_flags
                     .stats_legacy_path_dual_write
             )
-        ))
-        .style(Style::default().fg(app_color(app, Color::DarkGray)))
-        .wrap(Wrap { trim: true }),
+        )),
+    ];
+    frame.render_widget(
+        Paragraph::new(feature_flags_lines)
+            .style(Style::default().fg(app_color(app, Color::DarkGray)))
+            .wrap(Wrap { trim: true }),
         inner[5],
     );
 

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -30,12 +30,38 @@ impl TestEnv {
         Self { root }
     }
 
+    fn app_data_dir(&self) -> PathBuf {
+        self.root.join("focustime")
+    }
+
+    fn stats_canonical_dir(&self) -> PathBuf {
+        #[cfg(target_os = "windows")]
+        {
+            self.root.join("localappdata").join("focustime")
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.root.join(".state").join("focustime")
+        }
+    }
+
+    fn legacy_stats_path(&self) -> PathBuf {
+        self.app_data_dir().join("stats.toml")
+    }
+
+    fn canonical_stats_path(&self) -> PathBuf {
+        self.stats_canonical_dir().join("stats.toml")
+    }
+
     fn run(&self, args: &[&str]) -> Output {
         let mut command = Command::new(focustime_bin_path());
         command.args(args);
         command.current_dir(&self.root);
         command.env("APPDATA", &self.root);
+        command.env("LOCALAPPDATA", self.root.join("localappdata"));
         command.env("XDG_CONFIG_HOME", &self.root);
+        command.env("XDG_STATE_HOME", self.root.join(".state"));
+        command.env("XDG_DATA_HOME", self.root.join(".data"));
         command.env("HOME", &self.root);
         command
             .output()
@@ -47,7 +73,10 @@ impl TestEnv {
         command.args(args);
         command.current_dir(&self.root);
         command.env("APPDATA", &self.root);
+        command.env("LOCALAPPDATA", self.root.join("localappdata"));
         command.env("XDG_CONFIG_HOME", &self.root);
+        command.env("XDG_STATE_HOME", self.root.join(".state"));
+        command.env("XDG_DATA_HOME", self.root.join(".data"));
         command.env("HOME", &self.root);
         command.stdout(Stdio::piped());
         command.stderr(Stdio::piped());
@@ -84,10 +113,20 @@ fn stderr_text(output: &Output) -> String {
 }
 
 fn write_recovery_snapshot(env: &TestEnv, content: &str) {
-    let app_data_dir = env.root.join("focustime");
+    let app_data_dir = env.app_data_dir();
     fs::create_dir_all(&app_data_dir).expect("failed to create app data directory");
     fs::write(app_data_dir.join("session-recovery.toml"), content)
         .expect("failed to write recovery snapshot");
+}
+
+fn write_stats_snapshot(path: &std::path::Path, day: &str, pomodoros: u32, focused_seconds: u64) {
+    let content = format!(
+        "[daily.\"{day}\"]\npomodoros_completed = {pomodoros}\nfocused_seconds = {focused_seconds}\n"
+    );
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create stats parent directory");
+    }
+    fs::write(path, content).expect("failed to write stats snapshot");
 }
 
 #[test]
@@ -353,9 +392,62 @@ fn backup_and_restore_json_round_trip_config_and_stats_files() {
 }
 
 #[test]
+fn task_goal_json_dual_writes_stats_to_canonical_and_legacy_paths() {
+    let env = TestEnv::new("stats-dual-write");
+
+    let output = env.run(&["--task-goal=Docs:90,3", "--json"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let canonical_stats_path = env.canonical_stats_path();
+    let legacy_stats_path = env.legacy_stats_path();
+    assert!(canonical_stats_path.is_file());
+    assert!(legacy_stats_path.is_file());
+    assert_eq!(
+        fs::read_to_string(&canonical_stats_path).unwrap(),
+        fs::read_to_string(&legacy_stats_path).unwrap()
+    );
+}
+
+#[test]
+fn status_json_prefers_canonical_stats_and_falls_back_to_legacy() {
+    let env = TestEnv::new("stats-read-precedence");
+
+    let baseline_status = env.run(&["--status", "--json"]);
+    assert_eq!(baseline_status.status.code(), Some(0));
+    assert!(stderr_text(&baseline_status).trim().is_empty());
+    let baseline_payload: Value =
+        serde_json::from_slice(&baseline_status.stdout).expect("stdout should be JSON");
+    let day = baseline_payload["day"]
+        .as_str()
+        .expect("day should be a string")
+        .to_string();
+
+    let canonical_stats_path = env.canonical_stats_path();
+    let legacy_stats_path = env.legacy_stats_path();
+    write_stats_snapshot(&legacy_stats_path, &day, 7, 4200);
+    write_stats_snapshot(&canonical_stats_path, &day, 3, 1800);
+
+    let canonical_status = env.run(&["--status", "--json"]);
+    assert_eq!(canonical_status.status.code(), Some(0));
+    assert!(stderr_text(&canonical_status).trim().is_empty());
+    let canonical_payload: Value =
+        serde_json::from_slice(&canonical_status.stdout).expect("stdout should be JSON");
+    assert_eq!(canonical_payload["today"]["pomodoros_completed"], 3);
+
+    fs::remove_file(&canonical_stats_path).expect("failed to remove canonical stats file");
+    let fallback_status = env.run(&["--status", "--json"]);
+    assert_eq!(fallback_status.status.code(), Some(0));
+    assert!(stderr_text(&fallback_status).trim().is_empty());
+    let fallback_payload: Value =
+        serde_json::from_slice(&fallback_status.stdout).expect("stdout should be JSON");
+    assert_eq!(fallback_payload["today"]["pomodoros_completed"], 7);
+}
+
+#[test]
 fn backup_json_copies_raw_files_even_when_malformed() {
     let env = TestEnv::new("backup-raw-malformed");
-    let app_data_dir = env.root.join("focustime");
+    let app_data_dir = env.app_data_dir();
     fs::create_dir_all(&app_data_dir).expect("failed to create app data directory");
     let seed_output = env.run(&["--task", "Docs", "--json"]);
     assert_eq!(seed_output.status.code(), Some(0));


### PR DESCRIPTION
## What

- Adds migration-window stats persistence compatibility with a canonical data/state path while preserving a legacy config-directory path for transition safety.
- Introduces two feature flags to control legacy stats behavior: read fallback and dual-write mirroring.
- Refactors stats load/save flows to use canonical-first read precedence, optional legacy fallback, and rollback-aware dual-write behavior.
- Updates CLI backup/restore/status-related stats loading paths and setup diagnostics output to reflect effective compatibility state.
- Adds regression coverage for path resolution, canonical-vs-legacy read behavior, dual-write equivalence, and CLI contract expectations.
- Updates README and changelog documentation for the migration behavior.

## Why

Users upgrading during the migration window need existing stats data to remain readable without manual intervention, while newly written data stays consistent across legacy and new representations. This change provides a safe compatibility bridge with explicit controls and test coverage before later cleanup/removal milestones.

Closes #262.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stats migration compatibility path with dual-read/dual-write options for transitioning legacy → canonical storage
  * Added feature flags to control legacy-read fallback and dual-write mirroring during migration
  * Enhanced backup/restore to handle canonical and legacy stats with safe rollback and mirroring

* **Chores**
  * Updated README and changelog with migration controls and retention details
  * Exposed migration flags in diagnostics output and setup diagnostics

* **Tests**
  * Added/updated tests covering canonical vs legacy stats read/write behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/291)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->