### PR TITLE
CLI --json error contract consistency sweep

### DIFF
--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1393,6 +1393,28 @@ fn parse_with_contract_detects_json_on_early_parse_failures() {
     );
 }
 
+#[test]
+fn parse_with_contract_marks_json_usage_errors_from_key_value_parsing() {
+    let error = parse_with_contract(&["--goal=abc", "--json"]).unwrap_err();
+    assert_eq!(error.kind, CliErrorKind::Usage);
+    assert_eq!(error.output, OutputMode::Json);
+    assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert!(error.message.contains("Invalid goal"));
+}
+
+#[test]
+fn parse_with_contract_marks_json_usage_errors_from_finalize_step() {
+    let error = parse_with_contract(&["--watch", "--json"]).unwrap_err();
+    assert_eq!(error.kind, CliErrorKind::Usage);
+    assert_eq!(error.output, OutputMode::Json);
+    assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert!(
+        error
+            .message
+            .contains("`--watch` is only valid with `--status`.")
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn parse_rejects_non_utf8_arguments() {

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -112,6 +112,27 @@ fn stderr_text(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).to_string()
 }
 
+fn assert_json_error_contract(
+    output: &Output,
+    expected_exit_code: i32,
+    expected_kind: &str,
+) -> Value {
+    assert_eq!(output.status.code(), Some(expected_exit_code));
+    assert!(stderr_text(output).trim().is_empty());
+
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"]["kind"], expected_kind);
+    assert_eq!(payload["error"]["exit_code"], expected_exit_code);
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .is_some_and(|message| !message.trim().is_empty()),
+        "error message should be a non-empty string"
+    );
+    payload
+}
+
 fn write_recovery_snapshot(env: &TestEnv, content: &str) {
     let app_data_dir = env.app_data_dir();
     fs::create_dir_all(&app_data_dir).expect("failed to create app data directory");
@@ -600,13 +621,7 @@ fn parse_errors_in_json_mode_emit_usage_envelope() {
     let env = TestEnv::new("json-parse-error");
     let output = env.run(&["--status", "--unknown", "--json"]);
 
-    assert_eq!(output.status.code(), Some(2));
-    assert!(stderr_text(&output).trim().is_empty());
-
-    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
-    assert_eq!(payload["ok"], false);
-    assert_eq!(payload["error"]["kind"], "usage");
-    assert_eq!(payload["error"]["exit_code"], 2);
+    let payload = assert_json_error_contract(&output, 2, "usage");
     assert!(
         payload["error"]["message"]
             .as_str()
@@ -620,19 +635,76 @@ fn runtime_errors_in_json_mode_emit_runtime_envelope() {
     let env = TestEnv::new("json-runtime-error");
     let output = env.run(&["--resume", "--json"]);
 
-    assert_eq!(output.status.code(), Some(1));
-    assert!(stderr_text(&output).trim().is_empty());
-
-    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
-    assert_eq!(payload["ok"], false);
-    assert_eq!(payload["error"]["kind"], "runtime");
-    assert_eq!(payload["error"]["exit_code"], 1);
+    let payload = assert_json_error_contract(&output, 1, "runtime");
     assert!(
         payload["error"]["message"]
             .as_str()
             .expect("error message should be a string")
             .contains("Cannot resume")
     );
+}
+
+#[test]
+fn parse_errors_in_json_mode_preserve_contract_across_parser_stages() {
+    let env = TestEnv::new("json-parse-contract-matrix");
+    let cases: [(&[&str], &str); 5] = [
+        (&["--status", "--unknown", "--json"], "Unknown option"),
+        (
+            &["--schedule-set", "--json"],
+            "`--schedule-set` requires a JSON payload",
+        ),
+        (
+            &["--status", "--watch=0", "--json"],
+            "positive whole number of seconds",
+        ),
+        (&["--task=", "--json"], "`--task=` requires a task label"),
+        (
+            &["--status", "--watch", "--watch=2", "--json"],
+            "can only be specified once",
+        ),
+    ];
+
+    for (args, message_fragment) in cases {
+        let output = env.run(args);
+        let payload = assert_json_error_contract(&output, 2, "usage");
+        assert!(
+            payload["error"]["message"]
+                .as_str()
+                .expect("error message should be a string")
+                .contains(message_fragment),
+            "expected message fragment `{message_fragment}` for args {:?}, got {}",
+            args,
+            payload["error"]["message"]
+        );
+    }
+}
+
+#[test]
+fn runtime_errors_in_json_mode_preserve_contract_across_command_families() {
+    let env = TestEnv::new("json-runtime-contract-matrix");
+    let cases: [(&[&str], &str); 4] = [
+        (&["--start", "--json"], "select a task label first"),
+        (&["--pause", "--json"], "Cannot pause"),
+        (&["--resume", "--json"], "Cannot resume"),
+        (
+            &["--focus-intention", "Write docs", "--json"],
+            "focus session is not active or paused",
+        ),
+    ];
+
+    for (args, message_fragment) in cases {
+        let output = env.run(args);
+        let payload = assert_json_error_contract(&output, 1, "runtime");
+        assert!(
+            payload["error"]["message"]
+                .as_str()
+                .expect("error message should be a string")
+                .contains(message_fragment),
+            "expected message fragment `{message_fragment}` for args {:?}, got {}",
+            args,
+            payload["error"]["message"]
+        );
+    }
 }
 
 #[test]
@@ -643,6 +715,16 @@ fn text_parse_errors_still_use_stderr() {
     assert_eq!(output.status.code(), Some(2));
     assert!(stdout_text(&output).trim().is_empty());
     assert!(stderr_text(&output).contains("Unknown option"));
+}
+
+#[test]
+fn text_runtime_errors_still_use_stderr() {
+    let env = TestEnv::new("text-runtime-error");
+    let output = env.run(&["--resume"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout_text(&output).trim().is_empty());
+    assert!(stderr_text(&output).contains("Cannot resume"));
 }
 
 #[test]


### PR DESCRIPTION
## What

Expand CLI error-contract tests so `--json` failures are consistently validated for envelope shape, error kind, exit code, and output stream behavior.

## Why

Issue #312 requires consistent machine-readable error contracts and predictable exit-code mapping across CLI command failures. This PR adds matrix-style coverage for parse-stage and runtime-stage errors to prevent regressions across command families.

Closes #312.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added validation tests for CLI error handling with JSON output mode.
  * Introduced shared helper for verifying JSON error response structure (exit code, error type, message).
  * Added contract-matrix tests to validate error envelope consistency across different parser stages and command families.
  * Enhanced stderr validation for runtime error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->