### PR TITLE
Remove legacy config mirror fields and compatibility sync logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Removed legacy config mirror writes and compatibility-sync paths (#265):** canonical config/profile/blocklist and canonical stats persistence are now the only runtime/write paths, while legacy top-level config fields remain load-time compatibility input for migrated user configs.
+
 ## [0.10.1] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ deprecation warnings when legacy compatibility fields/paths are detected.
 | Top-level `focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval`                          | `[custom_profile]`                                                                                            | v0.12.0 (planned)      |
 | Top-level `notifications`, `auto_start`, `strict_mode`, `recurring_schedule`                                  | `[profile_automation.<profile>.notifications]`, `[profile_automation.<profile>.auto_start]`, and per-profile `strict_mode` / `recurring_schedule` | v0.12.0 (planned)      |
 | Top-level `blocked_sites` (without canonical profiles)                                                         | `[[blocklist_profiles]]` + `selected_blocklist_profile`                                                      | v0.12.0 (planned)      |
-| Legacy config-dir `stats.toml` path + migration-window flags (`stats_legacy_path_read_fallback`, `stats_legacy_path_dual_write`) | Canonical state/data `stats.toml` path and `focustime --migrate`                                             | v0.12.0 (planned)      |
+| Legacy config-dir `stats.toml` path                                                                          | Canonical state/data `stats.toml` path and `focustime --migrate`                                             | v0.12.0 (planned)      |
 
 Milestone policy:
 
@@ -400,16 +400,8 @@ strict_mode = false
 break_glass_duration_secs = 300
 
 [feature_flags]
-# Preserve per-profile automation values in legacy top-level fields.
-legacy_automation_mirror = true
-# Preserve active blocklist profile values in legacy blocked_sites.
-legacy_blocked_sites_mirror = true
 # Backfill legacy metadata from task_label when missing.
 metadata_task_label_fallback = true
-# Read stats from legacy config-dir path when canonical stats path is missing.
-stats_legacy_path_read_fallback = true
-# Mirror stats writes to legacy config-dir path during migration window.
-stats_legacy_path_dual_write = true
 
 [shortcuts]
 timer_toggle_pause = "space"

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ deprecation warnings when legacy compatibility fields/paths are detected.
 | Top-level `focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval`                          | `[custom_profile]`                                                                                            | v0.12.0 (planned)      |
 | Top-level `notifications`, `auto_start`, `strict_mode`, `recurring_schedule`                                  | `[profile_automation.<profile>.notifications]`, `[profile_automation.<profile>.auto_start]`, and per-profile `strict_mode` / `recurring_schedule` | v0.12.0 (planned)      |
 | Top-level `blocked_sites` (without canonical profiles)                                                         | `[[blocklist_profiles]]` + `selected_blocklist_profile`                                                      | v0.12.0 (planned)      |
-| Legacy config-dir `stats.toml` path                                                                          | Canonical state/data `stats.toml` path and `focustime --migrate`                                             | v0.12.0 (planned)      |
+| Legacy config-dir `stats.toml` path                                                                          | Canonical state/data `stats.toml` path and `focustime --migrate`                                             | Removed (canonical-only now) |
 
 Milestone policy:
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -541,7 +541,6 @@ pub struct App {
     selected_theme_preset: ThemePreset,
     feature_flags: FeatureFlagsConfig,
     config_deprecation_warnings: Vec<String>,
-    legacy_blocked_sites: Vec<String>,
     profile_automation: ProfileAutomationSettingsConfig,
     pub custom_profile: CustomProfileConfig,
     pub profile_selection_index: usize,
@@ -608,9 +607,7 @@ impl App {
         let selected_profile = config.selected_profile;
         let selected_theme_preset = config.selected_theme_preset;
         let feature_flags = config.feature_flags;
-        let setup_deprecation_warnings =
-            setup_deprecation_warnings(&config_deprecation_warnings, feature_flags);
-        let legacy_blocked_sites = config.blocked_sites.clone();
+        let setup_deprecation_warnings = setup_deprecation_warnings(&config_deprecation_warnings);
         let custom_profile = config.effective_custom_profile();
         let profile_automation = config.profile_automation.clone().unwrap_or_default();
         let selected_automation = config.profile_automation_for(selected_profile);
@@ -654,10 +651,6 @@ impl App {
         let (mut stats, stats_error) =
             match FocusStats::load_with_options(crate::stats::StatsLoadOptions {
                 metadata_task_label_fallback: feature_flags.metadata_task_label_fallback,
-                path_compatibility: crate::stats::StatsPathCompatibilityOptions {
-                    legacy_path_read_fallback: feature_flags.stats_legacy_path_read_fallback,
-                    legacy_path_dual_write: feature_flags.stats_legacy_path_dual_write,
-                },
             }) {
                 Ok(stats) => (stats, None),
                 Err(e) => (FocusStats::default(), Some(e)),
@@ -731,7 +724,6 @@ impl App {
             selected_theme_preset,
             feature_flags,
             config_deprecation_warnings,
-            legacy_blocked_sites,
             profile_automation,
             custom_profile,
             profile_selection_index: profile_index(selected_profile),
@@ -1586,12 +1578,9 @@ fn permission_remediation_guidance() -> &'static str {
     }
 }
 
-pub(super) fn setup_deprecation_warnings(
-    config_deprecation_warnings: &[String],
-    feature_flags: FeatureFlagsConfig,
-) -> Vec<String> {
+pub(super) fn setup_deprecation_warnings(config_deprecation_warnings: &[String]) -> Vec<String> {
     let mut warnings = config_deprecation_warnings.to_vec();
-    if let Some(stats_warning) = legacy_stats_path_deprecation_warning(feature_flags) {
+    if let Some(stats_warning) = legacy_stats_path_deprecation_warning() {
         warnings.push(stats_warning);
     }
     warnings
@@ -1601,18 +1590,13 @@ pub(super) fn format_legacy_stats_path_deprecation_warning(
     canonical_path: &std::path::Path,
     legacy_path: &std::path::Path,
     canonical_exists: bool,
-    feature_flags: FeatureFlagsConfig,
 ) -> String {
     let mut warning = format!(
         "Deprecated legacy stats path detected at `{}`.",
         legacy_path.display()
     );
-    if !canonical_exists && feature_flags.stats_legacy_path_read_fallback {
-        warning
-            .push_str(" Canonical stats are missing, so reads may still fall back to this path.");
-    }
-    if feature_flags.stats_legacy_path_dual_write {
-        warning.push_str(" Legacy stats mirror writes are still enabled.");
+    if !canonical_exists {
+        warning.push_str(" Canonical stats are missing and this path must be migrated.");
     }
     warning.push_str(&format!(
         " Move stats to `{}` and run `focustime --migrate`.",
@@ -1622,7 +1606,7 @@ pub(super) fn format_legacy_stats_path_deprecation_warning(
 }
 
 #[cfg(not(test))]
-fn legacy_stats_path_deprecation_warning(feature_flags: FeatureFlagsConfig) -> Option<String> {
+fn legacy_stats_path_deprecation_warning() -> Option<String> {
     let canonical_path = crate::config::stats_data_path(STATS_FILE_NAME)?;
     let legacy_path =
         crate::config::app_data_path(STATS_FILE_NAME).filter(|path| path != &canonical_path)?;
@@ -1635,12 +1619,11 @@ fn legacy_stats_path_deprecation_warning(feature_flags: FeatureFlagsConfig) -> O
         &canonical_path,
         &legacy_path,
         canonical_exists,
-        feature_flags,
     ))
 }
 
 #[cfg(test)]
-fn legacy_stats_path_deprecation_warning(_feature_flags: FeatureFlagsConfig) -> Option<String> {
+fn legacy_stats_path_deprecation_warning() -> Option<String> {
     None
 }
 

--- a/src/app/feedback_diagnostics.rs
+++ b/src/app/feedback_diagnostics.rs
@@ -105,10 +105,8 @@ impl App {
     }
 
     pub(super) fn refresh_setup_diagnostics(&mut self) {
-        let deprecation_warnings = crate::app::setup_deprecation_warnings(
-            &self.config_deprecation_warnings,
-            self.feature_flags,
-        );
+        let deprecation_warnings =
+            crate::app::setup_deprecation_warnings(&self.config_deprecation_warnings);
         self.setup_diagnostics =
             SetupDiagnostics::collect(&self.blocker, self.feature_flags, deprecation_warnings);
         self.refresh_blocking_preview();

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -1,7 +1,7 @@
 use crate::app::{
     App, AppConfig, BlocklistProfileConfig, DEFAULT_BLOCKLIST_PROFILE_NAME, Local,
-    PendingTimerAction, TimerPhase, TimerState, effective_blocked_sites_for_profile,
-    format_duration_label, occurrence_key, profile_index, profile_spec_for, task_label_index,
+    PendingTimerAction, TimerPhase, TimerState, format_duration_label, occurrence_key,
+    profile_index, profile_spec_for, task_label_index,
 };
 use crate::session_recovery::{self, InProgressSessionSnapshot, WorkflowStateSnapshot};
 use chrono::{LocalResult, TimeZone};
@@ -465,15 +465,6 @@ impl App {
             .or_else(|| blocklist_profiles.first())
             .map(|profile| profile.name.clone())
             .unwrap_or_else(|| DEFAULT_BLOCKLIST_PROFILE_NAME.to_string());
-        let mirrored_blocked_sites = blocklist_profiles
-            .get(active_index)
-            .map(effective_blocked_sites_for_profile)
-            .unwrap_or_default();
-        let blocked_sites = if self.feature_flags.legacy_blocked_sites_mirror {
-            mirrored_blocked_sites
-        } else {
-            self.legacy_blocked_sites.clone()
-        };
         let mut profile_automation = self.profile_automation.clone();
         profile_automation
             .set_for_profile(self.selected_profile, self.selected_profile_automation());
@@ -484,7 +475,7 @@ impl App {
             short_break_secs: custom_profile.short_break_secs,
             long_break_secs: custom_profile.long_break_secs,
             long_break_interval: custom_profile.long_break_interval,
-            blocked_sites,
+            blocked_sites: Vec::new(),
             blocklist_profiles,
             selected_blocklist_profile,
             selected_profile: self.selected_profile,
@@ -533,12 +524,7 @@ impl App {
     fn save_stats(&mut self) {
         if let Err(e) = self
             .stats
-            .save_with_options(crate::stats::StatsSaveOptions {
-                path_compatibility: crate::stats::StatsPathCompatibilityOptions {
-                    legacy_path_read_fallback: self.feature_flags.stats_legacy_path_read_fallback,
-                    legacy_path_dual_write: self.feature_flags.stats_legacy_path_dual_write,
-                },
-            })
+            .save_with_options(crate::stats::StatsSaveOptions::default())
         {
             self.stats_error = Some(format!("stats save failed: {e}"));
         } else {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -82,39 +82,27 @@ fn app_default_uses_canonical_config_in_tests() {
 }
 
 #[test]
-fn legacy_stats_path_warning_mentions_read_fallback_when_canonical_is_missing() {
+fn legacy_stats_path_warning_mentions_migration_when_canonical_is_missing() {
     let warning = format_legacy_stats_path_deprecation_warning(
         Path::new("state/stats.toml"),
         Path::new("config/stats.toml"),
         false,
-        FeatureFlagsConfig {
-            stats_legacy_path_read_fallback: true,
-            stats_legacy_path_dual_write: false,
-            ..FeatureFlagsConfig::default()
-        },
     );
 
     assert!(warning.contains("Deprecated legacy stats path detected"));
-    assert!(warning.contains("reads may still fall back"));
-    assert!(!warning.contains("Legacy stats mirror writes are still enabled"));
+    assert!(warning.contains("must be migrated"));
     assert!(warning.contains("run `focustime --migrate`"));
 }
 
 #[test]
-fn legacy_stats_path_warning_mentions_dual_write_when_enabled() {
+fn legacy_stats_path_warning_omits_missing_canonical_hint_when_canonical_exists() {
     let warning = format_legacy_stats_path_deprecation_warning(
         Path::new("state/stats.toml"),
         Path::new("config/stats.toml"),
         true,
-        FeatureFlagsConfig {
-            stats_legacy_path_read_fallback: true,
-            stats_legacy_path_dual_write: true,
-            ..FeatureFlagsConfig::default()
-        },
     );
 
-    assert!(!warning.contains("reads may still fall back"));
-    assert!(warning.contains("Legacy stats mirror writes are still enabled"));
+    assert!(!warning.contains("must be migrated"));
 }
 
 #[test]
@@ -2396,7 +2384,7 @@ fn site_manager_create_rename_and_delete_blocklist_profile() {
 }
 
 #[test]
-fn persisted_config_mirrors_active_profile_sites_to_legacy_blocked_sites() {
+fn persisted_config_does_not_write_legacy_blocked_sites_mirror() {
     let mut app = App::default();
     app.handle_key(key(KeyCode::Char('b')));
     app.handle_key(key(KeyCode::Char('a')));
@@ -2407,7 +2395,7 @@ fn persisted_config_mirrors_active_profile_sites_to_legacy_blocked_sites() {
 
     let persisted = app.persisted_config();
     assert_eq!(persisted.selected_blocklist_profile, "Default");
-    assert_eq!(persisted.blocked_sites, vec!["example.com".to_string()]);
+    assert!(persisted.blocked_sites.is_empty());
     assert_eq!(persisted.blocklist_profiles.len(), 1);
     assert_eq!(
         persisted.blocklist_profiles[0].sites,
@@ -2416,13 +2404,9 @@ fn persisted_config_mirrors_active_profile_sites_to_legacy_blocked_sites() {
 }
 
 #[test]
-fn persisted_config_keeps_legacy_blocked_sites_when_mirror_flag_is_disabled() {
+fn persisted_config_keeps_blocklist_profiles_for_blocked_sites() {
     let mut app = App::from_config(AppConfig {
         blocked_sites: vec!["legacy-only.com".to_string()],
-        feature_flags: FeatureFlagsConfig {
-            legacy_blocked_sites_mirror: false,
-            ..FeatureFlagsConfig::default()
-        },
         ..AppConfig::default()
     });
     app.handle_key(key(KeyCode::Char('b')));
@@ -2433,7 +2417,7 @@ fn persisted_config_keeps_legacy_blocked_sites_when_mirror_flag_is_disabled() {
     app.handle_key(key(KeyCode::Enter));
 
     let persisted = app.persisted_config();
-    assert_eq!(persisted.blocked_sites, vec!["legacy-only.com".to_string()]);
+    assert!(persisted.blocked_sites.is_empty());
     assert!(
         persisted.blocklist_profiles[0]
             .sites
@@ -5409,7 +5393,6 @@ fn planner_label_change_during_running_break_does_not_backfill_metadata_when_dis
     let mut app = App::from_config(AppConfig {
         feature_flags: FeatureFlagsConfig {
             metadata_task_label_fallback: false,
-            ..FeatureFlagsConfig::default()
         },
         ..AppConfig::default()
     });

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -626,10 +626,7 @@ fn persisted_config_seeds_fallback_profile_with_active_sites() {
         persisted.blocklist_profiles[0].sites,
         vec!["example.com".to_string(), "github.com".to_string()]
     );
-    assert_eq!(
-        persisted.blocked_sites,
-        vec!["example.com".to_string(), "github.com".to_string()]
-    );
+    assert!(persisted.blocked_sites.is_empty());
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -748,11 +748,7 @@ struct SetupCheckOutput {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 struct FeatureFlagsOutput {
-    legacy_automation_mirror: bool,
-    legacy_blocked_sites_mirror: bool,
     metadata_task_label_fallback: bool,
-    stats_legacy_path_read_fallback: bool,
-    stats_legacy_path_dual_write: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -46,8 +46,6 @@ struct MigrationPlan {
     canonical_stats_path: PathBuf,
     legacy_stats_path: Option<PathBuf>,
     copy_legacy_stats_to_canonical: bool,
-    disable_stats_legacy_path_read_fallback: bool,
-    disable_stats_legacy_path_dual_write: bool,
     stats_copy_skip_reason: String,
     warnings: Vec<String>,
 }
@@ -55,18 +53,10 @@ struct MigrationPlan {
 impl MigrationPlan {
     fn has_changes(&self) -> bool {
         self.copy_legacy_stats_to_canonical
-            || self.disable_stats_legacy_path_read_fallback
-            || self.disable_stats_legacy_path_dual_write
-    }
-
-    fn requires_config_update(&self) -> bool {
-        self.disable_stats_legacy_path_read_fallback || self.disable_stats_legacy_path_dual_write
     }
 }
 
 const MIGRATION_OPERATION_COPY_LEGACY_STATS: &str = "copy_legacy_stats_to_canonical";
-const MIGRATION_OPERATION_DISABLE_READ_FALLBACK: &str = "disable_stats_legacy_path_read_fallback";
-const MIGRATION_OPERATION_DISABLE_DUAL_WRITE: &str = "disable_stats_legacy_path_dual_write";
 
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
     match cli_command.kind {
@@ -353,7 +343,7 @@ pub(super) fn apply_blocklist_profile_command(
     };
 
     if updated {
-        sync_legacy_blocked_sites(config);
+        sync_selected_blocklist_profile(config);
     }
     Ok(build_blocklist_profile_command_output(
         config, action, updated,
@@ -458,7 +448,7 @@ pub(super) fn apply_site_add_command(
     let updated = !result.added.is_empty();
     *active_profile_sites_mut(config, index, target) = working.sites.clone();
     if updated {
-        sync_legacy_blocked_sites(config);
+        sync_selected_blocklist_profile(config);
     }
 
     let active_profile = &config.blocklist_profiles[index];
@@ -503,7 +493,7 @@ pub(super) fn apply_site_edit_command(
     match result {
         EditSiteResult::Updated { old, new } => {
             *active_profile_sites_mut(config, index, target) = working.sites.clone();
-            sync_legacy_blocked_sites(config);
+            sync_selected_blocklist_profile(config);
             let active_profile = &config.blocklist_profiles[index];
             Ok(SiteEditCommandOutput {
                 action: "site-edit",
@@ -565,7 +555,7 @@ pub(super) fn apply_site_delete_command(
         .remove_site(delete_index)
         .ok_or_else(|| format!("Site `{site}` was not found in {}.", target.id()))?;
     *active_profile_sites_mut(config, index, target) = working.sites.clone();
-    sync_legacy_blocked_sites(config);
+    sync_selected_blocklist_profile(config);
 
     let active_profile = &config.blocklist_profiles[index];
     Ok(SiteDeleteCommandOutput {
@@ -627,14 +617,10 @@ fn active_profile_sites_mut(
     }
 }
 
-fn sync_legacy_blocked_sites(config: &mut AppConfig) {
+fn sync_selected_blocklist_profile(config: &mut AppConfig) {
     ensure_blocklist_profiles(config);
     let index = selected_blocklist_profile_index(config);
     config.selected_blocklist_profile = config.blocklist_profiles[index].name.clone();
-    if config.feature_flags.legacy_blocked_sites_mirror {
-        config.blocked_sites =
-            effective_blocked_sites_for_profile(&config.blocklist_profiles[index]);
-    }
 }
 
 fn build_blocklist_profile_command_output(
@@ -712,7 +698,6 @@ fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Re
     let mut updated = false;
     if let Some(profile) = profile {
         config.selected_profile = profile;
-        config.align_legacy_automation_with_selected_profile();
         config
             .save()
             .map_err(|error| format!("Failed to save selected profile: {error}"))?;
@@ -1102,7 +1087,7 @@ fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
 }
 
 fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
-    let config = AppConfig::load().normalized();
+    let _config = AppConfig::load().normalized();
     let backup_dir = match dir {
         Some(path) => path,
         None => env::current_dir().map_err(|error| {
@@ -1114,10 +1099,7 @@ fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
 
     let source_config = config_file_path()?;
     let stats_paths = stats_persistence_paths()?;
-    let source_stats = resolve_stats_backup_source_path(
-        &stats_paths,
-        config.feature_flags.stats_legacy_path_read_fallback,
-    );
+    let source_stats = resolve_stats_backup_source_path(&stats_paths);
     ensure_backup_source_file(&source_config, CONFIG_FILE_NAME)?;
     ensure_backup_source_file(&source_stats, STATS_FILE_NAME)?;
     let config_backup_path = backup_dir.join(CONFIG_FILE_NAME);
@@ -1139,7 +1121,7 @@ fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
 }
 
 fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {
-    let config = AppConfig::load().normalized();
+    let _config = AppConfig::load().normalized();
     let restore_dir = match dir {
         Some(path) => path,
         None => env::current_dir().map_err(|error| {
@@ -1154,16 +1136,8 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
     let config_restored_path = config_file_path()?;
     let stats_paths = stats_persistence_paths()?;
     let stats_restored_path = stats_paths.canonical.clone();
-    let stats_legacy_restored_path = if config.feature_flags.stats_legacy_path_dual_write {
-        stats_paths.legacy.clone()
-    } else {
-        None
-    };
     let staged_config_path = temp_restore_path(&config_restored_path, "staged");
     let staged_stats_path = temp_restore_path(&stats_restored_path, "staged");
-    let staged_legacy_stats_path = stats_legacy_restored_path
-        .as_ref()
-        .map(|path| temp_restore_path(path, "staged"));
     copy_file_with_context(
         &source_config,
         &staged_config_path,
@@ -1174,13 +1148,6 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
         &staged_stats_path,
         "stage restore stats.toml",
     )?;
-    if let Some(staged_legacy) = staged_legacy_stats_path.as_deref() {
-        copy_file_with_context(
-            &source_stats,
-            staged_legacy,
-            "stage restore legacy stats.toml mirror",
-        )?;
-    }
 
     let original_config_snapshot = snapshot_existing_file(
         &config_restored_path,
@@ -1190,15 +1157,6 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
         &stats_restored_path,
         "snapshot existing stats.toml for rollback",
     )?;
-    let original_legacy_stats_snapshot =
-        if let Some(legacy_stats_path) = stats_legacy_restored_path.as_deref() {
-            snapshot_existing_file(
-                legacy_stats_path,
-                "snapshot existing legacy stats.toml for rollback",
-            )?
-        } else {
-            None
-        };
 
     replace_file_atomically(
         &staged_config_path,
@@ -1220,35 +1178,13 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
             &stats_restored_path,
             "roll back restored stats.toml",
         );
-        if let Some(legacy_stats_path) = stats_legacy_restored_path.as_deref() {
-            rollback_restored_file(
-                original_legacy_stats_snapshot.as_deref(),
-                legacy_stats_path,
-                "roll back restored legacy stats.toml",
-            );
-        }
         let _ = remove_file_if_exists(&staged_stats_path);
-        if let Some(staged_legacy) = staged_legacy_stats_path.as_deref() {
-            let _ = remove_file_if_exists(staged_legacy);
-        }
         return Err(error);
     }
-    restore_legacy_stats_mirror_if_enabled(
-        stats_legacy_restored_path.as_deref(),
-        staged_legacy_stats_path.as_deref(),
-        original_legacy_stats_snapshot.as_deref(),
-        original_config_snapshot.as_deref(),
-        &config_restored_path,
-        original_stats_snapshot.as_deref(),
-        &stats_restored_path,
-    )?;
     if let Some(snapshot) = original_config_snapshot.as_deref() {
         let _ = remove_file_if_exists(snapshot);
     }
     if let Some(snapshot) = original_stats_snapshot.as_deref() {
-        let _ = remove_file_if_exists(snapshot);
-    }
-    if let Some(snapshot) = original_legacy_stats_snapshot.as_deref() {
         let _ = remove_file_if_exists(snapshot);
     }
 
@@ -1288,7 +1224,7 @@ fn execute_migrate_command(dry_run: bool, output: OutputMode) -> Result<(), Stri
     Ok(())
 }
 
-fn build_migration_plan(config: &AppConfig) -> Result<MigrationPlan, String> {
+fn build_migration_plan(_config: &AppConfig) -> Result<MigrationPlan, String> {
     let config_path = config_file_path()?;
     ensure_regular_file_if_exists(&config_path, "config path")?;
     let stats_paths = stats_persistence_paths()?;
@@ -1356,10 +1292,6 @@ fn build_migration_plan(config: &AppConfig) -> Result<MigrationPlan, String> {
         canonical_stats_path: stats_paths.canonical,
         legacy_stats_path: stats_paths.legacy,
         copy_legacy_stats_to_canonical,
-        disable_stats_legacy_path_read_fallback: config
-            .feature_flags
-            .stats_legacy_path_read_fallback,
-        disable_stats_legacy_path_dual_write: config.feature_flags.stats_legacy_path_dual_write,
         stats_copy_skip_reason,
         warnings,
     })
@@ -1391,42 +1323,11 @@ fn migration_steps_for_plan(plan: &MigrationPlan) -> Vec<MigrationStepOutput> {
         });
     }
 
-    if plan.disable_stats_legacy_path_read_fallback {
-        steps.push(MigrationStepOutput {
-            operation: MIGRATION_OPERATION_DISABLE_READ_FALLBACK,
-            status: status_for_apply,
-            detail: "Set `feature_flags.stats_legacy_path_read_fallback = false` in config.toml."
-                .to_string(),
-        });
-    } else {
-        steps.push(MigrationStepOutput {
-            operation: MIGRATION_OPERATION_DISABLE_READ_FALLBACK,
-            status: MigrationStepStatus::Skipped,
-            detail: "`feature_flags.stats_legacy_path_read_fallback` is already disabled."
-                .to_string(),
-        });
-    }
-
-    if plan.disable_stats_legacy_path_dual_write {
-        steps.push(MigrationStepOutput {
-            operation: MIGRATION_OPERATION_DISABLE_DUAL_WRITE,
-            status: status_for_apply,
-            detail: "Set `feature_flags.stats_legacy_path_dual_write = false` in config.toml."
-                .to_string(),
-        });
-    } else {
-        steps.push(MigrationStepOutput {
-            operation: MIGRATION_OPERATION_DISABLE_DUAL_WRITE,
-            status: MigrationStepStatus::Skipped,
-            detail: "`feature_flags.stats_legacy_path_dual_write` is already disabled.".to_string(),
-        });
-    }
-
     steps
 }
 
 fn apply_migration_plan(
-    config: &AppConfig,
+    _config: &AppConfig,
     plan: &MigrationPlan,
     steps: &mut [MigrationStepOutput],
 ) -> Result<(), String> {
@@ -1434,7 +1335,7 @@ fn apply_migration_plan(
     prepare_migration_staging(plan, &mut state)?;
     capture_config_snapshot_if_needed(plan, &mut state)?;
     apply_staged_canonical_stats(plan, &mut state)?;
-    save_migrated_config_if_needed(config, plan, &state)?;
+    save_migrated_config_if_needed(_config, plan, &state)?;
     let _ = cleanup_migration_temp_files(
         state.config_snapshot.as_deref(),
         state.canonical_stats_snapshot.as_deref(),
@@ -1499,23 +1400,9 @@ fn prepare_migration_staging(
 }
 
 fn capture_config_snapshot_if_needed(
-    plan: &MigrationPlan,
-    state: &mut MigrationExecutionState,
+    _plan: &MigrationPlan,
+    _state: &mut MigrationExecutionState,
 ) -> Result<(), String> {
-    if !plan.requires_config_update() {
-        return Ok(());
-    }
-
-    state.config_snapshot = snapshot_existing_file(
-        &plan.config_path,
-        "snapshot existing config.toml for migration rollback",
-    )
-    .map_err(|error| {
-        migration_setup_failure_from_state(
-            format!("could not prepare config snapshot: {error}"),
-            state,
-        )
-    })?;
     Ok(())
 }
 
@@ -1550,34 +1437,11 @@ fn apply_staged_canonical_stats(
 }
 
 fn save_migrated_config_if_needed(
-    config: &AppConfig,
-    plan: &MigrationPlan,
-    state: &MigrationExecutionState,
+    _config: &AppConfig,
+    _plan: &MigrationPlan,
+    _state: &MigrationExecutionState,
 ) -> Result<(), String> {
-    if !plan.requires_config_update() {
-        return Ok(());
-    }
-
-    let mut migrated = config.clone();
-    if plan.disable_stats_legacy_path_read_fallback {
-        migrated.feature_flags.stats_legacy_path_read_fallback = false;
-    }
-    if plan.disable_stats_legacy_path_dual_write {
-        migrated.feature_flags.stats_legacy_path_dual_write = false;
-    }
-    migrated.save().map_err(|error| {
-        migration_failure_with_rollback(
-            format!("could not save migrated config.toml: {error}"),
-            rollback_migration_files(
-                state.config_snapshot.as_deref(),
-                &plan.config_path,
-                true,
-                state.canonical_stats_snapshot.as_deref(),
-                &plan.canonical_stats_path,
-                state.applied_canonical_stats,
-            ),
-        )
-    })
+    Ok(())
 }
 
 fn migration_setup_failure_from_state(error: String, state: &MigrationExecutionState) -> String {
@@ -1819,45 +1683,6 @@ fn rollback_restored_file(snapshot: Option<&Path>, destination: &Path, rollback_
     }
 }
 
-fn restore_legacy_stats_mirror_if_enabled(
-    legacy_stats_path: Option<&Path>,
-    staged_legacy_stats_path: Option<&Path>,
-    original_legacy_stats_snapshot: Option<&Path>,
-    original_config_snapshot: Option<&Path>,
-    config_restored_path: &Path,
-    original_stats_snapshot: Option<&Path>,
-    stats_restored_path: &Path,
-) -> Result<(), String> {
-    let (Some(legacy_stats_path), Some(staged_legacy_stats_path)) =
-        (legacy_stats_path, staged_legacy_stats_path)
-    else {
-        return Ok(());
-    };
-    if let Err(error) = replace_file_atomically(
-        staged_legacy_stats_path,
-        legacy_stats_path,
-        "restore legacy stats.toml mirror",
-    ) {
-        rollback_restored_file(
-            original_config_snapshot,
-            config_restored_path,
-            "roll back restored config.toml",
-        );
-        rollback_restored_file(
-            original_stats_snapshot,
-            stats_restored_path,
-            "roll back restored stats.toml",
-        );
-        rollback_restored_file(
-            original_legacy_stats_snapshot,
-            legacy_stats_path,
-            "roll back restored legacy stats.toml",
-        );
-        return Err(error);
-    }
-    Ok(())
-}
-
 fn config_file_path() -> Result<PathBuf, String> {
     crate::config::app_data_path(CONFIG_FILE_NAME).ok_or_else(|| {
         format!(
@@ -1876,15 +1701,11 @@ fn stats_persistence_paths() -> Result<StatsPersistencePaths, String> {
     Ok(StatsPersistencePaths { canonical, legacy })
 }
 
-fn resolve_stats_backup_source_path(
-    paths: &StatsPersistencePaths,
-    legacy_read_fallback: bool,
-) -> PathBuf {
+fn resolve_stats_backup_source_path(paths: &StatsPersistencePaths) -> PathBuf {
     if paths.canonical.exists() {
         return paths.canonical.clone();
     }
-    if legacy_read_fallback
-        && let Some(legacy) = paths.legacy.as_ref()
+    if let Some(legacy) = paths.legacy.as_ref()
         && legacy.exists()
     {
         return legacy.clone();
@@ -1892,24 +1713,14 @@ fn resolve_stats_backup_source_path(
     paths.canonical.clone()
 }
 
-fn stats_path_compatibility(config: &AppConfig) -> crate::stats::StatsPathCompatibilityOptions {
-    crate::stats::StatsPathCompatibilityOptions {
-        legacy_path_read_fallback: config.feature_flags.stats_legacy_path_read_fallback,
-        legacy_path_dual_write: config.feature_flags.stats_legacy_path_dual_write,
-    }
-}
-
 fn stats_load_options(config: &AppConfig) -> crate::stats::StatsLoadOptions {
     crate::stats::StatsLoadOptions {
         metadata_task_label_fallback: config.feature_flags.metadata_task_label_fallback,
-        path_compatibility: stats_path_compatibility(config),
     }
 }
 
-fn stats_save_options(config: &AppConfig) -> crate::stats::StatsSaveOptions {
-    crate::stats::StatsSaveOptions {
-        path_compatibility: stats_path_compatibility(config),
-    }
+fn stats_save_options(_config: &AppConfig) -> crate::stats::StatsSaveOptions {
+    crate::stats::StatsSaveOptions::default()
 }
 
 fn copy_file_with_context(source: &Path, destination: &Path, context: &str) -> Result<(), String> {
@@ -2069,8 +1880,6 @@ mod tests {
             canonical_stats_path: canonical_stats_path.clone(),
             legacy_stats_path: Some(legacy_stats_path),
             copy_legacy_stats_to_canonical: true,
-            disable_stats_legacy_path_read_fallback: false,
-            disable_stats_legacy_path_dual_write: false,
             stats_copy_skip_reason: String::new(),
             warnings: Vec::new(),
         };

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -667,12 +667,8 @@ pub(super) fn print_diagnostics_command_output(payload: &DiagnosticsCommandOutpu
     print_diagnostics_check("Hosts write capability", &payload.hosts_write_capability);
     print_diagnostics_check("WakaTime config", &payload.wakatime_config);
     println!(
-        "Feature flags: automation-mirror={}, blocked-sites-mirror={}, metadata-fallback={}, stats-read-fallback={}, stats-dual-write={}",
-        bool_label(payload.feature_flags.legacy_automation_mirror),
-        bool_label(payload.feature_flags.legacy_blocked_sites_mirror),
+        "Feature flags: metadata-fallback={}",
         bool_label(payload.feature_flags.metadata_task_label_fallback),
-        bool_label(payload.feature_flags.stats_legacy_path_read_fallback),
-        bool_label(payload.feature_flags.stats_legacy_path_dual_write),
     );
     if payload.deprecation_warnings.is_empty() {
         println!("Deprecation warnings: none");
@@ -697,13 +693,7 @@ pub(super) fn build_diagnostics_command_output(
         hosts_write_capability: setup_check_output(&diagnostics.hosts_write_capability),
         wakatime_config: setup_check_output(&diagnostics.wakatime_config),
         feature_flags: FeatureFlagsOutput {
-            legacy_automation_mirror: diagnostics.feature_flags.legacy_automation_mirror,
-            legacy_blocked_sites_mirror: diagnostics.feature_flags.legacy_blocked_sites_mirror,
             metadata_task_label_fallback: diagnostics.feature_flags.metadata_task_label_fallback,
-            stats_legacy_path_read_fallback: diagnostics
-                .feature_flags
-                .stats_legacy_path_read_fallback,
-            stats_legacy_path_dual_write: diagnostics.feature_flags.stats_legacy_path_dual_write,
         },
         deprecation_warnings: diagnostics.deprecation_warnings.clone(),
     }

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -647,11 +647,7 @@ fn diagnostics_output_includes_effective_feature_flags() {
     let app = App::default();
     let payload = build_diagnostics_command_output(&app.setup_diagnostics);
 
-    assert!(payload.feature_flags.legacy_automation_mirror);
-    assert!(payload.feature_flags.legacy_blocked_sites_mirror);
     assert!(payload.feature_flags.metadata_task_label_fallback);
-    assert!(payload.feature_flags.stats_legacy_path_read_fallback);
-    assert!(payload.feature_flags.stats_legacy_path_dual_write);
     assert!(payload.deprecation_warnings.is_empty());
 }
 
@@ -1971,7 +1967,6 @@ fn build_status_output_disables_task_label_metadata_mirror_when_flag_disabled() 
     let config = AppConfig {
         feature_flags: FeatureFlagsConfig {
             metadata_task_label_fallback: false,
-            ..FeatureFlagsConfig::default()
         },
         ..AppConfig::default()
     };

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1464,7 +1464,7 @@ fn apply_blocklist_profile_select_updates_selection_case_insensitively() {
     assert!(payload.updated);
     assert_eq!(payload.selected_blocklist_profile, "Study");
     assert_eq!(config.selected_blocklist_profile, "Study");
-    assert_eq!(config.blocked_sites, vec!["study.com".to_string()]);
+    assert!(config.blocked_sites.is_empty());
 }
 
 #[test]
@@ -1499,7 +1499,7 @@ fn apply_blocklist_profile_rename_updates_selection_and_name() {
     assert_eq!(payload.selected_blocklist_profile, "Deep Work");
     assert_eq!(config.selected_blocklist_profile, "Deep Work");
     assert_eq!(config.blocklist_profiles[0].name, "Deep Work");
-    assert_eq!(config.blocked_sites, vec!["a.com".to_string()]);
+    assert!(config.blocked_sites.is_empty());
 }
 
 #[test]
@@ -1529,7 +1529,7 @@ fn apply_blocklist_profile_delete_switches_selection() {
     assert_eq!(payload.selected_blocklist_profile, "Study");
     assert_eq!(config.selected_blocklist_profile, "Study");
     assert_eq!(config.blocklist_profiles.len(), 1);
-    assert_eq!(config.blocked_sites, vec!["study.com".to_string()]);
+    assert!(config.blocked_sites.is_empty());
 }
 
 #[test]
@@ -1587,10 +1587,7 @@ fn apply_site_edit_command_updates_blocklist_sites() {
         config.blocklist_profiles[0].sites,
         vec!["news.ycombinator.com".to_string(), "b.com".to_string()]
     );
-    assert_eq!(
-        config.blocked_sites,
-        vec!["news.ycombinator.com".to_string(), "b.com".to_string()]
-    );
+    assert!(config.blocked_sites.is_empty());
 }
 
 #[test]
@@ -1626,10 +1623,7 @@ fn apply_site_edit_command_handles_duplicate_case_entries() {
         config.blocklist_profiles[0].sites,
         vec!["news.com".to_string(), "b.com".to_string()]
     );
-    assert_eq!(
-        config.blocked_sites,
-        vec!["news.com".to_string(), "b.com".to_string()]
-    );
+    assert!(config.blocked_sites.is_empty());
 }
 
 #[test]
@@ -1651,10 +1645,7 @@ fn apply_site_delete_command_updates_allowlist_and_effective_blocking() {
     assert!(payload.updated);
     assert_eq!(payload.removed, "b.com");
     assert!(config.blocklist_profiles[0].allowlist_sites.is_empty());
-    assert_eq!(
-        config.blocked_sites,
-        vec!["a.com".to_string(), "b.com".to_string()]
-    );
+    assert!(config.blocked_sites.is_empty());
     assert_eq!(payload.effective_blocked_sites_count, 2);
 }
 
@@ -1683,7 +1674,7 @@ fn apply_site_delete_command_handles_duplicate_case_entries() {
         config.blocklist_profiles[0].sites,
         vec!["other.com".to_string()]
     );
-    assert_eq!(config.blocked_sites, vec!["other.com".to_string()]);
+    assert!(config.blocked_sites.is_empty());
     assert_eq!(payload.effective_blocked_sites_count, 1);
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,20 +36,20 @@ const WAKATIME_RETRY_BACKOFF_MAX_ENTRIES: usize = 8;
 /// - Windows:      `%APPDATA%\focustime\config.toml`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
-    /// Duration of a focus session in seconds (legacy compatibility field).
-    #[serde(default = "default_focus_secs")]
+    /// Duration of a focus session in seconds (legacy load-time compatibility field).
+    #[serde(default = "default_focus_secs", skip_serializing)]
     pub focus_secs: u64,
-    /// Duration of a short-break session in seconds (legacy compatibility field).
-    #[serde(default = "default_short_break_secs")]
+    /// Duration of a short-break session in seconds (legacy load-time compatibility field).
+    #[serde(default = "default_short_break_secs", skip_serializing)]
     pub short_break_secs: u64,
-    /// Duration of a long-break session in seconds (legacy compatibility field).
-    #[serde(default = "default_long_break_secs")]
+    /// Duration of a long-break session in seconds (legacy load-time compatibility field).
+    #[serde(default = "default_long_break_secs", skip_serializing)]
     pub long_break_secs: u64,
     /// Number of completed focus sessions before a long break.
-    #[serde(default = "default_long_break_interval")]
+    #[serde(default = "default_long_break_interval", skip_serializing)]
     pub long_break_interval: u32,
-    /// Sites that should be blocked during focus sessions.
-    #[serde(default)]
+    /// Deprecated blocked-sites mirror (legacy load-time compatibility field).
+    #[serde(default, skip_serializing)]
     pub blocked_sites: Vec<String>,
     /// Named blocklist profiles.
     ///
@@ -77,14 +77,14 @@ pub struct AppConfig {
     /// Selected UI theme preset.
     #[serde(default)]
     pub selected_theme_preset: ThemePreset,
-    /// Notification preferences for phase transitions.
-    #[serde(default)]
+    /// Deprecated top-level automation mirror (legacy load-time compatibility field).
+    #[serde(default, skip_serializing)]
     pub notifications: NotificationConfig,
-    /// Auto-start preferences for natural phase transitions.
-    #[serde(default)]
+    /// Deprecated top-level automation mirror (legacy load-time compatibility field).
+    #[serde(default, skip_serializing)]
     pub auto_start: AutoStartConfig,
-    /// Recurring schedule windows for automatic focus startup.
-    #[serde(default)]
+    /// Deprecated top-level automation mirror (legacy load-time compatibility field).
+    #[serde(default, skip_serializing)]
     pub recurring_schedule: RecurringScheduleConfig,
     /// Runtime tuning knobs for schedule editing and delay behavior.
     #[serde(default)]
@@ -95,11 +95,8 @@ pub struct AppConfig {
     /// for all profiles during normalization.
     #[serde(default)]
     pub profile_automation: Option<ProfileAutomationSettingsConfig>,
-    /// Whether strict focus mode is enabled.
-    ///
-    /// When enabled, active focus sessions disallow skip and require
-    /// confirmation before stop/reset.
-    #[serde(default)]
+    /// Deprecated top-level automation mirror (legacy load-time compatibility field).
+    #[serde(default, skip_serializing)]
     pub strict_mode: bool,
     /// Duration of a break-glass unblock override in seconds.
     ///
@@ -160,21 +157,9 @@ impl AppConfigDisk {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FeatureFlagsConfig {
-    /// Keep selected profile automation mirrored into legacy top-level automation fields.
-    #[serde(default = "default_true")]
-    pub legacy_automation_mirror: bool,
-    /// Keep selected blocklist profile mirrored into legacy `blocked_sites`.
-    #[serde(default = "default_true")]
-    pub legacy_blocked_sites_mirror: bool,
     /// Backfill missing metadata fields from task labels for legacy records/snapshots.
     #[serde(default = "default_true")]
     pub metadata_task_label_fallback: bool,
-    /// Allow stats loading to fall back to legacy config-directory persistence path.
-    #[serde(default = "default_true")]
-    pub stats_legacy_path_read_fallback: bool,
-    /// Mirror stats writes to legacy config-directory persistence path.
-    #[serde(default = "default_true")]
-    pub stats_legacy_path_dual_write: bool,
 }
 
 impl FeatureFlagsConfig {
@@ -186,11 +171,7 @@ impl FeatureFlagsConfig {
 impl Default for FeatureFlagsConfig {
     fn default() -> Self {
         Self {
-            legacy_automation_mirror: true,
-            legacy_blocked_sites_mirror: true,
             metadata_task_label_fallback: true,
-            stats_legacy_path_read_fallback: true,
-            stats_legacy_path_dual_write: true,
         }
     }
 }
@@ -1555,17 +1536,8 @@ impl AppConfig {
             .normalized()
     }
 
-    fn legacy_profile_automation(&self) -> ProfileAutomationConfig {
-        ProfileAutomationConfig::from_legacy(
-            self.notifications,
-            self.auto_start,
-            self.strict_mode,
-            self.recurring_schedule.clone(),
-        )
-    }
-
     pub fn profile_automation_for(&self, profile: ProfileId) -> ProfileAutomationConfig {
-        let fallback = self.legacy_profile_automation();
+        let fallback = ProfileAutomationConfig::default();
         self.profile_automation
             .as_ref()
             .map(|settings| settings.for_profile(profile, &fallback))
@@ -1577,7 +1549,7 @@ impl AppConfig {
         profile: ProfileId,
         automation: ProfileAutomationConfig,
     ) {
-        let fallback = self.legacy_profile_automation();
+        let fallback = ProfileAutomationConfig::default();
         let mut settings = self
             .profile_automation
             .clone()
@@ -1587,18 +1559,6 @@ impl AppConfig {
             .normalized_with_fallback(&fallback);
         settings.set_for_profile(profile, automation);
         self.profile_automation = Some(settings.normalized_with_fallback(&fallback));
-        self.align_legacy_automation_with_selected_profile();
-    }
-
-    pub(crate) fn align_legacy_automation_with_selected_profile(&mut self) {
-        if !self.feature_flags.legacy_automation_mirror {
-            return;
-        }
-        let selected = self.profile_automation_for(self.selected_profile);
-        self.notifications = selected.notifications;
-        self.auto_start = selected.auto_start;
-        self.strict_mode = selected.strict_mode;
-        self.recurring_schedule = selected.recurring_schedule;
     }
 
     fn try_load_with_deprecation_warnings() -> Option<(Self, Vec<String>)> {
@@ -1701,30 +1661,27 @@ impl AppConfig {
             &effective_custom_profile,
         );
         self.recurring_schedule = self.recurring_schedule.normalized();
-        let fallback_automation = self.legacy_profile_automation();
+        let legacy_automation = ProfileAutomationConfig::from_legacy(
+            self.notifications,
+            self.auto_start,
+            self.strict_mode,
+            self.recurring_schedule.clone(),
+        );
+        let fallback_automation = ProfileAutomationConfig::default();
         let normalized_profile_automation = self
             .profile_automation
             .clone()
             .unwrap_or_else(|| {
-                ProfileAutomationSettingsConfig::with_shared_defaults(fallback_automation.clone())
+                ProfileAutomationSettingsConfig::with_shared_defaults(legacy_automation)
             })
             .normalized_with_fallback(&fallback_automation);
         self.profile_automation = Some(normalized_profile_automation);
-        self.align_legacy_automation_with_selected_profile();
         self.blocklist_profiles =
             normalize_blocklist_profiles(&self.blocklist_profiles, &self.blocked_sites);
         self.selected_blocklist_profile = normalize_selected_blocklist_profile(
             &self.selected_blocklist_profile,
             &self.blocklist_profiles,
         );
-        if self.feature_flags.legacy_blocked_sites_mirror {
-            self.blocked_sites = self
-                .blocklist_profiles
-                .iter()
-                .find(|profile| profile.name == self.selected_blocklist_profile)
-                .map(effective_blocked_sites_for_profile)
-                .unwrap_or_default();
-        }
         self.schedule_runtime = self.schedule_runtime.normalized();
         self.wakatime = self.wakatime.normalized();
         self.wakatime_runtime = self.wakatime_runtime.normalized();
@@ -2183,20 +2140,6 @@ fn make_unique_profile_name(base_name: &str, seen_names: &mut HashSet<String>) -
         }
         suffix += 1;
     }
-}
-
-fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
-    let allowlist: HashSet<String> = profile
-        .allowlist_sites
-        .iter()
-        .map(|site| site.to_ascii_lowercase())
-        .collect();
-    profile
-        .sites
-        .iter()
-        .filter(|site| !allowlist.contains(&site.to_ascii_lowercase()))
-        .cloned()
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -249,11 +249,7 @@ fn round_trip_full_config() {
             queue_retry_delay_secs: 30,
         },
         feature_flags: FeatureFlagsConfig {
-            legacy_automation_mirror: true,
-            legacy_blocked_sites_mirror: true,
             metadata_task_label_fallback: true,
-            stats_legacy_path_read_fallback: true,
-            stats_legacy_path_dual_write: true,
         },
         shortcuts: ShortcutConfig {
             timer_toggle_pause: "space".to_string(),
@@ -265,12 +261,24 @@ fn round_trip_full_config() {
         },
     };
     let toml_str = toml::to_string_pretty(&original).unwrap();
+    let serialized: toml::Value = toml::from_str(&toml_str).unwrap();
+    let root = serialized.as_table().unwrap();
+    assert!(!root.contains_key("focus_secs"));
+    assert!(!root.contains_key("short_break_secs"));
+    assert!(!root.contains_key("long_break_secs"));
+    assert!(!root.contains_key("long_break_interval"));
+    assert!(!root.contains_key("blocked_sites"));
+    assert!(!root.contains_key("notifications"));
+    assert!(!root.contains_key("auto_start"));
+    assert!(!root.contains_key("strict_mode"));
+    assert!(!root.contains_key("recurring_schedule"));
+
     let parsed: AppConfig = toml::from_str(&toml_str).unwrap();
-    assert_eq!(parsed.focus_secs, original.focus_secs);
-    assert_eq!(parsed.short_break_secs, original.short_break_secs);
-    assert_eq!(parsed.long_break_secs, original.long_break_secs);
-    assert_eq!(parsed.long_break_interval, original.long_break_interval);
-    assert_eq!(parsed.blocked_sites, original.blocked_sites);
+    assert_eq!(parsed.focus_secs, default_focus_secs());
+    assert_eq!(parsed.short_break_secs, default_short_break_secs());
+    assert_eq!(parsed.long_break_secs, default_long_break_secs());
+    assert_eq!(parsed.long_break_interval, default_long_break_interval());
+    assert!(parsed.blocked_sites.is_empty());
     assert_eq!(parsed.blocklist_profiles, original.blocklist_profiles);
     assert_eq!(
         parsed.selected_blocklist_profile,
@@ -284,12 +292,15 @@ fn round_trip_full_config() {
         original.selected_break_template
     );
     assert_eq!(parsed.selected_theme_preset, original.selected_theme_preset);
-    assert_eq!(parsed.notifications, original.notifications);
-    assert_eq!(parsed.auto_start, original.auto_start);
-    assert_eq!(parsed.recurring_schedule, original.recurring_schedule);
+    assert_eq!(parsed.notifications, NotificationConfig::default());
+    assert_eq!(parsed.auto_start, AutoStartConfig::default());
+    assert_eq!(
+        parsed.recurring_schedule,
+        RecurringScheduleConfig::default()
+    );
     assert_eq!(parsed.schedule_runtime, original.schedule_runtime);
     assert_eq!(parsed.profile_automation, original.profile_automation);
-    assert_eq!(parsed.strict_mode, original.strict_mode);
+    assert!(!parsed.strict_mode);
     assert_eq!(
         parsed.break_glass_duration_secs,
         original.break_glass_duration_secs
@@ -1583,7 +1594,7 @@ fn normalize_selected_profile_automation_updates_legacy_view() {
 }
 
 #[test]
-fn normalize_keeps_legacy_automation_fields_when_mirror_flag_is_disabled() {
+fn normalize_legacy_automation_fields_do_not_override_profile_automation() {
     let deep_work = ProfileAutomationConfig {
         notifications: NotificationConfig {
             enabled: true,
@@ -1621,10 +1632,6 @@ fn normalize_keeps_legacy_automation_fields_when_mirror_flag_is_disabled() {
             deep_work: Some(deep_work.clone()),
             custom: None,
         }),
-        feature_flags: FeatureFlagsConfig {
-            legacy_automation_mirror: false,
-            ..FeatureFlagsConfig::default()
-        },
         ..AppConfig::default()
     }
     .normalize();
@@ -1649,7 +1656,7 @@ fn normalize_keeps_legacy_automation_fields_when_mirror_flag_is_disabled() {
 }
 
 #[test]
-fn normalize_keeps_legacy_blocked_sites_when_mirror_flag_is_disabled() {
+fn normalize_keeps_legacy_blocked_sites_when_profiles_exist() {
     let cfg = AppConfig {
         blocked_sites: vec!["legacy-only.com".to_string()],
         blocklist_profiles: vec![BlocklistProfileConfig {
@@ -1658,10 +1665,6 @@ fn normalize_keeps_legacy_blocked_sites_when_mirror_flag_is_disabled() {
             allowlist_sites: vec!["b.com".to_string()],
         }],
         selected_blocklist_profile: "Work".to_string(),
-        feature_flags: FeatureFlagsConfig {
-            legacy_blocked_sites_mirror: false,
-            ..FeatureFlagsConfig::default()
-        },
         ..AppConfig::default()
     }
     .normalize();

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1158,7 +1158,7 @@ fn save_with_env_writes_current_schema_version() {
         saved_toml
             .get("focus_secs")
             .and_then(toml::Value::as_integer),
-        Some(2100)
+        None
     );
 }
 
@@ -1465,11 +1465,11 @@ fn normalize_deduplicates_profile_names_and_fixes_selection() {
     assert_eq!(cfg.blocklist_profiles[0].name, "Work");
     assert_eq!(cfg.blocklist_profiles[1].name, "work (2)");
     assert_eq!(cfg.selected_blocklist_profile, "Work");
-    assert_eq!(cfg.blocked_sites, vec!["a.com".to_string()]);
+    assert!(cfg.blocked_sites.is_empty());
 }
 
 #[test]
-fn normalize_derives_legacy_blocked_sites_from_effective_blocked_set() {
+fn normalize_keeps_legacy_blocked_sites_empty_for_profile_only_config() {
     let cfg = AppConfig {
         blocklist_profiles: vec![BlocklistProfileConfig {
             name: "Work".to_string(),
@@ -1481,7 +1481,7 @@ fn normalize_derives_legacy_blocked_sites_from_effective_blocked_set() {
     }
     .normalize();
 
-    assert_eq!(cfg.blocked_sites, vec!["a.com".to_string()]);
+    assert!(cfg.blocked_sites.is_empty());
 }
 
 #[test]
@@ -1538,7 +1538,7 @@ fn normalize_migrates_legacy_automation_into_per_profile_settings() {
 }
 
 #[test]
-fn normalize_selected_profile_automation_updates_legacy_view() {
+fn normalize_selected_profile_automation_keeps_top_level_legacy_fields() {
     let classic = ProfileAutomationConfig {
         notifications: NotificationConfig {
             enabled: true,
@@ -1587,10 +1587,10 @@ fn normalize_selected_profile_automation_updates_legacy_view() {
     }
     .normalize();
 
-    assert_eq!(cfg.notifications, deep_work.notifications);
-    assert_eq!(cfg.auto_start, deep_work.auto_start);
-    assert_eq!(cfg.strict_mode, deep_work.strict_mode);
-    assert_eq!(cfg.recurring_schedule, deep_work.recurring_schedule);
+    assert_eq!(cfg.notifications, NotificationConfig::default());
+    assert_eq!(cfg.auto_start, AutoStartConfig::default());
+    assert!(!cfg.strict_mode);
+    assert_eq!(cfg.recurring_schedule, RecurringScheduleConfig::default());
 }
 
 #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -39,39 +39,20 @@ const EXPORT_SCHEMA_VERSION: u32 = 5;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct StatsPathCompatibilityOptions {
-    pub legacy_path_read_fallback: bool,
-    pub legacy_path_dual_write: bool,
-}
-
-impl Default for StatsPathCompatibilityOptions {
-    fn default() -> Self {
-        Self {
-            legacy_path_read_fallback: true,
-            legacy_path_dual_write: true,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StatsLoadOptions {
     pub metadata_task_label_fallback: bool,
-    pub path_compatibility: StatsPathCompatibilityOptions,
 }
 
 impl Default for StatsLoadOptions {
     fn default() -> Self {
         Self {
             metadata_task_label_fallback: true,
-            path_compatibility: StatsPathCompatibilityOptions::default(),
         }
     }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct StatsSaveOptions {
-    pub path_compatibility: StatsPathCompatibilityOptions,
-}
+pub struct StatsSaveOptions {}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SessionStats {

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -1,12 +1,12 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
+#[cfg(not(test))]
 use crate::stats::fs;
 use crate::stats::{
     BreakGlassOverrideEvent, FocusSessionRecord, FocusStats, PersistedStats, STATS_FILE_NAME,
-    SessionInterruptionEvent, SessionStats, StatsLoadOptions, StatsPathCompatibilityOptions,
-    StatsSaveOptions, io, normalize_session_metadata_text, normalize_task_goal_targets,
-    normalize_task_label, normalize_task_planner_state, planner_state_labels_for_keys,
-    write_atomic_bytes,
+    SessionInterruptionEvent, SessionStats, StatsLoadOptions, StatsSaveOptions, io,
+    normalize_session_metadata_text, normalize_task_goal_targets, normalize_task_label,
+    normalize_task_planner_state, planner_state_labels_for_keys, write_atomic_bytes,
 };
 
 impl FocusStats {
@@ -34,29 +34,15 @@ impl FocusStats {
 
     #[cfg(not(test))]
     fn try_load(options: StatsLoadOptions) -> Result<Self, String> {
-        let read_paths = stats_read_paths(options.path_compatibility)
-            .ok_or_else(|| "cannot determine stats directory".to_string())?;
-        let mut failures = Vec::new();
-        for path in &read_paths {
-            match fs::read_to_string(path) {
-                Ok(content) => match Self::try_from_toml_with_options(&content, options) {
-                    Ok(stats) => return Ok(stats),
-                    Err(error) => failures.push(format!(
-                        "stats parse failed at `{}`: {error}",
-                        path.display()
-                    )),
-                },
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                Err(error) => failures.push(format!(
-                    "stats read failed at `{}`: {error}",
-                    path.display()
-                )),
-            }
-        }
-        if failures.is_empty() {
-            Ok(Self::default())
-        } else {
-            Err(failures.join(" | "))
+        let path = stats_path().ok_or_else(|| "cannot determine stats directory".to_string())?;
+        match fs::read_to_string(&path) {
+            Ok(content) => Self::try_from_toml_with_options(&content, options)
+                .map_err(|error| format!("stats parse failed at `{}`: {error}", path.display())),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(error) => Err(format!(
+                "stats read failed at `{}`: {error}",
+                path.display()
+            )),
         }
     }
 
@@ -179,104 +165,16 @@ impl FocusStats {
         }
     }
 
-    pub fn save_with_options(&self, options: StatsSaveOptions) -> io::Result<()> {
-        let (canonical_path, legacy_path) = stats_write_paths(options.path_compatibility)
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::NotFound, "cannot determine stats directory")
-            })?;
+    pub fn save_with_options(&self, _options: StatsSaveOptions) -> io::Result<()> {
+        let path = stats_path().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotFound, "cannot determine stats directory")
+        })?;
         let content = toml::to_string_pretty(&self.to_persisted())
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        write_stats_with_rollback(&canonical_path, legacy_path.as_deref(), content.as_bytes())
+        write_atomic_bytes(&path, content.as_bytes())
     }
 }
 
-fn stats_paths() -> Option<(PathBuf, Option<PathBuf>)> {
-    let canonical_path = crate::config::stats_data_path(STATS_FILE_NAME)?;
-    let legacy_path =
-        crate::config::app_data_path(STATS_FILE_NAME).filter(|path| path != &canonical_path);
-    Some((canonical_path, legacy_path))
-}
-
-#[cfg(not(test))]
-fn stats_read_paths(path_compatibility: StatsPathCompatibilityOptions) -> Option<Vec<PathBuf>> {
-    let (canonical_path, legacy_path) = stats_paths()?;
-    let mut read_paths = vec![canonical_path];
-    if path_compatibility.legacy_path_read_fallback
-        && let Some(legacy_path) = legacy_path
-    {
-        read_paths.push(legacy_path);
-    }
-    Some(read_paths)
-}
-
-fn stats_write_paths(
-    path_compatibility: StatsPathCompatibilityOptions,
-) -> Option<(PathBuf, Option<PathBuf>)> {
-    let (canonical_path, legacy_path) = stats_paths()?;
-    let legacy_path = if path_compatibility.legacy_path_dual_write {
-        legacy_path
-    } else {
-        None
-    };
-    Some((canonical_path, legacy_path))
-}
-
-fn write_stats_with_rollback(
-    canonical_path: &Path,
-    legacy_path: Option<&Path>,
-    content: &[u8],
-) -> io::Result<()> {
-    let canonical_snapshot = read_existing_bytes(canonical_path)?;
-    let legacy_snapshot = if let Some(path) = legacy_path {
-        Some(read_existing_bytes(path)?)
-    } else {
-        None
-    };
-
-    write_atomic_bytes(canonical_path, content)?;
-    if let Some(path) = legacy_path
-        && let Err(error) = write_atomic_bytes(path, content)
-    {
-        let mut rollback_errors = Vec::new();
-        if let Err(rollback_error) = restore_existing_bytes(canonical_path, canonical_snapshot) {
-            rollback_errors.push(format!(
-                "rollback failed for `{}`: {rollback_error}",
-                canonical_path.display()
-            ));
-        }
-        if let Some(snapshot) = legacy_snapshot
-            && let Err(rollback_error) = restore_existing_bytes(path, snapshot)
-        {
-            rollback_errors.push(format!(
-                "rollback failed for `{}`: {rollback_error}",
-                path.display()
-            ));
-        }
-        let mut detail = format!("stats mirror write failed at `{}`: {error}", path.display());
-        if !rollback_errors.is_empty() {
-            detail.push_str("; ");
-            detail.push_str(&rollback_errors.join("; "));
-        }
-        return Err(io::Error::other(detail));
-    }
-    Ok(())
-}
-
-fn read_existing_bytes(path: &Path) -> io::Result<Option<Vec<u8>>> {
-    match fs::read(path) {
-        Ok(bytes) => Ok(Some(bytes)),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error),
-    }
-}
-
-fn restore_existing_bytes(path: &Path, snapshot: Option<Vec<u8>>) -> io::Result<()> {
-    if let Some(bytes) = snapshot {
-        return write_atomic_bytes(path, &bytes);
-    }
-    match fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error),
-    }
+fn stats_path() -> Option<PathBuf> {
+    crate::config::stats_data_path(STATS_FILE_NAME)
 }

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -905,7 +905,6 @@ fn legacy_focus_sessions_keep_empty_metadata_when_fallback_is_disabled() {
         legacy_toml,
         StatsLoadOptions {
             metadata_task_label_fallback: false,
-            ..StatsLoadOptions::default()
         },
     )
     .unwrap();

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -63,35 +63,14 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         "WakaTime config status",
         &app.setup_diagnostics.wakatime_config,
     );
-    let feature_flags_lines = vec![
-        Line::from(format!(
-            "Feature flags: automation-mirror={} · blocked-sites-mirror={} · metadata-fallback={}",
-            bool_label(app.setup_diagnostics.feature_flags.legacy_automation_mirror),
-            bool_label(
-                app.setup_diagnostics
-                    .feature_flags
-                    .legacy_blocked_sites_mirror
-            ),
-            bool_label(
-                app.setup_diagnostics
-                    .feature_flags
-                    .metadata_task_label_fallback
-            ),
-        )),
-        Line::from(format!(
-            "               stats-read-fallback={} · stats-dual-write={}",
-            bool_label(
-                app.setup_diagnostics
-                    .feature_flags
-                    .stats_legacy_path_read_fallback
-            ),
-            bool_label(
-                app.setup_diagnostics
-                    .feature_flags
-                    .stats_legacy_path_dual_write
-            )
-        )),
-    ];
+    let feature_flags_lines = vec![Line::from(format!(
+        "Feature flags: metadata-fallback={}",
+        bool_label(
+            app.setup_diagnostics
+                .feature_flags
+                .metadata_task_label_fallback
+        ),
+    ))];
     frame.render_widget(
         Paragraph::new(feature_flags_lines)
             .style(Style::default().fg(app_color(app, Color::DarkGray)))

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -392,8 +392,8 @@ fn backup_and_restore_json_round_trip_config_and_stats_files() {
 }
 
 #[test]
-fn task_goal_json_dual_writes_stats_to_canonical_and_legacy_paths() {
-    let env = TestEnv::new("stats-dual-write");
+fn task_goal_json_writes_stats_to_canonical_path_only() {
+    let env = TestEnv::new("stats-canonical-only");
 
     let output = env.run(&["--task-goal=Docs:90,3", "--json"]);
     assert_eq!(output.status.code(), Some(0));
@@ -402,16 +402,12 @@ fn task_goal_json_dual_writes_stats_to_canonical_and_legacy_paths() {
     let canonical_stats_path = env.canonical_stats_path();
     let legacy_stats_path = env.legacy_stats_path();
     assert!(canonical_stats_path.is_file());
-    assert!(legacy_stats_path.is_file());
-    assert_eq!(
-        fs::read_to_string(&canonical_stats_path).unwrap(),
-        fs::read_to_string(&legacy_stats_path).unwrap()
-    );
+    assert!(!legacy_stats_path.is_file());
 }
 
 #[test]
-fn status_json_prefers_canonical_stats_and_falls_back_to_legacy() {
-    let env = TestEnv::new("stats-read-precedence");
+fn status_json_uses_canonical_stats_without_legacy_fallback() {
+    let env = TestEnv::new("stats-canonical-read");
 
     let baseline_status = env.run(&["--status", "--json"]);
     assert_eq!(baseline_status.status.code(), Some(0));
@@ -441,7 +437,7 @@ fn status_json_prefers_canonical_stats_and_falls_back_to_legacy() {
     assert!(stderr_text(&fallback_status).trim().is_empty());
     let fallback_payload: Value =
         serde_json::from_slice(&fallback_status.stdout).expect("stdout should be JSON");
-    assert_eq!(fallback_payload["today"]["pomodoros_completed"], 7);
+    assert_eq!(fallback_payload["today"]["pomodoros_completed"], 0);
 }
 
 #[test]


### PR DESCRIPTION
## What

Finalize canonical config and stats behavior by removing legacy mirror/sync paths from runtime and persistence flows.

- Removed legacy mirror feature flags and mirror alignment logic from config/runtime surfaces.
- Made legacy top-level config fields load-time compatibility inputs only; they are no longer serialized on save.
- Simplified stats persistence and CLI migration/backup/restore flows to canonical-path behavior.
- Updated diagnostics output, UI setup rendering, tests, and docs/changelog to match finalized behavior.

## Why

Issue #265 requests removal of legacy config mirror fields and compatibility sync logic after migration coverage is in place. This change reduces runtime complexity and enforces a single canonical representation while keeping migrated legacy configs loadable.

Closes #265.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stats now persist to a single canonical location; legacy multi-path read/write and dual-write behavior removed.
  * Legacy top-level config fields are retained only for load-time compatibility and are no longer written back.
  * Blocked-sites legacy mirroring removed; persisted top-level blocked_sites are empty.
  * CLI/diagnostics output simplified to only report the metadata-fallback flag; migration flow simplified.

* **Documentation**
  * README and CHANGELOG updated with deprecation milestones and migration guidance (including focustime --migrate).

* **Tests**
  * Tests updated to expect canonical-only stats behavior and empty legacy blocked_sites in persisted config.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/297)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->