### PR TITLE
Recovery scope expansion for broader runtime continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Expanded runtime recovery scope and startup reconciliation notices (#272):** recovery now includes schedule arming continuity and strict-reset pending confirmation alongside existing timer/schedule-delay/break-glass artifacts, with deterministic partial-recovery startup notices when saved runtime fragments are dropped.
 - **Dual-read/dual-write stats persistence compatibility path (#262):** added canonical data/state stats persistence with legacy-path read fallback and dual-write mirroring controls, including CLI backup/restore and diagnostics visibility updates for migration windows.
 - **Migration tooling with dry-run and rollback safety (#263):** added `--migrate` with explicit `--dry-run` preview mode, structured migration step reporting, and rollback-aware migration execution/diagnostics for stats-path compatibility finalization.
 - **Deprecation warnings and migration docs for legacy fields/paths (#264):** added targeted setup/CLI diagnostics warnings for detected legacy config and stats-path compatibility usage, plus README mapping and planned removal milestones.

--- a/README.md
+++ b/README.md
@@ -637,10 +637,11 @@ You can configure notification and auto-start settings directly from the TUI:
 `focustime` persists in-progress timer sessions so restart/crash recovery can resume where you left off.
 
 - while a focus/break phase is running or paused, the app saves phase, remaining time, task metadata (`task_label`, `focus_intention`, `task_note`), and active profile
+- startup recovery also reconciles transient workflow runtime artifacts when still valid (schedule delay + arming continuity, break-glass state, and strict-reset confirmation state)
 - while editing with `m`, pressing `Enter` replaces the in-progress session `task_note` and immediately syncs recovery metadata; if the draft is blank or only whitespace, the note is not saved and the task label is used instead
 - on startup, valid in-progress state is restored and shown in the timer notice line
 - on startup, blocking is reconciled with recovered timer state: recovered active focus re-applies blocking, while non-recovered startup attempts to remove stale crash-era block entries
-- stale or invalid saved recovery state is ignored safely with a warning notice
+- stale or invalid saved recovery/runtime artifacts are ignored safely with a startup warning notice
 - recovery state is cleared when an in-progress phase ends naturally or when you reset/skip out of the active session
 
 ## Strict focus mode

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -1,7 +1,7 @@
 use crate::app::{
     App, AppConfig, BlocklistProfileConfig, DEFAULT_BLOCKLIST_PROFILE_NAME, Local,
     PendingTimerAction, TimerPhase, TimerState, effective_blocked_sites_for_profile,
-    format_duration_label, profile_index, profile_spec_for, task_label_index,
+    format_duration_label, occurrence_key, profile_index, profile_spec_for, task_label_index,
 };
 use crate::session_recovery::{self, InProgressSessionSnapshot, WorkflowStateSnapshot};
 use chrono::{LocalResult, TimeZone};
@@ -61,25 +61,64 @@ impl App {
         let Some(snapshot) = loaded_snapshot else {
             return;
         };
+        let WorkflowStateSnapshot {
+            schedule_delayed_occurrence_key,
+            schedule_delay_until_epoch_secs,
+            schedule_armed_occurrence_key,
+            last_schedule_occurrence_key,
+            break_glass_expires_at_epoch_secs,
+            break_glass_confirmation_pending,
+            strict_reset_confirmation_pending,
+        } = snapshot;
 
         self.current_frame_now = Local::now();
         self.schedule_delayed_occurrence_key = None;
         self.schedule_delay_until = None;
+        self.schedule_armed_occurrence_key = None;
+        self.last_schedule_occurrence_key = None;
+        let mut ignored_runtime_artifacts: Vec<&'static str> = Vec::new();
+        let has_saved_schedule_delay_state =
+            schedule_delayed_occurrence_key.is_some() || schedule_delay_until_epoch_secs.is_some();
 
         if let (Some(delayed_key), Some(delay_until_epoch_secs)) = (
-            snapshot.schedule_delayed_occurrence_key,
-            snapshot.schedule_delay_until_epoch_secs,
+            schedule_delayed_occurrence_key,
+            schedule_delay_until_epoch_secs,
         ) && let Some(delay_until) = local_datetime_from_epoch_secs(delay_until_epoch_secs)
             && delay_until > self.current_frame_now
         {
             self.schedule_delayed_occurrence_key = Some(delayed_key);
             self.schedule_delay_until = Some(delay_until);
+        } else if has_saved_schedule_delay_state {
+            push_ignored_artifact(&mut ignored_runtime_artifacts, "schedule delay state");
+        }
+
+        let active_occurrence_key = self
+            .active_schedule_occurrence_at(self.current_frame_now)
+            .map(|occurrence| occurrence_key(&occurrence));
+        if let Some(armed_key) = schedule_armed_occurrence_key {
+            if !self.focus_session_active_for_current_state()
+                && active_occurrence_key.as_deref() == Some(armed_key.as_str())
+            {
+                self.schedule_armed_occurrence_key = Some(armed_key);
+            } else {
+                push_ignored_artifact(&mut ignored_runtime_artifacts, "schedule arm state");
+            }
+        }
+        if let Some(last_key) = last_schedule_occurrence_key {
+            if active_occurrence_key.as_deref() == Some(last_key.as_str()) {
+                self.last_schedule_occurrence_key = Some(last_key);
+            } else {
+                push_ignored_artifact(
+                    &mut ignored_runtime_artifacts,
+                    "schedule trigger continuity",
+                );
+            }
         }
 
         self.pending_timer_action = None;
         self.break_glass_expires_at = None;
         if self.focus_session_active_for_current_state() {
-            if let Some(expires_at_epoch_secs) = snapshot.break_glass_expires_at_epoch_secs
+            if let Some(expires_at_epoch_secs) = break_glass_expires_at_epoch_secs
                 && let Some(expires_at) = local_datetime_from_epoch_secs(expires_at_epoch_secs)
                 && expires_at > self.current_frame_now
             {
@@ -88,14 +127,44 @@ impl App {
                     .to_std()
                     .ok();
                 self.break_glass_expires_at = remaining.map(|remaining| Instant::now() + remaining);
+            } else if break_glass_expires_at_epoch_secs.is_some() {
+                push_ignored_artifact(&mut ignored_runtime_artifacts, "break-glass override timer");
             }
-            if snapshot.break_glass_confirmation_pending && self.break_glass_expires_at.is_none() {
+            if break_glass_confirmation_pending && self.break_glass_expires_at.is_none() {
                 self.pending_timer_action = Some(PendingTimerAction::BreakGlassOverride);
+            } else if break_glass_confirmation_pending {
+                push_ignored_artifact(&mut ignored_runtime_artifacts, "break-glass confirmation");
+            }
+        } else {
+            if break_glass_expires_at_epoch_secs.is_some() {
+                push_ignored_artifact(&mut ignored_runtime_artifacts, "break-glass override timer");
+            }
+            if break_glass_confirmation_pending {
+                push_ignored_artifact(&mut ignored_runtime_artifacts, "break-glass confirmation");
+            }
+        }
+        if strict_reset_confirmation_pending {
+            if self.strict_mode_enforced_for_focus() && self.pending_timer_action.is_none() {
+                self.pending_timer_action = Some(PendingTimerAction::Reset);
+            } else {
+                push_ignored_artifact(&mut ignored_runtime_artifacts, "strict reset confirmation");
             }
         }
 
         if let Err(error) = self.sync_cli_workflow_state() {
             self.config_error = Some(error);
+        }
+        if !ignored_runtime_artifacts.is_empty() {
+            let notice = format!(
+                "Ignored saved runtime artifacts: {}.",
+                ignored_runtime_artifacts.join(", ")
+            );
+            if let Some(existing_notice) = self.phase_notification.as_mut() {
+                existing_notice.push(' ');
+                existing_notice.push_str(&notice);
+            } else {
+                self.phase_notification = Some(notice);
+            }
         }
     }
 
@@ -240,6 +309,10 @@ impl App {
 
     pub(super) fn sync_cli_workflow_state(&mut self) -> Result<(), String> {
         let now = Local::now();
+        let focus_active = self.focus_session_active_for_current_state();
+        let active_occurrence_key = self
+            .active_schedule_occurrence_at(now)
+            .map(|occurrence| occurrence_key(&occurrence));
         let schedule_state = match (
             self.schedule_delayed_occurrence_key.clone(),
             self.schedule_delay_until,
@@ -256,8 +329,21 @@ impl App {
             .and_then(|remaining| chrono::Duration::from_std(remaining).ok())
             .map(|remaining| (now + remaining).timestamp());
 
-        let break_glass_confirmation_pending = self.break_glass_confirmation_pending()
-            && self.focus_session_active_for_current_state();
+        let break_glass_confirmation_pending =
+            self.break_glass_confirmation_pending() && focus_active;
+        let strict_reset_confirmation_pending =
+            self.strict_reset_confirmation_pending() && self.strict_mode_enforced_for_focus();
+        let schedule_armed_occurrence_key = if !focus_active {
+            self.schedule_armed_occurrence_key
+                .clone()
+                .filter(|armed_key| active_occurrence_key.as_deref() == Some(armed_key.as_str()))
+        } else {
+            None
+        };
+        let last_schedule_occurrence_key = self
+            .last_schedule_occurrence_key
+            .clone()
+            .filter(|last_key| active_occurrence_key.as_deref() == Some(last_key.as_str()));
         let snapshot = WorkflowStateSnapshot {
             schedule_delayed_occurrence_key: schedule_state
                 .as_ref()
@@ -265,13 +351,19 @@ impl App {
             schedule_delay_until_epoch_secs: schedule_state
                 .as_ref()
                 .and_then(|(_, delayed_until)| *delayed_until),
+            schedule_armed_occurrence_key,
+            last_schedule_occurrence_key,
             break_glass_expires_at_epoch_secs,
             break_glass_confirmation_pending,
+            strict_reset_confirmation_pending,
         };
 
         let should_persist = snapshot.schedule_delayed_occurrence_key.is_some()
+            || snapshot.schedule_armed_occurrence_key.is_some()
+            || snapshot.last_schedule_occurrence_key.is_some()
             || snapshot.break_glass_expires_at_epoch_secs.is_some()
-            || snapshot.break_glass_confirmation_pending;
+            || snapshot.break_glass_confirmation_pending
+            || snapshot.strict_reset_confirmation_pending;
         if should_persist {
             session_recovery::save_workflow_state(&snapshot)
                 .map_err(|error| format!("workflow state save failed: {error}"))
@@ -412,5 +504,11 @@ fn local_datetime_from_epoch_secs(epoch_secs: i64) -> Option<chrono::DateTime<Lo
         LocalResult::Single(value) => Some(value),
         LocalResult::Ambiguous(earliest, _) => Some(earliest),
         LocalResult::None => None,
+    }
+}
+
+fn push_ignored_artifact(ignored_artifacts: &mut Vec<&'static str>, artifact: &'static str) {
+    if !ignored_artifacts.contains(&artifact) {
+        ignored_artifacts.push(artifact);
     }
 }

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -45,20 +45,7 @@ impl App {
     }
 
     pub(super) fn restore_cli_workflow_state(&mut self) {
-        let loaded_snapshot = match session_recovery::load_workflow_state() {
-            Ok(snapshot) => snapshot,
-            Err(error) => {
-                self.config_error = Some(format!("workflow state load failed: {error}"));
-                if let Err(clear_error) = session_recovery::clear_workflow_state() {
-                    self.config_error = Some(format!(
-                        "workflow state cleanup failed after load error: {clear_error}"
-                    ));
-                }
-                return;
-            }
-        };
-
-        let Some(snapshot) = loaded_snapshot else {
+        let Some(snapshot) = self.load_cli_workflow_snapshot_for_restore() else {
             return;
         };
         let WorkflowStateSnapshot {
@@ -71,15 +58,69 @@ impl App {
             strict_reset_confirmation_pending,
         } = snapshot;
 
+        self.reset_cli_workflow_runtime_state_for_restore();
+        let mut ignored_runtime_artifacts: Vec<&'static str> = Vec::new();
+        self.restore_schedule_delay_runtime_state(
+            schedule_delayed_occurrence_key,
+            schedule_delay_until_epoch_secs,
+            &mut ignored_runtime_artifacts,
+        );
+
+        let active_occurrence_key = self
+            .active_schedule_occurrence_at(self.current_frame_now)
+            .map(|occurrence| occurrence_key(&occurrence));
+        self.restore_schedule_continuity_runtime_state(
+            schedule_armed_occurrence_key,
+            last_schedule_occurrence_key,
+            active_occurrence_key.as_deref(),
+            &mut ignored_runtime_artifacts,
+        );
+        self.restore_break_glass_runtime_state(
+            break_glass_expires_at_epoch_secs,
+            break_glass_confirmation_pending,
+            &mut ignored_runtime_artifacts,
+        );
+        self.restore_strict_reset_runtime_state(
+            strict_reset_confirmation_pending,
+            &mut ignored_runtime_artifacts,
+        );
+        self.sync_restored_cli_workflow_state();
+        self.append_ignored_runtime_artifact_notice(&ignored_runtime_artifacts);
+    }
+
+    fn load_cli_workflow_snapshot_for_restore(&mut self) -> Option<WorkflowStateSnapshot> {
+        match session_recovery::load_workflow_state() {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                self.config_error = Some(format!("workflow state load failed: {error}"));
+                if let Err(clear_error) = session_recovery::clear_workflow_state() {
+                    self.config_error = Some(format!(
+                        "workflow state cleanup failed after load error: {clear_error}"
+                    ));
+                }
+                None
+            }
+        }
+    }
+
+    fn reset_cli_workflow_runtime_state_for_restore(&mut self) {
         self.current_frame_now = Local::now();
         self.schedule_delayed_occurrence_key = None;
         self.schedule_delay_until = None;
         self.schedule_armed_occurrence_key = None;
         self.last_schedule_occurrence_key = None;
-        let mut ignored_runtime_artifacts: Vec<&'static str> = Vec::new();
+        self.pending_timer_action = None;
+        self.break_glass_expires_at = None;
+    }
+
+    fn restore_schedule_delay_runtime_state(
+        &mut self,
+        schedule_delayed_occurrence_key: Option<String>,
+        schedule_delay_until_epoch_secs: Option<i64>,
+        ignored_runtime_artifacts: &mut Vec<&'static str>,
+    ) {
         let has_saved_schedule_delay_state =
             schedule_delayed_occurrence_key.is_some() || schedule_delay_until_epoch_secs.is_some();
-
         if let (Some(delayed_key), Some(delay_until_epoch_secs)) = (
             schedule_delayed_occurrence_key,
             schedule_delay_until_epoch_secs,
@@ -89,82 +130,107 @@ impl App {
             self.schedule_delayed_occurrence_key = Some(delayed_key);
             self.schedule_delay_until = Some(delay_until);
         } else if has_saved_schedule_delay_state {
-            push_ignored_artifact(&mut ignored_runtime_artifacts, "schedule delay state");
+            push_ignored_artifact(ignored_runtime_artifacts, "schedule delay state");
         }
+    }
 
-        let active_occurrence_key = self
-            .active_schedule_occurrence_at(self.current_frame_now)
-            .map(|occurrence| occurrence_key(&occurrence));
+    fn restore_schedule_continuity_runtime_state(
+        &mut self,
+        schedule_armed_occurrence_key: Option<String>,
+        last_schedule_occurrence_key: Option<String>,
+        active_occurrence_key: Option<&str>,
+        ignored_runtime_artifacts: &mut Vec<&'static str>,
+    ) {
         if let Some(armed_key) = schedule_armed_occurrence_key {
             if !self.focus_session_active_for_current_state()
-                && active_occurrence_key.as_deref() == Some(armed_key.as_str())
+                && active_occurrence_key == Some(armed_key.as_str())
             {
                 self.schedule_armed_occurrence_key = Some(armed_key);
             } else {
-                push_ignored_artifact(&mut ignored_runtime_artifacts, "schedule arm state");
+                push_ignored_artifact(ignored_runtime_artifacts, "schedule arm state");
             }
         }
         if let Some(last_key) = last_schedule_occurrence_key {
-            if active_occurrence_key.as_deref() == Some(last_key.as_str()) {
+            if active_occurrence_key == Some(last_key.as_str()) {
                 self.last_schedule_occurrence_key = Some(last_key);
             } else {
-                push_ignored_artifact(
-                    &mut ignored_runtime_artifacts,
-                    "schedule trigger continuity",
-                );
+                push_ignored_artifact(ignored_runtime_artifacts, "schedule trigger continuity");
             }
         }
+    }
 
-        self.pending_timer_action = None;
-        self.break_glass_expires_at = None;
-        if self.focus_session_active_for_current_state() {
-            if let Some(expires_at_epoch_secs) = break_glass_expires_at_epoch_secs
-                && let Some(expires_at) = local_datetime_from_epoch_secs(expires_at_epoch_secs)
-                && expires_at > self.current_frame_now
-            {
-                let remaining = expires_at
-                    .signed_duration_since(self.current_frame_now)
-                    .to_std()
-                    .ok();
-                self.break_glass_expires_at = remaining.map(|remaining| Instant::now() + remaining);
-            } else if break_glass_expires_at_epoch_secs.is_some() {
-                push_ignored_artifact(&mut ignored_runtime_artifacts, "break-glass override timer");
-            }
-            if break_glass_confirmation_pending && self.break_glass_expires_at.is_none() {
-                self.pending_timer_action = Some(PendingTimerAction::BreakGlassOverride);
-            } else if break_glass_confirmation_pending {
-                push_ignored_artifact(&mut ignored_runtime_artifacts, "break-glass confirmation");
-            }
-        } else {
+    fn restore_break_glass_runtime_state(
+        &mut self,
+        break_glass_expires_at_epoch_secs: Option<i64>,
+        break_glass_confirmation_pending: bool,
+        ignored_runtime_artifacts: &mut Vec<&'static str>,
+    ) {
+        if !self.focus_session_active_for_current_state() {
             if break_glass_expires_at_epoch_secs.is_some() {
-                push_ignored_artifact(&mut ignored_runtime_artifacts, "break-glass override timer");
+                push_ignored_artifact(ignored_runtime_artifacts, "break-glass override timer");
             }
             if break_glass_confirmation_pending {
-                push_ignored_artifact(&mut ignored_runtime_artifacts, "break-glass confirmation");
+                push_ignored_artifact(ignored_runtime_artifacts, "break-glass confirmation");
             }
-        }
-        if strict_reset_confirmation_pending {
-            if self.strict_mode_enforced_for_focus() && self.pending_timer_action.is_none() {
-                self.pending_timer_action = Some(PendingTimerAction::Reset);
-            } else {
-                push_ignored_artifact(&mut ignored_runtime_artifacts, "strict reset confirmation");
-            }
+            return;
         }
 
+        if let Some(expires_at_epoch_secs) = break_glass_expires_at_epoch_secs
+            && let Some(expires_at) = local_datetime_from_epoch_secs(expires_at_epoch_secs)
+            && expires_at > self.current_frame_now
+        {
+            let remaining = expires_at
+                .signed_duration_since(self.current_frame_now)
+                .to_std()
+                .ok();
+            self.break_glass_expires_at = remaining.map(|remaining| Instant::now() + remaining);
+        } else if break_glass_expires_at_epoch_secs.is_some() {
+            push_ignored_artifact(ignored_runtime_artifacts, "break-glass override timer");
+        }
+
+        if break_glass_confirmation_pending && self.break_glass_expires_at.is_none() {
+            self.pending_timer_action = Some(PendingTimerAction::BreakGlassOverride);
+        } else if break_glass_confirmation_pending {
+            push_ignored_artifact(ignored_runtime_artifacts, "break-glass confirmation");
+        }
+    }
+
+    fn restore_strict_reset_runtime_state(
+        &mut self,
+        strict_reset_confirmation_pending: bool,
+        ignored_runtime_artifacts: &mut Vec<&'static str>,
+    ) {
+        if !strict_reset_confirmation_pending {
+            return;
+        }
+
+        if self.strict_mode_enforced_for_focus() && self.pending_timer_action.is_none() {
+            self.pending_timer_action = Some(PendingTimerAction::Reset);
+        } else {
+            push_ignored_artifact(ignored_runtime_artifacts, "strict reset confirmation");
+        }
+    }
+
+    fn sync_restored_cli_workflow_state(&mut self) {
         if let Err(error) = self.sync_cli_workflow_state() {
             self.config_error = Some(error);
         }
-        if !ignored_runtime_artifacts.is_empty() {
-            let notice = format!(
-                "Ignored saved runtime artifacts: {}.",
-                ignored_runtime_artifacts.join(", ")
-            );
-            if let Some(existing_notice) = self.phase_notification.as_mut() {
-                existing_notice.push(' ');
-                existing_notice.push_str(&notice);
-            } else {
-                self.phase_notification = Some(notice);
-            }
+    }
+
+    fn append_ignored_runtime_artifact_notice(&mut self, ignored_runtime_artifacts: &[&str]) {
+        if ignored_runtime_artifacts.is_empty() {
+            return;
+        }
+
+        let notice = format!(
+            "Ignored saved runtime artifacts: {}.",
+            ignored_runtime_artifacts.join(", ")
+        );
+        if let Some(existing_notice) = self.phase_notification.as_mut() {
+            existing_notice.push(' ');
+            existing_notice.push_str(&notice);
+        } else {
+            self.phase_notification = Some(notice);
         }
     }
 
@@ -343,13 +409,13 @@ impl App {
         let delayed_occurrence_key = schedule_state
             .as_ref()
             .and_then(|(delayed_key, _)| delayed_key.as_deref());
-        let last_schedule_occurrence_key = self
-            .last_schedule_occurrence_key
-            .clone()
-            .filter(|last_key| {
-                active_occurrence_key.as_deref() == Some(last_key.as_str())
-                    && delayed_occurrence_key != Some(last_key.as_str())
-            });
+        let last_schedule_occurrence_key =
+            self.last_schedule_occurrence_key
+                .clone()
+                .filter(|last_key| {
+                    active_occurrence_key.as_deref() == Some(last_key.as_str())
+                        && delayed_occurrence_key != Some(last_key.as_str())
+                });
         let snapshot = WorkflowStateSnapshot {
             schedule_delayed_occurrence_key: schedule_state
                 .as_ref()

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -340,10 +340,16 @@ impl App {
         } else {
             None
         };
+        let delayed_occurrence_key = schedule_state
+            .as_ref()
+            .and_then(|(delayed_key, _)| delayed_key.as_deref());
         let last_schedule_occurrence_key = self
             .last_schedule_occurrence_key
             .clone()
-            .filter(|last_key| active_occurrence_key.as_deref() == Some(last_key.as_str()));
+            .filter(|last_key| {
+                active_occurrence_key.as_deref() == Some(last_key.as_str())
+                    && delayed_occurrence_key != Some(last_key.as_str())
+            });
         let snapshot = WorkflowStateSnapshot {
             schedule_delayed_occurrence_key: schedule_state
                 .as_ref()

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4486,7 +4486,7 @@ fn cli_schedule_delay_sets_delay_for_active_window() {
 
 #[test]
 fn cli_schedule_delay_persists_workflow_state() {
-    let now = Local::now();
+    let now = local_datetime_today(0, 0);
     let config = AppConfig {
         recurring_schedule: RecurringScheduleConfig {
             windows: vec![crate::config::RecurringFocusWindowConfig {
@@ -4662,7 +4662,7 @@ fn app_restores_cli_workflow_state_from_snapshot() {
 
 #[test]
 fn app_restores_schedule_arming_continuity_from_workflow_snapshot() {
-    let now = Local::now();
+    let now = local_datetime_today(10, 15);
     let config = AppConfig {
         recurring_schedule: RecurringScheduleConfig {
             windows: vec![RecurringFocusWindowConfig {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4609,8 +4609,11 @@ fn app_restores_cli_workflow_state_from_snapshot() {
     session_recovery::set_test_load_workflow_state(Some(session_recovery::WorkflowStateSnapshot {
         schedule_delayed_occurrence_key: Some("recurring:0:2026-05-10".to_string()),
         schedule_delay_until_epoch_secs: Some((now + ChronoDuration::minutes(5)).timestamp()),
+        schedule_armed_occurrence_key: None,
+        last_schedule_occurrence_key: None,
         break_glass_expires_at_epoch_secs: None,
         break_glass_confirmation_pending: true,
+        strict_reset_confirmation_pending: false,
     }));
 
     let app = App::default();
@@ -4624,6 +4627,103 @@ fn app_restores_cli_workflow_state_from_snapshot() {
             .is_some_and(|delay_until| delay_until > now)
     );
     assert!(app.break_glass_confirmation_pending());
+}
+
+#[test]
+fn app_restores_schedule_arming_continuity_from_workflow_snapshot() {
+    let now = Local::now();
+    let config = AppConfig {
+        recurring_schedule: RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec![weekday_token(now.weekday()).to_string()],
+                start: "00:00".to_string(),
+                end: "23:59".to_string(),
+            }],
+            ..RecurringScheduleConfig::default()
+        },
+        ..AppConfig::default()
+    };
+    let probe_app = App::from_config(config.clone());
+    let active_occurrence = probe_app
+        .active_schedule_occurrence_at(now)
+        .expect("schedule window should be active");
+    let active_occurrence_key = occurrence_key(&active_occurrence);
+
+    session_recovery::set_test_load_workflow_state(Some(session_recovery::WorkflowStateSnapshot {
+        schedule_delayed_occurrence_key: None,
+        schedule_delay_until_epoch_secs: None,
+        schedule_armed_occurrence_key: Some(active_occurrence_key.clone()),
+        last_schedule_occurrence_key: Some(active_occurrence_key.clone()),
+        break_glass_expires_at_epoch_secs: None,
+        break_glass_confirmation_pending: false,
+        strict_reset_confirmation_pending: false,
+    }));
+
+    let app = App::from_config(config);
+
+    assert_eq!(
+        app.schedule_armed_occurrence_key.as_deref(),
+        Some(active_occurrence_key.as_str())
+    );
+    assert_eq!(
+        app.last_schedule_occurrence_key.as_deref(),
+        Some(active_occurrence_key.as_str())
+    );
+}
+
+#[test]
+fn app_restores_strict_reset_confirmation_from_workflow_snapshot() {
+    session_recovery::set_test_load_snapshot(Some(snapshot_for_tests(
+        TimerPhase::Focus,
+        TimerStatus::Running,
+        300,
+        Some("Docs"),
+        ProfileId::Classic,
+    )));
+    session_recovery::set_test_load_workflow_state(Some(session_recovery::WorkflowStateSnapshot {
+        schedule_delayed_occurrence_key: None,
+        schedule_delay_until_epoch_secs: None,
+        schedule_armed_occurrence_key: None,
+        last_schedule_occurrence_key: None,
+        break_glass_expires_at_epoch_secs: None,
+        break_glass_confirmation_pending: false,
+        strict_reset_confirmation_pending: true,
+    }));
+
+    let app = App::from_config(AppConfig {
+        strict_mode: true,
+        ..AppConfig::default()
+    });
+
+    assert!(app.strict_reset_confirmation_pending());
+}
+
+#[test]
+fn app_reports_partial_runtime_recovery_notice_for_ignored_workflow_artifacts() {
+    session_recovery::set_test_load_workflow_state(Some(session_recovery::WorkflowStateSnapshot {
+        schedule_delayed_occurrence_key: Some("recurring:stale".to_string()),
+        schedule_delay_until_epoch_secs: Some(
+            (Local::now() - ChronoDuration::minutes(5)).timestamp(),
+        ),
+        schedule_armed_occurrence_key: Some("recurring:stale".to_string()),
+        last_schedule_occurrence_key: Some("recurring:stale".to_string()),
+        break_glass_expires_at_epoch_secs: None,
+        break_glass_confirmation_pending: true,
+        strict_reset_confirmation_pending: true,
+    }));
+
+    let app = App::default();
+
+    let notice = app
+        .phase_notification
+        .as_deref()
+        .expect("partial recovery should emit a startup notice");
+    assert!(notice.contains("Ignored saved runtime artifacts"));
+    assert!(notice.contains("schedule delay state"));
+    assert!(notice.contains("schedule arm state"));
+    assert!(notice.contains("schedule trigger continuity"));
+    assert!(notice.contains("break-glass confirmation"));
+    assert!(notice.contains("strict reset confirmation"));
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4514,6 +4514,37 @@ fn cli_schedule_delay_persists_workflow_state() {
 }
 
 #[test]
+fn cli_workflow_snapshot_skips_last_occurrence_for_active_delayed_window() {
+    let now = Local::now();
+    let config = AppConfig {
+        recurring_schedule: RecurringScheduleConfig {
+            windows: vec![crate::config::RecurringFocusWindowConfig {
+                days: vec![weekday_token(now.weekday()).to_string()],
+                start: "00:00".to_string(),
+                end: "23:59".to_string(),
+            }],
+            ..RecurringScheduleConfig::default()
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+    let active_occurrence = app
+        .active_schedule_occurrence_at(now)
+        .expect("schedule window should be active");
+    let active_occurrence_key = occurrence_key(&active_occurrence);
+    app.schedule_delayed_occurrence_key = Some(active_occurrence_key.clone());
+    app.schedule_delay_until = Some(now + ChronoDuration::minutes(5));
+    app.last_schedule_occurrence_key = Some(active_occurrence_key);
+
+    app.sync_cli_workflow_state().unwrap();
+
+    let snapshot = session_recovery::test_saved_workflow_snapshot()
+        .expect("workflow snapshot should be saved");
+    assert!(snapshot.schedule_delayed_occurrence_key.is_some());
+    assert!(snapshot.last_schedule_occurrence_key.is_none());
+}
+
+#[test]
 fn cli_break_glass_trigger_requires_active_focus() {
     let config = AppConfig {
         blocked_sites: vec!["example.com".to_string()],

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -96,9 +96,15 @@ pub struct WorkflowStateSnapshot {
     #[serde(default)]
     pub schedule_delay_until_epoch_secs: Option<i64>,
     #[serde(default)]
+    pub schedule_armed_occurrence_key: Option<String>,
+    #[serde(default)]
+    pub last_schedule_occurrence_key: Option<String>,
+    #[serde(default)]
     pub break_glass_expires_at_epoch_secs: Option<i64>,
     #[serde(default)]
     pub break_glass_confirmation_pending: bool,
+    #[serde(default)]
+    pub strict_reset_confirmation_pending: bool,
 }
 
 impl InProgressSessionSnapshot {
@@ -624,13 +630,46 @@ mod tests {
         save_workflow_state(&WorkflowStateSnapshot {
             schedule_delayed_occurrence_key: Some("recurring:0:2026-05-10".to_string()),
             schedule_delay_until_epoch_secs: Some(1_700_000_000),
+            schedule_armed_occurrence_key: None,
+            last_schedule_occurrence_key: None,
             break_glass_expires_at_epoch_secs: None,
             break_glass_confirmation_pending: true,
+            strict_reset_confirmation_pending: false,
         })
         .expect("save should succeed");
 
         let loaded = load_workflow_state().expect("load should succeed");
         assert!(loaded.is_none());
         assert!(test_saved_workflow_snapshot().is_none());
+    }
+
+    #[test]
+    fn workflow_state_snapshot_deserializes_legacy_payload_without_new_fields() {
+        let snapshot: WorkflowStateSnapshot = toml::from_str(
+            r#"
+schedule_delayed_occurrence_key = "recurring:0:2026-05-10"
+schedule_delay_until_epoch_secs = 1700000000
+break_glass_expires_at_epoch_secs = 1700000100
+break_glass_confirmation_pending = true
+"#,
+        )
+        .expect("legacy payload should deserialize");
+
+        assert_eq!(
+            snapshot.schedule_delayed_occurrence_key.as_deref(),
+            Some("recurring:0:2026-05-10")
+        );
+        assert_eq!(
+            snapshot.schedule_delay_until_epoch_secs,
+            Some(1_700_000_000)
+        );
+        assert!(snapshot.schedule_armed_occurrence_key.is_none());
+        assert!(snapshot.last_schedule_occurrence_key.is_none());
+        assert_eq!(
+            snapshot.break_glass_expires_at_epoch_secs,
+            Some(1_700_000_100)
+        );
+        assert!(snapshot.break_glass_confirmation_pending);
+        assert!(!snapshot.strict_reset_confirmation_pending);
     }
 }


### PR DESCRIPTION
## What

- Expands workflow runtime recovery to persist and restore schedule arming continuity and strict-reset pending confirmation state.
- Reconciles restored runtime artifacts deterministically at startup and appends a user-visible notice when stale or invalid runtime fragments are ignored.
- Adds regression coverage for restored schedule arming/strict-reset paths and partial-recovery notice behavior.
- Updates README and changelog notes for the broader runtime recovery scope.

## Why

Recovery previously covered in-progress timer state plus a narrow workflow snapshot. This improves post-crash/restart continuity for transient runtime state while keeping startup reconciliation deterministic and clearly observable when recovery is partial.

Closes #272.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded runtime recovery to include schedule arming/delay continuity, break‑glass state, and strict‑reset confirmation
  * Emits deterministic partial‑recovery startup notices when saved runtime fragments are ignored or dropped
  * More explicit handling and tracking of stale/invalid recovery artifacts with startup warnings

* **Documentation**
  * Updated session recovery docs with detailed startup‑recovery reconciliation

* **Chores**
  * Updated changelog

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/294)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->