### PR TITLE
Blocking backend hardening beyond hosts-file only

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ flowchart LR
     ST["stats.rs + stats/*<br/>persistence/analytics/export"]
     CFG["config.rs + config/paths.rs<br/>config model + path resolution"]
     TM["timer.rs<br/>Pomodoro state machine"]
-    BL["blocker.rs<br/>hosts-file blocking"]
+    BL["blocker.rs<br/>multi-backend blocking (hosts + command fallback)"]
     WK["wakatime.rs<br/>heartbeat tracking"]
     NT["notifications.rs<br/>phase notifications"]
     SCH["schedule.rs<br/>window compilation/selection"]
@@ -57,7 +57,7 @@ flowchart LR
 | `ui.rs` + `ui/*`                | Screen-oriented Ratatui rendering split into `timer`, `session_planner`, `site_manager`, `profile_manager`, `history`, and `setup`                                                                                                                   | `app`, `timer`, `wakatime`                                                     |
 | `config.rs` + `config/paths.rs` | Config schema/normalization and environment-aware config path resolution, including feature-flag compatibility defaults, runtime knob settings, and task-label-aware WakaTime metadata mapping rules                                                 | `app`, `cli`, filesystem/env                                                   |
 | `timer.rs`                      | Pomodoro timer domain model and phase transitions                                                                                                                                                                                                    | `app`, `ui`                                                                    |
-| `blocker.rs`                    | Hosts-file blocking/unblocking and diagnostics                                                                                                                                                                                                       | `app`, `cli`, OS/filesystem                                                    |
+| `blocker.rs`                    | Blocking backend orchestration (hosts + command), deterministic fallback selection, preview generation, and backend diagnostics                                                                                                                      | `app`, `cli`, OS/filesystem                                                    |
 | `schedule.rs`                   | Recurring/one-time schedule compile and conflict/occurrence logic                                                                                                                                                                                    | `app`, `cli`, `config`                                                         |
 | `session_recovery.rs`           | Runtime recovery snapshot read/write, transient runtime artifact reconciliation, and startup warning notices for dropped invalid fragments                                                                                                           | `app`, `cli`, filesystem                                                       |
 | `task_labels.rs`                | Task-label normalization, canonicalization, and index helpers                                                                                                                                                                                        | `app`, `stats`, `cli`                                                          |

--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ cargo run -- --break-glass-trigger --json
 # Cancel a pending break-glass confirmation
 cargo run -- --break-glass-cancel
 
-# Show setup diagnostics checks (including hosts and WakaTime readiness)
+# Show setup diagnostics checks (backend selection, hosts/command readiness, WakaTime)
 cargo run -- --diagnostics
 cargo run -- --diagnostics --json
 
-# Preview focustime-managed hosts-file changes without writing
+# Preview backend-selected blocking changes without writing
 cargo run -- --blocking-preview
 cargo run -- --blocking-preview --json
 
@@ -390,6 +390,16 @@ selected_profile = "custom"
 selected_break_template = "Classic"
 selected_theme_preset = "classic"
 selected_blocklist_profile = "Work"
+ 
+[blocking_backend]
+# hosts_only | hosts_then_command | command_then_hosts | command_only
+policy = "hosts_then_command"
+
+[blocking_backend.command]
+block_command = ""
+unblock_command = ""
+diagnostics_command = ""
+
 # Legacy compatibility mirror for the selected profile's automation strict mode.
 strict_mode = false
 break_glass_duration_secs = 300
@@ -544,6 +554,7 @@ Invalid and duplicate entries are reported inline so you can fix them without le
 Allowlist entries act as explicit exceptions: effective focus blocking is computed as **blocklist sites minus allowlist sites** for the active profile.
 
 For hosts-based blocking to apply reliably, keep DNS-over-HTTPS disabled in your browser.
+If you configure the command backend, ensure your custom commands enforce equivalent restrictions.
 
 ## Setup diagnostics
 
@@ -554,11 +565,21 @@ Open the setup diagnostics screen from timer view with **`d`**.
 
 The diagnostics screen reports:
 
+- backend policy/order and last backend selection (including fallback usage)
+- command backend readiness
 - blocking permissions
 - hosts file write capability
-- blocking preview summary and focustime-managed hosts section
-- remediation guidance when hosts permissions are insufficient
+- blocking preview summary and backend target details
+- remediation guidance when hosts or command backend readiness is insufficient
 - WakaTime config status (`~/.wakatime.cfg` and `api_key` availability)
+
+Blocking backend policy is deterministic:
+
+- `hosts_then_command` (default): try hosts first, then command backend fallback
+- `command_then_hosts`: try command first, then hosts fallback
+- `hosts_only` / `command_only`: disable fallback
+
+Command backend templates support `{sites_csv}`, `{sites_lines}`, and `{site_count}` placeholders.
 
 ## Phase notifications
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,11 +7,13 @@ use chrono::{DateTime, Datelike, Local, NaiveDate};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use crate::blocker::{
-    BlockingIntent, BlockingPreview, BlockingPreviewAction, BulkAddResult, EditSiteResult,
+    BlockingBackendKind, BlockingBackendPolicy, BlockingIntent, BlockingPreview,
+    BlockingPreviewAction, BulkAddResult, CommandBlockingBackend, EditSiteResult,
     HostsFileDiagnostics, InvalidSiteInput, SiteBlocker,
 };
 use crate::config::{
-    AppConfig, AutoStartConfig, BlocklistProfileConfig, BreakTemplateConfig, CustomProfileConfig,
+    AppConfig, AutoStartConfig, BlockingBackendConfig, BlockingBackendPolicyConfig,
+    BlocklistProfileConfig, BreakTemplateConfig, CommandBlockingBackendConfig, CustomProfileConfig,
     DailyGoalConfig, FeatureFlagsConfig, GoalCarryOverConfig, MonthlyGoalConfig,
     NotificationConfig, OneTimeFocusWindowConfig, ProfileAutomationConfig,
     ProfileAutomationSettingsConfig, ProfileId, RecurringFocusWindowConfig,
@@ -253,6 +255,54 @@ fn resolve_active_break_template(
     break_template_index_for_custom_profile(templates, custom_profile)
 }
 
+fn blocking_backend_policy_for_config(
+    policy: BlockingBackendPolicyConfig,
+) -> BlockingBackendPolicy {
+    match policy {
+        BlockingBackendPolicyConfig::HostsOnly => BlockingBackendPolicy::HostsOnly,
+        BlockingBackendPolicyConfig::HostsThenCommand => BlockingBackendPolicy::HostsThenCommand,
+        BlockingBackendPolicyConfig::CommandThenHosts => BlockingBackendPolicy::CommandThenHosts,
+        BlockingBackendPolicyConfig::CommandOnly => BlockingBackendPolicy::CommandOnly,
+    }
+}
+
+fn command_backend_for_config(config: &CommandBlockingBackendConfig) -> CommandBlockingBackend {
+    CommandBlockingBackend {
+        block_command: config.block_command.clone(),
+        unblock_command: config.unblock_command.clone(),
+        diagnostics_command: config.diagnostics_command.clone(),
+    }
+}
+
+fn blocking_backend_policy_to_config(policy: BlockingBackendPolicy) -> BlockingBackendPolicyConfig {
+    match policy {
+        BlockingBackendPolicy::HostsOnly => BlockingBackendPolicyConfig::HostsOnly,
+        BlockingBackendPolicy::HostsThenCommand => BlockingBackendPolicyConfig::HostsThenCommand,
+        BlockingBackendPolicy::CommandThenHosts => BlockingBackendPolicyConfig::CommandThenHosts,
+        BlockingBackendPolicy::CommandOnly => BlockingBackendPolicyConfig::CommandOnly,
+    }
+}
+
+fn command_backend_to_config(
+    command_backend: &CommandBlockingBackend,
+) -> CommandBlockingBackendConfig {
+    CommandBlockingBackendConfig {
+        block_command: command_backend.block_command.clone(),
+        unblock_command: command_backend.unblock_command.clone(),
+        diagnostics_command: command_backend.diagnostics_command.clone(),
+    }
+}
+
+fn blocking_backend_config_for_persistence(
+    policy: BlockingBackendPolicy,
+    command_backend: &CommandBlockingBackend,
+) -> BlockingBackendConfig {
+    BlockingBackendConfig {
+        policy: blocking_backend_policy_to_config(policy),
+        command: command_backend_to_config(command_backend),
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ProfileEditSnapshot {
     custom_profile: CustomProfileConfig,
@@ -431,8 +481,12 @@ impl SetupCheck {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetupDiagnostics {
     pub hosts_file_path: String,
+    pub backend_policy: String,
+    pub backend_order: String,
+    pub backend_selection: SetupCheck,
     pub blocking_permissions: SetupCheck,
     pub hosts_write_capability: SetupCheck,
+    pub command_backend: SetupCheck,
     pub wakatime_config: SetupCheck,
     pub deprecation_warnings: Vec<String>,
 }
@@ -440,9 +494,23 @@ pub struct SetupDiagnostics {
 impl SetupDiagnostics {
     fn collect(blocker: &SiteBlocker, deprecation_warnings: Vec<String>) -> Self {
         let hosts_diagnostics = blocker.hosts_file_diagnostics();
+        let backend_status = blocker.backend_status();
         let blocking_permissions = blocking_permissions_check(&hosts_diagnostics);
         let hosts_write_capability = hosts_write_capability_check(&hosts_diagnostics);
         let hosts_file_path = hosts_diagnostics.path.clone();
+        let backend_policy = backend_status.policy.id().to_string();
+        let backend_order = backend_status
+            .order
+            .iter()
+            .map(|backend| backend.id())
+            .collect::<Vec<_>>()
+            .join(" -> ");
+        let backend_selection = backend_selection_check(
+            backend_status.last_backend,
+            backend_status.fallback_used,
+            backend_status.last_error.as_deref(),
+        );
+        let command_backend = command_backend_check(blocker);
         let wakatime_diagnostics = WakatimeTracker::config_diagnostics();
         let wakatime_config = match wakatime_diagnostics.status {
             WakatimeConfigStatus::Configured => SetupCheck::ok(wakatime_diagnostics.detail),
@@ -455,8 +523,12 @@ impl SetupDiagnostics {
         };
         Self {
             hosts_file_path,
+            backend_policy,
+            backend_order,
+            backend_selection,
             blocking_permissions,
             hosts_write_capability,
+            command_backend,
             wakatime_config,
             deprecation_warnings,
         }
@@ -465,6 +537,10 @@ impl SetupDiagnostics {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockingPreviewSnapshot {
+    pub backend: Option<BlockingBackendKind>,
+    pub backend_target: Option<String>,
+    pub attempted_backends: Vec<BlockingBackendKind>,
+    pub fallback_used: bool,
     pub action: BlockingPreviewAction,
     pub would_change: bool,
     pub effective_blocked_sites_count: usize,
@@ -475,6 +551,10 @@ pub struct BlockingPreviewSnapshot {
 impl Default for BlockingPreviewSnapshot {
     fn default() -> Self {
         Self {
+            backend: None,
+            backend_target: None,
+            attempted_backends: Vec::new(),
+            fallback_used: false,
             action: BlockingPreviewAction::NoChange,
             would_change: false,
             effective_blocked_sites_count: 0,
@@ -658,7 +738,10 @@ impl App {
             profile_spec.long_break_secs,
             profile_spec.long_break_interval,
         );
-        let blocker = SiteBlocker::new();
+        let blocker = SiteBlocker::with_backend_config(
+            blocking_backend_policy_for_config(config.blocking_backend.policy),
+            command_backend_for_config(&config.blocking_backend.command),
+        );
         let setup_diagnostics =
             SetupDiagnostics::collect(&blocker, setup_deprecation_warnings.clone());
         let mut app = Self {
@@ -1634,6 +1717,37 @@ fn blocking_permissions_check(hosts_diagnostics: &HostsFileDiagnostics) -> Setup
             "Blocked: write permission unavailable ({reason}). {}",
             permission_remediation_guidance()
         ))
+    }
+}
+
+fn backend_selection_check(
+    last_backend: Option<BlockingBackendKind>,
+    fallback_used: bool,
+    last_error: Option<&str>,
+) -> SetupCheck {
+    if let Some(error) = last_error {
+        return SetupCheck::warning(format!("Blocked: backend selection failed ({error})"));
+    }
+    if let Some(backend) = last_backend {
+        if fallback_used {
+            return SetupCheck::warning(format!(
+                "Fallback active: using `{}` backend after primary backend failure",
+                backend.id()
+            ));
+        }
+        return SetupCheck::ok(format!("Ready: using `{}` backend", backend.id()));
+    }
+    SetupCheck::warning(
+        "Awaiting first block/unblock operation to confirm selected backend".to_string(),
+    )
+}
+
+fn command_backend_check(blocker: &SiteBlocker) -> SetupCheck {
+    match blocker.command_backend_diagnostics() {
+        Ok(()) => SetupCheck::ok("Ready: command backend diagnostics passed"),
+        Err(error) => SetupCheck::warning(format!(
+            "Blocked: command backend unavailable ({error}). Configure commands or use hosts backend."
+        )),
     }
 }
 

--- a/src/app/feedback_diagnostics.rs
+++ b/src/app/feedback_diagnostics.rs
@@ -114,6 +114,10 @@ impl App {
     pub(super) fn refresh_blocking_preview(&mut self) {
         self.blocking_preview = match self.compute_blocking_preview() {
             Ok(preview) => BlockingPreviewSnapshot {
+                backend: Some(preview.backend),
+                backend_target: Some(preview.backend_target.clone()),
+                attempted_backends: preview.attempted_backends.clone(),
+                fallback_used: preview.fallback_used,
                 action: preview.action,
                 would_change: preview.would_change,
                 effective_blocked_sites_count: preview.effective_blocked_sites.len(),

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -1,7 +1,7 @@
 use crate::app::{
     App, AppConfig, BlocklistProfileConfig, DEFAULT_BLOCKLIST_PROFILE_NAME, Local,
-    PendingTimerAction, TimerPhase, TimerState, format_duration_label, occurrence_key,
-    profile_index, profile_spec_for, task_label_index,
+    PendingTimerAction, TimerPhase, TimerState, blocking_backend_config_for_persistence,
+    format_duration_label, occurrence_key, profile_index, profile_spec_for, task_label_index,
 };
 use crate::session_recovery::{self, InProgressSessionSnapshot, WorkflowStateSnapshot};
 use chrono::{LocalResult, TimeZone};
@@ -431,6 +431,9 @@ impl App {
         let mut profile_automation = self.profile_automation.clone();
         profile_automation
             .set_for_profile(self.selected_profile, self.selected_profile_automation());
+        let (backend_policy, command_backend) = self.blocker.backend_config();
+        let blocking_backend =
+            blocking_backend_config_for_persistence(backend_policy, &command_backend);
         AppConfig {
             // Keep legacy fields aligned with the editable custom profile so
             // older releases retain user-configured values.
@@ -441,6 +444,7 @@ impl App {
             blocked_sites: Vec::new(),
             blocklist_profiles,
             selected_blocklist_profile,
+            blocking_backend,
             selected_profile: self.selected_profile,
             custom_profile: Some(custom_profile),
             break_templates: self.break_templates.clone(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -104,6 +104,7 @@ fn selected_builtin_profile_is_applied_on_startup() {
         blocked_sites: Vec::new(),
         blocklist_profiles: vec![BlocklistProfileConfig::default()],
         selected_blocklist_profile: "Default".to_string(),
+        blocking_backend: BlockingBackendConfig::default(),
         selected_profile: ProfileId::Classic,
         custom_profile: Some(CustomProfileConfig {
             focus_secs: 40 * 60,

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -33,6 +33,12 @@ pub(crate) fn take_test_blocking_action() -> Option<&'static str> {
 pub struct SiteBlocker {
     pub sites: Vec<String>,
     pub is_blocking: bool,
+    backend_policy: BlockingBackendPolicy,
+    command_backend: CommandBlockingBackend,
+    active_backend: Option<BlockingBackendKind>,
+    last_backend: Option<BlockingBackendKind>,
+    last_fallback_used: bool,
+    last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -110,8 +116,92 @@ pub enum BlockingPreviewAction {
     NoChange,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockingBackendKind {
+    Hosts,
+    Command,
+}
+
+impl BlockingBackendKind {
+    pub fn id(self) -> &'static str {
+        match self {
+            BlockingBackendKind::Hosts => "hosts",
+            BlockingBackendKind::Command => "command",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BlockingBackendPolicy {
+    HostsOnly,
+    #[default]
+    HostsThenCommand,
+    CommandThenHosts,
+    CommandOnly,
+}
+
+impl BlockingBackendPolicy {
+    pub fn id(self) -> &'static str {
+        match self {
+            BlockingBackendPolicy::HostsOnly => "hosts_only",
+            BlockingBackendPolicy::HostsThenCommand => "hosts_then_command",
+            BlockingBackendPolicy::CommandThenHosts => "command_then_hosts",
+            BlockingBackendPolicy::CommandOnly => "command_only",
+        }
+    }
+
+    fn backend_order(self) -> Vec<BlockingBackendKind> {
+        match self {
+            BlockingBackendPolicy::HostsOnly => vec![BlockingBackendKind::Hosts],
+            BlockingBackendPolicy::HostsThenCommand => {
+                vec![BlockingBackendKind::Hosts, BlockingBackendKind::Command]
+            }
+            BlockingBackendPolicy::CommandThenHosts => {
+                vec![BlockingBackendKind::Command, BlockingBackendKind::Hosts]
+            }
+            BlockingBackendPolicy::CommandOnly => vec![BlockingBackendKind::Command],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CommandBlockingBackend {
+    pub block_command: String,
+    pub unblock_command: String,
+    pub diagnostics_command: String,
+}
+
+impl CommandBlockingBackend {
+    pub fn normalized(&self) -> Self {
+        Self {
+            block_command: self.block_command.trim().to_string(),
+            unblock_command: self.unblock_command.trim().to_string(),
+            diagnostics_command: self.diagnostics_command.trim().to_string(),
+        }
+    }
+
+    pub fn is_configured(&self) -> bool {
+        !self.block_command.trim().is_empty() && !self.unblock_command.trim().is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockingBackendStatus {
+    pub policy: BlockingBackendPolicy,
+    pub order: Vec<BlockingBackendKind>,
+    pub active_backend: Option<BlockingBackendKind>,
+    pub last_backend: Option<BlockingBackendKind>,
+    pub fallback_used: bool,
+    pub last_error: Option<String>,
+    pub command_configured: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockingPreview {
+    pub backend: BlockingBackendKind,
+    pub backend_target: String,
+    pub attempted_backends: Vec<BlockingBackendKind>,
+    pub fallback_used: bool,
     pub hosts_file_path: String,
     pub action: BlockingPreviewAction,
     pub effective_blocked_sites: Vec<String>,
@@ -130,10 +220,55 @@ impl BlockingPreview {
 
 impl SiteBlocker {
     pub fn new() -> Self {
+        Self::with_backend_config(
+            BlockingBackendPolicy::default(),
+            CommandBlockingBackend::default(),
+        )
+    }
+
+    pub fn with_backend_config(
+        backend_policy: BlockingBackendPolicy,
+        command_backend: CommandBlockingBackend,
+    ) -> Self {
         Self {
             sites: Vec::new(),
             is_blocking: false,
+            backend_policy,
+            command_backend: command_backend.normalized(),
+            active_backend: None,
+            last_backend: None,
+            last_fallback_used: false,
+            last_error: None,
         }
+    }
+
+    pub fn backend_status(&self) -> BlockingBackendStatus {
+        BlockingBackendStatus {
+            policy: self.backend_policy,
+            order: self.backend_policy.backend_order(),
+            active_backend: self.active_backend,
+            last_backend: self.last_backend,
+            fallback_used: self.last_fallback_used,
+            last_error: self.last_error.clone(),
+            command_configured: self.command_backend.is_configured(),
+        }
+    }
+
+    pub fn backend_config(&self) -> (BlockingBackendPolicy, CommandBlockingBackend) {
+        (self.backend_policy, self.command_backend.clone())
+    }
+
+    pub fn command_backend_diagnostics(&self) -> io::Result<()> {
+        if self.command_backend.diagnostics_command.trim().is_empty() {
+            if self.command_backend.is_configured() {
+                return Ok(());
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "command backend block/unblock commands are not fully configured",
+            ));
+        }
+        run_shell_command(&self.command_backend.diagnostics_command)
     }
 
     pub fn add_site(&mut self, site: String) {
@@ -309,8 +444,22 @@ impl SiteBlocker {
     }
 
     pub fn preview_hosts_update(&self, intent: BlockingIntent) -> io::Result<BlockingPreview> {
-        let original = fs::read_to_string(HOSTS_FILE)?;
-        Ok(self.preview_from_content(HOSTS_FILE, &original, intent))
+        let order = self.backend_order_for_intent(intent);
+        let mut errors = Vec::new();
+        for (index, backend) in order.iter().copied().enumerate() {
+            match self.preview_with_backend(intent, backend) {
+                Ok(mut preview) => {
+                    preview.attempted_backends = order[..=index].to_vec();
+                    preview.fallback_used = index > 0;
+                    return Ok(preview);
+                }
+                Err(error) => errors.push(format!("{}: {error}", backend.id())),
+            }
+        }
+        Err(io::Error::other(format!(
+            "Failed to generate blocking preview ({})",
+            errors.join(" | ")
+        )))
     }
 
     /// Activate blocking by writing entries into the hosts file.
@@ -321,11 +470,15 @@ impl SiteBlocker {
 
         if self.sites.is_empty() {
             self.is_blocking = false;
+            self.active_backend = None;
+            self.last_backend = None;
+            self.last_fallback_used = false;
+            self.last_error = None;
             // Best-effort: strip any stale block section left by a prior run.
             let _ = self.remove_hosts_block();
             return Ok(());
         }
-        self.apply_hosts_block()?;
+        self.apply_with_fallback(BlockingIntent::Block)?;
         self.is_blocking = true;
         Ok(())
     }
@@ -337,14 +490,155 @@ impl SiteBlocker {
         #[cfg(test)]
         record_test_blocking_action("unblock");
 
-        self.remove_hosts_block()?;
+        self.apply_with_fallback(BlockingIntent::Unblock)?;
         self.is_blocking = false;
+        self.active_backend = None;
         Ok(())
     }
 
     /// Remove block entries on app exit (best-effort).
     pub fn cleanup(&mut self) {
         let _ = self.unblock();
+    }
+
+    fn apply_with_fallback(&mut self, intent: BlockingIntent) -> io::Result<()> {
+        let order = self.backend_order_for_intent(intent);
+        let mut errors = Vec::new();
+        for (index, backend) in order.iter().copied().enumerate() {
+            match self.apply_with_backend(intent, backend) {
+                Ok(()) => {
+                    self.last_backend = Some(backend);
+                    self.last_fallback_used = index > 0;
+                    self.last_error = None;
+                    if intent == BlockingIntent::Block {
+                        self.active_backend = Some(backend);
+                    }
+                    return Ok(());
+                }
+                Err(error) => errors.push(format!("{}: {error}", backend.id())),
+            }
+        }
+        let message = format!(
+            "all configured blocking backends failed for {} ({})",
+            blocking_intent_id(intent),
+            errors.join(" | ")
+        );
+        self.last_backend = None;
+        self.last_fallback_used = false;
+        self.last_error = Some(message.clone());
+        Err(io::Error::new(io::ErrorKind::PermissionDenied, message))
+    }
+
+    fn apply_with_backend(
+        &mut self,
+        intent: BlockingIntent,
+        backend: BlockingBackendKind,
+    ) -> io::Result<()> {
+        match backend {
+            BlockingBackendKind::Hosts => match intent {
+                BlockingIntent::Block => self.apply_hosts_block(),
+                BlockingIntent::Unblock => self.remove_hosts_block(),
+            },
+            BlockingBackendKind::Command => self.apply_command_backend(intent),
+        }
+    }
+
+    fn preview_with_backend(
+        &self,
+        intent: BlockingIntent,
+        backend: BlockingBackendKind,
+    ) -> io::Result<BlockingPreview> {
+        match backend {
+            BlockingBackendKind::Hosts => {
+                let original = fs::read_to_string(HOSTS_FILE)?;
+                Ok(self.preview_from_hosts_content(HOSTS_FILE, &original, intent))
+            }
+            BlockingBackendKind::Command => self.preview_from_command(intent),
+        }
+    }
+
+    fn backend_order_for_intent(&self, intent: BlockingIntent) -> Vec<BlockingBackendKind> {
+        if intent == BlockingIntent::Block {
+            return self.backend_policy.backend_order();
+        }
+
+        let mut order = Vec::new();
+        if let Some(active_backend) = self.active_backend {
+            order.push(active_backend);
+        }
+        for backend in self.backend_policy.backend_order() {
+            if !order.contains(&backend) {
+                order.push(backend);
+            }
+        }
+        order
+    }
+
+    fn apply_command_backend(&self, intent: BlockingIntent) -> io::Result<()> {
+        let template = match intent {
+            BlockingIntent::Block => self.command_backend.block_command.as_str(),
+            BlockingIntent::Unblock => self.command_backend.unblock_command.as_str(),
+        };
+        let template = template.trim();
+        if template.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "command backend `{}` command is not configured",
+                    blocking_intent_id(intent)
+                ),
+            ));
+        }
+        let rendered = render_command_template(template, &self.sites);
+        run_shell_command(&rendered)
+    }
+
+    fn preview_from_command(&self, intent: BlockingIntent) -> io::Result<BlockingPreview> {
+        let template = match intent {
+            BlockingIntent::Block => self.command_backend.block_command.as_str(),
+            BlockingIntent::Unblock => self.command_backend.unblock_command.as_str(),
+        }
+        .trim()
+        .to_string();
+        if template.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "command backend `{}` command is not configured",
+                    blocking_intent_id(intent)
+                ),
+            ));
+        }
+
+        let rendered = render_command_template(&template, &self.sites);
+        let action = match intent {
+            BlockingIntent::Block => {
+                if self.sites.is_empty() {
+                    BlockingPreviewAction::NoChange
+                } else {
+                    BlockingPreviewAction::Block
+                }
+            }
+            BlockingIntent::Unblock => BlockingPreviewAction::Unblock,
+        };
+        let effective_blocked_sites = if action == BlockingPreviewAction::Block {
+            self.sites.clone()
+        } else {
+            Vec::new()
+        };
+
+        Ok(BlockingPreview {
+            backend: BlockingBackendKind::Command,
+            backend_target: rendered.clone(),
+            attempted_backends: vec![BlockingBackendKind::Command],
+            fallback_used: false,
+            hosts_file_path: rendered,
+            action,
+            effective_blocked_sites,
+            would_change: action != BlockingPreviewAction::NoChange,
+            current_section: None,
+            next_section: None,
+        })
     }
 
     fn apply_hosts_block(&self) -> io::Result<()> {
@@ -410,7 +704,7 @@ impl SiteBlocker {
         result
     }
 
-    fn preview_from_content(
+    fn preview_from_hosts_content(
         &self,
         hosts_file_path: &str,
         original: &str,
@@ -441,6 +735,10 @@ impl SiteBlocker {
         };
 
         BlockingPreview {
+            backend: BlockingBackendKind::Hosts,
+            backend_target: hosts_file_path.to_string(),
+            attempted_backends: vec![BlockingBackendKind::Hosts],
+            fallback_used: false,
             hosts_file_path: hosts_file_path.to_string(),
             action,
             effective_blocked_sites,
@@ -522,6 +820,50 @@ impl Default for SiteBlocker {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn blocking_intent_id(intent: BlockingIntent) -> &'static str {
+    match intent {
+        BlockingIntent::Block => "block",
+        BlockingIntent::Unblock => "unblock",
+    }
+}
+
+fn render_command_template(template: &str, sites: &[String]) -> String {
+    let sites_csv = sites.join(",");
+    let sites_lines = sites.join("\n");
+    template
+        .replace("{sites_csv}", &sites_csv)
+        .replace("{sites_lines}", &sites_lines)
+        .replace("{site_count}", &sites.len().to_string())
+}
+
+fn run_shell_command(command: &str) -> io::Result<()> {
+    let status = shell_command(command).status()?;
+    if status.success() {
+        return Ok(());
+    }
+    Err(io::Error::other(format!(
+        "command exited with status {}",
+        status
+            .code()
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    )))
+}
+
+#[cfg(target_os = "windows")]
+fn shell_command(command: &str) -> Command {
+    let mut cmd = Command::new("cmd");
+    cmd.args(["/C", command]);
+    cmd
+}
+
+#[cfg(not(target_os = "windows"))]
+fn shell_command(command: &str) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.args(["-c", command]);
+    cmd
 }
 
 fn line_ending_for(content: &str) -> &'static str {
@@ -902,7 +1244,7 @@ mod tests {
         blocker.add_site("example.com".to_string());
         let original = "127.0.0.1 localhost\n";
 
-        let preview = blocker.preview_from_content("hosts", original, BlockingIntent::Block);
+        let preview = blocker.preview_from_hosts_content("hosts", original, BlockingIntent::Block);
 
         assert_eq!(preview.action, BlockingPreviewAction::Block);
         assert!(preview.would_change);
@@ -923,7 +1265,8 @@ mod tests {
         let blocker = SiteBlocker::new();
         let original = "127.0.0.1 localhost\n# focustime-block-start\n127.0.0.1 example.com\n# focustime-block-end\n";
 
-        let preview = blocker.preview_from_content("hosts", original, BlockingIntent::Unblock);
+        let preview =
+            blocker.preview_from_hosts_content("hosts", original, BlockingIntent::Unblock);
 
         assert_eq!(preview.action, BlockingPreviewAction::Unblock);
         assert!(preview.would_change);
@@ -950,7 +1293,8 @@ mod tests {
             "# focustime-block-end\n",
         );
 
-        let preview = blocker.preview_from_content("hosts", original, BlockingIntent::Unblock);
+        let preview =
+            blocker.preview_from_hosts_content("hosts", original, BlockingIntent::Unblock);
         let section = preview
             .current_section
             .as_deref()
@@ -967,7 +1311,7 @@ mod tests {
         blocker.add_site("example.com".to_string());
         let original = blocker.build_blocked_hosts_content("127.0.0.1 localhost\n");
 
-        let preview = blocker.preview_from_content("hosts", &original, BlockingIntent::Block);
+        let preview = blocker.preview_from_hosts_content("hosts", &original, BlockingIntent::Block);
 
         assert_eq!(preview.action, BlockingPreviewAction::NoChange);
         assert!(!preview.would_change);

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -507,20 +507,32 @@ impl SiteBlocker {
     fn apply_with_fallback(&mut self, intent: BlockingIntent) -> io::Result<()> {
         let order = self.backend_order_for_intent(intent);
         let mut errors = Vec::new();
+        let mut first_success: Option<(usize, BlockingBackendKind)> = None;
+        let attempt_all_backends = intent == BlockingIntent::Unblock;
         for (index, backend) in order.iter().copied().enumerate() {
             match self.apply_with_backend(intent, backend) {
                 Ok(()) => {
-                    self.last_backend = Some(backend);
-                    self.last_fallback_used = index > 0;
-                    self.last_error = None;
-                    if intent == BlockingIntent::Block {
-                        self.active_backend = Some(backend);
+                    if first_success.is_none() {
+                        first_success = Some((index, backend));
                     }
-                    return Ok(());
+                    if !attempt_all_backends {
+                        break;
+                    }
                 }
                 Err(error) => errors.push(format!("{}: {error}", backend.id())),
             }
         }
+
+        if let Some((index, backend)) = first_success {
+            self.last_backend = Some(backend);
+            self.last_fallback_used = index > 0;
+            self.last_error = None;
+            if intent == BlockingIntent::Block {
+                self.active_backend = Some(backend);
+            }
+            return Ok(());
+        }
+
         let message = format!(
             "all configured blocking backends failed for {} ({})",
             blocking_intent_id(intent),

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -469,13 +469,16 @@ impl SiteBlocker {
         record_test_blocking_action("block");
 
         if self.sites.is_empty() {
+            if let Some(active_backend) = self.active_backend {
+                let _ = self.apply_with_backend(BlockingIntent::Unblock, active_backend);
+            }
+            // Best-effort: strip any stale block section left by a prior run.
+            let _ = self.remove_hosts_block();
             self.is_blocking = false;
             self.active_backend = None;
             self.last_backend = None;
             self.last_fallback_used = false;
             self.last_error = None;
-            // Best-effort: strip any stale block section left by a prior run.
-            let _ = self.remove_hosts_block();
             return Ok(());
         }
         self.apply_with_fallback(BlockingIntent::Block)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -158,7 +158,7 @@ Options:
   --blocklist-site-delete     Delete blocklist hostname in active profile
   --allowlist-site-delete     Delete allowlist hostname in active profile
   --diagnostics   Show setup diagnostics checks
-  --blocking-preview  Preview focustime hosts-section changes without writing
+  --blocking-preview  Preview backend-selected blocking changes without writing
   --status        Print status summary (includes live timer/session fields and latest interruption)
   --watch         Stream periodic status updates (status command only; default 1s)
   --backup        Back up config.toml and stats.toml to current directory or DIR
@@ -712,6 +712,10 @@ struct SetupCheckOutput {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct DiagnosticsCommandOutput {
     hosts_file_path: String,
+    backend_policy: String,
+    backend_order: String,
+    backend_selection: SetupCheckOutput,
+    command_backend: SetupCheckOutput,
     blocking_permissions: SetupCheckOutput,
     hosts_write_capability: SetupCheckOutput,
     wakatime_config: SetupCheckOutput,
@@ -720,6 +724,10 @@ struct DiagnosticsCommandOutput {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct BlockingPreviewCommandOutput {
+    backend: &'static str,
+    backend_target: String,
+    attempted_backends: Vec<&'static str>,
+    fallback_used: bool,
     hosts_file_path: String,
     action: &'static str,
     would_change: bool,

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -619,6 +619,12 @@ pub(super) fn build_schedule_inspection_output(
 
 pub(super) fn print_diagnostics_command_output(payload: &DiagnosticsCommandOutput) {
     println!("Hosts file: {}", payload.hosts_file_path);
+    println!(
+        "Backend policy: {} (order: {})",
+        payload.backend_policy, payload.backend_order
+    );
+    print_diagnostics_check("Backend selection", &payload.backend_selection);
+    print_diagnostics_check("Command backend", &payload.command_backend);
     print_diagnostics_check("Blocking permissions", &payload.blocking_permissions);
     print_diagnostics_check("Hosts write capability", &payload.hosts_write_capability);
     print_diagnostics_check("WakaTime config", &payload.wakatime_config);
@@ -641,6 +647,10 @@ pub(super) fn build_diagnostics_command_output(
 ) -> DiagnosticsCommandOutput {
     DiagnosticsCommandOutput {
         hosts_file_path: diagnostics.hosts_file_path.clone(),
+        backend_policy: diagnostics.backend_policy.clone(),
+        backend_order: diagnostics.backend_order.clone(),
+        backend_selection: setup_check_output(&diagnostics.backend_selection),
+        command_backend: setup_check_output(&diagnostics.command_backend),
         blocking_permissions: setup_check_output(&diagnostics.blocking_permissions),
         hosts_write_capability: setup_check_output(&diagnostics.hosts_write_capability),
         wakatime_config: setup_check_output(&diagnostics.wakatime_config),
@@ -649,6 +659,20 @@ pub(super) fn build_diagnostics_command_output(
 }
 
 pub(super) fn print_blocking_preview_command_output(payload: &BlockingPreviewCommandOutput) {
+    println!(
+        "Backend: {} (target: {})",
+        payload.backend, payload.backend_target
+    );
+    if !payload.attempted_backends.is_empty() {
+        println!(
+            "Attempted backends: {}",
+            payload.attempted_backends.join(" -> ")
+        );
+    }
+    println!(
+        "Fallback used: {}",
+        if payload.fallback_used { "yes" } else { "no" }
+    );
     println!("Hosts file: {}", payload.hosts_file_path);
     println!(
         "Preview action: {} (changes: {})",
@@ -679,6 +703,14 @@ pub(super) fn build_blocking_preview_command_output(
         BlockingPreviewAction::NoChange => "no_change",
     };
     BlockingPreviewCommandOutput {
+        backend: preview.backend.id(),
+        backend_target: preview.backend_target.clone(),
+        attempted_backends: preview
+            .attempted_backends
+            .iter()
+            .map(|backend| backend.id())
+            .collect(),
+        fallback_used: preview.fallback_used,
         hosts_file_path: preview.hosts_file_path.clone(),
         action,
         would_change: preview.would_change,

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,9 @@ pub struct AppConfig {
     /// Name of the active blocklist profile.
     #[serde(default = "default_blocklist_profile_name")]
     pub selected_blocklist_profile: String,
+    /// Blocking backend selection and fallback behavior.
+    #[serde(default)]
+    pub blocking_backend: BlockingBackendConfig,
     /// Selected profile identifier.
     #[serde(default)]
     pub selected_profile: ProfileId,
@@ -161,6 +164,53 @@ pub struct FeatureFlagsConfig {}
 impl FeatureFlagsConfig {
     pub fn normalized(&self) -> Self {
         *self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct BlockingBackendConfig {
+    #[serde(default)]
+    pub policy: BlockingBackendPolicyConfig,
+    #[serde(default)]
+    pub command: CommandBlockingBackendConfig,
+}
+
+impl BlockingBackendConfig {
+    pub fn normalized(&self) -> Self {
+        Self {
+            policy: self.policy,
+            command: self.command.normalized(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockingBackendPolicyConfig {
+    HostsOnly,
+    #[default]
+    HostsThenCommand,
+    CommandThenHosts,
+    CommandOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CommandBlockingBackendConfig {
+    #[serde(default)]
+    pub block_command: String,
+    #[serde(default)]
+    pub unblock_command: String,
+    #[serde(default)]
+    pub diagnostics_command: String,
+}
+
+impl CommandBlockingBackendConfig {
+    pub fn normalized(&self) -> Self {
+        Self {
+            block_command: self.block_command.trim().to_string(),
+            unblock_command: self.unblock_command.trim().to_string(),
+            diagnostics_command: self.diagnostics_command.trim().to_string(),
+        }
     }
 }
 
@@ -1463,6 +1513,7 @@ impl Default for AppConfig {
             blocked_sites: Vec::new(),
             blocklist_profiles: Vec::new(),
             selected_blocklist_profile: default_blocklist_profile_name(),
+            blocking_backend: BlockingBackendConfig::default(),
             selected_profile: ProfileId::default(),
             custom_profile: None,
             break_templates: default_break_templates(),
@@ -1666,6 +1717,7 @@ impl AppConfig {
             &self.selected_blocklist_profile,
             &self.blocklist_profiles,
         );
+        self.blocking_backend = self.blocking_backend.normalized();
         self.schedule_runtime = self.schedule_runtime.normalized();
         self.wakatime = self.wakatime.normalized();
         self.wakatime_runtime = self.wakatime_runtime.normalized();

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -33,6 +33,7 @@ fn default_values_are_canonical_pomodoro() {
     assert!(cfg.blocked_sites.is_empty());
     assert_eq!(cfg.selected_blocklist_profile, "Default");
     assert!(cfg.blocklist_profiles.is_empty());
+    assert_eq!(cfg.blocking_backend, BlockingBackendConfig::default());
     assert_eq!(cfg.notifications, NotificationConfig::default());
     assert_eq!(cfg.auto_start, AutoStartConfig::default());
     assert_eq!(cfg.recurring_schedule, RecurringScheduleConfig::default());
@@ -113,6 +114,7 @@ fn round_trip_full_config() {
             },
         ],
         selected_blocklist_profile: "Study".to_string(),
+        blocking_backend: BlockingBackendConfig::default(),
         selected_profile: ProfileId::DeepWork,
         custom_profile: Some(CustomProfileConfig {
             focus_secs: 30 * 60,
@@ -801,6 +803,7 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
         blocked_sites: Vec::new(),
         blocklist_profiles: vec![BlocklistProfileConfig::default()],
         selected_blocklist_profile: "Default".to_string(),
+        blocking_backend: BlockingBackendConfig::default(),
         selected_profile: ProfileId::Custom,
         custom_profile: Some(CustomProfileConfig {
             focus_secs: 40 * 60,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -284,6 +284,7 @@ fn round_trip_full_config() {
         parsed.selected_blocklist_profile,
         original.selected_blocklist_profile
     );
+    assert_eq!(parsed.blocking_backend, original.blocking_backend);
     assert_eq!(parsed.selected_profile, original.selected_profile);
     assert_eq!(parsed.custom_profile, original.custom_profile);
     assert_eq!(parsed.break_templates, original.break_templates);

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -23,7 +23,10 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         .margin(2)
         .constraints([
             Constraint::Length(1),                                      // hosts path
+            Constraint::Length(1),                                      // backend policy/order
             Constraint::Length(1),                                      // spacer
+            Constraint::Length(2),                                      // backend selection
+            Constraint::Length(2),                                      // command backend
             Constraint::Length(2),                                      // blocking permissions
             Constraint::Length(2),                                      // hosts write capability
             Constraint::Length(2),                                      // wakatime config status
@@ -40,25 +43,48 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
     ))
     .style(Style::default().fg(app_color(app, Color::DarkGray)));
     frame.render_widget(hosts_path, inner[0]);
+    frame.render_widget(
+        Paragraph::new(format!(
+            "Backend policy: {} (order: {})",
+            app.setup_diagnostics.backend_policy, app.setup_diagnostics.backend_order
+        ))
+        .style(Style::default().fg(app_color(app, Color::DarkGray))),
+        inner[1],
+    );
 
     render_setup_check(
         frame,
         app,
-        inner[2],
+        inner[3],
+        "Backend selection",
+        &app.setup_diagnostics.backend_selection,
+    );
+    render_setup_check(
+        frame,
+        app,
+        inner[4],
+        "Command backend readiness",
+        &app.setup_diagnostics.command_backend,
+    );
+
+    render_setup_check(
+        frame,
+        app,
+        inner[5],
         "Blocking permissions",
         &app.setup_diagnostics.blocking_permissions,
     );
     render_setup_check(
         frame,
         app,
-        inner[3],
+        inner[6],
         "Hosts write capability",
         &app.setup_diagnostics.hosts_write_capability,
     );
     render_setup_check(
         frame,
         app,
-        inner[4],
+        inner[7],
         "WakaTime config status",
         &app.setup_diagnostics.wakatime_config,
     );
@@ -87,7 +113,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         Paragraph::new(deprecation_lines)
             .style(Style::default().fg(app_color(app, Color::Yellow)))
             .wrap(Wrap { trim: true }),
-        inner[5],
+        inner[8],
     );
 
     let (preview_summary, preview_style) = if let Some(error) = app.blocking_preview.error.as_ref()
@@ -102,9 +128,19 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             BlockingPreviewAction::Unblock => "unblock",
             BlockingPreviewAction::NoChange => "no-change",
         };
+        let backend = app
+            .blocking_preview
+            .backend
+            .map(|backend| backend.id())
+            .unwrap_or("unknown");
         (
             format!(
-                "Preview action: {action} · changes: {} · effective blocked sites: {}",
+                "Preview backend: {backend} · action: {action} · fallback: {} · changes: {} · effective blocked sites: {}",
+                if app.blocking_preview.fallback_used {
+                    "yes"
+                } else {
+                    "no"
+                },
                 if app.blocking_preview.would_change {
                     "yes"
                 } else {
@@ -119,32 +155,36 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         Paragraph::new(preview_summary)
             .alignment(Alignment::Left)
             .style(preview_style),
-        inner[6],
+        inner[9],
     );
 
     let preview_section_text = if app.blocking_preview.error.is_some() {
-        "Preview section unavailable due to hosts-file access error.".to_string()
+        "Preview section unavailable due to backend-access error.".to_string()
     } else if let Some(section) = app.blocking_preview.section.as_ref() {
         section.clone()
     } else {
-        "No focustime block section changes are required for the current state.".to_string()
+        app.blocking_preview
+            .backend_target
+            .as_ref()
+            .map(|target| format!("No hosts section preview. Backend target: {target}"))
+            .unwrap_or_else(|| "No blocking preview details are available.".to_string())
     };
     frame.render_widget(
         Paragraph::new(preview_section_text)
             .block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .title(" Blocking preview (focustime section) "),
+                    .title(" Blocking preview details "),
             )
             .style(Style::default().fg(app_color(app, Color::Gray)))
             .wrap(Wrap { trim: false }),
-        inner[7],
+        inner[10],
     );
 
     render_hint_lines(
         frame,
         app,
-        inner[8],
+        inner[11],
         vec![
             Line::from(format!(
                 "Diagnostics: {} Refresh checks + preview",

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -411,7 +411,7 @@ fn render_setup_check_wraps_long_warning_message() {
 #[test]
 fn setup_diagnostics_view_wraps_long_status_messages() {
     let width = 80;
-    let height = 24;
+    let height = 30;
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
     let mut app = App::default();
@@ -426,7 +426,10 @@ fn setup_diagnostics_view_wraps_long_status_messages() {
         .expect("render should succeed");
 
     let text = terminal_text(&terminal, width, height);
-    assert!(text.contains("WRAP-END"));
+    assert!(
+        text.contains("WRAP-END"),
+        "rendered diagnostics text:\n{text}"
+    );
 }
 
 #[test]
@@ -494,7 +497,7 @@ fn setup_diagnostics_view_renders_blocking_preview_section() {
         .expect("render should succeed");
 
     let text = terminal_text(&terminal, width, height);
-    assert!(text.contains("Preview action: block"));
+    assert!(text.contains("action: block"));
     assert!(
         text.contains("# focustime-block-start"),
         "rendered diagnostics text:\n{text}"


### PR DESCRIPTION
## What

- Add a pluggable blocking backend policy with deterministic fallback ordering.
- Introduce an optional command backend alongside the existing hosts backend.
- Surface backend selection, fallback status, and backend-aware preview details in TUI setup diagnostics and CLI output.
- Update tests and documentation for the new backend behavior.

## Why

Blocking previously depended only on hosts-file writes, which can fail in common non-elevated environments. This change makes backend selection and fallback predictable and visible so blocking can still operate with clearer diagnostics and remediation guidance.

Closes #271.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-backend blocking (hosts + command) with configurable policy and fallback
  * Blocking preview and diagnostics now show selected backend, attempted backends, target, and fallback usage
  * CLI preview/output and setup diagnostics include backend selection and command-backend readiness
  * Persisted configuration now stores blocking-backend settings

* **Documentation**
  * README and architecture docs updated with blocking-backend configuration, diagnostics, and preview guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/300)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->