### PR TITLE
Restart/recovery state-drift fixes

### DIFF
--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -1,7 +1,8 @@
 use crate::app::{
     App, AppConfig, BlocklistProfileConfig, DEFAULT_BLOCKLIST_PROFILE_NAME, Local,
-    PendingTimerAction, TimerPhase, TimerState, blocking_backend_config_for_persistence,
-    format_duration_label, occurrence_key, profile_index, profile_spec_for, task_label_index,
+    PendingTimerAction, TimerPhase, TimerState, TimerStatus,
+    blocking_backend_config_for_persistence, format_duration_label, occurrence_key, profile_index,
+    profile_spec_for, task_label_index,
 };
 use crate::session_recovery::{self, InProgressSessionSnapshot, WorkflowStateSnapshot};
 use chrono::{LocalResult, TimeZone};
@@ -27,21 +28,33 @@ impl App {
             return;
         };
 
-        if let Err(reason) = self.try_apply_recovery_snapshot(snapshot.clone()) {
-            self.phase_notification = Some(format!("Ignored saved in-progress session: {reason}."));
-            if let Err(clear_error) = session_recovery::clear() {
-                self.config_error = Some(format!(
-                    "session recovery cleanup failed after invalid state: {clear_error}"
-                ));
+        let recovered_snapshot = match self.try_apply_recovery_snapshot(snapshot) {
+            Ok(snapshot) => snapshot,
+            Err(reason) => {
+                self.phase_notification =
+                    Some(format!("Ignored saved in-progress session: {reason}."));
+                if let Err(clear_error) = session_recovery::clear() {
+                    self.config_error = Some(format!(
+                        "session recovery cleanup failed after invalid state: {clear_error}"
+                    ));
+                }
+                return;
             }
-            return;
-        }
+        };
 
-        self.phase_notification = Some(format!(
-            "Recovered in-progress {} session ({} remaining).",
-            snapshot.phase().label(),
-            format_duration_label(snapshot.remaining_secs)
-        ));
+        if recovered_snapshot.status() == TimerStatus::Idle {
+            self.phase_notification = Some(format!(
+                "Recovered elapsed timer state into {} phase ({} remaining).",
+                recovered_snapshot.phase().label(),
+                format_duration_label(recovered_snapshot.remaining_secs)
+            ));
+        } else {
+            self.phase_notification = Some(format!(
+                "Recovered in-progress {} session ({} remaining).",
+                recovered_snapshot.phase().label(),
+                format_duration_label(recovered_snapshot.remaining_secs)
+            ));
+        }
     }
 
     pub(super) fn restore_cli_workflow_state(&mut self) {
@@ -237,7 +250,7 @@ impl App {
     fn try_apply_recovery_snapshot(
         &mut self,
         snapshot: InProgressSessionSnapshot,
-    ) -> Result<(), String> {
+    ) -> Result<InProgressSessionSnapshot, String> {
         let profile_spec = profile_spec_for(snapshot.selected_profile, &self.custom_profile);
         let mut recovered_timer = TimerState::with_profile(
             profile_spec.focus_secs,
@@ -250,8 +263,13 @@ impl App {
         recovered_timer.remaining_secs = snapshot.remaining_secs;
         recovered_timer.pomodoros_completed = snapshot.pomodoros_completed;
         snapshot.validate_for_timer(&recovered_timer)?;
+        let reconciled_snapshot = snapshot.reconcile_elapsed_for_timer(&recovered_timer);
+        recovered_timer.phase = reconciled_snapshot.phase();
+        recovered_timer.status = reconciled_snapshot.status();
+        recovered_timer.remaining_secs = reconciled_snapshot.remaining_secs;
+        recovered_timer.pomodoros_completed = reconciled_snapshot.pomodoros_completed;
 
-        let task_label = snapshot
+        let task_label = reconciled_snapshot
             .normalized_task_label()
             .ok_or_else(|| "saved task label is missing or invalid".to_string())?;
         let selected_task_label =
@@ -262,36 +280,38 @@ impl App {
                 task_label
             };
 
-        self.selected_profile = snapshot.selected_profile;
-        self.profile_selection_index = profile_index(snapshot.selected_profile);
-        self.load_automation_runtime_for_profile(snapshot.selected_profile);
+        self.selected_profile = reconciled_snapshot.selected_profile;
+        self.profile_selection_index = profile_index(reconciled_snapshot.selected_profile);
+        self.load_automation_runtime_for_profile(reconciled_snapshot.selected_profile);
         self.current_frame_now = Local::now();
         self.timer = recovered_timer;
         self.selected_task_label = Some(selected_task_label);
         self.pending_timer_action = None;
         self.break_glass_expires_at = None;
-        self.active_focus_task_label = if self.timer.phase == TimerPhase::Focus {
+        let focus_active =
+            self.timer.phase == TimerPhase::Focus && self.timer.status != TimerStatus::Idle;
+        self.active_focus_task_label = if focus_active {
             self.selected_task_label.clone()
         } else {
             None
         };
-        self.active_focus_intention = if self.timer.phase == TimerPhase::Focus {
-            snapshot.normalized_focus_intention()
+        self.active_focus_intention = if focus_active {
+            reconciled_snapshot.normalized_focus_intention()
         } else {
             None
         };
-        self.active_focus_task_note = if self.timer.phase == TimerPhase::Focus {
-            snapshot.normalized_task_note()
+        self.active_focus_task_note = if focus_active {
+            reconciled_snapshot.normalized_task_note()
         } else {
             None
         };
-        self.active_focus_profile = if self.timer.phase == TimerPhase::Focus {
+        self.active_focus_profile = if focus_active {
             Some(self.selected_profile)
         } else {
             None
         };
         self.sync_task_planner_state();
-        Ok(())
+        Ok(reconciled_snapshot)
     }
 
     pub(super) fn sync_recovery_snapshot(&mut self) {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5229,7 +5229,7 @@ fn startup_reconciles_elapsed_recovery_time_while_session_is_running() {
 
     assert_eq!(app.timer.phase, TimerPhase::Focus);
     assert_eq!(app.timer.status, TimerStatus::Running);
-    assert!(app.timer.remaining_secs <= 110);
+    assert!((109..=111).contains(&app.timer.remaining_secs));
     assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -57,6 +57,7 @@ fn snapshot_for_tests(
         focus_intention: metadata_value.clone(),
         task_note: metadata_value,
         selected_profile,
+        captured_at_epoch_secs: None,
     }
 }
 
@@ -5207,6 +5208,61 @@ fn startup_restores_valid_in_progress_snapshot() {
 }
 
 #[test]
+fn startup_reconciles_elapsed_recovery_time_while_session_is_running() {
+    let now_epoch_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("current time should be after unix epoch")
+        .as_secs() as i64;
+    session_recovery::set_test_load_snapshot(Some(InProgressSessionSnapshot {
+        phase: RecoveryTimerPhase::Focus,
+        status: RecoveryTimerStatus::Running,
+        remaining_secs: 120,
+        pomodoros_completed: 0,
+        selected_task_label: Some("Docs".to_string()),
+        focus_intention: Some("Docs".to_string()),
+        task_note: Some("Docs".to_string()),
+        selected_profile: ProfileId::Classic,
+        captured_at_epoch_secs: Some(now_epoch_secs - 10),
+    }));
+
+    let app = App::from_config(AppConfig::default());
+
+    assert_eq!(app.timer.phase, TimerPhase::Focus);
+    assert_eq!(app.timer.status, TimerStatus::Running);
+    assert!(app.timer.remaining_secs <= 110);
+    assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
+}
+
+#[test]
+fn startup_reconciles_elapsed_recovery_time_when_phase_completed_offline() {
+    session_recovery::set_test_load_snapshot(Some(InProgressSessionSnapshot {
+        phase: RecoveryTimerPhase::Focus,
+        status: RecoveryTimerStatus::Running,
+        remaining_secs: 1,
+        pomodoros_completed: 0,
+        selected_task_label: Some("Docs".to_string()),
+        focus_intention: Some("Write docs".to_string()),
+        task_note: Some("Section 1".to_string()),
+        selected_profile: ProfileId::Classic,
+        captured_at_epoch_secs: Some(0),
+    }));
+
+    let app = App::from_config(AppConfig::default());
+
+    assert_eq!(app.timer.phase, TimerPhase::ShortBreak);
+    assert_eq!(app.timer.status, TimerStatus::Idle);
+    assert_eq!(app.timer.remaining_secs, app.timer.short_break_secs);
+    assert_eq!(app.timer.pomodoros_completed, 1);
+    assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
+    assert!(app.active_focus_intention.is_none());
+    assert!(app.active_focus_task_note.is_none());
+    assert!(app.phase_notification.as_deref().is_some_and(|message| {
+        message.contains("Recovered elapsed timer state into Short Break phase")
+    }));
+    assert!(session_recovery::test_saved_snapshot().is_none());
+}
+
+#[test]
 fn startup_recovery_rehydrates_profile_automation_runtime_for_snapshot_profile() {
     let deep_work_schedule = RecurringScheduleConfig {
         windows: vec![RecurringFocusWindowConfig {
@@ -5270,6 +5326,7 @@ fn startup_restores_pomodoro_count_for_phase_cadence() {
         focus_intention: Some("Docs".to_string()),
         task_note: Some("Docs".to_string()),
         selected_profile: ProfileId::Classic,
+        captured_at_epoch_secs: None,
     }));
 
     let mut app = App::from_config(AppConfig::default());

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -299,6 +299,7 @@ fn build_live_status_output(
         mirror_metadata_from_task_label(fallback_task_label);
     match session_recovery::load() {
         Ok(Some(snapshot)) => {
+            let pre_reconcile_in_progress = snapshot.status() != TimerStatus::Idle;
             let selected_profile = profile_view(snapshot.selected_profile, &custom);
             let timer_for_reconciliation = TimerState::with_profile(
                 selected_profile.focus_secs,
@@ -309,7 +310,7 @@ fn build_live_status_output(
             let snapshot = snapshot.reconcile_elapsed_for_timer(&timer_for_reconciliation);
             let phase = snapshot.phase();
             let status = snapshot.status();
-            let in_progress = status != TimerStatus::Idle;
+            let in_progress = pre_reconcile_in_progress || status != TimerStatus::Idle;
             LiveStatusOutput {
                 state_source: "recovery",
                 recovery_error: None,

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -7,6 +7,7 @@ use crate::cli::{
     TodayOutput, carry_over_goal_target, current_day_key, effective_blocked_sites_for_profile,
     session_recovery,
 };
+use crate::timer::TimerState;
 
 pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> StatusOutput {
     let day = current_day_key();
@@ -298,17 +299,26 @@ fn build_live_status_output(
         mirror_metadata_from_task_label(fallback_task_label);
     match session_recovery::load() {
         Ok(Some(snapshot)) => {
+            let selected_profile = profile_view(snapshot.selected_profile, &custom);
+            let timer_for_reconciliation = TimerState::with_profile(
+                selected_profile.focus_secs,
+                selected_profile.short_break_secs,
+                selected_profile.long_break_secs,
+                selected_profile.long_break_interval,
+            );
+            let snapshot = snapshot.reconcile_elapsed_for_timer(&timer_for_reconciliation);
             let phase = snapshot.phase();
             let status = snapshot.status();
+            let in_progress = status != TimerStatus::Idle;
             LiveStatusOutput {
                 state_source: "recovery",
                 recovery_error: None,
-                in_progress: true,
+                in_progress,
                 phase: timer_phase_id(phase),
                 status: timer_status_id(status),
                 remaining_secs: snapshot.remaining_secs,
                 pomodoros_completed: snapshot.pomodoros_completed,
-                selected_profile: profile_view(snapshot.selected_profile, &custom),
+                selected_profile,
                 selected_task_label: snapshot.normalized_task_label(),
                 focus_intention: snapshot.normalized_focus_intention(),
                 task_note: snapshot.normalized_task_note(),

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2266,12 +2266,14 @@ fn build_status_output_reconciles_elapsed_running_recovery_snapshot() {
 
     let output = build_status_output(&config, &stats);
 
-    assert!(!output.live.in_progress);
+    assert!(output.live.in_progress);
     assert_eq!(output.live.state_source, "recovery");
     assert_eq!(output.live.phase, "short-break");
     assert_eq!(output.live.status, "idle");
     assert_eq!(output.live.pomodoros_completed, 1);
     assert_eq!(output.live.remaining_secs, DEFAULT_SHORT_BREAK_SECS);
+    assert_eq!(output.session.pomodoros_completed, 1);
+    assert_eq!(output.session.focused_minutes, DEFAULT_FOCUS_SECS / 60);
     assert_eq!(output.live.selected_task_label.as_deref(), Some("Docs"));
     assert!(output.live.focus_intention.is_none());
     assert!(output.live.task_note.is_none());

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2226,6 +2226,7 @@ fn build_status_output_uses_recovery_snapshot_for_live_state() {
         focus_intention: Some("Write docs".to_string()),
         task_note: Some("API section".to_string()),
         selected_profile: ProfileId::DeepWork,
+        captured_at_epoch_secs: None,
     }));
     let config = AppConfig::default();
     let stats = FocusStats::default();
@@ -2245,6 +2246,36 @@ fn build_status_output_uses_recovery_snapshot_for_live_state() {
     assert!(output.live.recovery_error.is_none());
     assert_eq!(output.session.pomodoros_completed, 3);
     assert_eq!(output.session.focused_minutes, 199);
+}
+
+#[test]
+fn build_status_output_reconciles_elapsed_running_recovery_snapshot() {
+    session_recovery::set_test_load_snapshot(Some(InProgressSessionSnapshot {
+        phase: RecoveryTimerPhase::Focus,
+        status: RecoveryTimerStatus::Running,
+        remaining_secs: 1,
+        pomodoros_completed: 0,
+        selected_task_label: Some("Docs".to_string()),
+        focus_intention: Some("Write docs".to_string()),
+        task_note: Some("API section".to_string()),
+        selected_profile: ProfileId::Classic,
+        captured_at_epoch_secs: Some(0),
+    }));
+    let config = AppConfig::default();
+    let stats = FocusStats::default();
+
+    let output = build_status_output(&config, &stats);
+
+    assert!(!output.live.in_progress);
+    assert_eq!(output.live.state_source, "recovery");
+    assert_eq!(output.live.phase, "short-break");
+    assert_eq!(output.live.status, "idle");
+    assert_eq!(output.live.pomodoros_completed, 1);
+    assert_eq!(output.live.remaining_secs, DEFAULT_SHORT_BREAK_SECS);
+    assert_eq!(output.live.selected_task_label.as_deref(), Some("Docs"));
+    assert!(output.live.focus_intention.is_none());
+    assert!(output.live.task_note.is_none());
+    assert!(!output.live.strict_mode_enforced);
 }
 
 #[test]

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -1,4 +1,7 @@
-use std::io;
+use std::{
+    io,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 #[cfg(not(test))]
 use std::{fs, path::Path};
@@ -11,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::ProfileId,
     task_labels::normalize_task_label,
-    timer::{TimerPhase, TimerState, TimerStatus},
+    timer::{DEFAULT_LONG_BREAK_INTERVAL, TimerPhase, TimerState, TimerStatus},
 };
 
 #[cfg(not(test))]
@@ -87,6 +90,8 @@ pub struct InProgressSessionSnapshot {
     #[serde(default)]
     pub task_note: Option<String>,
     pub selected_profile: ProfileId,
+    #[serde(default)]
+    pub captured_at_epoch_secs: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -135,6 +140,7 @@ impl InProgressSessionSnapshot {
             focus_intention,
             task_note,
             selected_profile,
+            captured_at_epoch_secs: current_epoch_secs(),
         })
     }
 
@@ -187,6 +193,59 @@ impl InProgressSessionSnapshot {
         }
 
         Ok(())
+    }
+
+    pub fn reconcile_elapsed_for_timer(&self, timer: &TimerState) -> Self {
+        let Some(now_epoch_secs) = current_epoch_secs() else {
+            return self.clone();
+        };
+        self.reconcile_elapsed_for_timer_at_epoch_secs(timer, now_epoch_secs)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn reconcile_elapsed_for_timer_at_epoch_secs(
+        &self,
+        timer: &TimerState,
+        now_epoch_secs: i64,
+    ) -> Self {
+        if self.status != RecoveryTimerStatus::Running {
+            return self.clone();
+        }
+        let Some(captured_at_epoch_secs) = self.captured_at_epoch_secs else {
+            return self.clone();
+        };
+        if now_epoch_secs <= captured_at_epoch_secs {
+            return self.clone();
+        }
+
+        let elapsed_secs = (now_epoch_secs - captured_at_epoch_secs) as u64;
+        if elapsed_secs == 0 {
+            return self.clone();
+        }
+
+        let mut reconciled = self.clone();
+        if elapsed_secs < reconciled.remaining_secs {
+            reconciled.remaining_secs -= elapsed_secs;
+            return reconciled;
+        }
+
+        match reconciled.phase() {
+            TimerPhase::Focus => {
+                reconciled.pomodoros_completed = reconciled.pomodoros_completed.saturating_add(1);
+                let next_phase = next_phase_after_focus(timer, reconciled.pomodoros_completed);
+                reconciled.phase = RecoveryTimerPhase::from_timer_phase(next_phase);
+                reconciled.remaining_secs = phase_duration_secs(timer, next_phase);
+            }
+            TimerPhase::ShortBreak | TimerPhase::LongBreak => {
+                reconciled.phase = RecoveryTimerPhase::from_timer_phase(TimerPhase::Focus);
+                reconciled.remaining_secs = phase_duration_secs(timer, TimerPhase::Focus);
+            }
+        }
+
+        reconciled.status = RecoveryTimerStatus::Idle;
+        reconciled.focus_intention = None;
+        reconciled.task_note = None;
+        reconciled
     }
 }
 
@@ -314,6 +373,19 @@ fn phase_duration_secs(timer: &TimerState, phase: TimerPhase) -> u64 {
     }
 }
 
+fn next_phase_after_focus(timer: &TimerState, completed_focus_count: u32) -> TimerPhase {
+    let long_break_interval = if timer.long_break_interval == 0 {
+        DEFAULT_LONG_BREAK_INTERVAL
+    } else {
+        timer.long_break_interval
+    };
+    if completed_focus_count % long_break_interval == 0 {
+        TimerPhase::LongBreak
+    } else {
+        TimerPhase::ShortBreak
+    }
+}
+
 fn normalize_metadata_text(value: &str) -> Option<String> {
     let normalized = value.trim();
     if normalized.is_empty() {
@@ -321,6 +393,13 @@ fn normalize_metadata_text(value: &str) -> Option<String> {
     } else {
         Some(normalized.to_string())
     }
+}
+
+fn current_epoch_secs() -> Option<i64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
 }
 
 #[cfg(test)]
@@ -428,6 +507,7 @@ mod tests {
             focus_intention: Some("Docs".to_string()),
             task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
+            captured_at_epoch_secs: None,
         };
 
         assert!(snapshot.validate_for_timer(&timer).is_err());
@@ -445,6 +525,7 @@ mod tests {
             focus_intention: Some("Docs".to_string()),
             task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
+            captured_at_epoch_secs: None,
         };
 
         assert!(snapshot.validate_for_timer(&timer).is_err());
@@ -462,6 +543,7 @@ mod tests {
             focus_intention: Some("Docs".to_string()),
             task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
+            captured_at_epoch_secs: None,
         };
 
         assert!(snapshot.validate_for_timer(&timer).is_err());
@@ -479,6 +561,7 @@ mod tests {
             focus_intention: Some("Docs".to_string()),
             task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
+            captured_at_epoch_secs: None,
         };
 
         assert!(snapshot.validate_for_timer(&timer).is_err());
@@ -496,6 +579,7 @@ mod tests {
             focus_intention: Some("Docs".to_string()),
             task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::DeepWork,
+            captured_at_epoch_secs: None,
         };
 
         assert!(snapshot.validate_for_timer(&timer).is_ok());
@@ -513,11 +597,102 @@ mod tests {
             focus_intention: None,
             task_note: None,
             selected_profile: ProfileId::Classic,
+            captured_at_epoch_secs: None,
         };
 
         assert_eq!(snapshot.normalized_focus_intention(), None);
         assert_eq!(snapshot.normalized_task_note(), None);
         assert!(snapshot.validate_for_timer(&timer).is_ok());
+    }
+
+    #[test]
+    fn running_snapshot_reconciliation_subtracts_elapsed_time() {
+        let timer = TimerState::with_profile(60, 30, 90, 4);
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Running,
+            remaining_secs: 50,
+            pomodoros_completed: 1,
+            selected_task_label: Some("Docs".to_string()),
+            focus_intention: Some("Write docs".to_string()),
+            task_note: Some("Section 1".to_string()),
+            selected_profile: ProfileId::Classic,
+            captured_at_epoch_secs: Some(100),
+        };
+
+        let reconciled = snapshot.reconcile_elapsed_for_timer_at_epoch_secs(&timer, 120);
+
+        assert_eq!(reconciled.phase, RecoveryTimerPhase::Focus);
+        assert_eq!(reconciled.status, RecoveryTimerStatus::Running);
+        assert_eq!(reconciled.remaining_secs, 30);
+        assert_eq!(reconciled.pomodoros_completed, 1);
+        assert_eq!(reconciled.focus_intention.as_deref(), Some("Write docs"));
+        assert_eq!(reconciled.task_note.as_deref(), Some("Section 1"));
+    }
+
+    #[test]
+    fn running_focus_snapshot_reconciliation_advances_phase_when_elapsed_exceeds_remaining() {
+        let timer = TimerState::with_profile(60, 30, 90, 2);
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Running,
+            remaining_secs: 10,
+            pomodoros_completed: 1,
+            selected_task_label: Some("Docs".to_string()),
+            focus_intention: Some("Write docs".to_string()),
+            task_note: Some("Section 1".to_string()),
+            selected_profile: ProfileId::Classic,
+            captured_at_epoch_secs: Some(100),
+        };
+
+        let reconciled = snapshot.reconcile_elapsed_for_timer_at_epoch_secs(&timer, 115);
+
+        assert_eq!(reconciled.phase, RecoveryTimerPhase::LongBreak);
+        assert_eq!(reconciled.status, RecoveryTimerStatus::Idle);
+        assert_eq!(reconciled.remaining_secs, 90);
+        assert_eq!(reconciled.pomodoros_completed, 2);
+        assert!(reconciled.focus_intention.is_none());
+        assert!(reconciled.task_note.is_none());
+        assert_eq!(reconciled.selected_task_label.as_deref(), Some("Docs"));
+    }
+
+    #[test]
+    fn paused_snapshot_reconciliation_does_not_change_state() {
+        let timer = TimerState::with_profile(60, 30, 90, 4);
+        let snapshot = InProgressSessionSnapshot {
+            phase: RecoveryTimerPhase::Focus,
+            status: RecoveryTimerStatus::Paused,
+            remaining_secs: 50,
+            pomodoros_completed: 1,
+            selected_task_label: Some("Docs".to_string()),
+            focus_intention: Some("Write docs".to_string()),
+            task_note: Some("Section 1".to_string()),
+            selected_profile: ProfileId::Classic,
+            captured_at_epoch_secs: Some(100),
+        };
+
+        let reconciled = snapshot.reconcile_elapsed_for_timer_at_epoch_secs(&timer, 1_000);
+
+        assert_eq!(reconciled, snapshot);
+    }
+
+    #[test]
+    fn in_progress_snapshot_deserializes_legacy_payload_without_capture_timestamp() {
+        let snapshot: InProgressSessionSnapshot = toml::from_str(
+            r#"
+phase = "focus"
+status = "running"
+remaining_secs = 1200
+pomodoros_completed = 2
+selected_task_label = "Docs"
+focus_intention = "Write docs"
+task_note = "API section"
+selected_profile = "classic"
+"#,
+        )
+        .expect("legacy payload should deserialize");
+
+        assert!(snapshot.captured_at_epoch_secs.is_none());
     }
 
     #[test]

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -560,7 +560,7 @@ captured_at_epoch_secs = 0
 
     let payload: Value = serde_json::from_slice(&status_output.stdout).expect("stdout JSON");
     assert_eq!(payload["live"]["state_source"], "recovery");
-    assert_eq!(payload["live"]["in_progress"], false);
+    assert_eq!(payload["live"]["in_progress"], true);
     assert_eq!(payload["live"]["phase"], "short-break");
     assert_eq!(payload["live"]["status"], "idle");
     assert_eq!(payload["live"]["pomodoros_completed"], 1);

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -538,6 +538,44 @@ fn start_then_status_json_reports_running_recovery_state_across_processes() {
 }
 
 #[test]
+fn status_json_reconciles_elapsed_recovery_snapshot_from_disk() {
+    let env = TestEnv::new("status-json-reconcile-elapsed");
+    write_recovery_snapshot(
+        &env,
+        r#"phase = "focus"
+status = "running"
+remaining_secs = 1
+pomodoros_completed = 0
+selected_task_label = "Docs"
+focus_intention = "Write docs"
+task_note = "API section"
+selected_profile = "classic"
+captured_at_epoch_secs = 0
+"#,
+    );
+
+    let status_output = env.run(&["--status", "--json"]);
+    assert_eq!(status_output.status.code(), Some(0));
+    assert!(stderr_text(&status_output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&status_output.stdout).expect("stdout JSON");
+    assert_eq!(payload["live"]["state_source"], "recovery");
+    assert_eq!(payload["live"]["in_progress"], false);
+    assert_eq!(payload["live"]["phase"], "short-break");
+    assert_eq!(payload["live"]["status"], "idle");
+    assert_eq!(payload["live"]["pomodoros_completed"], 1);
+    assert_eq!(payload["live"]["selected_task_label"], "Docs");
+    assert!(payload["live"]["focus_intention"].is_null());
+    assert!(payload["live"]["task_note"].is_null());
+    assert!(
+        payload["live"]["remaining_secs"]
+            .as_u64()
+            .expect("remaining secs should be u64")
+            > 0
+    );
+}
+
+#[test]
 fn start_json_requires_selected_task_label() {
     let env = TestEnv::new("start-json-requires-task");
     let output = env.run(&["--start", "--json"]);


### PR DESCRIPTION
## What

- Add timestamped in-progress recovery snapshots and elapsed-time reconciliation logic.
- Apply reconciliation in both startup session restore and CLI live-status hydration paths.
- Add regression coverage for restart/resume drift scenarios across recovery, app, CLI, and JSON contract tests.

## Why

Recovery snapshots previously restored saved `remaining_secs` as-is. After relaunch gaps, this could drift phase/status/remaining state from real elapsed wall time. This change reconciles elapsed time during hydration while keeping legacy snapshot compatibility.

Closes #309.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery now accurately reconciles elapsed time, advancing phases and updating remaining time and pomodoro counts when appropriate.
  * Live status output reflects reconciled state and correctly reports whether a session is active.
  * Active-focus info is cleared when a recovered session has completed its focus period offline.

* **New Features**
  * Recovery snapshots include optional timestamps to enable precise elapsed-time reconciliation.

* **Tests**
  * Added unit and CLI tests validating elapsed-time reconciliation and recovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->