### PR TITLE
Cleanup deprecated CLI compatibility paths introduced during migration window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Removed legacy config mirror writes and compatibility-sync paths (#265):** canonical config/profile/blocklist and canonical stats persistence are now the only runtime/write paths, while legacy top-level config fields remain load-time compatibility input for migrated user configs.
+- **Retired migration-window CLI compatibility flags (#267):** removed deprecated `--migrate`/`--dry-run` command paths and transitional migration output shims; `--backup`/`--restore` remain supported and docs/guidance now reflect canonical-path-only persistence.
 
 ## [0.10.1] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -196,10 +196,6 @@ cargo run -- --backup=./reports --json
 cargo run -- --restore
 cargo run -- --restore=./reports --json
 
-# Run canonical persistence migration diagnostics (optional dry-run preview)
-cargo run -- --migrate
-cargo run -- --migrate --dry-run --json
-
 # Export stats to current directory or a target directory
 cargo run -- --export
 cargo run -- --export=./reports --json
@@ -209,8 +205,7 @@ Backup/restore behavior:
 
 - `--backup` creates the target directory if needed, then copies `config.toml` and `stats.toml` into it.
 - `--restore` requires both files in the source directory and uses staged replacement so failed restores roll back to the original files.
-- `--migrate` reports canonical persistence migration status; runtime persistence is canonical-path only.
-- `--migrate --dry-run` reports the same migration status in dry-run mode (no file changes).
+- Runtime persistence is canonical-path only; if only legacy `stats.toml` exists, copy it to the canonical stats path (the backup/restore commands can help).
 
 ### Legacy compatibility deprecation milestones
 
@@ -226,6 +221,7 @@ deprecation warnings when legacy compatibility fields are detected.
 Milestone policy:
 
 - **v0.11.x:** warning-only window with migration tooling (`--migrate`, `--backup`, `--restore`)
+- **Post-migration cleanup:** retired temporary migration-only CLI compatibility flags (`--migrate`, `--dry-run`); `--backup`/`--restore` remain supported.
 - **v0.12.0 (planned):** remove legacy field/path compatibility after the warning window
 
 ### CLI JSON/error contract

--- a/src/app.rs
+++ b/src/app.rs
@@ -1583,7 +1583,9 @@ pub(super) fn format_legacy_stats_path_migration_warning(
     legacy_path: &std::path::Path,
 ) -> String {
     format!(
-        "Legacy stats path `{}` is still in use while canonical stats `{}` are missing. Run `focustime --migrate` to migrate existing history.",
+        "Legacy stats path `{}` is still in use while canonical stats `{}` are missing. Copy `{}` to `{}` (you can use `focustime --backup` and `focustime --restore` to assist).",
+        legacy_path.display(),
+        canonical_path.display(),
         legacy_path.display(),
         canonical_path.display()
     )

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -90,7 +90,8 @@ fn legacy_stats_path_migration_warning_includes_actionable_guidance() {
 
     assert!(warning.contains("Legacy stats path"));
     assert!(warning.contains("canonical stats"));
-    assert!(warning.contains("Run `focustime --migrate`"));
+    assert!(warning.contains("focustime --backup"));
+    assert!(warning.contains("focustime --restore"));
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,20 +47,19 @@ use output::{
     flush_stdout, print_backup_output, print_blocking_preview_command_output,
     print_blocklist_profile_command_output, print_break_glass_command_output,
     print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
-    print_goal_command_output, print_json, print_json_compact, print_migration_output,
-    print_profile_output, print_restore_output, print_schedule_command_output,
-    print_schedule_delay_command_output, print_session_metadata_command_output,
-    print_site_add_command_output, print_site_delete_command_output,
-    print_site_edit_command_output, print_site_list_command_output, print_status_output,
-    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
-    print_timer_state_output,
+    print_goal_command_output, print_json, print_json_compact, print_profile_output,
+    print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
+    print_session_metadata_command_output, print_site_add_command_output,
+    print_site_delete_command_output, print_site_edit_command_output,
+    print_site_list_command_output, print_status_output, print_strict_command_output,
+    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
 };
 use parsing::{
-    finalize_cli_action, invalid_usage, parse_dry_run_option, parse_global_tokens,
-    parse_goal_carry_value, parse_goal_value, parse_monthly_goal_value, parse_primary_command,
-    parse_profile_id, parse_schedule_value, parse_site_edit_value, parse_strict_value,
-    parse_task_goal_value, parse_theme_preset, parse_watch_interval_option,
-    parse_watch_interval_secs, parse_weekly_goal_value, require_nonempty_key_value,
+    finalize_cli_action, invalid_usage, parse_global_tokens, parse_goal_carry_value,
+    parse_goal_value, parse_monthly_goal_value, parse_primary_command, parse_profile_id,
+    parse_schedule_value, parse_site_edit_value, parse_strict_value, parse_task_goal_value,
+    parse_theme_preset, parse_watch_interval_option, parse_watch_interval_secs,
+    parse_weekly_goal_value, require_nonempty_key_value,
 };
 use status::{
     available_break_template_views, available_theme_preset_views, build_status_output,
@@ -120,7 +119,6 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --status [--watch[=SECONDS]] [--json]
   focustime --backup[=DIR] [--json]
   focustime --restore[=DIR] [--json]
-  focustime --migrate [--dry-run] [--json]
   focustime --export[=DIR] [--json]
 
 Options:
@@ -165,8 +163,6 @@ Options:
   --watch         Stream periodic status updates (status command only; default 1s)
   --backup        Back up config.toml and stats.toml to current directory or DIR
   --restore       Restore config.toml and stats.toml from current directory or DIR
-  --migrate       Report canonical persistence migration status
-  --dry-run       Preview migration steps without mutating files (migration only)
   --export        Export stats to current directory or DIR
   --json          Emit machine-readable JSON output
   -h, --help      Show this help"#;
@@ -281,9 +277,6 @@ pub enum CommandKind {
     Restore {
         dir: Option<PathBuf>,
     },
-    Migrate {
-        dry_run: bool,
-    },
     Export {
         dir: Option<PathBuf>,
     },
@@ -342,7 +335,6 @@ enum PrimaryCommand {
     Status,
     Backup(Option<PathBuf>),
     Restore(Option<PathBuf>),
-    Migrate,
     Export(Option<PathBuf>),
     BlocklistProfile(Option<String>),
     BlocklistProfileCreate(String),
@@ -394,8 +386,6 @@ enum ParsedToken {
     BlockingPreview,
     Backup(Option<PathBuf>),
     Restore(Option<PathBuf>),
-    Migrate,
-    DryRun,
     Export(Option<PathBuf>),
     BlocklistProfile(Option<String>),
     BlocklistProfileCreate(String),
@@ -608,30 +598,6 @@ struct RestoreOutput {
     restore_dir: PathBuf,
     config_restored_path: PathBuf,
     stats_restored_path: PathBuf,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum MigrationStepStatus {
-    Skipped,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct MigrationStepOutput {
-    operation: &'static str,
-    status: MigrationStepStatus,
-    detail: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct MigrationCommandOutput {
-    action: &'static str,
-    dry_run: bool,
-    changed: bool,
-    config_path: PathBuf,
-    canonical_stats_path: PathBuf,
-    steps: Vec<MigrationStepOutput>,
-    warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -862,8 +828,7 @@ where
     let primary = parse_primary_command(&tokens).map_err(|message| usage_error(output, message))?;
     let watch_interval_secs =
         parse_watch_interval_option(&tokens).map_err(|message| usage_error(output, message))?;
-    let dry_run = parse_dry_run_option(&tokens).map_err(|message| usage_error(output, message))?;
-    finalize_cli_action(show_help, output, primary, watch_interval_secs, dry_run)
+    finalize_cli_action(show_help, output, primary, watch_interval_secs)
         .map_err(|message| usage_error(output, message))
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -122,8 +122,6 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "--break-glass-cancel" => Some(ParsedToken::BreakGlassCancel),
         "--diagnostics" => Some(ParsedToken::Diagnostics),
         "--blocking-preview" => Some(ParsedToken::BlockingPreview),
-        "--migrate" => Some(ParsedToken::Migrate),
-        "--dry-run" => Some(ParsedToken::DryRun),
         "--blocklist-profile-delete" => Some(ParsedToken::BlocklistProfileDelete),
         "--blocklist-sites" => Some(ParsedToken::BlocklistSites),
         "--allowlist-sites" => Some(ParsedToken::AllowlistSites),

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -7,9 +7,8 @@ use crate::cli::{
     BlocklistProfileConfig, BlocklistProfileSummaryOutput, BlocklistSiteCommandKind,
     BreakGlassCommandOutput, CliCommand, CommandKind, DailyGoalConfig, DailyGoalSnapshot,
     EditSiteResult, ExportOutput, FocusStats, GoalCarryCommandOutput, GoalCommandOutput,
-    InvalidSiteEntryOutput, InvalidSiteInput, MigrationCommandOutput, MigrationStepOutput,
-    MigrationStepStatus, MonthlyGoalConfig, OutputMode, PathBuf, ProfileId, ProfileOutput,
-    ProfileView, RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput,
+    InvalidSiteEntryOutput, InvalidSiteInput, MonthlyGoalConfig, OutputMode, PathBuf, ProfileId,
+    ProfileOutput, ProfileView, RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput,
     ScheduleDelayCommandOutput, SessionMetadataCommandOutput, SiteAddCommandOutput, SiteBlocker,
     SiteDeleteCommandOutput, SiteEditCommandOutput, SiteEditValue, SiteListCommandOutput,
     SiteListTarget, StatusOutput, StrictCommandOutput, TaskCommandOutput, TaskGoalCommandOutput,
@@ -21,33 +20,17 @@ use crate::cli::{
     print_blocking_preview_command_output, print_blocklist_profile_command_output,
     print_break_glass_command_output, print_diagnostics_command_output, print_export_output,
     print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
-    print_migration_output, print_profile_output, print_restore_output,
-    print_schedule_command_output, print_schedule_delay_command_output,
-    print_session_metadata_command_output, print_site_add_command_output,
-    print_site_delete_command_output, print_site_edit_command_output,
-    print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
-    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
-    timer_status_id,
+    print_profile_output, print_restore_output, print_schedule_command_output,
+    print_schedule_delay_command_output, print_session_metadata_command_output,
+    print_site_add_command_output, print_site_delete_command_output,
+    print_site_edit_command_output, print_site_list_command_output, print_status_output,
+    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
+    print_timer_state_output, profile_id, profile_view, selected_break_template_view,
+    theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
 const STATS_FILE_NAME: &str = "stats.toml";
-
-#[derive(Debug, Clone)]
-struct MigrationPlan {
-    config_path: PathBuf,
-    canonical_stats_path: PathBuf,
-    warnings: Vec<String>,
-}
-
-impl MigrationPlan {
-    fn has_changes(&self) -> bool {
-        false
-    }
-}
-
-const MIGRATION_OPERATION_VERIFY_CANONICAL_STATS: &str = "verify_canonical_stats_path";
 
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
     match cli_command.kind {
@@ -92,7 +75,6 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         } => execute_status_command(cli_command.output, watch_interval_secs),
         CommandKind::Backup { dir } => execute_backup_command(dir, cli_command.output),
         CommandKind::Restore { dir } => execute_restore_command(dir, cli_command.output),
-        CommandKind::Migrate { dry_run } => execute_migrate_command(dry_run, cli_command.output),
         CommandKind::Export { dir } => execute_export_command(dir, cli_command.output),
         CommandKind::BlocklistProfile { command } => {
             execute_blocklist_profile_command(command, cli_command.output)
@@ -1189,71 +1171,6 @@ fn execute_restore_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(
     Ok(())
 }
 
-fn execute_migrate_command(dry_run: bool, output: OutputMode) -> Result<(), String> {
-    let config = AppConfig::load().normalized();
-    let plan = build_migration_plan(&config)?;
-    let steps = migration_steps_for_plan(&plan);
-    let payload = MigrationCommandOutput {
-        action: "migrate",
-        dry_run,
-        changed: plan.has_changes(),
-        config_path: plan.config_path.clone(),
-        canonical_stats_path: plan.canonical_stats_path.clone(),
-        steps,
-        warnings: plan.warnings.clone(),
-    };
-    match output {
-        OutputMode::Text => print_migration_output(&payload),
-        OutputMode::Json => print_json(&payload)?,
-    }
-    Ok(())
-}
-
-fn build_migration_plan(_config: &AppConfig) -> Result<MigrationPlan, String> {
-    let config_path = config_file_path()?;
-    ensure_regular_file_if_exists(&config_path, "config path")?;
-    let canonical_stats_path = stats_persistence_path()?;
-    ensure_regular_file_if_exists(&canonical_stats_path, "canonical stats path")?;
-    let warnings = vec![
-        "Legacy stats-path migration has been retired. Runtime persistence is canonical-path only."
-            .to_string(),
-    ];
-    Ok(MigrationPlan {
-        config_path,
-        canonical_stats_path,
-        warnings,
-    })
-}
-
-fn migration_steps_for_plan(plan: &MigrationPlan) -> Vec<MigrationStepOutput> {
-    let detail = if plan.canonical_stats_path.exists() {
-        format!(
-            "Canonical stats path `{}` is active; no migration is required.",
-            plan.canonical_stats_path.display()
-        )
-    } else {
-        format!(
-            "Canonical stats path `{}` is not present yet; it will be created on next save.",
-            plan.canonical_stats_path.display()
-        )
-    };
-    vec![MigrationStepOutput {
-        operation: MIGRATION_OPERATION_VERIFY_CANONICAL_STATS,
-        status: MigrationStepStatus::Skipped,
-        detail,
-    }]
-}
-
-fn ensure_regular_file_if_exists(path: &Path, context: &str) -> Result<(), String> {
-    if path.exists() && !path.is_file() {
-        return Err(format!(
-            "Migration failed: {context} `{}` is not a regular file.",
-            path.display()
-        ));
-    }
-    Ok(())
-}
-
 fn ensure_restore_source_file(path: &Path, file_name: &str) -> Result<(), String> {
     if !path.exists() {
         return Err(format!(
@@ -1529,66 +1446,5 @@ fn build_timer_state_output(app: &App) -> TimerStateOutput {
         selected_task_label,
         focus_intention,
         task_note,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn create_temp_dir(test_name: &str) -> PathBuf {
-        let unique = format!(
-            "focustime-{test_name}-{}-{}",
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("current time should be after unix epoch")
-                .as_nanos()
-        );
-        let path = std::env::temp_dir().join(unique);
-        fs::create_dir_all(&path).expect("temp dir should be created");
-        path
-    }
-
-    #[test]
-    fn migration_plan_reports_canonical_only_behavior() {
-        let temp_dir = create_temp_dir("migrate-canonical-only");
-        let config_path = temp_dir.join("config.toml");
-        let canonical_stats_path = temp_dir.join("state").join("stats.toml");
-        fs::write(&config_path, "schema_version = 1\n").expect("config file should be writable");
-        fs::create_dir_all(
-            canonical_stats_path
-                .parent()
-                .expect("canonical path should have parent"),
-        )
-        .expect("canonical stats parent should be writable");
-        fs::write(&canonical_stats_path, "daily = {}\n")
-            .expect("canonical stats file should be writable");
-
-        let plan = MigrationPlan {
-            config_path,
-            canonical_stats_path: canonical_stats_path.clone(),
-            warnings: vec![
-                "Legacy stats-path migration has been retired. Runtime persistence is canonical-path only."
-                    .to_string(),
-            ],
-        };
-        let steps = migration_steps_for_plan(&plan);
-
-        assert!(!plan.has_changes());
-        assert!(
-            plan.warnings
-                .iter()
-                .any(|warning| warning.contains("Legacy stats-path migration has been retired"))
-        );
-        let verify_step = steps
-            .iter()
-            .find(|step| step.operation == MIGRATION_OPERATION_VERIFY_CANONICAL_STATS)
-            .expect("verify step should exist");
-        assert_eq!(verify_step.status, MigrationStepStatus::Skipped);
-        assert!(verify_step.detail.contains("Canonical stats path"));
-
-        fs::remove_dir_all(temp_dir).expect("temp dir should be removed");
     }
 }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -4,13 +4,13 @@ use crate::cli::{
     BackupOutput, BlockingPreviewAction, BlockingPreviewCommandOutput,
     BlocklistProfileCommandOutput, BlocklistProfileConfig, BreakGlassCommandOutput,
     DiagnosticsCommandOutput, ExportOutput, FocusScoreOutput, GoalCarryCommandOutput,
-    GoalCommandOutput, GoalOutput, MigrationCommandOutput, MigrationStepStatus, ProfileOutput,
-    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, ScheduleDelayCommandOutput,
-    ScheduleInspectionOutput, Serialize, SessionMetadataCommandOutput, SetupCheck, SetupCheckLevel,
-    SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput,
-    SiteEditCommandOutput, SiteListCommandOutput, StatsGrowthSummary, StatsRetentionStatusOutput,
-    StatusOutput, StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
-    TimerStateOutput, Write, format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    GoalCommandOutput, GoalOutput, ProfileOutput, RecurringScheduleConfig, RestoreOutput,
+    ScheduleCommandOutput, ScheduleDelayCommandOutput, ScheduleInspectionOutput, Serialize,
+    SessionMetadataCommandOutput, SetupCheck, SetupCheckLevel, SetupCheckOutput, SetupDiagnostics,
+    SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput,
+    StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput, StrictCommandOutput,
+    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, TimerStateOutput, Write,
+    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -501,42 +501,6 @@ pub(super) fn print_restore_output(payload: &RestoreOutput) {
     println!("Restored app data from {}", payload.restore_dir.display());
     println!("Config: {}", payload.config_restored_path.display());
     println!("Stats: {}", payload.stats_restored_path.display());
-}
-
-pub(super) fn print_migration_output(payload: &MigrationCommandOutput) {
-    if payload.dry_run {
-        println!("Migration dry-run complete. No files were changed.");
-    } else if payload.changed {
-        println!("Migration completed.");
-    } else {
-        println!("Migration completed. No changes were required.");
-    }
-    println!("Config: {}", payload.config_path.display());
-    println!(
-        "Canonical stats: {}",
-        payload.canonical_stats_path.display()
-    );
-    println!("Steps:");
-    for step in &payload.steps {
-        println!(
-            "  - [{}] {}: {}",
-            migration_step_status_id(step.status),
-            step.operation,
-            step.detail
-        );
-    }
-    if !payload.warnings.is_empty() {
-        println!("Warnings:");
-        for warning in &payload.warnings {
-            println!("  - {warning}");
-        }
-    }
-}
-
-fn migration_step_status_id(status: MigrationStepStatus) -> &'static str {
-    match status {
-        MigrationStepStatus::Skipped => "skipped",
-    }
 }
 
 pub(super) fn print_goal_command_output(label: &str, payload: &GoalCommandOutput) {

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -56,8 +56,6 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::BlockingPreview
             | ParsedToken::Backup(_)
             | ParsedToken::Restore(_)
-            | ParsedToken::Migrate
-            | ParsedToken::DryRun
             | ParsedToken::Export(_)
             | ParsedToken::BlocklistProfile(_)
             | ParsedToken::BlocklistProfileCreate(_)
@@ -157,7 +155,6 @@ pub(super) fn parse_primary_command(
             ParsedToken::Restore(dir) => {
                 set_primary_command(&mut primary, PrimaryCommand::Restore(dir.clone()))?
             }
-            ParsedToken::Migrate => set_primary_command(&mut primary, PrimaryCommand::Migrate)?,
             ParsedToken::Export(dir) => {
                 set_primary_command(&mut primary, PrimaryCommand::Export(dir.clone()))?
             }
@@ -208,7 +205,6 @@ pub(super) fn parse_primary_command(
             )?,
             ParsedToken::Help
             | ParsedToken::Json
-            | ParsedToken::DryRun
             | ParsedToken::UnknownOption(_)
             | ParsedToken::Positional(_) => {}
         }
@@ -221,7 +217,6 @@ pub(super) fn finalize_cli_action(
     output: OutputMode,
     primary: Option<PrimaryCommand>,
     watch_interval_secs: Option<u64>,
-    dry_run: bool,
 ) -> Result<CliAction, String> {
     if show_help {
         return Ok(CliAction::ShowHelp);
@@ -229,9 +224,6 @@ pub(super) fn finalize_cli_action(
 
     if watch_interval_secs.is_some() && !matches!(primary, Some(PrimaryCommand::Status)) {
         return Err(invalid_usage("`--watch` is only valid with `--status`."));
-    }
-    if dry_run && !matches!(primary, Some(PrimaryCommand::Migrate)) {
-        return Err(invalid_usage("`--dry-run` is only valid with `--migrate`."));
     }
 
     match primary {
@@ -357,10 +349,6 @@ pub(super) fn finalize_cli_action(
         })),
         Some(PrimaryCommand::Restore(dir)) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Restore { dir },
-            output,
-        })),
-        Some(PrimaryCommand::Migrate) => Ok(CliAction::RunCommand(CliCommand {
-            kind: CommandKind::Migrate { dry_run },
             output,
         })),
         Some(PrimaryCommand::Export(dir)) => Ok(CliAction::RunCommand(CliCommand {
@@ -762,7 +750,6 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Status => "--status",
         PrimaryCommand::Backup(_) => "--backup",
         PrimaryCommand::Restore(_) => "--restore",
-        PrimaryCommand::Migrate => "--migrate",
         PrimaryCommand::Export(_) => "--export",
         PrimaryCommand::BlocklistProfile(_) => "--blocklist-profile",
         PrimaryCommand::BlocklistProfileCreate(_) => "--blocklist-profile-create",
@@ -794,19 +781,6 @@ pub(super) fn parse_watch_interval_option(tokens: &[ParsedToken]) -> Result<Opti
         }
     }
     Ok(interval)
-}
-
-pub(super) fn parse_dry_run_option(tokens: &[ParsedToken]) -> Result<bool, String> {
-    let mut count = 0u8;
-    for token in tokens {
-        if matches!(token, ParsedToken::DryRun) {
-            count += 1;
-            if count > 1 {
-                return Err(invalid_usage("`--dry-run` can only be specified once."));
-            }
-        }
-    }
-    Ok(count == 1)
 }
 
 pub(super) fn parse_watch_interval_secs(value: &str) -> Result<u64, String> {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -775,30 +775,6 @@ fn parse_restore_with_equals_accepts_directory() {
 }
 
 #[test]
-fn parse_migrate_runs_command() {
-    let parsed = parse(&["--migrate"]).unwrap();
-    assert_eq!(
-        parsed,
-        CliAction::RunCommand(CliCommand {
-            kind: CommandKind::Migrate { dry_run: false },
-            output: OutputMode::Text
-        })
-    );
-}
-
-#[test]
-fn parse_migrate_supports_dry_run_and_json_mode() {
-    let parsed = parse(&["--migrate", "--dry-run", "--json"]).unwrap();
-    assert_eq!(
-        parsed,
-        CliAction::RunCommand(CliCommand {
-            kind: CommandKind::Migrate { dry_run: true },
-            output: OutputMode::Json
-        })
-    );
-}
-
-#[test]
 fn parse_export_with_equals_accepts_directory() {
     let parsed = parse(&["--export=reports"]).unwrap();
     assert_eq!(
@@ -1312,12 +1288,6 @@ fn parse_rejects_multiple_primary_commands_for_backup_and_restore() {
 }
 
 #[test]
-fn parse_rejects_multiple_primary_commands_for_migrate_and_backup() {
-    let error = parse(&["--migrate", "--backup"]).unwrap_err();
-    assert!(error.contains("Multiple primary commands"));
-}
-
-#[test]
 fn parse_rejects_multiple_primary_commands_for_schedule_delay_and_break_glass() {
     let error = parse(&["--schedule-delay", "--break-glass-trigger"]).unwrap_err();
     assert!(error.contains("Multiple primary commands"));
@@ -1360,15 +1330,15 @@ fn parse_rejects_watch_with_non_status_command() {
 }
 
 #[test]
-fn parse_rejects_dry_run_without_migrate() {
-    let error = parse(&["--dry-run"]).unwrap_err();
-    assert!(error.contains("`--dry-run` is only valid with `--migrate`"));
+fn parse_rejects_removed_migrate_option() {
+    let error = parse(&["--migrate"]).unwrap_err();
+    assert!(error.contains("Unknown option `--migrate`"));
 }
 
 #[test]
-fn parse_rejects_duplicate_dry_run_flags() {
-    let error = parse(&["--migrate", "--dry-run", "--dry-run"]).unwrap_err();
-    assert!(error.contains("`--dry-run` can only be specified once"));
+fn parse_rejects_removed_dry_run_option() {
+    let error = parse(&["--dry-run"]).unwrap_err();
+    assert!(error.contains("Unknown option `--dry-run`"));
 }
 
 #[test]


### PR DESCRIPTION
## What

- Removes deprecated migration-window CLI flags (`--migrate`, `--dry-run`) and related migration-only execution/output shims.
- Keeps supported final CLI contracts intact, with parser tests updated to assert unknown-option behavior for retired flags.
- Updates legacy stats-path warning guidance to point to canonical-path copy plus `--backup`/`--restore` assistance.
- Aligns README and changelog entries with the post-migration CLI interface.

## Why

This cleanup removes temporary compatibility paths from the migration window so the CLI surface now reflects only supported final commands and guidance.

Closes #267.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI guidance in README and CHANGELOG to reflect supported persistence methods.
  * Updated warning messages to direct users toward `--backup` and `--restore` for managing stats.

* **Chores**
  * Removed deprecated `--migrate` and `--dry-run` CLI flags and related command implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/299)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->