### PR TITLE
Migration tooling with dry-run and rollback support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Dual-read/dual-write stats persistence compatibility path (#262):** added canonical data/state stats persistence with legacy-path read fallback and dual-write mirroring controls, including CLI backup/restore and diagnostics visibility updates for migration windows.
+- **Migration tooling with dry-run and rollback safety (#263):** added `--migrate` with explicit `--dry-run` preview mode, structured migration step reporting, and rollback-aware migration execution/diagnostics for stats-path compatibility finalization.
 
 ## [0.10.0] - 2026-05-11
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ cargo run -- --backup=./reports --json
 cargo run -- --restore
 cargo run -- --restore=./reports --json
 
+# Run stats-path compatibility migration (legacy -> canonical) with optional dry-run preview
+cargo run -- --migrate
+cargo run -- --migrate --dry-run --json
+
 # Export stats to current directory or a target directory
 cargo run -- --export
 cargo run -- --export=./reports --json
@@ -205,6 +209,8 @@ Backup/restore behavior:
 
 - `--backup` creates the target directory if needed, then copies `config.toml` and `stats.toml` into it.
 - `--restore` requires both files in the source directory and uses staged replacement so failed restores roll back to the original files.
+- `--migrate` applies compatibility migration updates for canonical stats persistence and disables migration-window feature flags after success.
+- `--migrate --dry-run` reports planned migration steps without mutating any files.
 
 ### CLI JSON/error contract
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,19 +47,20 @@ use output::{
     flush_stdout, print_backup_output, print_blocking_preview_command_output,
     print_blocklist_profile_command_output, print_break_glass_command_output,
     print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
-    print_goal_command_output, print_json, print_json_compact, print_profile_output,
-    print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
-    print_session_metadata_command_output, print_site_add_command_output,
-    print_site_delete_command_output, print_site_edit_command_output,
-    print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
+    print_goal_command_output, print_json, print_json_compact, print_migration_output,
+    print_profile_output, print_restore_output, print_schedule_command_output,
+    print_schedule_delay_command_output, print_session_metadata_command_output,
+    print_site_add_command_output, print_site_delete_command_output,
+    print_site_edit_command_output, print_site_list_command_output, print_status_output,
+    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
+    print_timer_state_output,
 };
 use parsing::{
-    finalize_cli_action, invalid_usage, parse_global_tokens, parse_goal_carry_value,
-    parse_goal_value, parse_monthly_goal_value, parse_primary_command, parse_profile_id,
-    parse_schedule_value, parse_site_edit_value, parse_strict_value, parse_task_goal_value,
-    parse_theme_preset, parse_watch_interval_option, parse_watch_interval_secs,
-    parse_weekly_goal_value, require_nonempty_key_value,
+    finalize_cli_action, invalid_usage, parse_dry_run_option, parse_global_tokens,
+    parse_goal_carry_value, parse_goal_value, parse_monthly_goal_value, parse_primary_command,
+    parse_profile_id, parse_schedule_value, parse_site_edit_value, parse_strict_value,
+    parse_task_goal_value, parse_theme_preset, parse_watch_interval_option,
+    parse_watch_interval_secs, parse_weekly_goal_value, require_nonempty_key_value,
 };
 use status::{
     available_break_template_views, available_theme_preset_views, build_status_output,
@@ -119,6 +120,7 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --status [--watch[=SECONDS]] [--json]
   focustime --backup[=DIR] [--json]
   focustime --restore[=DIR] [--json]
+  focustime --migrate [--dry-run] [--json]
   focustime --export[=DIR] [--json]
 
 Options:
@@ -163,6 +165,8 @@ Options:
   --watch         Stream periodic status updates (status command only; default 1s)
   --backup        Back up config.toml and stats.toml to current directory or DIR
   --restore       Restore config.toml and stats.toml from current directory or DIR
+  --migrate       Run compatibility migration for canonical stats/config persistence
+  --dry-run       Preview migration steps without mutating files (migration only)
   --export        Export stats to current directory or DIR
   --json          Emit machine-readable JSON output
   -h, --help      Show this help"#;
@@ -277,6 +281,9 @@ pub enum CommandKind {
     Restore {
         dir: Option<PathBuf>,
     },
+    Migrate {
+        dry_run: bool,
+    },
     Export {
         dir: Option<PathBuf>,
     },
@@ -335,6 +342,7 @@ enum PrimaryCommand {
     Status,
     Backup(Option<PathBuf>),
     Restore(Option<PathBuf>),
+    Migrate,
     Export(Option<PathBuf>),
     BlocklistProfile(Option<String>),
     BlocklistProfileCreate(String),
@@ -386,6 +394,8 @@ enum ParsedToken {
     BlockingPreview,
     Backup(Option<PathBuf>),
     Restore(Option<PathBuf>),
+    Migrate,
+    DryRun,
     Export(Option<PathBuf>),
     BlocklistProfile(Option<String>),
     BlocklistProfileCreate(String),
@@ -598,6 +608,33 @@ struct RestoreOutput {
     restore_dir: PathBuf,
     config_restored_path: PathBuf,
     stats_restored_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum MigrationStepStatus {
+    Planned,
+    Applied,
+    Skipped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct MigrationStepOutput {
+    operation: &'static str,
+    status: MigrationStepStatus,
+    detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct MigrationCommandOutput {
+    action: &'static str,
+    dry_run: bool,
+    changed: bool,
+    config_path: PathBuf,
+    canonical_stats_path: PathBuf,
+    legacy_stats_path: Option<PathBuf>,
+    steps: Vec<MigrationStepOutput>,
+    warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -837,7 +874,8 @@ where
     let primary = parse_primary_command(&tokens).map_err(|message| usage_error(output, message))?;
     let watch_interval_secs =
         parse_watch_interval_option(&tokens).map_err(|message| usage_error(output, message))?;
-    finalize_cli_action(show_help, output, primary, watch_interval_secs)
+    let dry_run = parse_dry_run_option(&tokens).map_err(|message| usage_error(output, message))?;
+    finalize_cli_action(show_help, output, primary, watch_interval_secs, dry_run)
         .map_err(|message| usage_error(output, message))
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -122,6 +122,8 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "--break-glass-cancel" => Some(ParsedToken::BreakGlassCancel),
         "--diagnostics" => Some(ParsedToken::Diagnostics),
         "--blocking-preview" => Some(ParsedToken::BlockingPreview),
+        "--migrate" => Some(ParsedToken::Migrate),
+        "--dry-run" => Some(ParsedToken::DryRun),
         "--blocklist-profile-delete" => Some(ParsedToken::BlocklistProfileDelete),
         "--blocklist-sites" => Some(ParsedToken::BlocklistSites),
         "--allowlist-sites" => Some(ParsedToken::AllowlistSites),

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1430,123 +1430,16 @@ fn apply_migration_plan(
     plan: &MigrationPlan,
     steps: &mut [MigrationStepOutput],
 ) -> Result<(), String> {
-    let mut config_snapshot = None;
-    let mut canonical_stats_snapshot = None;
-    let mut staged_canonical_stats_path = None;
-    let mut applied_canonical_stats = false;
-
-    if plan.copy_legacy_stats_to_canonical {
-        canonical_stats_snapshot = match snapshot_existing_file(
-            &plan.canonical_stats_path,
-            "snapshot existing canonical stats.toml for migration rollback",
-        ) {
-            Ok(snapshot) => snapshot,
-            Err(error) => {
-                return Err(migration_setup_failure(
-                    format!("could not prepare canonical stats snapshot: {error}"),
-                    config_snapshot.as_deref(),
-                    canonical_stats_snapshot.as_deref(),
-                    staged_canonical_stats_path.as_deref(),
-                ));
-            }
-        };
-        let staged_path = temp_restore_path(&plan.canonical_stats_path, "staged");
-        staged_canonical_stats_path = Some(staged_path.clone());
-        let legacy_stats_path = match plan.legacy_stats_path.as_ref() {
-            Some(path) => path,
-            None => {
-                return Err(migration_setup_failure(
-                    "missing legacy stats path for planned copy step".to_string(),
-                    config_snapshot.as_deref(),
-                    canonical_stats_snapshot.as_deref(),
-                    staged_canonical_stats_path.as_deref(),
-                ));
-            }
-        };
-        if let Err(error) = copy_file_with_context(
-            legacy_stats_path,
-            &staged_path,
-            "stage migration copy of stats.toml",
-        ) {
-            return Err(migration_setup_failure(
-                format!("could not stage canonical stats update: {error}"),
-                config_snapshot.as_deref(),
-                canonical_stats_snapshot.as_deref(),
-                staged_canonical_stats_path.as_deref(),
-            ));
-        }
-    }
-
-    if plan.requires_config_update() {
-        config_snapshot = match snapshot_existing_file(
-            &plan.config_path,
-            "snapshot existing config.toml for migration rollback",
-        ) {
-            Ok(snapshot) => snapshot,
-            Err(error) => {
-                return Err(migration_setup_failure(
-                    format!("could not prepare config snapshot: {error}"),
-                    config_snapshot.as_deref(),
-                    canonical_stats_snapshot.as_deref(),
-                    staged_canonical_stats_path.as_deref(),
-                ));
-            }
-        };
-    }
-
-    if let Some(staged_path) = staged_canonical_stats_path.as_deref() {
-        if let Err(error) = replace_file_atomically(
-            staged_path,
-            &plan.canonical_stats_path,
-            "apply migration copy of stats.toml",
-        ) {
-            return Err(migration_failure_with_rollback(
-                format!("could not update canonical stats.toml: {error}"),
-                rollback_migration_files(
-                    config_snapshot.as_deref(),
-                    &plan.config_path,
-                    false,
-                    canonical_stats_snapshot.as_deref(),
-                    &plan.canonical_stats_path,
-                    true,
-                ),
-            ));
-        }
-        applied_canonical_stats = true;
-    }
-
-    if plan.requires_config_update() {
-        let mut migrated = config.clone();
-        if plan.disable_stats_legacy_path_read_fallback {
-            migrated.feature_flags.stats_legacy_path_read_fallback = false;
-        }
-        if plan.disable_stats_legacy_path_dual_write {
-            migrated.feature_flags.stats_legacy_path_dual_write = false;
-        }
-        if let Err(error) = migrated.save() {
-            return Err(migration_failure_with_rollback(
-                format!("could not save migrated config.toml: {error}"),
-                rollback_migration_files(
-                    config_snapshot.as_deref(),
-                    &plan.config_path,
-                    true,
-                    canonical_stats_snapshot.as_deref(),
-                    &plan.canonical_stats_path,
-                    applied_canonical_stats,
-                ),
-            ));
-        }
-    }
-
-    if let Some(snapshot) = config_snapshot.as_deref() {
-        let _ = remove_file_if_exists(snapshot);
-    }
-    if let Some(snapshot) = canonical_stats_snapshot.as_deref() {
-        let _ = remove_file_if_exists(snapshot);
-    }
-    if let Some(staged_path) = staged_canonical_stats_path.as_deref() {
-        let _ = remove_file_if_exists(staged_path);
-    }
+    let mut state = MigrationExecutionState::default();
+    prepare_migration_staging(plan, &mut state)?;
+    capture_config_snapshot_if_needed(plan, &mut state)?;
+    apply_staged_canonical_stats(plan, &mut state)?;
+    save_migrated_config_if_needed(config, plan, &state)?;
+    let _ = cleanup_migration_temp_files(
+        state.config_snapshot.as_deref(),
+        state.canonical_stats_snapshot.as_deref(),
+        state.staged_canonical_stats_path.as_deref(),
+    );
 
     for step in steps {
         if step.status == MigrationStepStatus::Planned {
@@ -1554,6 +1447,146 @@ fn apply_migration_plan(
         }
     }
     Ok(())
+}
+
+#[derive(Debug, Default)]
+struct MigrationExecutionState {
+    config_snapshot: Option<PathBuf>,
+    canonical_stats_snapshot: Option<PathBuf>,
+    staged_canonical_stats_path: Option<PathBuf>,
+    applied_canonical_stats: bool,
+}
+
+fn prepare_migration_staging(
+    plan: &MigrationPlan,
+    state: &mut MigrationExecutionState,
+) -> Result<(), String> {
+    if !plan.copy_legacy_stats_to_canonical {
+        return Ok(());
+    }
+
+    state.canonical_stats_snapshot = snapshot_existing_file(
+        &plan.canonical_stats_path,
+        "snapshot existing canonical stats.toml for migration rollback",
+    )
+    .map_err(|error| {
+        migration_setup_failure_from_state(
+            format!("could not prepare canonical stats snapshot: {error}"),
+            state,
+        )
+    })?;
+
+    let staged_path = temp_restore_path(&plan.canonical_stats_path, "staged");
+    state.staged_canonical_stats_path = Some(staged_path.clone());
+    let legacy_stats_path = plan.legacy_stats_path.as_ref().ok_or_else(|| {
+        migration_setup_failure_from_state(
+            "missing legacy stats path for planned copy step".to_string(),
+            state,
+        )
+    })?;
+
+    copy_file_with_context(
+        legacy_stats_path,
+        &staged_path,
+        "stage migration copy of stats.toml",
+    )
+    .map_err(|error| {
+        migration_setup_failure_from_state(
+            format!("could not stage canonical stats update: {error}"),
+            state,
+        )
+    })
+}
+
+fn capture_config_snapshot_if_needed(
+    plan: &MigrationPlan,
+    state: &mut MigrationExecutionState,
+) -> Result<(), String> {
+    if !plan.requires_config_update() {
+        return Ok(());
+    }
+
+    state.config_snapshot = snapshot_existing_file(
+        &plan.config_path,
+        "snapshot existing config.toml for migration rollback",
+    )
+    .map_err(|error| {
+        migration_setup_failure_from_state(
+            format!("could not prepare config snapshot: {error}"),
+            state,
+        )
+    })?;
+    Ok(())
+}
+
+fn apply_staged_canonical_stats(
+    plan: &MigrationPlan,
+    state: &mut MigrationExecutionState,
+) -> Result<(), String> {
+    let Some(staged_path) = state.staged_canonical_stats_path.as_deref() else {
+        return Ok(());
+    };
+
+    replace_file_atomically(
+        staged_path,
+        &plan.canonical_stats_path,
+        "apply migration copy of stats.toml",
+    )
+    .map_err(|error| {
+        migration_failure_with_rollback(
+            format!("could not update canonical stats.toml: {error}"),
+            rollback_migration_files(
+                state.config_snapshot.as_deref(),
+                &plan.config_path,
+                false,
+                state.canonical_stats_snapshot.as_deref(),
+                &plan.canonical_stats_path,
+                true,
+            ),
+        )
+    })?;
+    state.applied_canonical_stats = true;
+    Ok(())
+}
+
+fn save_migrated_config_if_needed(
+    config: &AppConfig,
+    plan: &MigrationPlan,
+    state: &MigrationExecutionState,
+) -> Result<(), String> {
+    if !plan.requires_config_update() {
+        return Ok(());
+    }
+
+    let mut migrated = config.clone();
+    if plan.disable_stats_legacy_path_read_fallback {
+        migrated.feature_flags.stats_legacy_path_read_fallback = false;
+    }
+    if plan.disable_stats_legacy_path_dual_write {
+        migrated.feature_flags.stats_legacy_path_dual_write = false;
+    }
+    migrated.save().map_err(|error| {
+        migration_failure_with_rollback(
+            format!("could not save migrated config.toml: {error}"),
+            rollback_migration_files(
+                state.config_snapshot.as_deref(),
+                &plan.config_path,
+                true,
+                state.canonical_stats_snapshot.as_deref(),
+                &plan.canonical_stats_path,
+                state.applied_canonical_stats,
+            ),
+        )
+    })
+}
+
+fn migration_setup_failure_from_state(error: String, state: &MigrationExecutionState) -> String {
+    migration_setup_failure(
+        error,
+        state.config_snapshot.as_deref(),
+        state.canonical_stats_snapshot.as_deref(),
+        state.staged_canonical_stats_path.as_deref(),
+    )
 }
 
 fn rollback_migration_files(

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -7,8 +7,9 @@ use crate::cli::{
     BlocklistProfileConfig, BlocklistProfileSummaryOutput, BlocklistSiteCommandKind,
     BreakGlassCommandOutput, CliCommand, CommandKind, DailyGoalConfig, DailyGoalSnapshot,
     EditSiteResult, ExportOutput, FocusStats, GoalCarryCommandOutput, GoalCommandOutput,
-    InvalidSiteEntryOutput, InvalidSiteInput, MonthlyGoalConfig, OutputMode, PathBuf, ProfileId,
-    ProfileOutput, ProfileView, RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput,
+    InvalidSiteEntryOutput, InvalidSiteInput, MigrationCommandOutput, MigrationStepOutput,
+    MigrationStepStatus, MonthlyGoalConfig, OutputMode, PathBuf, ProfileId, ProfileOutput,
+    ProfileView, RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput,
     ScheduleDelayCommandOutput, SessionMetadataCommandOutput, SiteAddCommandOutput, SiteBlocker,
     SiteDeleteCommandOutput, SiteEditCommandOutput, SiteEditValue, SiteListCommandOutput,
     SiteListTarget, StatusOutput, StrictCommandOutput, TaskCommandOutput, TaskGoalCommandOutput,
@@ -20,13 +21,14 @@ use crate::cli::{
     print_blocking_preview_command_output, print_blocklist_profile_command_output,
     print_break_glass_command_output, print_diagnostics_command_output, print_export_output,
     print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
-    print_profile_output, print_restore_output, print_schedule_command_output,
-    print_schedule_delay_command_output, print_session_metadata_command_output,
-    print_site_add_command_output, print_site_delete_command_output,
-    print_site_edit_command_output, print_site_list_command_output, print_status_output,
-    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
-    print_timer_state_output, profile_id, profile_view, selected_break_template_view,
-    theme_preset_view, timer_phase_id, timer_status_id,
+    print_migration_output, print_profile_output, print_restore_output,
+    print_schedule_command_output, print_schedule_delay_command_output,
+    print_session_metadata_command_output, print_site_add_command_output,
+    print_site_delete_command_output, print_site_edit_command_output,
+    print_site_list_command_output, print_status_output, print_strict_command_output,
+    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
+    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
+    timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
@@ -37,6 +39,34 @@ struct StatsPersistencePaths {
     canonical: PathBuf,
     legacy: Option<PathBuf>,
 }
+
+#[derive(Debug, Clone)]
+struct MigrationPlan {
+    config_path: PathBuf,
+    canonical_stats_path: PathBuf,
+    legacy_stats_path: Option<PathBuf>,
+    copy_legacy_stats_to_canonical: bool,
+    disable_stats_legacy_path_read_fallback: bool,
+    disable_stats_legacy_path_dual_write: bool,
+    stats_copy_skip_reason: String,
+    warnings: Vec<String>,
+}
+
+impl MigrationPlan {
+    fn has_changes(&self) -> bool {
+        self.copy_legacy_stats_to_canonical
+            || self.disable_stats_legacy_path_read_fallback
+            || self.disable_stats_legacy_path_dual_write
+    }
+
+    fn requires_config_update(&self) -> bool {
+        self.disable_stats_legacy_path_read_fallback || self.disable_stats_legacy_path_dual_write
+    }
+}
+
+const MIGRATION_OPERATION_COPY_LEGACY_STATS: &str = "copy_legacy_stats_to_canonical";
+const MIGRATION_OPERATION_DISABLE_READ_FALLBACK: &str = "disable_stats_legacy_path_read_fallback";
+const MIGRATION_OPERATION_DISABLE_DUAL_WRITE: &str = "disable_stats_legacy_path_dual_write";
 
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
     match cli_command.kind {
@@ -81,6 +111,7 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         } => execute_status_command(cli_command.output, watch_interval_secs),
         CommandKind::Backup { dir } => execute_backup_command(dir, cli_command.output),
         CommandKind::Restore { dir } => execute_restore_command(dir, cli_command.output),
+        CommandKind::Migrate { dry_run } => execute_migrate_command(dry_run, cli_command.output),
         CommandKind::Export { dir } => execute_export_command(dir, cli_command.output),
         CommandKind::BlocklistProfile { command } => {
             execute_blocklist_profile_command(command, cli_command.output)
@@ -1233,6 +1264,323 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
     Ok(())
 }
 
+fn execute_migrate_command(dry_run: bool, output: OutputMode) -> Result<(), String> {
+    let config = AppConfig::load().normalized();
+    let plan = build_migration_plan(&config)?;
+    let mut steps = migration_steps_for_plan(&plan);
+    if !dry_run && plan.has_changes() {
+        apply_migration_plan(&config, &plan, &mut steps)?;
+    }
+    let payload = MigrationCommandOutput {
+        action: "migrate",
+        dry_run,
+        changed: plan.has_changes(),
+        config_path: plan.config_path.clone(),
+        canonical_stats_path: plan.canonical_stats_path.clone(),
+        legacy_stats_path: plan.legacy_stats_path.clone(),
+        steps,
+        warnings: plan.warnings.clone(),
+    };
+    match output {
+        OutputMode::Text => print_migration_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn build_migration_plan(config: &AppConfig) -> Result<MigrationPlan, String> {
+    let config_path = config_file_path()?;
+    ensure_regular_file_if_exists(&config_path, "config path")?;
+    let stats_paths = stats_persistence_paths()?;
+    ensure_regular_file_if_exists(&stats_paths.canonical, "canonical stats path")?;
+    if let Some(legacy) = stats_paths.legacy.as_deref() {
+        ensure_regular_file_if_exists(legacy, "legacy stats path")?;
+    }
+
+    let mut copy_legacy_stats_to_canonical = false;
+    let mut stats_copy_skip_reason = "No legacy stats file was found to migrate.".to_string();
+    let mut warnings = Vec::new();
+
+    let canonical_exists = stats_paths.canonical.exists();
+    let legacy_exists = stats_paths
+        .legacy
+        .as_ref()
+        .is_some_and(|path| path.exists());
+    if let Some(legacy) = stats_paths.legacy.as_ref() {
+        if legacy_exists && !canonical_exists {
+            copy_legacy_stats_to_canonical = true;
+            stats_copy_skip_reason.clear();
+        } else if legacy_exists && canonical_exists {
+            let canonical_bytes = fs::read(&stats_paths.canonical).map_err(|error| {
+                format!(
+                    "Migration planning failed: could not read canonical stats file `{}`: {error}",
+                    stats_paths.canonical.display()
+                )
+            })?;
+            let legacy_bytes = fs::read(legacy).map_err(|error| {
+                format!(
+                    "Migration planning failed: could not read legacy stats file `{}`: {error}",
+                    legacy.display()
+                )
+            })?;
+            if canonical_bytes != legacy_bytes {
+                return Err(format!(
+                    "Migration failed: canonical stats `{}` and legacy stats `{}` differ. Run `focustime --backup`, reconcile the two files, and rerun `focustime --migrate`.",
+                    stats_paths.canonical.display(),
+                    legacy.display()
+                ));
+            }
+            stats_copy_skip_reason =
+                "Canonical and legacy stats files already match; copy is not required.".to_string();
+        } else if !legacy_exists && !canonical_exists {
+            stats_copy_skip_reason = format!(
+                "Neither canonical (`{}`) nor legacy (`{}`) stats files exist.",
+                stats_paths.canonical.display(),
+                legacy.display()
+            );
+        } else {
+            stats_copy_skip_reason =
+                "Canonical stats file already exists; legacy copy is not required.".to_string();
+        }
+    } else {
+        stats_copy_skip_reason =
+            "No distinct legacy stats path exists for this environment.".to_string();
+    }
+
+    if !copy_legacy_stats_to_canonical {
+        warnings.push(stats_copy_skip_reason.clone());
+    }
+
+    Ok(MigrationPlan {
+        config_path,
+        canonical_stats_path: stats_paths.canonical,
+        legacy_stats_path: stats_paths.legacy,
+        copy_legacy_stats_to_canonical,
+        disable_stats_legacy_path_read_fallback: config
+            .feature_flags
+            .stats_legacy_path_read_fallback,
+        disable_stats_legacy_path_dual_write: config.feature_flags.stats_legacy_path_dual_write,
+        stats_copy_skip_reason,
+        warnings,
+    })
+}
+
+fn migration_steps_for_plan(plan: &MigrationPlan) -> Vec<MigrationStepOutput> {
+    let mut steps = Vec::new();
+    let status_for_apply = MigrationStepStatus::Planned;
+
+    if plan.copy_legacy_stats_to_canonical {
+        let legacy = plan
+            .legacy_stats_path
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "<unavailable>".to_string());
+        steps.push(MigrationStepOutput {
+            operation: MIGRATION_OPERATION_COPY_LEGACY_STATS,
+            status: status_for_apply,
+            detail: format!(
+                "Copy legacy stats `{legacy}` to canonical path `{}`.",
+                plan.canonical_stats_path.display()
+            ),
+        });
+    } else {
+        steps.push(MigrationStepOutput {
+            operation: MIGRATION_OPERATION_COPY_LEGACY_STATS,
+            status: MigrationStepStatus::Skipped,
+            detail: plan.stats_copy_skip_reason.clone(),
+        });
+    }
+
+    if plan.disable_stats_legacy_path_read_fallback {
+        steps.push(MigrationStepOutput {
+            operation: MIGRATION_OPERATION_DISABLE_READ_FALLBACK,
+            status: status_for_apply,
+            detail: "Set `feature_flags.stats_legacy_path_read_fallback = false` in config.toml."
+                .to_string(),
+        });
+    } else {
+        steps.push(MigrationStepOutput {
+            operation: MIGRATION_OPERATION_DISABLE_READ_FALLBACK,
+            status: MigrationStepStatus::Skipped,
+            detail: "`feature_flags.stats_legacy_path_read_fallback` is already disabled."
+                .to_string(),
+        });
+    }
+
+    if plan.disable_stats_legacy_path_dual_write {
+        steps.push(MigrationStepOutput {
+            operation: MIGRATION_OPERATION_DISABLE_DUAL_WRITE,
+            status: status_for_apply,
+            detail: "Set `feature_flags.stats_legacy_path_dual_write = false` in config.toml."
+                .to_string(),
+        });
+    } else {
+        steps.push(MigrationStepOutput {
+            operation: MIGRATION_OPERATION_DISABLE_DUAL_WRITE,
+            status: MigrationStepStatus::Skipped,
+            detail: "`feature_flags.stats_legacy_path_dual_write` is already disabled.".to_string(),
+        });
+    }
+
+    steps
+}
+
+fn apply_migration_plan(
+    config: &AppConfig,
+    plan: &MigrationPlan,
+    steps: &mut [MigrationStepOutput],
+) -> Result<(), String> {
+    let mut config_snapshot = None;
+    let mut canonical_stats_snapshot = None;
+    let mut staged_canonical_stats_path = None;
+    let mut applied_canonical_stats = false;
+
+    if plan.copy_legacy_stats_to_canonical {
+        canonical_stats_snapshot = snapshot_existing_file(
+            &plan.canonical_stats_path,
+            "snapshot existing canonical stats.toml for migration rollback",
+        )?;
+        let staged_path = temp_restore_path(&plan.canonical_stats_path, "staged");
+        let legacy_stats_path = plan.legacy_stats_path.as_ref().ok_or_else(|| {
+            "Migration failed: missing legacy stats path for planned copy step.".to_string()
+        })?;
+        copy_file_with_context(
+            legacy_stats_path,
+            &staged_path,
+            "stage migration copy of stats.toml",
+        )?;
+        staged_canonical_stats_path = Some(staged_path);
+    }
+
+    if plan.requires_config_update() {
+        config_snapshot = snapshot_existing_file(
+            &plan.config_path,
+            "snapshot existing config.toml for migration rollback",
+        )?;
+    }
+
+    if let Some(staged_path) = staged_canonical_stats_path.as_deref() {
+        if let Err(error) = replace_file_atomically(
+            staged_path,
+            &plan.canonical_stats_path,
+            "apply migration copy of stats.toml",
+        ) {
+            return Err(migration_failure_with_rollback(
+                format!("could not update canonical stats.toml: {error}"),
+                rollback_migration_files(
+                    config_snapshot.as_deref(),
+                    &plan.config_path,
+                    false,
+                    canonical_stats_snapshot.as_deref(),
+                    &plan.canonical_stats_path,
+                    true,
+                ),
+            ));
+        }
+        applied_canonical_stats = true;
+    }
+
+    if plan.requires_config_update() {
+        let mut migrated = config.clone();
+        if plan.disable_stats_legacy_path_read_fallback {
+            migrated.feature_flags.stats_legacy_path_read_fallback = false;
+        }
+        if plan.disable_stats_legacy_path_dual_write {
+            migrated.feature_flags.stats_legacy_path_dual_write = false;
+        }
+        if let Err(error) = migrated.save() {
+            return Err(migration_failure_with_rollback(
+                format!("could not save migrated config.toml: {error}"),
+                rollback_migration_files(
+                    config_snapshot.as_deref(),
+                    &plan.config_path,
+                    true,
+                    canonical_stats_snapshot.as_deref(),
+                    &plan.canonical_stats_path,
+                    applied_canonical_stats,
+                ),
+            ));
+        }
+    }
+
+    if let Some(snapshot) = config_snapshot.as_deref() {
+        let _ = remove_file_if_exists(snapshot);
+    }
+    if let Some(snapshot) = canonical_stats_snapshot.as_deref() {
+        let _ = remove_file_if_exists(snapshot);
+    }
+    if let Some(staged_path) = staged_canonical_stats_path.as_deref() {
+        let _ = remove_file_if_exists(staged_path);
+    }
+
+    for step in steps {
+        if step.status == MigrationStepStatus::Planned {
+            step.status = MigrationStepStatus::Applied;
+        }
+    }
+    Ok(())
+}
+
+fn rollback_migration_files(
+    config_snapshot: Option<&Path>,
+    config_path: &Path,
+    config_was_updated: bool,
+    canonical_stats_snapshot: Option<&Path>,
+    canonical_stats_path: &Path,
+    canonical_stats_was_updated: bool,
+) -> Vec<String> {
+    let mut rollback_errors = Vec::new();
+    if config_was_updated
+        && let Err(error) = rollback_file(
+            config_snapshot,
+            config_path,
+            "roll back migrated config.toml",
+        )
+    {
+        rollback_errors.push(error);
+    }
+    if canonical_stats_was_updated
+        && let Err(error) = rollback_file(
+            canonical_stats_snapshot,
+            canonical_stats_path,
+            "roll back migrated canonical stats.toml",
+        )
+    {
+        rollback_errors.push(error);
+    }
+    rollback_errors
+}
+
+fn rollback_file(snapshot: Option<&Path>, destination: &Path, context: &str) -> Result<(), String> {
+    if let Some(snapshot) = snapshot {
+        replace_file_atomically(snapshot, destination, context)
+    } else {
+        remove_file_if_exists(destination)
+    }
+}
+
+fn migration_failure_with_rollback(error: String, rollback_errors: Vec<String>) -> String {
+    let mut message = format!("Migration failed: {error}");
+    if !rollback_errors.is_empty() {
+        message.push_str("; rollback failed: ");
+        message.push_str(&rollback_errors.join("; "));
+    }
+    message.push_str(
+        ". Next steps: run `focustime --backup`, inspect `config.toml` and `stats.toml`, then retry with `focustime --migrate --dry-run`.",
+    );
+    message
+}
+
+fn ensure_regular_file_if_exists(path: &Path, context: &str) -> Result<(), String> {
+    if path.exists() && !path.is_file() {
+        return Err(format!(
+            "Migration failed: {context} `{}` is not a regular file.",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
 fn ensure_restore_source_file(path: &Path, file_name: &str) -> Result<(), String> {
     if !path.exists() {
         return Err(format!(
@@ -1577,5 +1925,96 @@ fn build_timer_state_output(app: &App) -> TimerStateOutput {
         selected_task_label,
         focus_intention,
         task_note,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn create_temp_dir(test_name: &str) -> PathBuf {
+        let unique = format!(
+            "focustime-{test_name}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("current time should be after unix epoch")
+                .as_nanos()
+        );
+        let path = std::env::temp_dir().join(unique);
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn apply_migration_plan_copies_legacy_stats_to_canonical() {
+        let temp_dir = create_temp_dir("migrate-copy");
+        let config_path = temp_dir.join("config.toml");
+        let legacy_stats_path = temp_dir.join("legacy-stats.toml");
+        let canonical_stats_path = temp_dir.join("state").join("stats.toml");
+        fs::write(&legacy_stats_path, "daily = {}\n")
+            .expect("legacy stats file should be writable");
+
+        let plan = MigrationPlan {
+            config_path,
+            canonical_stats_path: canonical_stats_path.clone(),
+            legacy_stats_path: Some(legacy_stats_path),
+            copy_legacy_stats_to_canonical: true,
+            disable_stats_legacy_path_read_fallback: false,
+            disable_stats_legacy_path_dual_write: false,
+            stats_copy_skip_reason: String::new(),
+            warnings: Vec::new(),
+        };
+        let mut steps = migration_steps_for_plan(&plan);
+        apply_migration_plan(&AppConfig::default(), &plan, &mut steps)
+            .expect("migration copy should succeed");
+
+        let canonical_bytes =
+            fs::read(&canonical_stats_path).expect("canonical stats file should be readable");
+        assert_eq!(canonical_bytes, b"daily = {}\n");
+
+        let copy_step = steps
+            .iter()
+            .find(|step| step.operation == MIGRATION_OPERATION_COPY_LEGACY_STATS)
+            .expect("copy step should exist");
+        assert_eq!(copy_step.status, MigrationStepStatus::Applied);
+
+        fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn rollback_migration_files_restores_snapshots() {
+        let temp_dir = create_temp_dir("migrate-rollback");
+        let config_path = temp_dir.join("config.toml");
+        let config_snapshot = temp_dir.join("config.snapshot.toml");
+        let canonical_stats_path = temp_dir.join("stats.toml");
+        let canonical_snapshot = temp_dir.join("stats.snapshot.toml");
+        fs::write(&config_path, "schema_version = 1\n").expect("config file should be writable");
+        fs::write(&canonical_stats_path, "daily = {}\n")
+            .expect("canonical stats file should be writable");
+        fs::write(&config_snapshot, "schema_version = 0\n")
+            .expect("config snapshot should be writable");
+        fs::write(&canonical_snapshot, "daily = { old = true }\n")
+            .expect("stats snapshot should be writable");
+
+        let rollback_errors = rollback_migration_files(
+            Some(config_snapshot.as_path()),
+            &config_path,
+            true,
+            Some(canonical_snapshot.as_path()),
+            &canonical_stats_path,
+            true,
+        );
+
+        assert!(rollback_errors.is_empty());
+        let restored_config =
+            fs::read_to_string(&config_path).expect("restored config should exist");
+        let restored_stats =
+            fs::read_to_string(&canonical_stats_path).expect("restored stats should exist");
+        assert_eq!(restored_config, "schema_version = 0\n");
+        assert_eq!(restored_stats, "daily = { old = true }\n");
+
+        fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
     }
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1436,27 +1436,62 @@ fn apply_migration_plan(
     let mut applied_canonical_stats = false;
 
     if plan.copy_legacy_stats_to_canonical {
-        canonical_stats_snapshot = snapshot_existing_file(
+        canonical_stats_snapshot = match snapshot_existing_file(
             &plan.canonical_stats_path,
             "snapshot existing canonical stats.toml for migration rollback",
-        )?;
+        ) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                return Err(migration_setup_failure(
+                    format!("could not prepare canonical stats snapshot: {error}"),
+                    config_snapshot.as_deref(),
+                    canonical_stats_snapshot.as_deref(),
+                    staged_canonical_stats_path.as_deref(),
+                ));
+            }
+        };
         let staged_path = temp_restore_path(&plan.canonical_stats_path, "staged");
-        let legacy_stats_path = plan.legacy_stats_path.as_ref().ok_or_else(|| {
-            "Migration failed: missing legacy stats path for planned copy step.".to_string()
-        })?;
-        copy_file_with_context(
+        staged_canonical_stats_path = Some(staged_path.clone());
+        let legacy_stats_path = match plan.legacy_stats_path.as_ref() {
+            Some(path) => path,
+            None => {
+                return Err(migration_setup_failure(
+                    "missing legacy stats path for planned copy step".to_string(),
+                    config_snapshot.as_deref(),
+                    canonical_stats_snapshot.as_deref(),
+                    staged_canonical_stats_path.as_deref(),
+                ));
+            }
+        };
+        if let Err(error) = copy_file_with_context(
             legacy_stats_path,
             &staged_path,
             "stage migration copy of stats.toml",
-        )?;
-        staged_canonical_stats_path = Some(staged_path);
+        ) {
+            return Err(migration_setup_failure(
+                format!("could not stage canonical stats update: {error}"),
+                config_snapshot.as_deref(),
+                canonical_stats_snapshot.as_deref(),
+                staged_canonical_stats_path.as_deref(),
+            ));
+        }
     }
 
     if plan.requires_config_update() {
-        config_snapshot = snapshot_existing_file(
+        config_snapshot = match snapshot_existing_file(
             &plan.config_path,
             "snapshot existing config.toml for migration rollback",
-        )?;
+        ) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                return Err(migration_setup_failure(
+                    format!("could not prepare config snapshot: {error}"),
+                    config_snapshot.as_deref(),
+                    canonical_stats_snapshot.as_deref(),
+                    staged_canonical_stats_path.as_deref(),
+                ));
+            }
+        };
     }
 
     if let Some(staged_path) = staged_canonical_stats_path.as_deref() {
@@ -1569,6 +1604,46 @@ fn migration_failure_with_rollback(error: String, rollback_errors: Vec<String>) 
         ". Next steps: run `focustime --backup`, inspect `config.toml` and `stats.toml`, then retry with `focustime --migrate --dry-run`.",
     );
     message
+}
+
+fn migration_setup_failure(
+    error: String,
+    config_snapshot: Option<&Path>,
+    canonical_stats_snapshot: Option<&Path>,
+    staged_canonical_stats_path: Option<&Path>,
+) -> String {
+    migration_failure_with_rollback(
+        error,
+        cleanup_migration_temp_files(
+            config_snapshot,
+            canonical_stats_snapshot,
+            staged_canonical_stats_path,
+        ),
+    )
+}
+
+fn cleanup_migration_temp_files(
+    config_snapshot: Option<&Path>,
+    canonical_stats_snapshot: Option<&Path>,
+    staged_canonical_stats_path: Option<&Path>,
+) -> Vec<String> {
+    let mut cleanup_errors = Vec::new();
+    let cleanup_targets = [
+        ("config snapshot", config_snapshot),
+        ("canonical stats snapshot", canonical_stats_snapshot),
+        ("staged canonical stats", staged_canonical_stats_path),
+    ];
+    for (label, path) in cleanup_targets {
+        if let Some(path) = path
+            && let Err(error) = remove_file_if_exists(path)
+        {
+            cleanup_errors.push(format!(
+                "cleanup failed for {label} `{}`: {error}",
+                path.display()
+            ));
+        }
+    }
+    cleanup_errors
 }
 
 fn ensure_regular_file_if_exists(path: &Path, context: &str) -> Result<(), String> {
@@ -2014,6 +2089,30 @@ mod tests {
             fs::read_to_string(&canonical_stats_path).expect("restored stats should exist");
         assert_eq!(restored_config, "schema_version = 0\n");
         assert_eq!(restored_stats, "daily = { old = true }\n");
+
+        fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
+    }
+
+    #[test]
+    fn cleanup_migration_temp_files_removes_snapshot_artifacts() {
+        let temp_dir = create_temp_dir("migrate-cleanup");
+        let config_snapshot = temp_dir.join("config.original.tmp");
+        let canonical_snapshot = temp_dir.join("stats.original.tmp");
+        let staged_stats = temp_dir.join("stats.staged.tmp");
+        fs::write(&config_snapshot, "config").expect("config snapshot should be writable");
+        fs::write(&canonical_snapshot, "stats").expect("stats snapshot should be writable");
+        fs::write(&staged_stats, "staged").expect("staged stats should be writable");
+
+        let cleanup_errors = cleanup_migration_temp_files(
+            Some(config_snapshot.as_path()),
+            Some(canonical_snapshot.as_path()),
+            Some(staged_stats.as_path()),
+        );
+
+        assert!(cleanup_errors.is_empty());
+        assert!(!config_snapshot.exists());
+        assert!(!canonical_snapshot.exists());
+        assert!(!staged_stats.exists());
 
         fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
     }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -4,13 +4,14 @@ use crate::cli::{
     BackupOutput, BlockingPreviewAction, BlockingPreviewCommandOutput,
     BlocklistProfileCommandOutput, BlocklistProfileConfig, BreakGlassCommandOutput,
     DiagnosticsCommandOutput, ExportOutput, FeatureFlagsOutput, FocusScoreOutput,
-    GoalCarryCommandOutput, GoalCommandOutput, GoalOutput, ProfileOutput, RecurringScheduleConfig,
-    RestoreOutput, ScheduleCommandOutput, ScheduleDelayCommandOutput, ScheduleInspectionOutput,
-    Serialize, SessionMetadataCommandOutput, SetupCheck, SetupCheckLevel, SetupCheckOutput,
-    SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput,
-    SiteListCommandOutput, StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput,
-    StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
-    TimerStateOutput, Write, format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    GoalCarryCommandOutput, GoalCommandOutput, GoalOutput, MigrationCommandOutput,
+    MigrationStepStatus, ProfileOutput, RecurringScheduleConfig, RestoreOutput,
+    ScheduleCommandOutput, ScheduleDelayCommandOutput, ScheduleInspectionOutput, Serialize,
+    SessionMetadataCommandOutput, SetupCheck, SetupCheckLevel, SetupCheckOutput, SetupDiagnostics,
+    SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput,
+    StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput, StrictCommandOutput,
+    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, TimerStateOutput, Write,
+    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -501,6 +502,49 @@ pub(super) fn print_restore_output(payload: &RestoreOutput) {
     println!("Restored app data from {}", payload.restore_dir.display());
     println!("Config: {}", payload.config_restored_path.display());
     println!("Stats: {}", payload.stats_restored_path.display());
+}
+
+pub(super) fn print_migration_output(payload: &MigrationCommandOutput) {
+    if payload.dry_run {
+        println!("Migration dry-run complete. No files were changed.");
+    } else if payload.changed {
+        println!("Migration completed.");
+    } else {
+        println!("Migration completed. No changes were required.");
+    }
+    println!("Config: {}", payload.config_path.display());
+    println!(
+        "Canonical stats: {}",
+        payload.canonical_stats_path.display()
+    );
+    if let Some(legacy_stats_path) = payload.legacy_stats_path.as_deref() {
+        println!("Legacy stats: {}", legacy_stats_path.display());
+    } else {
+        println!("Legacy stats: n/a");
+    }
+    println!("Steps:");
+    for step in &payload.steps {
+        println!(
+            "  - [{}] {}: {}",
+            migration_step_status_id(step.status),
+            step.operation,
+            step.detail
+        );
+    }
+    if !payload.warnings.is_empty() {
+        println!("Warnings:");
+        for warning in &payload.warnings {
+            println!("  - {warning}");
+        }
+    }
+}
+
+fn migration_step_status_id(status: MigrationStepStatus) -> &'static str {
+    match status {
+        MigrationStepStatus::Planned => "planned",
+        MigrationStepStatus::Applied => "applied",
+        MigrationStepStatus::Skipped => "skipped",
+    }
 }
 
 pub(super) fn print_goal_command_output(label: &str, payload: &GoalCommandOutput) {

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -56,6 +56,8 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::BlockingPreview
             | ParsedToken::Backup(_)
             | ParsedToken::Restore(_)
+            | ParsedToken::Migrate
+            | ParsedToken::DryRun
             | ParsedToken::Export(_)
             | ParsedToken::BlocklistProfile(_)
             | ParsedToken::BlocklistProfileCreate(_)
@@ -155,6 +157,7 @@ pub(super) fn parse_primary_command(
             ParsedToken::Restore(dir) => {
                 set_primary_command(&mut primary, PrimaryCommand::Restore(dir.clone()))?
             }
+            ParsedToken::Migrate => set_primary_command(&mut primary, PrimaryCommand::Migrate)?,
             ParsedToken::Export(dir) => {
                 set_primary_command(&mut primary, PrimaryCommand::Export(dir.clone()))?
             }
@@ -205,6 +208,7 @@ pub(super) fn parse_primary_command(
             )?,
             ParsedToken::Help
             | ParsedToken::Json
+            | ParsedToken::DryRun
             | ParsedToken::UnknownOption(_)
             | ParsedToken::Positional(_) => {}
         }
@@ -217,6 +221,7 @@ pub(super) fn finalize_cli_action(
     output: OutputMode,
     primary: Option<PrimaryCommand>,
     watch_interval_secs: Option<u64>,
+    dry_run: bool,
 ) -> Result<CliAction, String> {
     if show_help {
         return Ok(CliAction::ShowHelp);
@@ -224,6 +229,9 @@ pub(super) fn finalize_cli_action(
 
     if watch_interval_secs.is_some() && !matches!(primary, Some(PrimaryCommand::Status)) {
         return Err(invalid_usage("`--watch` is only valid with `--status`."));
+    }
+    if dry_run && !matches!(primary, Some(PrimaryCommand::Migrate)) {
+        return Err(invalid_usage("`--dry-run` is only valid with `--migrate`."));
     }
 
     match primary {
@@ -349,6 +357,10 @@ pub(super) fn finalize_cli_action(
         })),
         Some(PrimaryCommand::Restore(dir)) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Restore { dir },
+            output,
+        })),
+        Some(PrimaryCommand::Migrate) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Migrate { dry_run },
             output,
         })),
         Some(PrimaryCommand::Export(dir)) => Ok(CliAction::RunCommand(CliCommand {
@@ -750,6 +762,7 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Status => "--status",
         PrimaryCommand::Backup(_) => "--backup",
         PrimaryCommand::Restore(_) => "--restore",
+        PrimaryCommand::Migrate => "--migrate",
         PrimaryCommand::Export(_) => "--export",
         PrimaryCommand::BlocklistProfile(_) => "--blocklist-profile",
         PrimaryCommand::BlocklistProfileCreate(_) => "--blocklist-profile-create",
@@ -781,6 +794,19 @@ pub(super) fn parse_watch_interval_option(tokens: &[ParsedToken]) -> Result<Opti
         }
     }
     Ok(interval)
+}
+
+pub(super) fn parse_dry_run_option(tokens: &[ParsedToken]) -> Result<bool, String> {
+    let mut count = 0u8;
+    for token in tokens {
+        if matches!(token, ParsedToken::DryRun) {
+            count += 1;
+            if count > 1 {
+                return Err(invalid_usage("`--dry-run` can only be specified once."));
+            }
+        }
+    }
+    Ok(count == 1)
 }
 
 pub(super) fn parse_watch_interval_secs(value: &str) -> Result<u64, String> {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -761,6 +761,30 @@ fn parse_restore_with_equals_accepts_directory() {
 }
 
 #[test]
+fn parse_migrate_runs_command() {
+    let parsed = parse(&["--migrate"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Migrate { dry_run: false },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_migrate_supports_dry_run_and_json_mode() {
+    let parsed = parse(&["--migrate", "--dry-run", "--json"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::Migrate { dry_run: true },
+            output: OutputMode::Json
+        })
+    );
+}
+
+#[test]
 fn parse_export_with_equals_accepts_directory() {
     let parsed = parse(&["--export=reports"]).unwrap();
     assert_eq!(
@@ -1274,6 +1298,12 @@ fn parse_rejects_multiple_primary_commands_for_backup_and_restore() {
 }
 
 #[test]
+fn parse_rejects_multiple_primary_commands_for_migrate_and_backup() {
+    let error = parse(&["--migrate", "--backup"]).unwrap_err();
+    assert!(error.contains("Multiple primary commands"));
+}
+
+#[test]
 fn parse_rejects_multiple_primary_commands_for_schedule_delay_and_break_glass() {
     let error = parse(&["--schedule-delay", "--break-glass-trigger"]).unwrap_err();
     assert!(error.contains("Multiple primary commands"));
@@ -1313,6 +1343,18 @@ fn parse_rejects_watch_without_status() {
 fn parse_rejects_watch_with_non_status_command() {
     let error = parse(&["--export", "--watch"]).unwrap_err();
     assert!(error.contains("`--watch` is only valid with `--status`"));
+}
+
+#[test]
+fn parse_rejects_dry_run_without_migrate() {
+    let error = parse(&["--dry-run"]).unwrap_err();
+    assert!(error.contains("`--dry-run` is only valid with `--migrate`"));
+}
+
+#[test]
+fn parse_rejects_duplicate_dry_run_flags() {
+    let error = parse(&["--migrate", "--dry-run", "--dry-run"]).unwrap_err();
+    assert!(error.contains("`--dry-run` can only be specified once"));
 }
 
 #[test]


### PR DESCRIPTION
## What

- Add a dedicated `--migrate` CLI command with explicit `--dry-run` support.
- Implement a migration planner/executor for the stats compatibility path (legacy config-dir stats path to canonical state-dir stats path) using staged writes, snapshots, and rollback on failure.
- Add structured migration output for text and JSON, including step-level status (`planned`, `applied`, `skipped`) and actionable warnings.
- Add parser coverage for migrate/dry-run command contracts and rollback-oriented execution tests.
- Update README usage docs and changelog entries for the new migration flow.

## Why

The project needed explicit migration tooling that can safely finalize compatibility-window behavior without risking data loss. This adds a no-mutation preview mode and a rollback-safe apply path so operators can inspect planned changes first and recover cleanly if any migration step fails.

Closes #263.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--migrate` CLI command with optional `--dry-run` preview to plan/apply stats-path compatibility migrations and emit structured migration results.
  * Migration runs include safe snapshots and rollback behavior plus automatic cleanup and disabling of legacy compatibility flags after success.

* **Documentation**
  * Updated CLI docs with migration workflow examples and explicit behavior for `--migrate` and `--migrate --dry-run`.

* **Tests**
  * Added CLI parsing and migration tests covering dry-run, application, rollback, and error cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/292)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->