### PR TITLE
Finalize new persistence path and retire deprecated schema handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ cargo run -- --backup=./reports --json
 cargo run -- --restore
 cargo run -- --restore=./reports --json
 
-# Run stats-path compatibility migration (legacy -> canonical) with optional dry-run preview
+# Run canonical persistence migration diagnostics (optional dry-run preview)
 cargo run -- --migrate
 cargo run -- --migrate --dry-run --json
 
@@ -209,20 +209,19 @@ Backup/restore behavior:
 
 - `--backup` creates the target directory if needed, then copies `config.toml` and `stats.toml` into it.
 - `--restore` requires both files in the source directory and uses staged replacement so failed restores roll back to the original files.
-- `--migrate` applies compatibility migration updates for canonical stats persistence and disables migration-window feature flags after success.
-- `--migrate --dry-run` reports planned migration steps without mutating any files.
+- `--migrate` reports canonical persistence migration status; runtime persistence is canonical-path only.
+- `--migrate --dry-run` reports the same migration status in dry-run mode (no file changes).
 
 ### Legacy compatibility deprecation milestones
 
-`focustime --diagnostics` and the TUI Setup Diagnostics screen now report targeted
-deprecation warnings when legacy compatibility fields/paths are detected.
+`focustime --diagnostics` and the TUI Setup Diagnostics screen report targeted
+deprecation warnings when legacy compatibility fields are detected.
 
 | Legacy field/path                                                                                               | Canonical replacement                                                                                         | Removal milestone      |
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------- |
 | Top-level `focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval`                          | `[custom_profile]`                                                                                            | v0.12.0 (planned)      |
 | Top-level `notifications`, `auto_start`, `strict_mode`, `recurring_schedule`                                  | `[profile_automation.<profile>.notifications]`, `[profile_automation.<profile>.auto_start]`, and per-profile `strict_mode` / `recurring_schedule` | v0.12.0 (planned)      |
 | Top-level `blocked_sites` (without canonical profiles)                                                         | `[[blocklist_profiles]]` + `selected_blocklist_profile`                                                      | v0.12.0 (planned)      |
-| Legacy config-dir `stats.toml` path                                                                          | Canonical state/data `stats.toml` path and `focustime --migrate`                                             | Removed (canonical-only now) |
 
 Milestone policy:
 
@@ -398,10 +397,6 @@ selected_blocklist_profile = "Work"
 # Legacy compatibility mirror for the selected profile's automation strict mode.
 strict_mode = false
 break_glass_duration_secs = 300
-
-[feature_flags]
-# Backfill legacy metadata from task_label when missing.
-metadata_task_label_fallback = true
 
 [shortcuts]
 timer_toggle_pause = "space"
@@ -667,7 +662,7 @@ Override events are recorded for audit visibility in the History view and includ
 
 - completed pomodoros for the current app session
 - focused minutes for the current app session
-- daily aggregates persisted in `stats.toml` (canonical data/state directory with optional legacy config-dir mirror during migration)
+- daily aggregates persisted in `stats.toml` in the canonical data/state directory
 - weekly totals derived from daily aggregates in the History view
 - weekly consistency score (`active_days / 7`, rounded to `%`) derived from daily activity
 - weekly focus score KPI (50/50 blend of consistency and weekly goal completion; `n/a` when weekly goal is off)

--- a/src/app.rs
+++ b/src/app.rs
@@ -130,6 +130,8 @@ const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
 const UNLINKED_BREAK_TEMPLATE_NAME: &str = "Custom";
+#[cfg(not(test))]
+const STATS_FILE_NAME: &str = "stats.toml";
 pub(crate) const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
 const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
 const SCHEDULE_DAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -642,7 +644,7 @@ impl App {
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
         let (mut stats, stats_error) =
             match FocusStats::load_with_options(crate::stats::StatsLoadOptions::default()) {
-                Ok(stats) => (stats, None),
+                Ok(stats) => (stats, legacy_stats_path_migration_warning()),
                 Err(e) => (FocusStats::default(), Some(e)),
             };
         let retained = stats.apply_retention_policy(stats_retention, Local::now().date_naive());
@@ -1569,7 +1571,44 @@ fn permission_remediation_guidance() -> &'static str {
 }
 
 pub(super) fn setup_deprecation_warnings(config_deprecation_warnings: &[String]) -> Vec<String> {
-    config_deprecation_warnings.to_vec()
+    let mut warnings = config_deprecation_warnings.to_vec();
+    if let Some(stats_warning) = legacy_stats_path_migration_warning() {
+        warnings.push(stats_warning);
+    }
+    warnings
+}
+
+pub(super) fn format_legacy_stats_path_migration_warning(
+    canonical_path: &std::path::Path,
+    legacy_path: &std::path::Path,
+) -> String {
+    format!(
+        "Legacy stats path `{}` is still in use while canonical stats `{}` are missing. Run `focustime --migrate` to migrate existing history.",
+        legacy_path.display(),
+        canonical_path.display()
+    )
+}
+
+#[cfg(not(test))]
+fn legacy_stats_path_migration_warning() -> Option<String> {
+    let canonical_path = crate::config::stats_data_path(STATS_FILE_NAME)?;
+    if canonical_path.exists() {
+        return None;
+    }
+    let legacy_path =
+        crate::config::app_data_path(STATS_FILE_NAME).filter(|path| path != &canonical_path)?;
+    if !legacy_path.exists() {
+        return None;
+    }
+    Some(format_legacy_stats_path_migration_warning(
+        &canonical_path,
+        &legacy_path,
+    ))
+}
+
+#[cfg(test)]
+fn legacy_stats_path_migration_warning() -> Option<String> {
+    None
 }
 
 impl Drop for App {

--- a/src/app.rs
+++ b/src/app.rs
@@ -129,8 +129,6 @@ const PROFILE_EDIT_THEME_PRESET_INDEX: usize = 35;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
-#[cfg(not(test))]
-const STATS_FILE_NAME: &str = "stats.toml";
 const UNLINKED_BREAK_TEMPLATE_NAME: &str = "Custom";
 pub(crate) const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
 const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
@@ -434,16 +432,11 @@ pub struct SetupDiagnostics {
     pub blocking_permissions: SetupCheck,
     pub hosts_write_capability: SetupCheck,
     pub wakatime_config: SetupCheck,
-    pub feature_flags: FeatureFlagsConfig,
     pub deprecation_warnings: Vec<String>,
 }
 
 impl SetupDiagnostics {
-    fn collect(
-        blocker: &SiteBlocker,
-        feature_flags: FeatureFlagsConfig,
-        deprecation_warnings: Vec<String>,
-    ) -> Self {
+    fn collect(blocker: &SiteBlocker, deprecation_warnings: Vec<String>) -> Self {
         let hosts_diagnostics = blocker.hosts_file_diagnostics();
         let blocking_permissions = blocking_permissions_check(&hosts_diagnostics);
         let hosts_write_capability = hosts_write_capability_check(&hosts_diagnostics);
@@ -463,7 +456,6 @@ impl SetupDiagnostics {
             blocking_permissions,
             hosts_write_capability,
             wakatime_config,
-            feature_flags,
             deprecation_warnings,
         }
     }
@@ -649,9 +641,7 @@ impl App {
         );
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
         let (mut stats, stats_error) =
-            match FocusStats::load_with_options(crate::stats::StatsLoadOptions {
-                metadata_task_label_fallback: feature_flags.metadata_task_label_fallback,
-            }) {
+            match FocusStats::load_with_options(crate::stats::StatsLoadOptions::default()) {
                 Ok(stats) => (stats, None),
                 Err(e) => (FocusStats::default(), Some(e)),
             };
@@ -668,7 +658,7 @@ impl App {
         );
         let blocker = SiteBlocker::new();
         let setup_diagnostics =
-            SetupDiagnostics::collect(&blocker, feature_flags, setup_deprecation_warnings.clone());
+            SetupDiagnostics::collect(&blocker, setup_deprecation_warnings.clone());
         let mut app = Self {
             timer,
             should_quit: false,
@@ -1579,52 +1569,7 @@ fn permission_remediation_guidance() -> &'static str {
 }
 
 pub(super) fn setup_deprecation_warnings(config_deprecation_warnings: &[String]) -> Vec<String> {
-    let mut warnings = config_deprecation_warnings.to_vec();
-    if let Some(stats_warning) = legacy_stats_path_deprecation_warning() {
-        warnings.push(stats_warning);
-    }
-    warnings
-}
-
-pub(super) fn format_legacy_stats_path_deprecation_warning(
-    canonical_path: &std::path::Path,
-    legacy_path: &std::path::Path,
-    canonical_exists: bool,
-) -> String {
-    let mut warning = format!(
-        "Deprecated legacy stats path detected at `{}`.",
-        legacy_path.display()
-    );
-    if !canonical_exists {
-        warning.push_str(" Canonical stats are missing and this path must be migrated.");
-    }
-    warning.push_str(&format!(
-        " Move stats to `{}` and run `focustime --migrate`.",
-        canonical_path.display()
-    ));
-    warning
-}
-
-#[cfg(not(test))]
-fn legacy_stats_path_deprecation_warning() -> Option<String> {
-    let canonical_path = crate::config::stats_data_path(STATS_FILE_NAME)?;
-    let legacy_path =
-        crate::config::app_data_path(STATS_FILE_NAME).filter(|path| path != &canonical_path)?;
-    if !legacy_path.exists() {
-        return None;
-    }
-
-    let canonical_exists = canonical_path.exists();
-    Some(format_legacy_stats_path_deprecation_warning(
-        &canonical_path,
-        &legacy_path,
-        canonical_exists,
-    ))
-}
-
-#[cfg(test)]
-fn legacy_stats_path_deprecation_warning() -> Option<String> {
-    None
+    config_deprecation_warnings.to_vec()
 }
 
 impl Drop for App {

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -136,24 +136,16 @@ impl App {
 
     pub fn focus_intention_for_cli(&self) -> Option<String> {
         if self.focus_session_active_for_current_state() {
-            return self
-                .active_focus_intention
-                .clone()
-                .or_else(|| self.active_focus_task_label.clone())
-                .or_else(|| self.selected_task_label.clone());
+            return self.active_focus_intention.clone();
         }
-        self.cli_metadata_fallback_value()
+        None
     }
 
     pub fn task_note_for_cli(&self) -> Option<String> {
         if self.focus_session_active_for_current_state() {
-            return self
-                .active_focus_task_note
-                .clone()
-                .or_else(|| self.active_focus_task_label.clone())
-                .or_else(|| self.selected_task_label.clone());
+            return self.active_focus_task_note.clone();
         }
-        self.cli_metadata_fallback_value()
+        None
     }
 
     pub fn set_focus_intention_for_cli(&mut self, value: &str) -> Result<(), String> {
@@ -179,14 +171,6 @@ impl App {
             self.timer.remaining_secs,
             self.timer.pomodoros_completed,
         )
-    }
-
-    fn cli_metadata_fallback_value(&self) -> Option<String> {
-        if self.feature_flags.metadata_task_label_fallback {
-            self.selected_task_label.clone()
-        } else {
-            None
-        }
     }
 
     fn ensure_focus_active_for_cli_metadata_update(&self, command: &str) -> Result<(), String> {

--- a/src/app/feedback_diagnostics.rs
+++ b/src/app/feedback_diagnostics.rs
@@ -107,8 +107,7 @@ impl App {
     pub(super) fn refresh_setup_diagnostics(&mut self) {
         let deprecation_warnings =
             crate::app::setup_deprecation_warnings(&self.config_deprecation_warnings);
-        self.setup_diagnostics =
-            SetupDiagnostics::collect(&self.blocker, self.feature_flags, deprecation_warnings);
+        self.setup_diagnostics = SetupDiagnostics::collect(&self.blocker, deprecation_warnings);
         self.refresh_blocking_preview();
     }
 

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -249,8 +249,7 @@ impl App {
         recovered_timer.status = snapshot.status();
         recovered_timer.remaining_secs = snapshot.remaining_secs;
         recovered_timer.pomodoros_completed = snapshot.pomodoros_completed;
-        let metadata_fallback_enabled = self.feature_flags.metadata_task_label_fallback;
-        snapshot.validate_for_timer_with_fallback(&recovered_timer, metadata_fallback_enabled)?;
+        snapshot.validate_for_timer(&recovered_timer)?;
 
         let task_label = snapshot
             .normalized_task_label()
@@ -277,12 +276,12 @@ impl App {
             None
         };
         self.active_focus_intention = if self.timer.phase == TimerPhase::Focus {
-            snapshot.normalized_focus_intention_with_fallback(metadata_fallback_enabled)
+            snapshot.normalized_focus_intention()
         } else {
             None
         };
         self.active_focus_task_note = if self.timer.phase == TimerPhase::Focus {
-            snapshot.normalized_task_note_with_fallback(metadata_fallback_enabled)
+            snapshot.normalized_task_note()
         } else {
             None
         };
@@ -295,41 +294,8 @@ impl App {
         Ok(())
     }
 
-    fn recovery_snapshot_task_label_fallback(
-        recovery_task_label: &Option<String>,
-        metadata_fallback_enabled: bool,
-    ) -> Option<String> {
-        if metadata_fallback_enabled {
-            recovery_task_label.clone()
-        } else {
-            None
-        }
-    }
-
-    fn recovery_snapshot_metadata_value(
-        focus_active: bool,
-        active_value: Option<String>,
-        recovery_task_label: &Option<String>,
-        metadata_fallback_enabled: bool,
-    ) -> Option<String> {
-        if focus_active {
-            active_value.or_else(|| {
-                Self::recovery_snapshot_task_label_fallback(
-                    recovery_task_label,
-                    metadata_fallback_enabled,
-                )
-            })
-        } else {
-            Self::recovery_snapshot_task_label_fallback(
-                recovery_task_label,
-                metadata_fallback_enabled,
-            )
-        }
-    }
-
     pub(super) fn sync_recovery_snapshot(&mut self) {
         let focus_active = self.focus_session_active_for_current_state();
-        let metadata_fallback_enabled = self.feature_flags.metadata_task_label_fallback;
         let recovery_task_label = if focus_active {
             self.active_focus_task_label
                 .clone()
@@ -337,26 +303,23 @@ impl App {
         } else {
             self.selected_task_label.clone()
         };
-        let recovery_focus_intention = Self::recovery_snapshot_metadata_value(
-            focus_active,
-            self.active_focus_intention.clone(),
-            &recovery_task_label,
-            metadata_fallback_enabled,
-        );
-        let recovery_task_note = Self::recovery_snapshot_metadata_value(
-            focus_active,
-            self.active_focus_task_note.clone(),
-            &recovery_task_label,
-            metadata_fallback_enabled,
-        );
+        let recovery_focus_intention = if focus_active {
+            self.active_focus_intention.clone()
+        } else {
+            None
+        };
+        let recovery_task_note = if focus_active {
+            self.active_focus_task_note.clone()
+        } else {
+            None
+        };
 
-        let snapshot = InProgressSessionSnapshot::from_timer_state_with_metadata_with_fallback(
+        let snapshot = InProgressSessionSnapshot::from_timer_state_with_metadata(
             &self.timer,
             recovery_task_label,
             recovery_focus_intention,
             recovery_task_note,
             self.selected_profile,
-            metadata_fallback_enabled,
         );
 
         match snapshot {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7,7 +7,6 @@ use crate::session_recovery::{
 use chrono::{Datelike, Duration as ChronoDuration, Local, LocalResult, TimeZone, Weekday};
 use std::{
     fs,
-    path::Path,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -79,30 +78,6 @@ fn app_default_uses_canonical_config_in_tests() {
     assert_eq!(app.daily_goal, DailyGoalConfig::default());
     assert_eq!(app.weekly_goal, WeeklyGoalConfig::default());
     assert_eq!(app.monthly_goal, MonthlyGoalConfig::default());
-}
-
-#[test]
-fn legacy_stats_path_warning_mentions_migration_when_canonical_is_missing() {
-    let warning = format_legacy_stats_path_deprecation_warning(
-        Path::new("state/stats.toml"),
-        Path::new("config/stats.toml"),
-        false,
-    );
-
-    assert!(warning.contains("Deprecated legacy stats path detected"));
-    assert!(warning.contains("must be migrated"));
-    assert!(warning.contains("run `focustime --migrate`"));
-}
-
-#[test]
-fn legacy_stats_path_warning_omits_missing_canonical_hint_when_canonical_exists() {
-    let warning = format_legacy_stats_path_deprecation_warning(
-        Path::new("state/stats.toml"),
-        Path::new("config/stats.toml"),
-        true,
-    );
-
-    assert!(!warning.contains("must be migrated"));
 }
 
 #[test]
@@ -5379,38 +5354,10 @@ fn planner_label_change_during_running_break_updates_recovery_snapshot() {
 
     let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
     assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task B"));
-    assert_eq!(snapshot.focus_intention.as_deref(), Some("Task B"));
-    assert_eq!(snapshot.task_note.as_deref(), Some("Task B"));
-    assert_eq!(snapshot.phase, RecoveryTimerPhase::ShortBreak);
-    assert_eq!(snapshot.status, RecoveryTimerStatus::Running);
-}
-
-#[test]
-fn planner_label_change_during_running_break_does_not_backfill_metadata_when_disabled() {
-    let mut app = App::from_config(AppConfig {
-        feature_flags: FeatureFlagsConfig {
-            metadata_task_label_fallback: false,
-        },
-        ..AppConfig::default()
-    });
-    app.task_labels = vec!["Task A".to_string(), "Task B".to_string()];
-    app.selected_task_label = Some("Task A".to_string());
-    app.sync_task_planner_state();
-
-    app.handle_key(key(KeyCode::Char(' '))); // focus running
-    app.handle_key(key(KeyCode::Char('n'))); // short break idle
-    app.handle_key(key(KeyCode::Char(' '))); // short break running
-    assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
-    assert_eq!(app.timer.status, TimerStatus::Running);
-
-    app.open_session_planner();
-    app.planner_selection_index = 1;
-    app.select_planner_label();
-
-    let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
-    assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task B"));
     assert_eq!(snapshot.focus_intention, None);
     assert_eq!(snapshot.task_note, None);
+    assert_eq!(snapshot.phase, RecoveryTimerPhase::ShortBreak);
+    assert_eq!(snapshot.status, RecoveryTimerStatus::Running);
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7,6 +7,7 @@ use crate::session_recovery::{
 use chrono::{Datelike, Duration as ChronoDuration, Local, LocalResult, TimeZone, Weekday};
 use std::{
     fs,
+    path::Path,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -78,6 +79,18 @@ fn app_default_uses_canonical_config_in_tests() {
     assert_eq!(app.daily_goal, DailyGoalConfig::default());
     assert_eq!(app.weekly_goal, WeeklyGoalConfig::default());
     assert_eq!(app.monthly_goal, MonthlyGoalConfig::default());
+}
+
+#[test]
+fn legacy_stats_path_migration_warning_includes_actionable_guidance() {
+    let warning = format_legacy_stats_path_migration_warning(
+        Path::new("state/stats.toml"),
+        Path::new("config/stats.toml"),
+    );
+
+    assert!(warning.contains("Legacy stats path"));
+    assert!(warning.contains("canonical stats"));
+    assert!(warning.contains("Run `focustime --migrate`"));
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -165,7 +165,7 @@ Options:
   --watch         Stream periodic status updates (status command only; default 1s)
   --backup        Back up config.toml and stats.toml to current directory or DIR
   --restore       Restore config.toml and stats.toml from current directory or DIR
-  --migrate       Run compatibility migration for canonical stats/config persistence
+  --migrate       Report canonical persistence migration status
   --dry-run       Preview migration steps without mutating files (migration only)
   --export        Export stats to current directory or DIR
   --json          Emit machine-readable JSON output
@@ -613,8 +613,6 @@ struct RestoreOutput {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 enum MigrationStepStatus {
-    Planned,
-    Applied,
     Skipped,
 }
 
@@ -632,7 +630,6 @@ struct MigrationCommandOutput {
     changed: bool,
     config_path: PathBuf,
     canonical_stats_path: PathBuf,
-    legacy_stats_path: Option<PathBuf>,
     steps: Vec<MigrationStepOutput>,
     warnings: Vec<String>,
 }
@@ -746,18 +743,12 @@ struct SetupCheckOutput {
     message: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-struct FeatureFlagsOutput {
-    metadata_task_label_fallback: bool,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct DiagnosticsCommandOutput {
     hosts_file_path: String,
     blocking_permissions: SetupCheckOutput,
     hosts_write_capability: SetupCheckOutput,
     wakatime_config: SetupCheckOutput,
-    feature_flags: FeatureFlagsOutput,
     deprecation_warnings: Vec<String>,
 }
 

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -35,28 +35,19 @@ const CONFIG_FILE_NAME: &str = "config.toml";
 const STATS_FILE_NAME: &str = "stats.toml";
 
 #[derive(Debug, Clone)]
-struct StatsPersistencePaths {
-    canonical: PathBuf,
-    legacy: Option<PathBuf>,
-}
-
-#[derive(Debug, Clone)]
 struct MigrationPlan {
     config_path: PathBuf,
     canonical_stats_path: PathBuf,
-    legacy_stats_path: Option<PathBuf>,
-    copy_legacy_stats_to_canonical: bool,
-    stats_copy_skip_reason: String,
     warnings: Vec<String>,
 }
 
 impl MigrationPlan {
     fn has_changes(&self) -> bool {
-        self.copy_legacy_stats_to_canonical
+        false
     }
 }
 
-const MIGRATION_OPERATION_COPY_LEGACY_STATS: &str = "copy_legacy_stats_to_canonical";
+const MIGRATION_OPERATION_VERIFY_CANONICAL_STATS: &str = "verify_canonical_stats_path";
 
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
     match cli_command.kind {
@@ -1098,8 +1089,7 @@ fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
         .map_err(|error| format!("Backup failed: could not create backup directory: {error}"))?;
 
     let source_config = config_file_path()?;
-    let stats_paths = stats_persistence_paths()?;
-    let source_stats = resolve_stats_backup_source_path(&stats_paths);
+    let source_stats = stats_persistence_path()?;
     ensure_backup_source_file(&source_config, CONFIG_FILE_NAME)?;
     ensure_backup_source_file(&source_stats, STATS_FILE_NAME)?;
     let config_backup_path = backup_dir.join(CONFIG_FILE_NAME);
@@ -1134,8 +1124,7 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
     ensure_restore_source_file(&source_stats, STATS_FILE_NAME)?;
 
     let config_restored_path = config_file_path()?;
-    let stats_paths = stats_persistence_paths()?;
-    let stats_restored_path = stats_paths.canonical.clone();
+    let stats_restored_path = stats_persistence_path()?;
     let staged_config_path = temp_restore_path(&config_restored_path, "staged");
     let staged_stats_path = temp_restore_path(&stats_restored_path, "staged");
     copy_file_with_context(
@@ -1203,17 +1192,13 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
 fn execute_migrate_command(dry_run: bool, output: OutputMode) -> Result<(), String> {
     let config = AppConfig::load().normalized();
     let plan = build_migration_plan(&config)?;
-    let mut steps = migration_steps_for_plan(&plan);
-    if !dry_run && plan.has_changes() {
-        apply_migration_plan(&config, &plan, &mut steps)?;
-    }
+    let steps = migration_steps_for_plan(&plan);
     let payload = MigrationCommandOutput {
         action: "migrate",
         dry_run,
         changed: plan.has_changes(),
         config_path: plan.config_path.clone(),
         canonical_stats_path: plan.canonical_stats_path.clone(),
-        legacy_stats_path: plan.legacy_stats_path.clone(),
         steps,
         warnings: plan.warnings.clone(),
     };
@@ -1227,320 +1212,36 @@ fn execute_migrate_command(dry_run: bool, output: OutputMode) -> Result<(), Stri
 fn build_migration_plan(_config: &AppConfig) -> Result<MigrationPlan, String> {
     let config_path = config_file_path()?;
     ensure_regular_file_if_exists(&config_path, "config path")?;
-    let stats_paths = stats_persistence_paths()?;
-    ensure_regular_file_if_exists(&stats_paths.canonical, "canonical stats path")?;
-    if let Some(legacy) = stats_paths.legacy.as_deref() {
-        ensure_regular_file_if_exists(legacy, "legacy stats path")?;
-    }
-
-    let mut copy_legacy_stats_to_canonical = false;
-    let mut stats_copy_skip_reason = "No legacy stats file was found to migrate.".to_string();
-    let mut warnings = Vec::new();
-
-    let canonical_exists = stats_paths.canonical.exists();
-    let legacy_exists = stats_paths
-        .legacy
-        .as_ref()
-        .is_some_and(|path| path.exists());
-    if let Some(legacy) = stats_paths.legacy.as_ref() {
-        if legacy_exists && !canonical_exists {
-            copy_legacy_stats_to_canonical = true;
-            stats_copy_skip_reason.clear();
-        } else if legacy_exists && canonical_exists {
-            let canonical_bytes = fs::read(&stats_paths.canonical).map_err(|error| {
-                format!(
-                    "Migration planning failed: could not read canonical stats file `{}`: {error}",
-                    stats_paths.canonical.display()
-                )
-            })?;
-            let legacy_bytes = fs::read(legacy).map_err(|error| {
-                format!(
-                    "Migration planning failed: could not read legacy stats file `{}`: {error}",
-                    legacy.display()
-                )
-            })?;
-            if canonical_bytes != legacy_bytes {
-                return Err(format!(
-                    "Migration failed: canonical stats `{}` and legacy stats `{}` differ. Run `focustime --backup`, reconcile the two files, and rerun `focustime --migrate`.",
-                    stats_paths.canonical.display(),
-                    legacy.display()
-                ));
-            }
-            stats_copy_skip_reason =
-                "Canonical and legacy stats files already match; copy is not required.".to_string();
-        } else if !legacy_exists && !canonical_exists {
-            stats_copy_skip_reason = format!(
-                "Neither canonical (`{}`) nor legacy (`{}`) stats files exist.",
-                stats_paths.canonical.display(),
-                legacy.display()
-            );
-        } else {
-            stats_copy_skip_reason =
-                "Canonical stats file already exists; legacy copy is not required.".to_string();
-        }
-    } else {
-        stats_copy_skip_reason =
-            "No distinct legacy stats path exists for this environment.".to_string();
-    }
-
-    if !copy_legacy_stats_to_canonical {
-        warnings.push(stats_copy_skip_reason.clone());
-    }
-
+    let canonical_stats_path = stats_persistence_path()?;
+    ensure_regular_file_if_exists(&canonical_stats_path, "canonical stats path")?;
+    let warnings = vec![
+        "Legacy stats-path migration has been retired. Runtime persistence is canonical-path only."
+            .to_string(),
+    ];
     Ok(MigrationPlan {
         config_path,
-        canonical_stats_path: stats_paths.canonical,
-        legacy_stats_path: stats_paths.legacy,
-        copy_legacy_stats_to_canonical,
-        stats_copy_skip_reason,
+        canonical_stats_path,
         warnings,
     })
 }
 
 fn migration_steps_for_plan(plan: &MigrationPlan) -> Vec<MigrationStepOutput> {
-    let mut steps = Vec::new();
-    let status_for_apply = MigrationStepStatus::Planned;
-
-    if plan.copy_legacy_stats_to_canonical {
-        let legacy = plan
-            .legacy_stats_path
-            .as_ref()
-            .map(|path| path.display().to_string())
-            .unwrap_or_else(|| "<unavailable>".to_string());
-        steps.push(MigrationStepOutput {
-            operation: MIGRATION_OPERATION_COPY_LEGACY_STATS,
-            status: status_for_apply,
-            detail: format!(
-                "Copy legacy stats `{legacy}` to canonical path `{}`.",
-                plan.canonical_stats_path.display()
-            ),
-        });
+    let detail = if plan.canonical_stats_path.exists() {
+        format!(
+            "Canonical stats path `{}` is active; no migration is required.",
+            plan.canonical_stats_path.display()
+        )
     } else {
-        steps.push(MigrationStepOutput {
-            operation: MIGRATION_OPERATION_COPY_LEGACY_STATS,
-            status: MigrationStepStatus::Skipped,
-            detail: plan.stats_copy_skip_reason.clone(),
-        });
-    }
-
-    steps
-}
-
-fn apply_migration_plan(
-    _config: &AppConfig,
-    plan: &MigrationPlan,
-    steps: &mut [MigrationStepOutput],
-) -> Result<(), String> {
-    let mut state = MigrationExecutionState::default();
-    prepare_migration_staging(plan, &mut state)?;
-    capture_config_snapshot_if_needed(plan, &mut state)?;
-    apply_staged_canonical_stats(plan, &mut state)?;
-    save_migrated_config_if_needed(_config, plan, &state)?;
-    let _ = cleanup_migration_temp_files(
-        state.config_snapshot.as_deref(),
-        state.canonical_stats_snapshot.as_deref(),
-        state.staged_canonical_stats_path.as_deref(),
-    );
-
-    for step in steps {
-        if step.status == MigrationStepStatus::Planned {
-            step.status = MigrationStepStatus::Applied;
-        }
-    }
-    Ok(())
-}
-
-#[derive(Debug, Default)]
-struct MigrationExecutionState {
-    config_snapshot: Option<PathBuf>,
-    canonical_stats_snapshot: Option<PathBuf>,
-    staged_canonical_stats_path: Option<PathBuf>,
-    applied_canonical_stats: bool,
-}
-
-fn prepare_migration_staging(
-    plan: &MigrationPlan,
-    state: &mut MigrationExecutionState,
-) -> Result<(), String> {
-    if !plan.copy_legacy_stats_to_canonical {
-        return Ok(());
-    }
-
-    state.canonical_stats_snapshot = snapshot_existing_file(
-        &plan.canonical_stats_path,
-        "snapshot existing canonical stats.toml for migration rollback",
-    )
-    .map_err(|error| {
-        migration_setup_failure_from_state(
-            format!("could not prepare canonical stats snapshot: {error}"),
-            state,
+        format!(
+            "Canonical stats path `{}` is not present yet; it will be created on next save.",
+            plan.canonical_stats_path.display()
         )
-    })?;
-
-    let staged_path = temp_restore_path(&plan.canonical_stats_path, "staged");
-    state.staged_canonical_stats_path = Some(staged_path.clone());
-    let legacy_stats_path = plan.legacy_stats_path.as_ref().ok_or_else(|| {
-        migration_setup_failure_from_state(
-            "missing legacy stats path for planned copy step".to_string(),
-            state,
-        )
-    })?;
-
-    copy_file_with_context(
-        legacy_stats_path,
-        &staged_path,
-        "stage migration copy of stats.toml",
-    )
-    .map_err(|error| {
-        migration_setup_failure_from_state(
-            format!("could not stage canonical stats update: {error}"),
-            state,
-        )
-    })
-}
-
-fn capture_config_snapshot_if_needed(
-    _plan: &MigrationPlan,
-    _state: &mut MigrationExecutionState,
-) -> Result<(), String> {
-    Ok(())
-}
-
-fn apply_staged_canonical_stats(
-    plan: &MigrationPlan,
-    state: &mut MigrationExecutionState,
-) -> Result<(), String> {
-    let Some(staged_path) = state.staged_canonical_stats_path.as_deref() else {
-        return Ok(());
     };
-
-    replace_file_atomically(
-        staged_path,
-        &plan.canonical_stats_path,
-        "apply migration copy of stats.toml",
-    )
-    .map_err(|error| {
-        migration_failure_with_rollback(
-            format!("could not update canonical stats.toml: {error}"),
-            rollback_migration_files(
-                state.config_snapshot.as_deref(),
-                &plan.config_path,
-                false,
-                state.canonical_stats_snapshot.as_deref(),
-                &plan.canonical_stats_path,
-                true,
-            ),
-        )
-    })?;
-    state.applied_canonical_stats = true;
-    Ok(())
-}
-
-fn save_migrated_config_if_needed(
-    _config: &AppConfig,
-    _plan: &MigrationPlan,
-    _state: &MigrationExecutionState,
-) -> Result<(), String> {
-    Ok(())
-}
-
-fn migration_setup_failure_from_state(error: String, state: &MigrationExecutionState) -> String {
-    migration_setup_failure(
-        error,
-        state.config_snapshot.as_deref(),
-        state.canonical_stats_snapshot.as_deref(),
-        state.staged_canonical_stats_path.as_deref(),
-    )
-}
-
-fn rollback_migration_files(
-    config_snapshot: Option<&Path>,
-    config_path: &Path,
-    config_was_updated: bool,
-    canonical_stats_snapshot: Option<&Path>,
-    canonical_stats_path: &Path,
-    canonical_stats_was_updated: bool,
-) -> Vec<String> {
-    let mut rollback_errors = Vec::new();
-    if config_was_updated
-        && let Err(error) = rollback_file(
-            config_snapshot,
-            config_path,
-            "roll back migrated config.toml",
-        )
-    {
-        rollback_errors.push(error);
-    }
-    if canonical_stats_was_updated
-        && let Err(error) = rollback_file(
-            canonical_stats_snapshot,
-            canonical_stats_path,
-            "roll back migrated canonical stats.toml",
-        )
-    {
-        rollback_errors.push(error);
-    }
-    rollback_errors
-}
-
-fn rollback_file(snapshot: Option<&Path>, destination: &Path, context: &str) -> Result<(), String> {
-    if let Some(snapshot) = snapshot {
-        replace_file_atomically(snapshot, destination, context)
-    } else {
-        remove_file_if_exists(destination)
-    }
-}
-
-fn migration_failure_with_rollback(error: String, rollback_errors: Vec<String>) -> String {
-    let mut message = format!("Migration failed: {error}");
-    if !rollback_errors.is_empty() {
-        message.push_str("; rollback failed: ");
-        message.push_str(&rollback_errors.join("; "));
-    }
-    message.push_str(
-        ". Next steps: run `focustime --backup`, inspect `config.toml` and `stats.toml`, then retry with `focustime --migrate --dry-run`.",
-    );
-    message
-}
-
-fn migration_setup_failure(
-    error: String,
-    config_snapshot: Option<&Path>,
-    canonical_stats_snapshot: Option<&Path>,
-    staged_canonical_stats_path: Option<&Path>,
-) -> String {
-    migration_failure_with_rollback(
-        error,
-        cleanup_migration_temp_files(
-            config_snapshot,
-            canonical_stats_snapshot,
-            staged_canonical_stats_path,
-        ),
-    )
-}
-
-fn cleanup_migration_temp_files(
-    config_snapshot: Option<&Path>,
-    canonical_stats_snapshot: Option<&Path>,
-    staged_canonical_stats_path: Option<&Path>,
-) -> Vec<String> {
-    let mut cleanup_errors = Vec::new();
-    let cleanup_targets = [
-        ("config snapshot", config_snapshot),
-        ("canonical stats snapshot", canonical_stats_snapshot),
-        ("staged canonical stats", staged_canonical_stats_path),
-    ];
-    for (label, path) in cleanup_targets {
-        if let Some(path) = path
-            && let Err(error) = remove_file_if_exists(path)
-        {
-            cleanup_errors.push(format!(
-                "cleanup failed for {label} `{}`: {error}",
-                path.display()
-            ));
-        }
-    }
-    cleanup_errors
+    vec![MigrationStepOutput {
+        operation: MIGRATION_OPERATION_VERIFY_CANONICAL_STATS,
+        status: MigrationStepStatus::Skipped,
+        detail,
+    }]
 }
 
 fn ensure_regular_file_if_exists(path: &Path, context: &str) -> Result<(), String> {
@@ -1691,32 +1392,16 @@ fn config_file_path() -> Result<PathBuf, String> {
     })
 }
 
-fn stats_persistence_paths() -> Result<StatsPersistencePaths, String> {
-    let canonical = crate::config::stats_data_path(STATS_FILE_NAME).ok_or_else(|| {
+fn stats_persistence_path() -> Result<PathBuf, String> {
+    crate::config::stats_data_path(STATS_FILE_NAME).ok_or_else(|| {
         format!(
             "could not determine application data path for `{STATS_FILE_NAME}` (environment is not configured)"
         )
-    })?;
-    let legacy = crate::config::app_data_path(STATS_FILE_NAME).filter(|path| path != &canonical);
-    Ok(StatsPersistencePaths { canonical, legacy })
+    })
 }
 
-fn resolve_stats_backup_source_path(paths: &StatsPersistencePaths) -> PathBuf {
-    if paths.canonical.exists() {
-        return paths.canonical.clone();
-    }
-    if let Some(legacy) = paths.legacy.as_ref()
-        && legacy.exists()
-    {
-        return legacy.clone();
-    }
-    paths.canonical.clone()
-}
-
-fn stats_load_options(config: &AppConfig) -> crate::stats::StatsLoadOptions {
-    crate::stats::StatsLoadOptions {
-        metadata_task_label_fallback: config.feature_flags.metadata_task_label_fallback,
-    }
+fn stats_load_options(_config: &AppConfig) -> crate::stats::StatsLoadOptions {
+    crate::stats::StatsLoadOptions::default()
 }
 
 fn stats_save_options(_config: &AppConfig) -> crate::stats::StatsSaveOptions {
@@ -1867,94 +1552,42 @@ mod tests {
     }
 
     #[test]
-    fn apply_migration_plan_copies_legacy_stats_to_canonical() {
-        let temp_dir = create_temp_dir("migrate-copy");
+    fn migration_plan_reports_canonical_only_behavior() {
+        let temp_dir = create_temp_dir("migrate-canonical-only");
         let config_path = temp_dir.join("config.toml");
-        let legacy_stats_path = temp_dir.join("legacy-stats.toml");
         let canonical_stats_path = temp_dir.join("state").join("stats.toml");
-        fs::write(&legacy_stats_path, "daily = {}\n")
-            .expect("legacy stats file should be writable");
+        fs::write(&config_path, "schema_version = 1\n").expect("config file should be writable");
+        fs::create_dir_all(
+            canonical_stats_path
+                .parent()
+                .expect("canonical path should have parent"),
+        )
+        .expect("canonical stats parent should be writable");
+        fs::write(&canonical_stats_path, "daily = {}\n")
+            .expect("canonical stats file should be writable");
 
         let plan = MigrationPlan {
             config_path,
             canonical_stats_path: canonical_stats_path.clone(),
-            legacy_stats_path: Some(legacy_stats_path),
-            copy_legacy_stats_to_canonical: true,
-            stats_copy_skip_reason: String::new(),
-            warnings: Vec::new(),
+            warnings: vec![
+                "Legacy stats-path migration has been retired. Runtime persistence is canonical-path only."
+                    .to_string(),
+            ],
         };
-        let mut steps = migration_steps_for_plan(&plan);
-        apply_migration_plan(&AppConfig::default(), &plan, &mut steps)
-            .expect("migration copy should succeed");
+        let steps = migration_steps_for_plan(&plan);
 
-        let canonical_bytes =
-            fs::read(&canonical_stats_path).expect("canonical stats file should be readable");
-        assert_eq!(canonical_bytes, b"daily = {}\n");
-
-        let copy_step = steps
+        assert!(!plan.has_changes());
+        assert!(
+            plan.warnings
+                .iter()
+                .any(|warning| warning.contains("Legacy stats-path migration has been retired"))
+        );
+        let verify_step = steps
             .iter()
-            .find(|step| step.operation == MIGRATION_OPERATION_COPY_LEGACY_STATS)
-            .expect("copy step should exist");
-        assert_eq!(copy_step.status, MigrationStepStatus::Applied);
-
-        fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
-    }
-
-    #[test]
-    fn rollback_migration_files_restores_snapshots() {
-        let temp_dir = create_temp_dir("migrate-rollback");
-        let config_path = temp_dir.join("config.toml");
-        let config_snapshot = temp_dir.join("config.snapshot.toml");
-        let canonical_stats_path = temp_dir.join("stats.toml");
-        let canonical_snapshot = temp_dir.join("stats.snapshot.toml");
-        fs::write(&config_path, "schema_version = 1\n").expect("config file should be writable");
-        fs::write(&canonical_stats_path, "daily = {}\n")
-            .expect("canonical stats file should be writable");
-        fs::write(&config_snapshot, "schema_version = 0\n")
-            .expect("config snapshot should be writable");
-        fs::write(&canonical_snapshot, "daily = { old = true }\n")
-            .expect("stats snapshot should be writable");
-
-        let rollback_errors = rollback_migration_files(
-            Some(config_snapshot.as_path()),
-            &config_path,
-            true,
-            Some(canonical_snapshot.as_path()),
-            &canonical_stats_path,
-            true,
-        );
-
-        assert!(rollback_errors.is_empty());
-        let restored_config =
-            fs::read_to_string(&config_path).expect("restored config should exist");
-        let restored_stats =
-            fs::read_to_string(&canonical_stats_path).expect("restored stats should exist");
-        assert_eq!(restored_config, "schema_version = 0\n");
-        assert_eq!(restored_stats, "daily = { old = true }\n");
-
-        fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
-    }
-
-    #[test]
-    fn cleanup_migration_temp_files_removes_snapshot_artifacts() {
-        let temp_dir = create_temp_dir("migrate-cleanup");
-        let config_snapshot = temp_dir.join("config.original.tmp");
-        let canonical_snapshot = temp_dir.join("stats.original.tmp");
-        let staged_stats = temp_dir.join("stats.staged.tmp");
-        fs::write(&config_snapshot, "config").expect("config snapshot should be writable");
-        fs::write(&canonical_snapshot, "stats").expect("stats snapshot should be writable");
-        fs::write(&staged_stats, "staged").expect("staged stats should be writable");
-
-        let cleanup_errors = cleanup_migration_temp_files(
-            Some(config_snapshot.as_path()),
-            Some(canonical_snapshot.as_path()),
-            Some(staged_stats.as_path()),
-        );
-
-        assert!(cleanup_errors.is_empty());
-        assert!(!config_snapshot.exists());
-        assert!(!canonical_snapshot.exists());
-        assert!(!staged_stats.exists());
+            .find(|step| step.operation == MIGRATION_OPERATION_VERIFY_CANONICAL_STATS)
+            .expect("verify step should exist");
+        assert_eq!(verify_step.status, MigrationStepStatus::Skipped);
+        assert!(verify_step.detail.contains("Canonical stats path"));
 
         fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
     }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -3,15 +3,14 @@ use std::collections::HashSet;
 use crate::cli::{
     BackupOutput, BlockingPreviewAction, BlockingPreviewCommandOutput,
     BlocklistProfileCommandOutput, BlocklistProfileConfig, BreakGlassCommandOutput,
-    DiagnosticsCommandOutput, ExportOutput, FeatureFlagsOutput, FocusScoreOutput,
-    GoalCarryCommandOutput, GoalCommandOutput, GoalOutput, MigrationCommandOutput,
-    MigrationStepStatus, ProfileOutput, RecurringScheduleConfig, RestoreOutput,
-    ScheduleCommandOutput, ScheduleDelayCommandOutput, ScheduleInspectionOutput, Serialize,
-    SessionMetadataCommandOutput, SetupCheck, SetupCheckLevel, SetupCheckOutput, SetupDiagnostics,
-    SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput,
-    StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput, StrictCommandOutput,
-    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, TimerStateOutput, Write,
-    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    DiagnosticsCommandOutput, ExportOutput, FocusScoreOutput, GoalCarryCommandOutput,
+    GoalCommandOutput, GoalOutput, MigrationCommandOutput, MigrationStepStatus, ProfileOutput,
+    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, ScheduleDelayCommandOutput,
+    ScheduleInspectionOutput, Serialize, SessionMetadataCommandOutput, SetupCheck, SetupCheckLevel,
+    SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput,
+    SiteEditCommandOutput, SiteListCommandOutput, StatsGrowthSummary, StatsRetentionStatusOutput,
+    StatusOutput, StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
+    TimerStateOutput, Write, format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -517,11 +516,6 @@ pub(super) fn print_migration_output(payload: &MigrationCommandOutput) {
         "Canonical stats: {}",
         payload.canonical_stats_path.display()
     );
-    if let Some(legacy_stats_path) = payload.legacy_stats_path.as_deref() {
-        println!("Legacy stats: {}", legacy_stats_path.display());
-    } else {
-        println!("Legacy stats: n/a");
-    }
     println!("Steps:");
     for step in &payload.steps {
         println!(
@@ -541,8 +535,6 @@ pub(super) fn print_migration_output(payload: &MigrationCommandOutput) {
 
 fn migration_step_status_id(status: MigrationStepStatus) -> &'static str {
     match status {
-        MigrationStepStatus::Planned => "planned",
-        MigrationStepStatus::Applied => "applied",
         MigrationStepStatus::Skipped => "skipped",
     }
 }
@@ -666,10 +658,6 @@ pub(super) fn print_diagnostics_command_output(payload: &DiagnosticsCommandOutpu
     print_diagnostics_check("Blocking permissions", &payload.blocking_permissions);
     print_diagnostics_check("Hosts write capability", &payload.hosts_write_capability);
     print_diagnostics_check("WakaTime config", &payload.wakatime_config);
-    println!(
-        "Feature flags: metadata-fallback={}",
-        bool_label(payload.feature_flags.metadata_task_label_fallback),
-    );
     if payload.deprecation_warnings.is_empty() {
         println!("Deprecation warnings: none");
     } else {
@@ -692,9 +680,6 @@ pub(super) fn build_diagnostics_command_output(
         blocking_permissions: setup_check_output(&diagnostics.blocking_permissions),
         hosts_write_capability: setup_check_output(&diagnostics.hosts_write_capability),
         wakatime_config: setup_check_output(&diagnostics.wakatime_config),
-        feature_flags: FeatureFlagsOutput {
-            metadata_task_label_fallback: diagnostics.feature_flags.metadata_task_label_fallback,
-        },
         deprecation_warnings: diagnostics.deprecation_warnings.clone(),
     }
 }
@@ -751,10 +736,6 @@ fn setup_check_level_id(level: SetupCheckLevel) -> &'static str {
         SetupCheckLevel::Ok => "ok",
         SetupCheckLevel::Warning => "warning",
     }
-}
-
-fn bool_label(enabled: bool) -> &'static str {
-    if enabled { "on" } else { "off" }
 }
 
 pub(super) fn print_json<T: Serialize>(payload: &T) -> Result<(), String> {

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -16,10 +16,8 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
     let week = stats.weekly_for_day(day_date);
     let month = stats.monthly_for_day(day_date);
     let (_, selected_task_label) = stats.task_planner_state();
-    let (selected_task_label, focus_intention, task_note) = mirror_metadata_from_task_label(
-        selected_task_label,
-        config.feature_flags.metadata_task_label_fallback,
-    );
+    let (selected_task_label, focus_intention, task_note) =
+        mirror_metadata_from_task_label(selected_task_label);
     let goal_snapshot = effective_daily_goal_snapshot_for_day(config, stats, day_date);
     let weekly_goal_snapshot = effective_weekly_goal_snapshot(config, stats, day_date);
     let monthly_goal_snapshot = effective_monthly_goal_snapshot(config, stats, day_date);
@@ -296,9 +294,8 @@ fn build_live_status_output(
     let strict_mode_enabled = config
         .profile_automation_for(config.selected_profile)
         .strict_mode;
-    let metadata_fallback = config.feature_flags.metadata_task_label_fallback;
     let (fallback_task_label, fallback_focus_intention, fallback_task_note) =
-        mirror_metadata_from_task_label(fallback_task_label, metadata_fallback);
+        mirror_metadata_from_task_label(fallback_task_label);
     match session_recovery::load() {
         Ok(Some(snapshot)) => {
             let phase = snapshot.phase();
@@ -313,9 +310,8 @@ fn build_live_status_output(
                 pomodoros_completed: snapshot.pomodoros_completed,
                 selected_profile: profile_view(snapshot.selected_profile, &custom),
                 selected_task_label: snapshot.normalized_task_label(),
-                focus_intention: snapshot
-                    .normalized_focus_intention_with_fallback(metadata_fallback),
-                task_note: snapshot.normalized_task_note_with_fallback(metadata_fallback),
+                focus_intention: snapshot.normalized_focus_intention(),
+                task_note: snapshot.normalized_task_note(),
                 strict_mode_enforced: strict_mode_enabled
                     && phase == TimerPhase::Focus
                     && status != TimerStatus::Idle,
@@ -360,16 +356,12 @@ fn build_live_status_output(
 
 pub(super) fn mirror_metadata_from_task_label(
     task_label: Option<String>,
-    metadata_fallback: bool,
 ) -> (Option<String>, Option<String>, Option<String>) {
     let task_label = task_label
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    let (focus_intention, task_note) = if metadata_fallback {
-        (task_label.clone(), task_label.clone())
-    } else {
-        (None, None)
-    };
+    let focus_intention = None;
+    let task_note = None;
     (task_label, focus_intention, task_note)
 }
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,5 +1,4 @@
 use crate::cli::*;
-use crate::config::FeatureFlagsConfig;
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
 };
@@ -643,11 +642,10 @@ fn parse_diagnostics_supports_json_mode() {
 }
 
 #[test]
-fn diagnostics_output_includes_effective_feature_flags() {
+fn diagnostics_output_includes_deprecation_warnings_field() {
     let app = App::default();
     let payload = build_diagnostics_command_output(&app.setup_diagnostics);
 
-    assert!(payload.feature_flags.metadata_task_label_fallback);
     assert!(payload.deprecation_warnings.is_empty());
 }
 
@@ -656,7 +654,7 @@ fn diagnostics_output_includes_deprecation_warnings() {
     let mut app = App::default();
     app.setup_diagnostics.deprecation_warnings = vec![
         "Deprecated top-level timer fields are in use.".to_string(),
-        "Deprecated legacy stats path detected.".to_string(),
+        "Deprecated top-level automation fields are in use.".to_string(),
     ];
 
     let payload = build_diagnostics_command_output(&app.setup_diagnostics);
@@ -665,7 +663,7 @@ fn diagnostics_output_includes_deprecation_warnings() {
         payload.deprecation_warnings,
         vec![
             "Deprecated top-level timer fields are in use.".to_string(),
-            "Deprecated legacy stats path detected.".to_string()
+            "Deprecated top-level automation fields are in use.".to_string()
         ]
     );
 }
@@ -1950,17 +1948,12 @@ fn build_status_output_includes_unconfigured_selected_task_goal() {
 }
 
 #[test]
-fn build_status_output_disables_task_label_metadata_mirror_when_flag_disabled() {
+fn build_status_output_does_not_mirror_task_label_metadata() {
     let mut stats = FocusStats::default();
     let changed =
         stats.update_task_planner_state(vec!["Docs".to_string()], Some("Docs".to_string()));
     assert!(changed);
-    let config = AppConfig {
-        feature_flags: FeatureFlagsConfig {
-            metadata_task_label_fallback: false,
-        },
-        ..AppConfig::default()
-    };
+    let config = AppConfig::default();
 
     let output = build_status_output(&config, &stats);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,24 +155,12 @@ impl AppConfigDisk {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FeatureFlagsConfig {
-    /// Backfill missing metadata fields from task labels for legacy records/snapshots.
-    #[serde(default = "default_true")]
-    pub metadata_task_label_fallback: bool,
-}
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct FeatureFlagsConfig {}
 
 impl FeatureFlagsConfig {
     pub fn normalized(&self) -> Self {
         *self
-    }
-}
-
-impl Default for FeatureFlagsConfig {
-    fn default() -> Self {
-        Self {
-            metadata_task_label_fallback: true,
-        }
     }
 }
 
@@ -1463,10 +1451,6 @@ fn default_long_break_interval() -> u32 {
 }
 fn default_legacy_config_schema_version() -> u32 {
     LEGACY_CONFIG_SCHEMA_VERSION
-}
-
-fn default_true() -> bool {
-    true
 }
 
 impl Default for AppConfig {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -248,9 +248,7 @@ fn round_trip_full_config() {
             queue_capacity: 512,
             queue_retry_delay_secs: 30,
         },
-        feature_flags: FeatureFlagsConfig {
-            metadata_task_label_fallback: true,
-        },
+        feature_flags: FeatureFlagsConfig::default(),
         shortcuts: ShortcutConfig {
             timer_toggle_pause: "space".to_string(),
             timer_stop_reset: "x".to_string(),

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -116,24 +116,6 @@ impl InProgressSessionSnapshot {
         task_note: Option<String>,
         selected_profile: ProfileId,
     ) -> Option<Self> {
-        Self::from_timer_state_with_metadata_with_fallback(
-            timer,
-            selected_task_label,
-            focus_intention,
-            task_note,
-            selected_profile,
-            true,
-        )
-    }
-
-    pub fn from_timer_state_with_metadata_with_fallback(
-        timer: &TimerState,
-        selected_task_label: Option<String>,
-        focus_intention: Option<String>,
-        task_note: Option<String>,
-        selected_profile: ProfileId,
-        metadata_fallback_to_task_label: bool,
-    ) -> Option<Self> {
         if timer.status == TimerStatus::Idle {
             return None;
         }
@@ -143,16 +125,6 @@ impl InProgressSessionSnapshot {
             .and_then(normalize_task_label)?;
         let focus_intention = focus_intention.as_deref().and_then(normalize_metadata_text);
         let task_note = task_note.as_deref().and_then(normalize_metadata_text);
-        let focus_intention = if focus_intention.is_some() || !metadata_fallback_to_task_label {
-            focus_intention
-        } else {
-            Some(selected_task_label.clone())
-        };
-        let task_note = if task_note.is_some() || !metadata_fallback_to_task_label {
-            task_note
-        } else {
-            Some(selected_task_label.clone())
-        };
 
         Some(Self {
             phase: RecoveryTimerPhase::from_timer_phase(timer.phase),
@@ -182,51 +154,18 @@ impl InProgressSessionSnapshot {
 
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn normalized_focus_intention(&self) -> Option<String> {
-        self.normalized_focus_intention_with_fallback(true)
-    }
-
-    pub fn normalized_focus_intention_with_fallback(
-        &self,
-        fallback_to_task_label: bool,
-    ) -> Option<String> {
-        let normalized = self
-            .focus_intention
+        self.focus_intention
             .as_deref()
-            .and_then(normalize_metadata_text);
-        if normalized.is_some() || !fallback_to_task_label {
-            normalized
-        } else {
-            self.normalized_task_label()
-        }
+            .and_then(normalize_metadata_text)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn normalized_task_note(&self) -> Option<String> {
-        self.normalized_task_note_with_fallback(true)
-    }
-
-    pub fn normalized_task_note_with_fallback(
-        &self,
-        fallback_to_task_label: bool,
-    ) -> Option<String> {
-        let normalized = self.task_note.as_deref().and_then(normalize_metadata_text);
-        if normalized.is_some() || !fallback_to_task_label {
-            normalized
-        } else {
-            self.normalized_task_label()
-        }
+        self.task_note.as_deref().and_then(normalize_metadata_text)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn validate_for_timer(&self, timer: &TimerState) -> Result<(), String> {
-        self.validate_for_timer_with_fallback(timer, true)
-    }
-
-    pub fn validate_for_timer_with_fallback(
-        &self,
-        timer: &TimerState,
-        fallback_to_task_label: bool,
-    ) -> Result<(), String> {
         if !matches!(
             self.status,
             RecoveryTimerStatus::Running | RecoveryTimerStatus::Paused
@@ -236,18 +175,6 @@ impl InProgressSessionSnapshot {
 
         if self.normalized_task_label().is_none() {
             return Err("saved task label is missing or invalid".to_string());
-        }
-        if self
-            .normalized_focus_intention_with_fallback(fallback_to_task_label)
-            .is_none()
-        {
-            return Err("saved focus intention is missing or invalid".to_string());
-        }
-        if self
-            .normalized_task_note_with_fallback(fallback_to_task_label)
-            .is_none()
-        {
-            return Err("saved task note is missing or invalid".to_string());
         }
 
         let phase_duration_secs = phase_duration_secs(timer, self.phase());
@@ -320,6 +247,79 @@ pub fn clear_workflow_state() -> io::Result<()> {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e),
+    }
+}
+
+#[cfg(not(test))]
+fn recovery_path() -> io::Result<std::path::PathBuf> {
+    app_data_path(RECOVERY_FILE_NAME).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "cannot determine session recovery directory",
+        )
+    })
+}
+
+#[cfg(not(test))]
+fn workflow_state_path() -> io::Result<std::path::PathBuf> {
+    app_data_path(WORKFLOW_STATE_FILE_NAME).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "cannot determine workflow state directory",
+        )
+    })
+}
+
+#[cfg(not(test))]
+fn write_atomic_text(path: &Path, content: &str) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let tmp_path = path.with_extension("toml.tmp");
+    fs::write(&tmp_path, content)?;
+
+    #[cfg(target_os = "windows")]
+    {
+        match fs::rename(&tmp_path, path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                fs::remove_file(path)?;
+                fs::rename(&tmp_path, path)
+            }
+            Err(e) => {
+                let _ = fs::remove_file(&tmp_path);
+                Err(e)
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        match fs::rename(&tmp_path, path) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let _ = fs::remove_file(&tmp_path);
+                Err(e)
+            }
+        }
+    }
+}
+
+fn phase_duration_secs(timer: &TimerState, phase: TimerPhase) -> u64 {
+    match phase {
+        TimerPhase::Focus => timer.focus_secs,
+        TimerPhase::ShortBreak => timer.short_break_secs,
+        TimerPhase::LongBreak => timer.long_break_secs,
+    }
+}
+
+fn normalize_metadata_text(value: &str) -> Option<String> {
+    let normalized = value.trim();
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized.to_string())
     }
 }
 
@@ -412,75 +412,6 @@ pub(crate) fn test_saved_workflow_snapshot() -> Option<WorkflowStateSnapshot> {
     TEST_SAVED_WORKFLOW_SNAPSHOT.with(|slot| slot.borrow().clone())
 }
 
-#[cfg(not(test))]
-fn recovery_path() -> io::Result<std::path::PathBuf> {
-    app_data_path(RECOVERY_FILE_NAME).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::NotFound,
-            "cannot determine session recovery directory",
-        )
-    })
-}
-
-#[cfg(not(test))]
-fn workflow_state_path() -> io::Result<std::path::PathBuf> {
-    app_data_path(WORKFLOW_STATE_FILE_NAME).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::NotFound,
-            "cannot determine workflow state directory",
-        )
-    })
-}
-
-#[cfg(not(test))]
-fn write_atomic_text(path: &Path, content: &str) -> io::Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
-    let tmp_path = path.with_extension("toml.tmp");
-    fs::write(&tmp_path, content)?;
-
-    #[cfg(target_os = "windows")]
-    {
-        match fs::rename(&tmp_path, path) {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
-                fs::remove_file(path)?;
-                fs::rename(&tmp_path, path)
-            }
-            Err(e) => {
-                let _ = fs::remove_file(&tmp_path);
-                Err(e)
-            }
-        }
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        match fs::rename(&tmp_path, path) {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                let _ = fs::remove_file(&tmp_path);
-                Err(e)
-            }
-        }
-    }
-}
-
-fn phase_duration_secs(timer: &TimerState, phase: TimerPhase) -> u64 {
-    match phase {
-        TimerPhase::Focus => timer.focus_secs,
-        TimerPhase::ShortBreak => timer.short_break_secs,
-        TimerPhase::LongBreak => timer.long_break_secs,
-    }
-}
-
-fn normalize_metadata_text(value: &str) -> Option<String> {
-    let trimmed = value.trim();
-    (!trimmed.is_empty()).then(|| trimmed.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use crate::session_recovery::*;
@@ -571,7 +502,7 @@ mod tests {
     }
 
     #[test]
-    fn metadata_defaults_to_task_label_for_legacy_snapshots() {
+    fn metadata_remains_empty_for_legacy_snapshots_without_backfill() {
         let timer = TimerState::with_profile(60, 30, 90, 4);
         let snapshot = InProgressSessionSnapshot {
             phase: RecoveryTimerPhase::Focus,
@@ -584,45 +515,9 @@ mod tests {
             selected_profile: ProfileId::Classic,
         };
 
-        assert_eq!(
-            snapshot.normalized_focus_intention().as_deref(),
-            Some("Docs")
-        );
-        assert_eq!(snapshot.normalized_task_note().as_deref(), Some("Docs"));
+        assert_eq!(snapshot.normalized_focus_intention(), None);
+        assert_eq!(snapshot.normalized_task_note(), None);
         assert!(snapshot.validate_for_timer(&timer).is_ok());
-    }
-
-    #[test]
-    fn metadata_fallback_can_be_disabled_for_legacy_snapshots() {
-        let timer = TimerState::with_profile(60, 30, 90, 4);
-        let snapshot = InProgressSessionSnapshot {
-            phase: RecoveryTimerPhase::Focus,
-            status: RecoveryTimerStatus::Running,
-            remaining_secs: 60,
-            pomodoros_completed: 1,
-            selected_task_label: Some("Docs".to_string()),
-            focus_intention: None,
-            task_note: None,
-            selected_profile: ProfileId::Classic,
-        };
-
-        assert_eq!(
-            snapshot
-                .normalized_focus_intention_with_fallback(false)
-                .as_deref(),
-            None
-        );
-        assert_eq!(
-            snapshot
-                .normalized_task_note_with_fallback(false)
-                .as_deref(),
-            None
-        );
-        assert!(
-            snapshot
-                .validate_for_timer_with_fallback(&timer, false)
-                .is_err()
-        );
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -38,18 +38,8 @@ const CSV_EXPORT_FILE_NAME: &str = "focustime-stats.csv";
 const EXPORT_SCHEMA_VERSION: u32 = 5;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct StatsLoadOptions {
-    pub metadata_task_label_fallback: bool,
-}
-
-impl Default for StatsLoadOptions {
-    fn default() -> Self {
-        Self {
-            metadata_task_label_fallback: true,
-        }
-    }
-}
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StatsLoadOptions {}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct StatsSaveOptions {}

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -60,7 +60,7 @@ impl FocusStats {
         Ok(Self::from_persisted(persisted, options))
     }
 
-    fn from_persisted(persisted: PersistedStats, options: StatsLoadOptions) -> Self {
+    fn from_persisted(persisted: PersistedStats, _options: StatsLoadOptions) -> Self {
         let (task_labels, selected_task_label, task_label_favorites, task_label_archived) =
             normalize_task_planner_state(
                 persisted.task_labels,
@@ -74,16 +74,8 @@ impl FocusStats {
             if let Some(task_label) = normalize_task_label(&session.task_label) {
                 let focus_intention = normalize_session_metadata_text(&session.focus_intention);
                 let task_note = normalize_session_metadata_text(&session.task_note);
-                let focus_intention = if options.metadata_task_label_fallback {
-                    focus_intention.unwrap_or_else(|| task_label.clone())
-                } else {
-                    focus_intention.unwrap_or_default()
-                };
-                let task_note = if options.metadata_task_label_fallback {
-                    task_note.unwrap_or_else(|| task_label.clone())
-                } else {
-                    task_note.unwrap_or_default()
-                };
+                let focus_intention = focus_intention.unwrap_or_default();
+                let task_note = task_note.unwrap_or_default();
                 focus_sessions.push(FocusSessionRecord {
                     date: session.date.trim().to_string(),
                     task_label,

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -877,7 +877,7 @@ fn persisted_stats_round_trip_preserves_task_label_states() {
 }
 
 #[test]
-fn legacy_focus_sessions_default_metadata_from_task_label() {
+fn legacy_focus_sessions_keep_empty_metadata() {
     let legacy_toml = r#"
             [[focus_sessions]]
             date = "2026-04-09"
@@ -885,29 +885,6 @@ fn legacy_focus_sessions_default_metadata_from_task_label() {
             focused_seconds = 1500
         "#;
     let restored = FocusStats::try_from_toml(legacy_toml).unwrap();
-
-    let export = restored.export_data();
-    assert_eq!(export.sessions.len(), 1);
-    assert_eq!(export.sessions[0].task_label, "Project A");
-    assert_eq!(export.sessions[0].focus_intention, "Project A");
-    assert_eq!(export.sessions[0].task_note, "Project A");
-}
-
-#[test]
-fn legacy_focus_sessions_keep_empty_metadata_when_fallback_is_disabled() {
-    let legacy_toml = r#"
-            [[focus_sessions]]
-            date = "2026-04-09"
-            task_label = "Project A"
-            focused_seconds = 1500
-        "#;
-    let restored = FocusStats::try_from_toml_with_options(
-        legacy_toml,
-        StatsLoadOptions {
-            metadata_task_label_fallback: false,
-        },
-    )
-    .unwrap();
 
     let export = restored.export_data();
     assert_eq!(export.sessions.len(), 1);

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -27,7 +27,6 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             Constraint::Length(2),                                      // blocking permissions
             Constraint::Length(2),                                      // hosts write capability
             Constraint::Length(2),                                      // wakatime config status
-            Constraint::Length(3),                                      // feature flags
             Constraint::Length(DEPRECATION_WARNING_PANEL_LINES as u16), // deprecation warnings
             Constraint::Length(1),                                      // preview summary
             Constraint::Min(0),                                         // preview section
@@ -63,21 +62,6 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         "WakaTime config status",
         &app.setup_diagnostics.wakatime_config,
     );
-    let feature_flags_lines = vec![Line::from(format!(
-        "Feature flags: metadata-fallback={}",
-        bool_label(
-            app.setup_diagnostics
-                .feature_flags
-                .metadata_task_label_fallback
-        ),
-    ))];
-    frame.render_widget(
-        Paragraph::new(feature_flags_lines)
-            .style(Style::default().fg(app_color(app, Color::DarkGray)))
-            .wrap(Wrap { trim: true }),
-        inner[5],
-    );
-
     let deprecation_lines = if app.setup_diagnostics.deprecation_warnings.is_empty() {
         vec![Line::from("Deprecation warnings: none")]
     } else {
@@ -103,7 +87,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         Paragraph::new(deprecation_lines)
             .style(Style::default().fg(app_color(app, Color::Yellow)))
             .wrap(Wrap { trim: true }),
-        inner[6],
+        inner[5],
     );
 
     let (preview_summary, preview_style) = if let Some(error) = app.blocking_preview.error.as_ref()
@@ -135,7 +119,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         Paragraph::new(preview_summary)
             .alignment(Alignment::Left)
             .style(preview_style),
-        inner[7],
+        inner[6],
     );
 
     let preview_section_text = if app.blocking_preview.error.is_some() {
@@ -154,13 +138,13 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             )
             .style(Style::default().fg(app_color(app, Color::Gray)))
             .wrap(Wrap { trim: false }),
-        inner[8],
+        inner[7],
     );
 
     render_hint_lines(
         frame,
         app,
-        inner[9],
+        inner[8],
         vec![
             Line::from(format!(
                 "Diagnostics: {} Refresh checks + preview",
@@ -183,10 +167,6 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             }),
         ],
     );
-}
-
-fn bool_label(enabled: bool) -> &'static str {
-    if enabled { "on" } else { "off" }
 }
 
 pub(super) fn render_setup_check(

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -439,7 +439,7 @@ fn setup_diagnostics_view_renders_deprecation_warnings() {
     app.mode = AppMode::SetupDiagnostics;
     app.setup_diagnostics.deprecation_warnings = vec![
         "Deprecated top-level timer fields are in use.".to_string(),
-        "Deprecated legacy stats path detected.".to_string(),
+        "Deprecated top-level automation fields are in use.".to_string(),
     ];
 
     terminal

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -219,8 +219,8 @@ fn task_goal_json_reads_unconfigured_selected_task_goal() {
 }
 
 #[test]
-fn session_metadata_json_reads_fallback_from_selected_task_label() {
-    let env = TestEnv::new("metadata-json-read-fallback");
+fn session_metadata_json_does_not_fallback_from_selected_task_label() {
+    let env = TestEnv::new("metadata-json-read-no-fallback");
 
     let select_output = env.run(&["--task", "Docs", "--json"]);
     assert_eq!(select_output.status.code(), Some(0));
@@ -234,8 +234,8 @@ fn session_metadata_json_reads_fallback_from_selected_task_label() {
         serde_json::from_slice(&read_output.stdout).expect("stdout should be JSON");
     assert_eq!(payload["action"], "focus-intention");
     assert_eq!(payload["updated"], false);
-    assert_eq!(payload["focus_intention"], "Docs");
-    assert_eq!(payload["task_note"], "Docs");
+    assert!(payload["focus_intention"].is_null());
+    assert!(payload["task_note"].is_null());
     assert_eq!(payload["timer"]["selected_task_label"], "Docs");
 }
 
@@ -420,8 +420,6 @@ fn status_json_uses_canonical_stats_without_legacy_fallback() {
         .to_string();
 
     let canonical_stats_path = env.canonical_stats_path();
-    let legacy_stats_path = env.legacy_stats_path();
-    write_stats_snapshot(&legacy_stats_path, &day, 7, 4200);
     write_stats_snapshot(&canonical_stats_path, &day, 3, 1800);
 
     let canonical_status = env.run(&["--status", "--json"]);


### PR DESCRIPTION
## What

- Finalize normal persistence behavior to use only the canonical stats path.
- Remove deprecated metadata schema fallback compatibility (`task_label` backfill for `focus_intention` and `task_note`) across config, stats loading, recovery snapshots, and CLI status surfaces.
- Simplify `--migrate` to explicit canonical-path migration status reporting, and remove transition-era legacy stats copy/rollback flow.
- Update diagnostics/setup output plus tests and README to match the finalized persistence contract.

## Why

Issue #266 requests closing the migration window and removing deprecated schema handling from normal operation. This makes persistence behavior explicit and deterministic, and removes legacy compatibility branches that are no longer part of the supported runtime path.

Closes #266.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI migration now reports canonical persistence verification and shows actionable migration guidance.

* **Bug Fixes**
  * Session metadata (intention/note) no longer silently falls back to task labels; absent metadata is shown as empty/null.

* **Documentation**
  * README updated with clearer migration guidance, examples, and canonical stats location.

* **Chores**
  * Removed legacy stats-path compatibility UI and feature-flag reporting from diagnostics and status outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/298)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->