### PR TITLE
WakaTime queue replay/backoff tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **WakaTime queue replay/backoff tuning (#311):** retuned default retry/runtime queue knobs to reduce aggressive retry loops, added exponential replay cooldown for consecutive retryable queue failures, and expanded queued/replaying/retrying/error status transition coverage in runtime/UI tests.
+
 ## [0.11.0] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -482,9 +482,9 @@ project = "focustime"
 language = "Pomodoro"
 
 [wakatime_runtime]
-retry_backoff_secs = [1, 2]
-queue_capacity = 256
-queue_retry_delay_secs = 10
+retry_backoff_secs = [2, 5, 10]
+queue_capacity = 512
+queue_retry_delay_secs = 30
 
 [[wakatime.task_mappings]]
 task_label = "Docs"
@@ -520,8 +520,8 @@ schedule runtime defaults (`time_step_minutes = 15`, `delay_secs = 600`).
 `60..43200`.
 
 `[wakatime_runtime]` is optional. When omitted, focustime keeps existing
-WakaTime runtime defaults (`retry_backoff_secs = [1, 2]`,
-`queue_capacity = 256`, `queue_retry_delay_secs = 10`). Backoff entries are
+WakaTime runtime defaults (`retry_backoff_secs = [2, 5, 10]`,
+`queue_capacity = 512`, `queue_retry_delay_secs = 30`). Backoff entries are
 bounded to `1..300` seconds (up to 8 entries, empty/invalid falls back to
 defaults), queue capacity is clamped to `1..4096`, and queue replay delay is
 clamped to `1..3600`.
@@ -757,13 +757,14 @@ When WakaTime is configured, heartbeats are still best-effort and non-blocking.
 The timer never waits on network calls.
 
 - transient heartbeat failures (`429`, `5xx`, and connectivity/timeout errors)
-  retry with bounded backoff (default `1s`, then `2s`, configurable via
+  retry with bounded backoff (default `2s`, then `5s`, then `10s`, configurable via
   `[wakatime_runtime].retry_backoff_secs`)
 - retryable failures that still cannot be delivered are queued in a durable local
-  backlog (bounded, drop-oldest at capacity; default `256`, configurable via
+  backlog (bounded, drop-oldest at capacity; default `512`, configurable via
   `[wakatime_runtime].queue_capacity`) and replayed oldest-first after restart
   and when connectivity recovers
-- queued heartbeat replay delay after retryable failure defaults to `10s` and is
+- queued heartbeat replay delay after retryable failure starts at `30s`, doubles
+  after each consecutive retryable replay failure (up to `3600s`), and is
   configurable via `[wakatime_runtime].queue_retry_delay_secs`
 - invalid/corrupt persisted queue snapshots are dropped on startup and surfaced
   as a runtime warning in WakaTime status

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4115,6 +4115,24 @@ fn poll_wakatime_status_applies_async_failure_event() {
 }
 
 #[test]
+fn poll_wakatime_status_transitions_queued_backlog_to_replaying() {
+    let mut app = App::default();
+    app.wakatime = WakatimeTracker::new_configured_for_tests();
+    app.wakatime.set_pending_heartbeats_for_tests(2);
+    assert!(matches!(
+        app.wakatime.runtime_state(),
+        crate::wakatime::WakatimeRuntimeState::Queued { pending: 2 }
+    ));
+
+    app.poll_wakatime_status();
+
+    assert!(matches!(
+        app.wakatime.runtime_state(),
+        crate::wakatime::WakatimeRuntimeState::Replaying { pending: 2 }
+    ));
+}
+
+#[test]
 fn focus_does_not_start_without_selected_task_label() {
     let mut app = App::default();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1046,15 +1046,15 @@ fn default_wakatime_language() -> String {
 }
 
 fn default_wakatime_retry_backoff_secs() -> Vec<u64> {
-    vec![1, 2]
+    vec![2, 5, 10]
 }
 
 fn default_wakatime_queue_capacity() -> usize {
-    256
+    512
 }
 
 fn default_wakatime_queue_retry_delay_secs() -> u64 {
-    10
+    30
 }
 
 fn default_schedule_time_step_minutes() -> u16 {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -735,7 +735,7 @@ fn normalize_clamps_wakatime_runtime_knobs_and_falls_back_for_invalid_backoff() 
         ..AppConfig::default()
     }
     .normalize();
-    assert_eq!(cfg.wakatime_runtime.retry_backoff_secs, vec![1, 2]);
+    assert_eq!(cfg.wakatime_runtime.retry_backoff_secs, vec![2, 5, 10]);
     assert_eq!(cfg.wakatime_runtime.queue_retry_delay_secs, 1);
 
     let cfg = AppConfig {

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -916,6 +916,39 @@ fn wakatime_status_line_shows_replaying_queue_backlog() {
 }
 
 #[test]
+fn wakatime_status_line_shows_retrying_state() {
+    let mut app = App::default();
+    app.wakatime = WakatimeTracker::new_configured_for_tests();
+    app.wakatime
+        .push_retrying_event_for_tests(2, 4, 5, "HTTP 503");
+    app.wakatime.poll_events();
+
+    let (text, color) = wakatime_status_line(&app);
+
+    assert_eq!(
+        text,
+        "⏱  WakaTime: retrying (2/4) in 5s (HTTP 503) · last success not yet sent"
+    );
+    assert_eq!(color, Color::Yellow);
+}
+
+#[test]
+fn wakatime_status_line_shows_error_state() {
+    let mut app = App::default();
+    app.wakatime = WakatimeTracker::new_configured_for_tests();
+    app.wakatime.push_failed_event_for_tests("HTTP 500");
+    app.wakatime.poll_events();
+
+    let (text, color) = wakatime_status_line(&app);
+
+    assert_eq!(
+        text,
+        "⏱  WakaTime: error (HTTP 500) · last success not yet sent"
+    );
+    assert_eq!(color, Color::Red);
+}
+
+#[test]
 fn wakatime_status_line_for_not_configured_omits_last_success_suffix() {
     let mut app = App::default();
     app.wakatime = WakatimeTracker::new_unconfigured_for_tests();

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -10,9 +10,9 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::{Deserialize, Serialize};
 
 const HEARTBEAT_INTERVAL_SECS: u64 = 120;
-const DEFAULT_HEARTBEAT_RETRY_BACKOFF_SECS: [u64; 2] = [1, 2];
-const DEFAULT_HEARTBEAT_QUEUE_CAPACITY: usize = 256;
-const DEFAULT_HEARTBEAT_QUEUE_RETRY_DELAY_SECS: u64 = 10;
+const DEFAULT_HEARTBEAT_RETRY_BACKOFF_SECS: [u64; 3] = [2, 5, 10];
+const DEFAULT_HEARTBEAT_QUEUE_CAPACITY: usize = 512;
+const DEFAULT_HEARTBEAT_QUEUE_RETRY_DELAY_SECS: u64 = 30;
 const MAX_HEARTBEAT_RETRY_BACKOFF_ENTRIES: usize = 8;
 const MAX_HEARTBEAT_RETRY_BACKOFF_SECS: u64 = 300;
 const MAX_HEARTBEAT_QUEUE_CAPACITY: usize = 4096;
@@ -305,6 +305,8 @@ pub struct WakatimeTracker {
     in_flight_from_queue: bool,
     /// Earliest time at which queued heartbeats should be replayed again.
     queue_retry_not_before_epoch_secs: Option<u64>,
+    /// Consecutive retryable replay failures used to scale queue replay delay.
+    queue_retry_failure_streak: u32,
     /// Durable snapshot path for queued heartbeats and replay state.
     queue_snapshot_path: Option<PathBuf>,
     /// Latches an immediate heartbeat request while another worker is in flight.
@@ -348,6 +350,7 @@ impl WakatimeTracker {
             in_flight_heartbeat: None,
             in_flight_from_queue: false,
             queue_retry_not_before_epoch_secs: None,
+            queue_retry_failure_streak: 0,
             queue_snapshot_path: heartbeat_queue_snapshot_path(),
             pending_immediate_heartbeat: false,
             heartbeat_metadata: metadata.normalized(),
@@ -461,6 +464,7 @@ impl WakatimeTracker {
                 } else {
                     snapshot.queue_retry_not_before_epoch_secs
                 };
+                self.queue_retry_failure_streak = 0;
                 self.retry_state = None;
             }
             Ok(None) => {}
@@ -520,6 +524,7 @@ impl WakatimeTracker {
                     self.in_flight_from_queue = false;
                     self.in_flight_heartbeat = None;
                     self.queue_retry_not_before_epoch_secs = None;
+                    self.queue_retry_failure_streak = 0;
                     self.retry_state = None;
                     self.last_error = None;
                     self.last_successful_heartbeat_epoch_secs = Some(current_unix_epoch_secs());
@@ -546,12 +551,16 @@ impl WakatimeTracker {
                     self.last_error = Some(error);
                     if retryable {
                         self.requeue_in_flight_heartbeat();
-                        self.queue_retry_not_before_epoch_secs = Some(
-                            current_unix_epoch_secs()
-                                .saturating_add(self.runtime.queue_retry_delay_secs),
-                        );
+                        self.queue_retry_failure_streak =
+                            self.queue_retry_failure_streak.saturating_add(1);
+                        let retry_delay_secs =
+                            self.scaled_queue_retry_delay_secs(self.queue_retry_failure_streak);
+                        self.queue_retry_not_before_epoch_secs =
+                            Some(current_unix_epoch_secs().saturating_add(retry_delay_secs));
                     } else {
                         self.in_flight_heartbeat = None;
+                        self.queue_retry_not_before_epoch_secs = None;
+                        self.queue_retry_failure_streak = 0;
                     }
                     queue_state_changed = true;
                 }
@@ -667,6 +676,15 @@ impl WakatimeTracker {
             .is_none_or(|not_before| current_unix_epoch_secs() >= not_before)
     }
 
+    fn scaled_queue_retry_delay_secs(&self, failure_streak: u32) -> u64 {
+        let exponent = failure_streak.saturating_sub(1);
+        let multiplier = 2u64.checked_pow(exponent).unwrap_or(u64::MAX);
+        self.runtime
+            .queue_retry_delay_secs
+            .saturating_mul(multiplier)
+            .min(MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS)
+    }
+
     fn dispatch_pending_work(&mut self) {
         if self.api_key.is_none() || self.heartbeat_in_flight {
             return;
@@ -755,6 +773,7 @@ impl WakatimeTracker {
             in_flight_heartbeat: None,
             in_flight_from_queue: false,
             queue_retry_not_before_epoch_secs: None,
+            queue_retry_failure_streak: 0,
             queue_snapshot_path: None,
             pending_immediate_heartbeat: false,
             heartbeat_metadata: WakatimeHeartbeatMetadata::default(),
@@ -786,6 +805,7 @@ impl WakatimeTracker {
             in_flight_heartbeat: None,
             in_flight_from_queue: false,
             queue_retry_not_before_epoch_secs: None,
+            queue_retry_failure_streak: 0,
             queue_snapshot_path: None,
             pending_immediate_heartbeat: false,
             heartbeat_metadata: WakatimeHeartbeatMetadata::default(),
@@ -813,6 +833,22 @@ impl WakatimeTracker {
     }
 
     #[cfg(test)]
+    pub(crate) fn push_retrying_event_for_tests(
+        &self,
+        attempt: u8,
+        max_attempts: u8,
+        next_backoff_secs: u64,
+        error: impl Into<String>,
+    ) {
+        let _ = self.result_tx.send(HeartbeatEvent::Retrying {
+            attempt,
+            max_attempts,
+            next_backoff_secs,
+            error: error.into(),
+        });
+    }
+
+    #[cfg(test)]
     pub(crate) fn heartbeat_metadata_for_tests(&self) -> WakatimeHeartbeatMetadata {
         self.heartbeat_metadata.clone()
     }
@@ -835,6 +871,7 @@ impl WakatimeTracker {
         self.in_flight_heartbeat = None;
         self.in_flight_from_queue = false;
         self.queue_retry_not_before_epoch_secs = None;
+        self.queue_retry_failure_streak = 0;
         self.pending_immediate_heartbeat = false;
         self.retry_state = None;
         self.last_error = None;
@@ -1180,6 +1217,7 @@ mod tests {
             in_flight_heartbeat: None,
             in_flight_from_queue: false,
             queue_retry_not_before_epoch_secs: None,
+            queue_retry_failure_streak: 0,
             queue_snapshot_path: None,
             pending_immediate_heartbeat: false,
             heartbeat_metadata: WakatimeHeartbeatMetadata::default(),
@@ -1361,6 +1399,69 @@ mod tests {
         }
         .normalized();
         assert_eq!(normalized.retry_backoff_secs, vec![5]);
+    }
+
+    #[test]
+    fn scaled_queue_retry_delay_grows_exponentially_and_is_capped() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        tracker.runtime.queue_retry_delay_secs = 30;
+
+        assert_eq!(tracker.scaled_queue_retry_delay_secs(1), 30);
+        assert_eq!(tracker.scaled_queue_retry_delay_secs(2), 60);
+        assert_eq!(tracker.scaled_queue_retry_delay_secs(3), 120);
+        assert_eq!(
+            tracker.scaled_queue_retry_delay_secs(8),
+            MAX_HEARTBEAT_QUEUE_RETRY_DELAY_SECS
+        );
+    }
+
+    #[test]
+    fn retryable_queue_failures_increase_replay_delay_until_success() {
+        let mut tracker = tracker_with(Some("test-key"), true, 0);
+        tracker.runtime.queue_retry_delay_secs = 2;
+        tracker.request_heartbeat(true);
+
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Failed {
+                error: "network unavailable".to_string(),
+                retryable: true,
+            })
+            .expect("test event send must succeed");
+        tracker.poll_events();
+
+        let first_not_before = tracker
+            .queue_retry_not_before_epoch_secs
+            .expect("first retryable failure should set queue replay delay");
+        assert_eq!(tracker.queue_retry_failure_streak, 1);
+
+        tracker.queue_retry_not_before_epoch_secs =
+            Some(current_unix_epoch_secs().saturating_sub(1));
+        tracker.poll_events();
+        assert!(tracker.heartbeat_in_flight);
+
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Failed {
+                error: "still offline".to_string(),
+                retryable: true,
+            })
+            .expect("test event send must succeed");
+        tracker.poll_events();
+
+        let second_not_before = tracker
+            .queue_retry_not_before_epoch_secs
+            .expect("second retryable failure should set queue replay delay");
+        assert_eq!(tracker.queue_retry_failure_streak, 2);
+        assert!(second_not_before > first_not_before);
+
+        tracker
+            .result_tx
+            .send(HeartbeatEvent::Sent)
+            .expect("test event send must succeed");
+        tracker.poll_events();
+        assert_eq!(tracker.queue_retry_failure_streak, 0);
+        assert!(tracker.queue_retry_not_before_epoch_secs.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Tune WakaTime queue replay behavior to avoid aggressive retry loops during transient outages while preserving delivery guarantees. This updates runtime defaults, adds adaptive replay cooldown logic for repeated retryable failures, expands queued/retrying/error transition test coverage, and aligns docs/changelog with the new behavior.

## Why

Issue #311 requests more robust replay and backoff handling after connectivity failures, plus better visibility confidence around queued/replaying/error transitions. The previous defaults and fixed replay delay could re-attempt too aggressively under prolonged network instability.

Closes #311.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WakaTime queue replay behavior with exponential backoff for consecutive retryable failures
  * Enhanced offline resilience with updated retry and queue parameters

* **Documentation**
  * Updated WakaTime runtime defaults and reliability behavior documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->