### PR TITLE
Deprecation warnings and docs for legacy fields/paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Dual-read/dual-write stats persistence compatibility path (#262):** added canonical data/state stats persistence with legacy-path read fallback and dual-write mirroring controls, including CLI backup/restore and diagnostics visibility updates for migration windows.
 - **Migration tooling with dry-run and rollback safety (#263):** added `--migrate` with explicit `--dry-run` preview mode, structured migration step reporting, and rollback-aware migration execution/diagnostics for stats-path compatibility finalization.
+- **Deprecation warnings and migration docs for legacy fields/paths (#264):** added targeted setup/CLI diagnostics warnings for detected legacy config and stats-path compatibility usage, plus README mapping and planned removal milestones.
 
 ## [0.10.0] - 2026-05-11
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,23 @@ Backup/restore behavior:
 - `--migrate` applies compatibility migration updates for canonical stats persistence and disables migration-window feature flags after success.
 - `--migrate --dry-run` reports planned migration steps without mutating any files.
 
+### Legacy compatibility deprecation milestones
+
+`focustime --diagnostics` and the TUI Setup Diagnostics screen now report targeted
+deprecation warnings when legacy compatibility fields/paths are detected.
+
+| Legacy field/path                                                                                               | Canonical replacement                                                                                         | Removal milestone      |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| Top-level `focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval`                          | `[custom_profile]`                                                                                            | v0.12.0 (planned)      |
+| Top-level `notifications`, `auto_start`, `strict_mode`, `recurring_schedule`                                  | `[profile_automation.<profile>.notifications]`, `[profile_automation.<profile>.auto_start]`, and per-profile `strict_mode` / `recurring_schedule` | v0.12.0 (planned)      |
+| Top-level `blocked_sites` (without canonical profiles)                                                         | `[[blocklist_profiles]]` + `selected_blocklist_profile`                                                      | v0.12.0 (planned)      |
+| Legacy config-dir `stats.toml` path + migration-window flags (`stats_legacy_path_read_fallback`, `stats_legacy_path_dual_write`) | Canonical state/data `stats.toml` path and `focustime --migrate`                                             | v0.12.0 (planned)      |
+
+Milestone policy:
+
+- **v0.11.x:** warning-only window with migration tooling (`--migrate`, `--backup`, `--restore`)
+- **v0.12.0 (planned):** remove legacy field/path compatibility after the warning window
+
 ### CLI JSON/error contract
 
 - `--json` success responses are emitted to `stdout` as JSON and exit with code `0`.

--- a/src/app.rs
+++ b/src/app.rs
@@ -129,6 +129,8 @@ const PROFILE_EDIT_THEME_PRESET_INDEX: usize = 35;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
+#[cfg(not(test))]
+const STATS_FILE_NAME: &str = "stats.toml";
 const UNLINKED_BREAK_TEMPLATE_NAME: &str = "Custom";
 pub(crate) const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
 const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
@@ -433,10 +435,15 @@ pub struct SetupDiagnostics {
     pub hosts_write_capability: SetupCheck,
     pub wakatime_config: SetupCheck,
     pub feature_flags: FeatureFlagsConfig,
+    pub deprecation_warnings: Vec<String>,
 }
 
 impl SetupDiagnostics {
-    fn collect(blocker: &SiteBlocker, feature_flags: FeatureFlagsConfig) -> Self {
+    fn collect(
+        blocker: &SiteBlocker,
+        feature_flags: FeatureFlagsConfig,
+        deprecation_warnings: Vec<String>,
+    ) -> Self {
         let hosts_diagnostics = blocker.hosts_file_diagnostics();
         let blocking_permissions = blocking_permissions_check(&hosts_diagnostics);
         let hosts_write_capability = hosts_write_capability_check(&hosts_diagnostics);
@@ -457,6 +464,7 @@ impl SetupDiagnostics {
             hosts_write_capability,
             wakatime_config,
             feature_flags,
+            deprecation_warnings,
         }
     }
 }
@@ -532,6 +540,7 @@ pub struct App {
     pub selected_profile: ProfileId,
     selected_theme_preset: ThemePreset,
     feature_flags: FeatureFlagsConfig,
+    config_deprecation_warnings: Vec<String>,
     legacy_blocked_sites: Vec<String>,
     profile_automation: ProfileAutomationSettingsConfig,
     pub custom_profile: CustomProfileConfig,
@@ -581,15 +590,26 @@ impl App {
         }
         #[cfg(not(test))]
         {
-            Self::from_config(AppConfig::load())
+            let (config, deprecation_warnings) = AppConfig::load_with_deprecation_warnings();
+            Self::from_config_with_deprecation_warnings(config, deprecation_warnings)
         }
     }
 
+    #[cfg(test)]
     fn from_config(config: AppConfig) -> Self {
+        Self::from_config_with_deprecation_warnings(config, Vec::new())
+    }
+
+    fn from_config_with_deprecation_warnings(
+        config: AppConfig,
+        config_deprecation_warnings: Vec<String>,
+    ) -> Self {
         let config = config.normalized();
         let selected_profile = config.selected_profile;
         let selected_theme_preset = config.selected_theme_preset;
         let feature_flags = config.feature_flags;
+        let setup_deprecation_warnings =
+            setup_deprecation_warnings(&config_deprecation_warnings, feature_flags);
         let legacy_blocked_sites = config.blocked_sites.clone();
         let custom_profile = config.effective_custom_profile();
         let profile_automation = config.profile_automation.clone().unwrap_or_default();
@@ -654,7 +674,8 @@ impl App {
             profile_spec.long_break_interval,
         );
         let blocker = SiteBlocker::new();
-        let setup_diagnostics = SetupDiagnostics::collect(&blocker, feature_flags);
+        let setup_diagnostics =
+            SetupDiagnostics::collect(&blocker, feature_flags, setup_deprecation_warnings.clone());
         let mut app = Self {
             timer,
             should_quit: false,
@@ -709,6 +730,7 @@ impl App {
             selected_profile,
             selected_theme_preset,
             feature_flags,
+            config_deprecation_warnings,
             legacy_blocked_sites,
             profile_automation,
             custom_profile,
@@ -1562,6 +1584,64 @@ fn permission_remediation_guidance() -> &'static str {
     } else {
         "Run focustime with elevated privileges (e.g. sudo), verify hosts-file permissions, then press [r] Refresh."
     }
+}
+
+pub(super) fn setup_deprecation_warnings(
+    config_deprecation_warnings: &[String],
+    feature_flags: FeatureFlagsConfig,
+) -> Vec<String> {
+    let mut warnings = config_deprecation_warnings.to_vec();
+    if let Some(stats_warning) = legacy_stats_path_deprecation_warning(feature_flags) {
+        warnings.push(stats_warning);
+    }
+    warnings
+}
+
+pub(super) fn format_legacy_stats_path_deprecation_warning(
+    canonical_path: &std::path::Path,
+    legacy_path: &std::path::Path,
+    canonical_exists: bool,
+    feature_flags: FeatureFlagsConfig,
+) -> String {
+    let mut warning = format!(
+        "Deprecated legacy stats path detected at `{}`.",
+        legacy_path.display()
+    );
+    if !canonical_exists && feature_flags.stats_legacy_path_read_fallback {
+        warning
+            .push_str(" Canonical stats are missing, so reads may still fall back to this path.");
+    }
+    if feature_flags.stats_legacy_path_dual_write {
+        warning.push_str(" Legacy stats mirror writes are still enabled.");
+    }
+    warning.push_str(&format!(
+        " Move stats to `{}` and run `focustime --migrate`.",
+        canonical_path.display()
+    ));
+    warning
+}
+
+#[cfg(not(test))]
+fn legacy_stats_path_deprecation_warning(feature_flags: FeatureFlagsConfig) -> Option<String> {
+    let canonical_path = crate::config::stats_data_path(STATS_FILE_NAME)?;
+    let legacy_path =
+        crate::config::app_data_path(STATS_FILE_NAME).filter(|path| path != &canonical_path)?;
+    if !legacy_path.exists() {
+        return None;
+    }
+
+    let canonical_exists = canonical_path.exists();
+    Some(format_legacy_stats_path_deprecation_warning(
+        &canonical_path,
+        &legacy_path,
+        canonical_exists,
+        feature_flags,
+    ))
+}
+
+#[cfg(test)]
+fn legacy_stats_path_deprecation_warning(_feature_flags: FeatureFlagsConfig) -> Option<String> {
+    None
 }
 
 impl Drop for App {

--- a/src/app/feedback_diagnostics.rs
+++ b/src/app/feedback_diagnostics.rs
@@ -105,7 +105,12 @@ impl App {
     }
 
     pub(super) fn refresh_setup_diagnostics(&mut self) {
-        self.setup_diagnostics = SetupDiagnostics::collect(&self.blocker, self.feature_flags);
+        let deprecation_warnings = crate::app::setup_deprecation_warnings(
+            &self.config_deprecation_warnings,
+            self.feature_flags,
+        );
+        self.setup_diagnostics =
+            SetupDiagnostics::collect(&self.blocker, self.feature_flags, deprecation_warnings);
         self.refresh_blocking_preview();
     }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7,6 +7,7 @@ use crate::session_recovery::{
 use chrono::{Datelike, Duration as ChronoDuration, Local, LocalResult, TimeZone, Weekday};
 use std::{
     fs,
+    path::Path,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -78,6 +79,42 @@ fn app_default_uses_canonical_config_in_tests() {
     assert_eq!(app.daily_goal, DailyGoalConfig::default());
     assert_eq!(app.weekly_goal, WeeklyGoalConfig::default());
     assert_eq!(app.monthly_goal, MonthlyGoalConfig::default());
+}
+
+#[test]
+fn legacy_stats_path_warning_mentions_read_fallback_when_canonical_is_missing() {
+    let warning = format_legacy_stats_path_deprecation_warning(
+        Path::new("state/stats.toml"),
+        Path::new("config/stats.toml"),
+        false,
+        FeatureFlagsConfig {
+            stats_legacy_path_read_fallback: true,
+            stats_legacy_path_dual_write: false,
+            ..FeatureFlagsConfig::default()
+        },
+    );
+
+    assert!(warning.contains("Deprecated legacy stats path detected"));
+    assert!(warning.contains("reads may still fall back"));
+    assert!(!warning.contains("Legacy stats mirror writes are still enabled"));
+    assert!(warning.contains("run `focustime --migrate`"));
+}
+
+#[test]
+fn legacy_stats_path_warning_mentions_dual_write_when_enabled() {
+    let warning = format_legacy_stats_path_deprecation_warning(
+        Path::new("state/stats.toml"),
+        Path::new("config/stats.toml"),
+        true,
+        FeatureFlagsConfig {
+            stats_legacy_path_read_fallback: true,
+            stats_legacy_path_dual_write: true,
+            ..FeatureFlagsConfig::default()
+        },
+    );
+
+    assert!(!warning.contains("reads may still fall back"));
+    assert!(warning.contains("Legacy stats mirror writes are still enabled"));
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -762,6 +762,7 @@ struct DiagnosticsCommandOutput {
     hosts_write_capability: SetupCheckOutput,
     wakatime_config: SetupCheckOutput,
     feature_flags: FeatureFlagsOutput,
+    deprecation_warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -674,6 +674,14 @@ pub(super) fn print_diagnostics_command_output(payload: &DiagnosticsCommandOutpu
         bool_label(payload.feature_flags.stats_legacy_path_read_fallback),
         bool_label(payload.feature_flags.stats_legacy_path_dual_write),
     );
+    if payload.deprecation_warnings.is_empty() {
+        println!("Deprecation warnings: none");
+    } else {
+        println!("Deprecation warnings:");
+        for warning in &payload.deprecation_warnings {
+            println!("  - {warning}");
+        }
+    }
 }
 
 fn print_diagnostics_check(label: &str, check: &SetupCheckOutput) {
@@ -697,6 +705,7 @@ pub(super) fn build_diagnostics_command_output(
                 .stats_legacy_path_read_fallback,
             stats_legacy_path_dual_write: diagnostics.feature_flags.stats_legacy_path_dual_write,
         },
+        deprecation_warnings: diagnostics.deprecation_warnings.clone(),
     }
 }
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -652,6 +652,26 @@ fn diagnostics_output_includes_effective_feature_flags() {
     assert!(payload.feature_flags.metadata_task_label_fallback);
     assert!(payload.feature_flags.stats_legacy_path_read_fallback);
     assert!(payload.feature_flags.stats_legacy_path_dual_write);
+    assert!(payload.deprecation_warnings.is_empty());
+}
+
+#[test]
+fn diagnostics_output_includes_deprecation_warnings() {
+    let mut app = App::default();
+    app.setup_diagnostics.deprecation_warnings = vec![
+        "Deprecated top-level timer fields are in use.".to_string(),
+        "Deprecated legacy stats path detected.".to_string(),
+    ];
+
+    let payload = build_diagnostics_command_output(&app.setup_diagnostics);
+
+    assert_eq!(
+        payload.deprecation_warnings,
+        vec![
+            "Deprecated top-level timer fields are in use.".to_string(),
+            "Deprecated legacy stats path detected.".to_string()
+        ]
+    );
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1528,11 +1528,15 @@ impl AppConfig {
         self.normalize()
     }
 
+    pub(crate) fn load_with_deprecation_warnings() -> (Self, Vec<String>) {
+        Self::try_load_with_deprecation_warnings().unwrap_or_else(|| (Self::default(), Vec::new()))
+    }
+
     /// Load the config from disk, falling back to [`AppConfig::default`] on any
     /// error (missing file, parse error, corrupt data, etc.).
     #[cfg_attr(test, allow(dead_code))]
     pub fn load() -> Self {
-        Self::try_load().unwrap_or_default()
+        Self::load_with_deprecation_warnings().0
     }
 
     /// Returns the effective custom profile configuration.
@@ -1597,23 +1601,33 @@ impl AppConfig {
         self.recurring_schedule = selected.recurring_schedule;
     }
 
-    #[cfg_attr(test, allow(dead_code))]
-    fn try_load() -> Option<Self> {
-        Self::try_load_with_env(|key| std::env::var_os(key))
+    fn try_load_with_deprecation_warnings() -> Option<(Self, Vec<String>)> {
+        Self::try_load_with_env_and_deprecation_warnings(|key| std::env::var_os(key))
     }
 
     #[cfg(test)]
     fn load_with_env(get_var: impl FnMut(&str) -> Option<OsString>) -> Self {
-        Self::try_load_with_env(get_var).unwrap_or_default()
+        Self::load_with_env_and_deprecation_warnings(get_var).0
     }
 
-    fn try_load_with_env(get_var: impl FnMut(&str) -> Option<OsString>) -> Option<Self> {
+    #[cfg(test)]
+    fn load_with_env_and_deprecation_warnings(
+        get_var: impl FnMut(&str) -> Option<OsString>,
+    ) -> (Self, Vec<String>) {
+        Self::try_load_with_env_and_deprecation_warnings(get_var)
+            .unwrap_or_else(|| (Self::default(), Vec::new()))
+    }
+
+    fn try_load_with_env_and_deprecation_warnings(
+        get_var: impl FnMut(&str) -> Option<OsString>,
+    ) -> Option<(Self, Vec<String>)> {
         let path = Self::config_path_with_env(get_var)?;
         let content = fs::read_to_string(path).ok()?;
         let config_toml: toml::Value = toml::from_str(&content).ok()?;
         let migrated_toml = migrate_config_toml_to_current(config_toml)?;
         let disk: AppConfigDisk = migrated_toml.try_into().ok()?;
-        Some(disk.config.normalize())
+        let deprecation_warnings = detect_legacy_config_deprecation_warnings(&disk.config);
+        Some((disk.config.normalize(), deprecation_warnings))
     }
 
     /// Persist the current config to disk.
@@ -1742,6 +1756,39 @@ fn migrate_config_toml_to_current(mut config_toml: toml::Value) -> Option<toml::
         from_schema_version += 1;
     }
     Some(config_toml)
+}
+
+fn detect_legacy_config_deprecation_warnings(config: &AppConfig) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let duration_override_without_custom_profile = config.custom_profile.is_none()
+        && (config.focus_secs != default_focus_secs()
+            || config.short_break_secs != default_short_break_secs()
+            || config.long_break_secs != default_long_break_secs()
+            || config.long_break_interval != default_long_break_interval());
+    if duration_override_without_custom_profile {
+        warnings.push(
+            "Deprecated top-level timer fields (`focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval`) are in use. Move these values into `[custom_profile]`.".to_string(),
+        );
+    }
+
+    let legacy_automation_in_use = config.profile_automation.is_none()
+        && (config.notifications != NotificationConfig::default()
+            || config.auto_start != AutoStartConfig::default()
+            || config.strict_mode
+            || config.recurring_schedule != RecurringScheduleConfig::default());
+    if legacy_automation_in_use {
+        warnings.push(
+            "Deprecated top-level automation fields (`notifications`, `auto_start`, `strict_mode`, `recurring_schedule`) are in use. Move them under `[profile_automation.<profile>]`.".to_string(),
+        );
+    }
+
+    if config.blocklist_profiles.is_empty() && !config.blocked_sites.is_empty() {
+        warnings.push(
+            "Deprecated `blocked_sites` is in use without `[[blocklist_profiles]]`. Move entries into a blocklist profile (for example `Default`).".to_string(),
+        );
+    }
+
+    warnings
 }
 
 fn detect_config_schema_version(config_toml: &toml::Value) -> Option<u32> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1771,11 +1771,19 @@ fn detect_legacy_config_deprecation_warnings(config: &AppConfig) -> Vec<String> 
         );
     }
 
-    let legacy_automation_in_use = config.profile_automation.is_none()
-        && (config.notifications != NotificationConfig::default()
-            || config.auto_start != AutoStartConfig::default()
-            || config.strict_mode
-            || config.recurring_schedule != RecurringScheduleConfig::default());
+    let legacy_automation_values_configured = config.notifications != NotificationConfig::default()
+        || config.auto_start != AutoStartConfig::default()
+        || config.strict_mode
+        || config.recurring_schedule != RecurringScheduleConfig::default();
+    let profile_automation_incomplete = config
+        .profile_automation
+        .as_ref()
+        .map(|settings| {
+            settings.classic.is_none() || settings.deep_work.is_none() || settings.custom.is_none()
+        })
+        .unwrap_or(true);
+    let legacy_automation_in_use =
+        legacy_automation_values_configured && profile_automation_incomplete;
     if legacy_automation_in_use {
         warnings.push(
             "Deprecated top-level automation fields (`notifications`, `auto_start`, `strict_mode`, `recurring_schedule`) are in use. Move them under `[profile_automation.<profile>]`.".to_string(),

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -896,6 +896,107 @@ fn load_with_env_migrates_legacy_config_without_schema_version() {
 }
 
 #[test]
+fn load_with_env_reports_deprecation_warnings_for_legacy_fields() {
+    let temp_base = unique_temp_base("legacy-deprecation-warnings");
+    let app_dir = temp_base.join("focustime");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("config.toml"),
+        r#"
+focus_secs = 1800
+short_break_secs = 360
+long_break_secs = 900
+long_break_interval = 3
+strict_mode = true
+blocked_sites = ["youtube.com", "reddit.com"]
+"#,
+    )
+    .unwrap();
+
+    let (_, warnings) = AppConfig::load_with_env_and_deprecation_warnings(|key| {
+        if key == CONFIG_DIR_ENV {
+            Some(temp_base.clone().into_os_string())
+        } else {
+            None
+        }
+    });
+    let _ = fs::remove_dir_all(&temp_base);
+
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("Deprecated top-level timer fields"))
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("Deprecated top-level automation fields"))
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("Deprecated `blocked_sites` is in use"))
+    );
+}
+
+#[test]
+fn load_with_env_avoids_duration_deprecation_warning_when_custom_profile_exists() {
+    let temp_base = unique_temp_base("custom-profile-no-duration-warning");
+    let app_dir = temp_base.join("focustime");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("config.toml"),
+        r#"
+focus_secs = 1800
+short_break_secs = 360
+long_break_secs = 900
+long_break_interval = 3
+
+[custom_profile]
+focus_secs = 1800
+short_break_secs = 360
+long_break_secs = 900
+long_break_interval = 3
+"#,
+    )
+    .unwrap();
+
+    let (_, warnings) = AppConfig::load_with_env_and_deprecation_warnings(|key| {
+        if key == CONFIG_DIR_ENV {
+            Some(temp_base.clone().into_os_string())
+        } else {
+            None
+        }
+    });
+    let _ = fs::remove_dir_all(&temp_base);
+
+    assert!(
+        !warnings
+            .iter()
+            .any(|warning| warning.contains("Deprecated top-level timer fields"))
+    );
+}
+
+#[test]
+fn load_with_env_defaults_do_not_emit_deprecation_warnings() {
+    let temp_base = unique_temp_base("default-no-deprecation-warning");
+    let app_dir = temp_base.join("focustime");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(app_dir.join("config.toml"), "").unwrap();
+
+    let (_, warnings) = AppConfig::load_with_env_and_deprecation_warnings(|key| {
+        if key == CONFIG_DIR_ENV {
+            Some(temp_base.clone().into_os_string())
+        } else {
+            None
+        }
+    });
+    let _ = fs::remove_dir_all(&temp_base);
+
+    assert!(warnings.is_empty());
+}
+
+#[test]
 fn load_with_env_migrates_explicit_legacy_schema_version() {
     let temp_base = unique_temp_base("legacy-version-zero");
     let app_dir = temp_base.join("focustime");

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -997,6 +997,80 @@ fn load_with_env_defaults_do_not_emit_deprecation_warnings() {
 }
 
 #[test]
+fn load_with_env_reports_automation_deprecation_when_profile_automation_is_partial() {
+    let temp_base = unique_temp_base("legacy-automation-partial-profile");
+    let app_dir = temp_base.join("focustime");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("config.toml"),
+        r#"
+[notifications]
+enabled = true
+sound = true
+
+[profile_automation.deep_work]
+strict_mode = true
+"#,
+    )
+    .unwrap();
+
+    let (_, warnings) = AppConfig::load_with_env_and_deprecation_warnings(|key| {
+        if key == CONFIG_DIR_ENV {
+            Some(temp_base.clone().into_os_string())
+        } else {
+            None
+        }
+    });
+    let _ = fs::remove_dir_all(&temp_base);
+
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("Deprecated top-level automation fields"))
+    );
+}
+
+#[test]
+fn load_with_env_skips_automation_deprecation_when_all_profiles_are_configured() {
+    let temp_base = unique_temp_base("legacy-automation-all-profiles");
+    let app_dir = temp_base.join("focustime");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("config.toml"),
+        r#"
+[notifications]
+enabled = true
+sound = true
+
+[profile_automation.classic]
+strict_mode = false
+
+[profile_automation.deep_work]
+strict_mode = true
+
+[profile_automation.custom]
+strict_mode = false
+"#,
+    )
+    .unwrap();
+
+    let (_, warnings) = AppConfig::load_with_env_and_deprecation_warnings(|key| {
+        if key == CONFIG_DIR_ENV {
+            Some(temp_base.clone().into_os_string())
+        } else {
+            None
+        }
+    });
+    let _ = fs::remove_dir_all(&temp_base);
+
+    assert!(
+        !warnings
+            .iter()
+            .any(|warning| warning.contains("Deprecated top-level automation fields"))
+    );
+}
+
+#[test]
 fn load_with_env_migrates_explicit_legacy_schema_version() {
     let temp_base = unique_temp_base("legacy-version-zero");
     let app_dir = temp_base.join("focustime");

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -4,6 +4,9 @@ use crate::ui::{
     ShortcutAction, Span, Style, Wrap, app_color, centered_rect, render_hint_lines,
 };
 
+const DEPRECATION_WARNING_PANEL_LINES: usize = 4;
+const MAX_VISIBLE_DEPRECATION_WARNINGS: usize = DEPRECATION_WARNING_PANEL_LINES - 2;
+
 pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
     let area = frame.area();
     let outer = centered_rect(72, 68, area);
@@ -19,16 +22,16 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(1), // hosts path
-            Constraint::Length(1), // spacer
-            Constraint::Length(2), // blocking permissions
-            Constraint::Length(2), // hosts write capability
-            Constraint::Length(2), // wakatime config status
-            Constraint::Length(3), // feature flags
-            Constraint::Length(4), // deprecation warnings
-            Constraint::Length(1), // preview summary
-            Constraint::Min(0),    // preview section
-            Constraint::Length(2), // key hints
+            Constraint::Length(1),                                      // hosts path
+            Constraint::Length(1),                                      // spacer
+            Constraint::Length(2),                                      // blocking permissions
+            Constraint::Length(2),                                      // hosts write capability
+            Constraint::Length(2),                                      // wakatime config status
+            Constraint::Length(3),                                      // feature flags
+            Constraint::Length(DEPRECATION_WARNING_PANEL_LINES as u16), // deprecation warnings
+            Constraint::Length(1),                                      // preview summary
+            Constraint::Min(0),                                         // preview section
+            Constraint::Length(2),                                      // key hints
         ])
         .split(outer);
 
@@ -100,12 +103,21 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         vec![Line::from("Deprecation warnings: none")]
     } else {
         let mut lines = vec![Line::from("Deprecation warnings:")];
+        let warnings = &app.setup_diagnostics.deprecation_warnings;
+        let hidden = warnings
+            .len()
+            .saturating_sub(MAX_VISIBLE_DEPRECATION_WARNINGS);
         lines.extend(
-            app.setup_diagnostics
-                .deprecation_warnings
+            warnings
                 .iter()
+                .take(MAX_VISIBLE_DEPRECATION_WARNINGS)
                 .map(|warning| Line::from(format!("- {warning}"))),
         );
+        if hidden > 0 {
+            lines.push(Line::from(format!(
+                "- +{hidden} more (run --diagnostics for full list)"
+            )));
+        }
         lines
     };
     frame.render_widget(

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -25,6 +25,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             Constraint::Length(2), // hosts write capability
             Constraint::Length(2), // wakatime config status
             Constraint::Length(3), // feature flags
+            Constraint::Length(4), // deprecation warnings
             Constraint::Length(1), // preview summary
             Constraint::Min(0),    // preview section
             Constraint::Length(2), // key hints
@@ -95,6 +96,25 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         inner[5],
     );
 
+    let deprecation_lines = if app.setup_diagnostics.deprecation_warnings.is_empty() {
+        vec![Line::from("Deprecation warnings: none")]
+    } else {
+        let mut lines = vec![Line::from("Deprecation warnings:")];
+        lines.extend(
+            app.setup_diagnostics
+                .deprecation_warnings
+                .iter()
+                .map(|warning| Line::from(format!("- {warning}"))),
+        );
+        lines
+    };
+    frame.render_widget(
+        Paragraph::new(deprecation_lines)
+            .style(Style::default().fg(app_color(app, Color::Yellow)))
+            .wrap(Wrap { trim: true }),
+        inner[6],
+    );
+
     let (preview_summary, preview_style) = if let Some(error) = app.blocking_preview.error.as_ref()
     {
         (
@@ -124,7 +144,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         Paragraph::new(preview_summary)
             .alignment(Alignment::Left)
             .style(preview_style),
-        inner[6],
+        inner[7],
     );
 
     let preview_section_text = if app.blocking_preview.error.is_some() {
@@ -143,13 +163,13 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             )
             .style(Style::default().fg(app_color(app, Color::Gray)))
             .wrap(Wrap { trim: false }),
-        inner[7],
+        inner[8],
     );
 
     render_hint_lines(
         frame,
         app,
-        inner[8],
+        inner[9],
         vec![
             Line::from(format!(
                 "Diagnostics: {} Refresh checks + preview",

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -452,6 +452,30 @@ fn setup_diagnostics_view_renders_deprecation_warnings() {
 }
 
 #[test]
+fn setup_diagnostics_view_shows_truncation_indicator_for_many_warnings() {
+    let width = 120;
+    let height = 50;
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    let mut app = App::default();
+    app.mode = AppMode::SetupDiagnostics;
+    app.setup_diagnostics.deprecation_warnings = vec![
+        "warning one".to_string(),
+        "warning two".to_string(),
+        "warning three".to_string(),
+        "warning four".to_string(),
+    ];
+
+    terminal
+        .draw(|frame| render(frame, &app))
+        .expect("render should succeed");
+
+    let text = terminal_text(&terminal, width, height);
+    assert!(text.contains("warning one"));
+    assert!(text.contains("+2 more"));
+}
+
+#[test]
 fn setup_diagnostics_view_renders_blocking_preview_section() {
     let width = 100;
     let height = 40;

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -430,6 +430,28 @@ fn setup_diagnostics_view_wraps_long_status_messages() {
 }
 
 #[test]
+fn setup_diagnostics_view_renders_deprecation_warnings() {
+    let width = 100;
+    let height = 30;
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    let mut app = App::default();
+    app.mode = AppMode::SetupDiagnostics;
+    app.setup_diagnostics.deprecation_warnings = vec![
+        "Deprecated top-level timer fields are in use.".to_string(),
+        "Deprecated legacy stats path detected.".to_string(),
+    ];
+
+    terminal
+        .draw(|frame| render(frame, &app))
+        .expect("render should succeed");
+
+    let text = terminal_text(&terminal, width, height);
+    assert!(text.contains("Deprecation warnings:"));
+    assert!(text.contains("Deprecated top-level timer fields"));
+}
+
+#[test]
 fn setup_diagnostics_view_renders_blocking_preview_section() {
     let width = 100;
     let height = 40;


### PR DESCRIPTION
## What

- Detect deprecated legacy config usage at load time for top-level timer fields, legacy automation fields, and `blocked_sites`-only setups.
- Detect legacy stats-path compatibility usage and generate migration-focused warnings.
- Surface deprecation warnings in both diagnostics surfaces:
  - CLI `--diagnostics` output and JSON payload
  - TUI Setup Diagnostics view
- Add focused regression tests for detection and diagnostics rendering/output.
- Update docs with a legacy-to-canonical mapping table and planned deprecation/removal milestones.

## Why

Users still running legacy fields and paths did not receive clear, actionable guidance before planned compatibility removal. This adds precise warnings only when deprecated usage is detected, and points users to canonical fields/paths and migration flow.

Closes #264.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Deprecation warnings for legacy config fields/paths shown in CLI diagnostics and the TUI Setup Diagnostics screen (with truncation/summary when many).

* **Documentation**
  - Added migration guidance mapping deprecated fields to canonical replacements and a deprecation timeline (warning window in v0.11.x; planned removal in v0.12.0).

* **Tests**
  - Added tests validating diagnostics output and UI rendering of deprecation warnings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/293)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->