### PR TITLE
--status --watch CPU/interrupt handling polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cargo run -- --blocking-preview --json
 cargo run -- --status
 cargo run -- --status --json
 
-# Watch status continuously (default 1s cadence, optional seconds override)
+# Watch status continuously (default 1s cadence, optional seconds override; Ctrl-C exits cleanly)
 cargo run -- --status --watch
 cargo run -- --status --watch=2 --json
 
@@ -228,7 +228,7 @@ Milestone policy:
 
 - `--json` success responses are emitted to `stdout` as JSON and exit with code `0`.
 - `--json` failures are emitted to `stdout` as JSON (no mixed human text) and exit with a non-zero code.
-- `--status --watch --json` emits newline-delimited compact JSON snapshots continuously until interrupted.
+- `--status --watch --json` emits newline-delimited compact JSON snapshots continuously until interrupted, then exits cleanly after the current snapshot.
 - Text-mode failures are emitted to `stderr` for interactive readability.
 
 Exit codes:

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1071,21 +1071,13 @@ unsafe fn install_platform_watch_interrupt_handler() -> Result<(), String> {
     }
 
     unsafe extern "C" {
-        fn signal(signum: i32, handler: usize) -> usize;
+        fn signal(signum: i32, handler: unsafe extern "C" fn(i32)) -> unsafe extern "C" fn(i32);
     }
 
     const SIGINT: i32 = 2;
-    const SIG_ERR: usize = usize::MAX;
 
-    let previous = unsafe { signal(SIGINT, handle_sigint as usize) };
-    if previous == SIG_ERR {
-        Err(
-            "Failed to install watch interrupt handler: signal(SIGINT) returned SIG_ERR."
-                .to_string(),
-        )
-    } else {
-        Ok(())
-    }
+    let _previous = unsafe { signal(SIGINT, handle_sigint) };
+    Ok(())
 }
 
 #[cfg(target_os = "windows")]

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1,4 +1,13 @@
-use std::{env, fs, path::Path, thread, time::Duration};
+use std::{
+    env, fs,
+    path::Path,
+    sync::{
+        OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
 
 use crate::app::App;
 
@@ -31,6 +40,10 @@ use crate::cli::{
 
 const CONFIG_FILE_NAME: &str = "config.toml";
 const STATS_FILE_NAME: &str = "stats.toml";
+const WATCH_INTERRUPT_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+static WATCH_INTERRUPTED: AtomicBool = AtomicBool::new(false);
+static WATCH_INTERRUPT_HANDLER: OnceLock<Result<(), String>> = OnceLock::new();
 
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
     match cli_command.kind {
@@ -996,12 +1009,118 @@ fn execute_status_watch_command(output: OutputMode, interval_secs: u64) -> Resul
         return Err("`--watch` interval must be greater than 0 seconds.".to_string());
     }
 
+    install_watch_interrupt_handler()?;
+    WATCH_INTERRUPTED.store(false, Ordering::SeqCst);
+    let interval = Duration::from_secs(interval_secs);
+    let mut next_deadline = Instant::now();
+
     loop {
+        if WATCH_INTERRUPTED.load(Ordering::SeqCst) {
+            break;
+        }
+
         let payload = load_status_output()?;
         emit_status_output(&payload, output, true)?;
         flush_stdout()?;
-        thread::sleep(Duration::from_secs(interval_secs));
+
+        next_deadline = next_watch_deadline(next_deadline, interval, Instant::now());
+        if wait_for_next_watch_tick(next_deadline) {
+            break;
+        }
     }
+
+    Ok(())
+}
+
+fn install_watch_interrupt_handler() -> Result<(), String> {
+    WATCH_INTERRUPT_HANDLER
+        .get_or_init(|| unsafe { install_platform_watch_interrupt_handler() })
+        .clone()
+}
+
+fn next_watch_deadline(previous_deadline: Instant, interval: Duration, now: Instant) -> Instant {
+    let mut deadline = previous_deadline + interval;
+    while deadline <= now {
+        deadline += interval;
+    }
+    deadline
+}
+
+fn wait_for_next_watch_tick(deadline: Instant) -> bool {
+    loop {
+        if WATCH_INTERRUPTED.load(Ordering::SeqCst) {
+            return true;
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            return false;
+        }
+
+        let sleep_for = deadline
+            .saturating_duration_since(now)
+            .min(WATCH_INTERRUPT_POLL_INTERVAL);
+        thread::sleep(sleep_for);
+    }
+}
+
+#[cfg(unix)]
+unsafe fn install_platform_watch_interrupt_handler() -> Result<(), String> {
+    unsafe extern "C" fn handle_sigint(_signal: i32) {
+        WATCH_INTERRUPTED.store(true, Ordering::SeqCst);
+    }
+
+    unsafe extern "C" {
+        fn signal(signum: i32, handler: usize) -> usize;
+    }
+
+    const SIGINT: i32 = 2;
+    const SIG_ERR: usize = usize::MAX;
+
+    let previous = unsafe { signal(SIGINT, handle_sigint as usize) };
+    if previous == SIG_ERR {
+        Err(
+            "Failed to install watch interrupt handler: signal(SIGINT) returned SIG_ERR."
+                .to_string(),
+        )
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn install_platform_watch_interrupt_handler() -> Result<(), String> {
+    unsafe extern "system" fn handle_console_ctrl(ctrl_type: u32) -> i32 {
+        const CTRL_C_EVENT: u32 = 0;
+        const CTRL_BREAK_EVENT: u32 = 1;
+        if ctrl_type == CTRL_C_EVENT || ctrl_type == CTRL_BREAK_EVENT {
+            WATCH_INTERRUPTED.store(true, Ordering::SeqCst);
+            return 1;
+        }
+        0
+    }
+
+    unsafe extern "system" {
+        fn SetConsoleCtrlHandler(
+            handler_routine: Option<unsafe extern "system" fn(u32) -> i32>,
+            add: i32,
+        ) -> i32;
+    }
+
+    let installed = unsafe { SetConsoleCtrlHandler(Some(handle_console_ctrl), 1) };
+    if installed == 0 {
+        Err(
+            "Failed to install watch interrupt handler: SetConsoleCtrlHandler returned 0."
+                .to_string(),
+        )
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
+unsafe fn install_platform_watch_interrupt_handler() -> Result<(), String> {
+    Ok(())
 }
 
 fn load_status_output() -> Result<StatusOutput, String> {
@@ -1446,5 +1565,81 @@ fn build_timer_state_output(app: &App) -> TimerStateOutput {
         selected_task_label,
         focus_intention,
         task_note,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    static WATCH_TEST_GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn guard_watch_state() -> std::sync::MutexGuard<'static, ()> {
+        WATCH_TEST_GUARD
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("watch test guard should lock")
+    }
+
+    #[test]
+    fn next_watch_deadline_advances_when_on_schedule() {
+        let _guard = guard_watch_state();
+        let base = Instant::now();
+        let interval = Duration::from_secs(2);
+        let now = base + Duration::from_millis(500);
+
+        let deadline = next_watch_deadline(base, interval, now);
+
+        assert_eq!(deadline, base + interval);
+    }
+
+    #[test]
+    fn next_watch_deadline_skips_missed_intervals() {
+        let _guard = guard_watch_state();
+        let base = Instant::now();
+        let interval = Duration::from_secs(1);
+        let now = base + Duration::from_millis(3300);
+
+        let deadline = next_watch_deadline(base, interval, now);
+
+        assert_eq!(deadline, base + Duration::from_secs(4));
+    }
+
+    #[test]
+    fn wait_for_next_watch_tick_returns_interrupt_state_immediately() {
+        let _guard = guard_watch_state();
+        WATCH_INTERRUPTED.store(true, Ordering::SeqCst);
+
+        let interrupted = wait_for_next_watch_tick(Instant::now() + Duration::from_secs(1));
+
+        WATCH_INTERRUPTED.store(false, Ordering::SeqCst);
+        assert!(interrupted);
+    }
+
+    #[test]
+    fn wait_for_next_watch_tick_returns_false_after_deadline() {
+        let _guard = guard_watch_state();
+        WATCH_INTERRUPTED.store(false, Ordering::SeqCst);
+
+        let interrupted = wait_for_next_watch_tick(Instant::now());
+
+        WATCH_INTERRUPTED.store(false, Ordering::SeqCst);
+        assert!(!interrupted);
+    }
+
+    #[test]
+    fn wait_for_next_watch_tick_observes_interrupt_request() {
+        let _guard = guard_watch_state();
+        WATCH_INTERRUPTED.store(false, Ordering::SeqCst);
+        let deadline = Instant::now() + Duration::from_secs(2);
+
+        let wait_thread = std::thread::spawn(move || wait_for_next_watch_tick(deadline));
+        std::thread::sleep(Duration::from_millis(30));
+        WATCH_INTERRUPTED.store(true, Ordering::SeqCst);
+
+        let interrupted = wait_thread.join().expect("watch wait thread should join");
+        WATCH_INTERRUPTED.store(false, Ordering::SeqCst);
+        assert!(interrupted);
     }
 }

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     path::PathBuf,
-    process::{Command, Output, Stdio},
+    process::{Child, Command, Output, Stdio},
     sync::atomic::{AtomicU64, Ordering},
     thread,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -68,7 +68,7 @@ impl TestEnv {
             .expect("failed to run focustime integration command")
     }
 
-    fn run_watch(&self, args: &[&str], runtime: Duration) -> Output {
+    fn spawn_watch(&self, args: &[&str]) -> Child {
         let mut command = Command::new(focustime_bin_path());
         command.args(args);
         command.current_dir(&self.root);
@@ -81,14 +81,36 @@ impl TestEnv {
         command.stdout(Stdio::piped());
         command.stderr(Stdio::piped());
 
-        let mut child = command
+        command
             .spawn()
-            .expect("failed to spawn focustime integration command");
+            .expect("failed to spawn focustime integration command")
+    }
+
+    fn run_watch(&self, args: &[&str], runtime: Duration) -> Output {
+        let mut child = self.spawn_watch(args);
         thread::sleep(runtime);
         let _ = child.kill();
         child
             .wait_with_output()
             .expect("failed to collect watch command output")
+    }
+
+    #[cfg(unix)]
+    fn run_watch_with_sigint(&self, args: &[&str], runtime: Duration) -> Output {
+        let mut child = self.spawn_watch(args);
+        thread::sleep(runtime);
+        let interrupt_status = Command::new("kill")
+            .arg("-INT")
+            .arg(child.id().to_string())
+            .status()
+            .expect("failed to send SIGINT to watch command");
+        assert!(
+            interrupt_status.success(),
+            "kill -INT should succeed, got status: {interrupt_status}"
+        );
+        child
+            .wait_with_output()
+            .expect("failed to collect watch command output after SIGINT")
     }
 }
 
@@ -351,6 +373,36 @@ fn status_watch_json_streams_multiple_snapshots() {
     for line in lines {
         let payload: Value =
             serde_json::from_str(line).expect("snapshot line should be valid JSON");
+        assert!(payload.get("day").is_some());
+        assert!(payload.get("live").is_some());
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn status_watch_json_sigint_exits_cleanly_without_partial_snapshot() {
+    let env = TestEnv::new("status-watch-json-sigint");
+    let output = env.run_watch_with_sigint(
+        &["--status", "--watch=1", "--json"],
+        Duration::from_millis(1400),
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let lines: Vec<&str> = stdout_text(&output)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    assert!(
+        !lines.is_empty(),
+        "expected at least one snapshot before SIGINT, got none"
+    );
+
+    for line in lines {
+        let payload: Value =
+            serde_json::from_str(line).expect("SIGINT watch output should stay valid NDJSON");
         assert!(payload.get("day").is_some());
         assert!(payload.get("live").is_some());
     }

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -97,7 +97,7 @@ impl TestEnv {
 
     #[cfg(unix)]
     fn run_watch_with_sigint(&self, args: &[&str], runtime: Duration) -> Output {
-        let mut child = self.spawn_watch(args);
+        let child = self.spawn_watch(args);
         thread::sleep(runtime);
         let interrupt_status = Command::new("kill")
             .arg("-INT")
@@ -390,7 +390,8 @@ fn status_watch_json_sigint_exits_cleanly_without_partial_snapshot() {
     assert_eq!(output.status.code(), Some(0));
     assert!(stderr_text(&output).trim().is_empty());
 
-    let lines: Vec<&str> = stdout_text(&output)
+    let stdout = stdout_text(&output);
+    let lines: Vec<&str> = stdout
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())


### PR DESCRIPTION
## What

- Refactors `--status --watch` scheduling to use monotonic deadlines instead of fixed post-print sleeps.
- Adds explicit SIGINT/Ctrl-C handling for watch mode so it exits cleanly on snapshot boundaries.
- Adds regression coverage for cadence and interrupt behavior in `src/cli/execute.rs` tests and CLI JSON watch contract coverage on Unix.
- Updates README watch-mode wording to document clean interrupt semantics.

## Why

Issue #313 asks for lower-overhead watch behavior and cleaner interrupt handling. This change keeps watch cadence stable, improves interrupt responsiveness during wait periods, and preserves output integrity for text and NDJSON streams.

Closes #313.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified watch mode behavior including default polling interval, interrupt handling, and JSON output format specifications.

* **Bug Fixes**
  * Watch mode now responds promptly to interrupt signals and exits cleanly without partial output.

* **Tests**
  * Added integration tests validating clean exit behavior when watch mode is interrupted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->