### PR TITLE
Session templates for task/profile/blocklist/schedule bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ cargo run -- --blocklist-profile-create Study
 cargo run -- --blocklist-profile-rename "Deep Work"
 cargo run -- --blocklist-profile-delete --json
 
+# Manage session templates (task/profile/blocklist/schedule bundles)
+cargo run -- --session-template
+cargo run -- --session-template "Deep Flow"
+cargo run -- --session-template-create "Deep Flow"
+cargo run -- --session-template-rename "Sprint Focus"
+cargo run -- --session-template-apply
+cargo run -- --session-template-apply "Deep Flow"
+cargo run -- --session-template-delete --json
+
 # Manage blocklist/allowlist sites for the active blocklist profile
 cargo run -- --blocklist-sites
 cargo run -- --allowlist-sites --json
@@ -352,16 +361,15 @@ and profile-scoped automation settings are persisted in `config.toml`.
 
 Open the session planner from timer view with **`t`**.
 
-- `a`: add a new task label
-- `e`: rename highlighted task label
-- `f`: toggle favorite for highlighted task label (favorites are listed first)
-- `x`: toggle archive state for highlighted task label
-- `d` or `Delete`: delete highlighted task label
-- `r` or `1-5`: quick-pick recent task labels
-- `↑/↓` (default `navigate_up`/`navigate_down`): move selection
-- `Enter` (default `confirm`): select highlighted task label (archived labels are visible but cannot be selected)
+- `←/→` (default `navigate_left`/`navigate_right`): switch between **Task Labels** and **Session Templates** panes
+- `a`: in task pane, add a new task label; in template pane, capture a new template from current task/profile/blocklist/schedule
+- `e`: in task pane, rename highlighted task label; in template pane, rename highlighted session template
+- `d` or `Delete`: delete highlighted task label/template in the active pane
+- `Enter` (default `confirm`): in task pane, select highlighted task label (archived labels are visible but cannot be selected); in template pane, apply highlighted template
+- Task pane only: `f` toggle favorite (favorites are listed first), `x` toggle archive, `r` or `1-5` quick-pick recent labels
+- `↑/↓` (default `navigate_up`/`navigate_down`): move selection in the active pane
 - `t` or `Esc` (default `cancel`): return to timer view
-- while adding/renaming a label, `Enter` (default `confirm`) saves and `Esc` (default `cancel`) cancels
+- while adding/renaming a label or template, `Enter` (default `confirm`) saves and `Esc` (default `cancel`) cancels
 
 Starting a focus session from idle now requires a selected task label. The timer
 view always shows the current task label (or a reminder to select one).
@@ -379,8 +387,8 @@ Saved notes are reflected in live status metadata (`task_note`), recovery state,
 and interruption/completed-session history export fields.
 
 CLI parity is available via `--focus-intention`, `--task-note`, `--schedule-delay`,
-`--break-glass-trigger`, and `--break-glass-cancel` for non-interactive inspection and
-in-session workflow control.
+`--session-template*`, `--break-glass-trigger`, and `--break-glass-cancel` for
+non-interactive inspection and in-session workflow control.
 
 ### Example config
 
@@ -388,6 +396,7 @@ in-session workflow control.
 schema_version = 1
 selected_profile = "custom"
 selected_break_template = "Classic"
+selected_session_template = "Deep Flow"
 selected_theme_preset = "classic"
 selected_blocklist_profile = "Work"
 
@@ -432,6 +441,17 @@ allowlist_sites = ["reddit.com"]
 name = "Study"
 sites = ["x.com", "news.ycombinator.com"]
 allowlist_sites = []
+
+[[session_templates]]
+name = "Deep Flow"
+task_label = "Docs"
+profile = "deep-work"
+blocklist_profile = "Work"
+
+[[session_templates.schedule.windows]]
+days = ["mon", "tue", "wed", "thu", "fri"]
+start = "09:00"
+end = "11:00"
 
 [custom_profile]
 focus_secs = 1800

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,8 +17,8 @@ use crate::config::{
     DailyGoalConfig, FeatureFlagsConfig, GoalCarryOverConfig, MonthlyGoalConfig,
     NotificationConfig, OneTimeFocusWindowConfig, ProfileAutomationConfig,
     ProfileAutomationSettingsConfig, ProfileId, RecurringFocusWindowConfig,
-    RecurringScheduleConfig, ScheduleRuntimeConfig, StatsRetentionConfig, ThemePreset,
-    WakatimeMetadataConfig, WakatimeRuntimeConfig, WeeklyGoalConfig,
+    RecurringScheduleConfig, ScheduleRuntimeConfig, SessionTemplateConfig, StatsRetentionConfig,
+    ThemePreset, WakatimeMetadataConfig, WakatimeRuntimeConfig, WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -55,6 +55,7 @@ mod profile_management;
 mod schedule_editor;
 mod schedule_runtime;
 mod session_planner;
+mod session_templates;
 mod shortcuts;
 mod site_manager;
 mod timer_flow;
@@ -212,6 +213,15 @@ fn blocklist_profile_index(profiles: &[BlocklistProfileConfig], selected_name: &
 }
 
 fn break_template_index(templates: &[BreakTemplateConfig], selected_name: &str) -> Option<usize> {
+    templates
+        .iter()
+        .position(|template| template.name.eq_ignore_ascii_case(selected_name))
+}
+
+fn session_template_index(
+    templates: &[SessionTemplateConfig],
+    selected_name: &str,
+) -> Option<usize> {
     templates
         .iter()
         .position(|template| template.name.eq_ignore_ascii_case(selected_name))
@@ -387,6 +397,14 @@ pub enum BlocklistProfileInputMode {
 pub enum PlannerInputMode {
     Add,
     Rename,
+    CreateTemplate,
+    RenameTemplate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlannerPane {
+    Tasks,
+    Templates,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -578,6 +596,8 @@ pub struct App {
     active_blocklist_profile: usize,
     pub break_templates: Vec<BreakTemplateConfig>,
     active_break_template: Option<usize>,
+    pub session_templates: Vec<SessionTemplateConfig>,
+    active_session_template: Option<usize>,
     pub blocklist_profile_input: String,
     pub blocklist_profile_input_active: bool,
     blocklist_profile_input_mode: Option<BlocklistProfileInputMode>,
@@ -587,6 +607,8 @@ pub struct App {
     task_label_favorites: BTreeSet<String>,
     task_label_archived: BTreeSet<String>,
     pub planner_selection_index: usize,
+    pub planner_template_selection_index: usize,
+    pub planner_pane: PlannerPane,
     pub planner_input: String,
     pub planner_input_active: bool,
     pub planner_input_mode: Option<PlannerInputMode>,
@@ -721,6 +743,9 @@ impl App {
             &config.selected_break_template,
             &custom_profile,
         );
+        let session_templates = config.session_templates.clone();
+        let active_session_template =
+            session_template_index(&session_templates, &config.selected_session_template);
         let profile_spec = profile_spec_for(selected_profile, &custom_profile);
         let (mut stats, stats_error) =
             match FocusStats::load_with_options(crate::stats::StatsLoadOptions::default()) {
@@ -732,6 +757,7 @@ impl App {
         let task_label_favorites = task_label_state_keys(stats.task_label_favorites());
         let task_label_archived = task_label_state_keys(stats.task_label_archived());
         let planner_selection_index = 0;
+        let planner_template_selection_index = active_session_template.unwrap_or(0);
         let timer = TimerState::with_profile(
             profile_spec.focus_secs,
             profile_spec.short_break_secs,
@@ -756,6 +782,8 @@ impl App {
             active_blocklist_profile,
             break_templates,
             active_break_template,
+            session_templates,
+            active_session_template,
             blocklist_profile_input: String::new(),
             blocklist_profile_input_active: false,
             blocklist_profile_input_mode: None,
@@ -765,6 +793,8 @@ impl App {
             task_label_favorites,
             task_label_archived,
             planner_selection_index,
+            planner_template_selection_index,
+            planner_pane: PlannerPane::Tasks,
             planner_input: String::new(),
             planner_input_active: false,
             planner_input_mode: None,
@@ -1246,6 +1276,16 @@ impl App {
             .unwrap_or(UNLINKED_BREAK_TEMPLATE_NAME)
     }
 
+    pub fn active_session_template_name(&self) -> Option<&str> {
+        self.active_session_template
+            .and_then(|index| self.session_templates.get(index))
+            .map(|template| template.name.as_str())
+    }
+
+    pub fn session_template_count(&self) -> usize {
+        self.session_templates.len()
+    }
+
     pub fn active_break_template_summary(&self) -> String {
         if let Some(template) = self
             .active_break_template
@@ -1271,6 +1311,13 @@ impl App {
     fn selected_break_template_for_persistence(&self) -> String {
         self.active_break_template
             .and_then(|index| self.break_templates.get(index))
+            .map(|template| template.name.clone())
+            .unwrap_or_default()
+    }
+
+    fn selected_session_template_for_persistence(&self) -> String {
+        self.active_session_template
+            .and_then(|index| self.session_templates.get(index))
             .map(|template| template.name.clone())
             .unwrap_or_default()
     }

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -8,6 +8,7 @@ impl App {
         if self.timer.phase != TimerPhase::Focus || self.timer.status != TimerStatus::Idle {
             return Err("Cannot start focus: timer is not idle in focus phase.".to_string());
         }
+        self.apply_selected_session_template_before_start()?;
         if !self.has_selectable_task_label_for_focus() {
             return Err(format!(
                 "Cannot start focus: select a task label first (run TUI and press {}).",
@@ -171,6 +172,26 @@ impl App {
             self.timer.remaining_secs,
             self.timer.pomodoros_completed,
         )
+    }
+
+    pub fn select_session_template_for_cli(&mut self, name: Option<&str>) -> Result<bool, String> {
+        self.select_session_template(name)
+    }
+
+    pub fn apply_session_template_for_cli(&mut self, name: Option<&str>) -> Result<bool, String> {
+        self.apply_session_template(name)
+    }
+
+    pub fn create_session_template_for_cli(&mut self, name: &str) -> Result<bool, String> {
+        self.capture_session_template(name)
+    }
+
+    pub fn rename_active_session_template_for_cli(&mut self, name: &str) -> Result<bool, String> {
+        self.rename_active_session_template(name)
+    }
+
+    pub fn delete_active_session_template_for_cli(&mut self) -> Result<bool, String> {
+        self.delete_active_session_template()
     }
 
     fn ensure_focus_active_for_cli_metadata_update(&self, command: &str) -> Result<(), String> {

--- a/src/app/mode_keys.rs
+++ b/src/app/mode_keys.rs
@@ -91,15 +91,18 @@ impl App {
     }
 
     fn handle_timer_toggle_pause_key(&mut self) {
-        if self.timer.phase == TimerPhase::Focus
-            && self.timer.status == TimerStatus::Idle
-            && !self.has_selectable_task_label_for_focus()
-        {
-            self.phase_notification = Some(format!(
-                "Select a task label with {} before starting focus.",
-                self.shortcut_hint(ShortcutAction::OpenSessionPlanner)
-            ));
-            return;
+        if self.timer.phase == TimerPhase::Focus && self.timer.status == TimerStatus::Idle {
+            if let Err(error) = self.apply_selected_session_template_before_start() {
+                self.phase_notification = Some(error);
+                return;
+            }
+            if !self.has_selectable_task_label_for_focus() {
+                self.phase_notification = Some(format!(
+                    "Select a task label with {} before starting focus.",
+                    self.shortcut_hint(ShortcutAction::OpenSessionPlanner)
+                ));
+                return;
+            }
         }
         self.update_timer_and_sync(TimerState::toggle_pause);
     }

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -469,6 +469,8 @@ impl App {
             custom_profile: Some(custom_profile),
             break_templates: self.break_templates.clone(),
             selected_break_template: self.selected_break_template_for_persistence(),
+            session_templates: self.session_templates.clone(),
+            selected_session_template: self.selected_session_template_for_persistence(),
             selected_theme_preset: self.selected_theme_preset,
             notifications: self.notification_settings,
             auto_start: self.auto_start,

--- a/src/app/schedule_runtime.rs
+++ b/src/app/schedule_runtime.rs
@@ -193,6 +193,12 @@ impl App {
             self.update_timer_and_sync(TimerState::next_phase);
         }
 
+        if let Err(error) = self.apply_selected_session_template_before_start() {
+            self.schedule_armed_occurrence_key = Some(active_occurrence_key.to_string());
+            self.phase_notification = Some(error);
+            return;
+        }
+
         if self.can_auto_start_focus_for_schedule() {
             self.update_timer_and_sync(TimerState::toggle_pause);
             self.phase_notification =

--- a/src/app/session_planner.rs
+++ b/src/app/session_planner.rs
@@ -50,35 +50,10 @@ impl App {
             self.mode = AppMode::Timer;
             return true;
         }
-        if self.navigation_matches(NavigationAction::MoveUp, key) {
-            match self.planner_pane {
-                PlannerPane::Tasks => {
-                    self.planner_selection_index = self.planner_selection_index.saturating_sub(1);
-                }
-                PlannerPane::Templates => {
-                    self.planner_template_selection_index =
-                        self.planner_template_selection_index.saturating_sub(1);
-                }
-            }
+        if self.handle_session_planner_move_up(key) {
             return true;
         }
-        if self.navigation_matches(NavigationAction::MoveDown, key) {
-            match self.planner_pane {
-                PlannerPane::Tasks => {
-                    let labels = self.planner_labels_for_display();
-                    if !labels.is_empty() {
-                        self.planner_selection_index =
-                            (self.planner_selection_index + 1).min(labels.len().saturating_sub(1));
-                    }
-                }
-                PlannerPane::Templates => {
-                    if !self.session_templates.is_empty() {
-                        self.planner_template_selection_index =
-                            (self.planner_template_selection_index + 1)
-                                .min(self.session_templates.len().saturating_sub(1));
-                    }
-                }
-            }
+        if self.handle_session_planner_move_down(key) {
             return true;
         }
         if self.navigation_matches(NavigationAction::MoveLeft, key) {
@@ -89,14 +64,57 @@ impl App {
             self.planner_pane = PlannerPane::Templates;
             return true;
         }
-        if self.navigation_matches(NavigationAction::Confirm, key) {
-            match self.planner_pane {
-                PlannerPane::Tasks => self.select_planner_label(),
-                PlannerPane::Templates => self.apply_planner_template(),
-            }
-            return true;
+        self.handle_session_planner_confirm_key(key)
+    }
+
+    fn handle_session_planner_move_up(&mut self, key: &KeyEvent) -> bool {
+        if !self.navigation_matches(NavigationAction::MoveUp, key) {
+            return false;
         }
-        false
+        match self.planner_pane {
+            PlannerPane::Tasks => {
+                self.planner_selection_index = self.planner_selection_index.saturating_sub(1);
+            }
+            PlannerPane::Templates => {
+                self.planner_template_selection_index =
+                    self.planner_template_selection_index.saturating_sub(1);
+            }
+        }
+        true
+    }
+
+    fn handle_session_planner_move_down(&mut self, key: &KeyEvent) -> bool {
+        if !self.navigation_matches(NavigationAction::MoveDown, key) {
+            return false;
+        }
+        match self.planner_pane {
+            PlannerPane::Tasks => {
+                let labels = self.planner_labels_for_display();
+                if !labels.is_empty() {
+                    self.planner_selection_index =
+                        (self.planner_selection_index + 1).min(labels.len().saturating_sub(1));
+                }
+            }
+            PlannerPane::Templates => {
+                if !self.session_templates.is_empty() {
+                    self.planner_template_selection_index = (self.planner_template_selection_index
+                        + 1)
+                    .min(self.session_templates.len().saturating_sub(1));
+                }
+            }
+        }
+        true
+    }
+
+    fn handle_session_planner_confirm_key(&mut self, key: &KeyEvent) -> bool {
+        if !self.navigation_matches(NavigationAction::Confirm, key) {
+            return false;
+        }
+        match self.planner_pane {
+            PlannerPane::Tasks => self.select_planner_label(),
+            PlannerPane::Templates => self.apply_planner_template(),
+        }
+        true
     }
 
     fn handle_session_planner_recent_digit_key(&mut self, key: &KeyEvent) -> bool {

--- a/src/app/session_planner.rs
+++ b/src/app/session_planner.rs
@@ -505,11 +505,15 @@ impl App {
             .get(index)
             .map(|template| template.name.clone())
             .unwrap_or_default();
-        self.active_session_template = Some(index);
-        match self.rename_active_session_template(name) {
+        match self.rename_session_template_at(index, name) {
             Ok(updated) => {
                 self.cancel_planner_input();
-                self.planner_template_selection_index = self.active_session_template.unwrap_or(0);
+                if self.session_templates.is_empty() {
+                    self.planner_template_selection_index = 0;
+                } else {
+                    self.planner_template_selection_index =
+                        index.min(self.session_templates.len().saturating_sub(1));
+                }
                 if updated {
                     self.set_planner_feedback(
                         PlannerFeedbackLevel::Success,
@@ -626,10 +630,14 @@ impl App {
             .get(index)
             .map(|template| template.name.clone())
             .unwrap_or_default();
-        self.active_session_template = Some(index);
-        match self.delete_active_session_template() {
+        match self.delete_session_template_at(index) {
             Ok(_) => {
-                self.planner_template_selection_index = self.active_session_template.unwrap_or(0);
+                if self.session_templates.is_empty() {
+                    self.planner_template_selection_index = 0;
+                } else {
+                    self.planner_template_selection_index =
+                        index.min(self.session_templates.len().saturating_sub(1));
+                }
                 self.set_planner_feedback(
                     PlannerFeedbackLevel::Success,
                     format!("Deleted session template `{removed}`"),

--- a/src/app/session_planner.rs
+++ b/src/app/session_planner.rs
@@ -1,7 +1,7 @@
 use crate::app::{
     App, AppMode, KeyCode, KeyEvent, NavigationAction, PLANNER_RECENT_LABEL_LIMIT,
-    PlannerFeedbackLevel, PlannerInputMode, ShortcutAction, normalize_task_label, task_label_index,
-    task_label_key, task_label_state_labels,
+    PlannerFeedbackLevel, PlannerInputMode, PlannerPane, ShortcutAction, normalize_task_label,
+    task_label_index, task_label_key, task_label_state_labels,
 };
 
 impl App {
@@ -34,37 +34,84 @@ impl App {
                 self.mode = AppMode::Timer;
             }
             _ if self.navigation_matches(NavigationAction::MoveUp, &key) => {
-                self.planner_selection_index = self.planner_selection_index.saturating_sub(1);
+                match self.planner_pane {
+                    PlannerPane::Tasks => {
+                        self.planner_selection_index =
+                            self.planner_selection_index.saturating_sub(1);
+                    }
+                    PlannerPane::Templates => {
+                        self.planner_template_selection_index =
+                            self.planner_template_selection_index.saturating_sub(1);
+                    }
+                }
             }
-            _ if self.navigation_matches(NavigationAction::MoveDown, &key)
-                && !self.planner_labels_for_display().is_empty() =>
-            {
-                self.planner_selection_index = (self.planner_selection_index + 1)
-                    .min(self.planner_labels_for_display().len().saturating_sub(1));
+            _ if self.navigation_matches(NavigationAction::MoveDown, &key) => {
+                match self.planner_pane {
+                    PlannerPane::Tasks => {
+                        let labels = self.planner_labels_for_display();
+                        if !labels.is_empty() {
+                            self.planner_selection_index = (self.planner_selection_index + 1)
+                                .min(labels.len().saturating_sub(1));
+                        }
+                    }
+                    PlannerPane::Templates => {
+                        if !self.session_templates.is_empty() {
+                            self.planner_template_selection_index =
+                                (self.planner_template_selection_index + 1)
+                                    .min(self.session_templates.len().saturating_sub(1));
+                        }
+                    }
+                }
+            }
+            _ if self.navigation_matches(NavigationAction::MoveLeft, &key) => {
+                self.planner_pane = PlannerPane::Tasks;
+            }
+            _ if self.navigation_matches(NavigationAction::MoveRight, &key) => {
+                self.planner_pane = PlannerPane::Templates;
             }
             KeyCode::Char(c @ '1'..='9') => {
                 let index = (c as usize).saturating_sub('1' as usize);
-                self.select_recent_planner_label(index);
+                if self.planner_pane == PlannerPane::Tasks {
+                    self.select_recent_planner_label(index);
+                }
             }
             _ if self.navigation_matches(NavigationAction::Confirm, &key) => {
-                self.select_planner_label()
+                match self.planner_pane {
+                    PlannerPane::Tasks => self.select_planner_label(),
+                    PlannerPane::Templates => self.apply_planner_template(),
+                }
             }
             _ => {
                 if self.shortcut_matches(ShortcutAction::BackSessionPlanner, &key) {
                     self.mode = AppMode::Timer;
                 } else if self.shortcut_matches(ShortcutAction::PlannerAdd, &key) {
-                    self.start_planner_input();
+                    match self.planner_pane {
+                        PlannerPane::Tasks => self.start_planner_input(),
+                        PlannerPane::Templates => self.start_planner_template_create_input(),
+                    }
                 } else if self.shortcut_matches(ShortcutAction::PlannerRename, &key) {
-                    self.start_planner_rename_input();
+                    match self.planner_pane {
+                        PlannerPane::Tasks => self.start_planner_rename_input(),
+                        PlannerPane::Templates => self.start_planner_template_rename_input(),
+                    }
                 } else if self.shortcut_matches(ShortcutAction::PlannerFavorite, &key) {
-                    self.toggle_planner_favorite();
+                    if self.planner_pane == PlannerPane::Tasks {
+                        self.toggle_planner_favorite();
+                    }
                 } else if self.shortcut_matches(ShortcutAction::PlannerArchive, &key) {
-                    self.toggle_planner_archive();
+                    if self.planner_pane == PlannerPane::Tasks {
+                        self.toggle_planner_archive();
+                    }
                 } else if self.navigation_matches(NavigationAction::Delete, &key)
                     || self.shortcut_matches(ShortcutAction::PlannerDelete, &key)
                 {
-                    self.remove_planner_label();
-                } else if self.shortcut_matches(ShortcutAction::PlannerSelectRecent, &key) {
+                    match self.planner_pane {
+                        PlannerPane::Tasks => self.remove_planner_label(),
+                        PlannerPane::Templates => self.remove_planner_template(),
+                    }
+                } else if self.shortcut_matches(ShortcutAction::PlannerSelectRecent, &key)
+                    && self.planner_pane == PlannerPane::Tasks
+                {
                     self.select_recent_planner_label(0);
                 }
             }
@@ -96,6 +143,28 @@ impl App {
         self.planner_feedback = None;
     }
 
+    fn start_planner_template_create_input(&mut self) {
+        self.planner_input.clear();
+        self.planner_input_active = true;
+        self.planner_input_mode = Some(PlannerInputMode::CreateTemplate);
+        self.planner_feedback = None;
+    }
+
+    fn start_planner_template_rename_input(&mut self) {
+        self.clamp_planner_template_selection();
+        let Some(name) = self.selected_planner_template_name() else {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                "No session templates available",
+            );
+            return;
+        };
+        self.planner_input = name;
+        self.planner_input_active = true;
+        self.planner_input_mode = Some(PlannerInputMode::RenameTemplate);
+        self.planner_feedback = None;
+    }
+
     fn cancel_planner_input(&mut self) {
         self.planner_input.clear();
         self.planner_input_active = false;
@@ -110,14 +179,36 @@ impl App {
             );
             return;
         };
-        let Some(label) = normalize_task_label(&self.planner_input) else {
-            self.set_planner_feedback(PlannerFeedbackLevel::Warning, "Task label cannot be empty");
-            return;
-        };
-
         match mode {
-            PlannerInputMode::Add => self.commit_planner_add_input(label),
-            PlannerInputMode::Rename => self.commit_planner_rename_input(label),
+            PlannerInputMode::Add | PlannerInputMode::Rename => {
+                let Some(label) = normalize_task_label(&self.planner_input) else {
+                    self.set_planner_feedback(
+                        PlannerFeedbackLevel::Warning,
+                        "Task label cannot be empty",
+                    );
+                    return;
+                };
+                match mode {
+                    PlannerInputMode::Add => self.commit_planner_add_input(label),
+                    PlannerInputMode::Rename => self.commit_planner_rename_input(label),
+                    PlannerInputMode::CreateTemplate | PlannerInputMode::RenameTemplate => {}
+                }
+            }
+            PlannerInputMode::CreateTemplate | PlannerInputMode::RenameTemplate => {
+                let name = self.planner_input.trim().to_string();
+                if name.is_empty() {
+                    self.set_planner_feedback(
+                        PlannerFeedbackLevel::Warning,
+                        "Template name cannot be empty",
+                    );
+                    return;
+                }
+                match mode {
+                    PlannerInputMode::CreateTemplate => self.commit_planner_template_create(&name),
+                    PlannerInputMode::RenameTemplate => self.commit_planner_template_rename(&name),
+                    PlannerInputMode::Add | PlannerInputMode::Rename => {}
+                }
+            }
         }
     }
 
@@ -272,6 +363,89 @@ impl App {
         );
     }
 
+    fn commit_planner_template_create(&mut self, name: &str) {
+        match self.capture_session_template(name) {
+            Ok(updated) => {
+                self.cancel_planner_input();
+                self.planner_template_selection_index = self.active_session_template.unwrap_or(0);
+                if updated {
+                    self.set_planner_feedback(
+                        PlannerFeedbackLevel::Success,
+                        format!("Created session template `{name}`"),
+                    );
+                } else {
+                    self.set_planner_feedback(
+                        PlannerFeedbackLevel::Warning,
+                        format!("No change for session template `{name}`"),
+                    );
+                }
+            }
+            Err(error) => {
+                self.set_planner_feedback(PlannerFeedbackLevel::Warning, error);
+            }
+        }
+    }
+
+    fn commit_planner_template_rename(&mut self, name: &str) {
+        self.clamp_planner_template_selection();
+        let Some(index) = self.selected_planner_template_index() else {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                "No session templates available",
+            );
+            return;
+        };
+        let previous = self
+            .session_templates
+            .get(index)
+            .map(|template| template.name.clone())
+            .unwrap_or_default();
+        self.active_session_template = Some(index);
+        match self.rename_active_session_template(name) {
+            Ok(updated) => {
+                self.cancel_planner_input();
+                self.planner_template_selection_index = self.active_session_template.unwrap_or(0);
+                if updated {
+                    self.set_planner_feedback(
+                        PlannerFeedbackLevel::Success,
+                        format!("Renamed session template `{previous}` -> `{name}`"),
+                    );
+                } else {
+                    self.set_planner_feedback(
+                        PlannerFeedbackLevel::Warning,
+                        format!("No change for session template `{name}`"),
+                    );
+                }
+            }
+            Err(error) => {
+                self.set_planner_feedback(PlannerFeedbackLevel::Warning, error);
+            }
+        }
+    }
+
+    fn apply_planner_template(&mut self) {
+        self.clamp_planner_template_selection();
+        let Some(name) = self.selected_planner_template_name() else {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                "No session templates available",
+            );
+            return;
+        };
+        match self.apply_session_template(Some(&name)) {
+            Ok(_) => {
+                self.planner_template_selection_index = self.active_session_template.unwrap_or(0);
+                self.set_planner_feedback(
+                    PlannerFeedbackLevel::Success,
+                    format!("Applied session template `{name}`"),
+                );
+            }
+            Err(error) => {
+                self.set_planner_feedback(PlannerFeedbackLevel::Warning, error);
+            }
+        }
+    }
+
     fn remove_planner_label(&mut self) {
         if self.task_labels.is_empty() {
             self.set_planner_feedback(PlannerFeedbackLevel::Warning, "No task labels available");
@@ -331,6 +505,35 @@ impl App {
             format!("Deleted `{removed}`")
         };
         self.set_planner_feedback(PlannerFeedbackLevel::Success, feedback);
+    }
+
+    fn remove_planner_template(&mut self) {
+        self.clamp_planner_template_selection();
+        let Some(index) = self.selected_planner_template_index() else {
+            self.set_planner_feedback(
+                PlannerFeedbackLevel::Warning,
+                "No session templates available",
+            );
+            return;
+        };
+        let removed = self
+            .session_templates
+            .get(index)
+            .map(|template| template.name.clone())
+            .unwrap_or_default();
+        self.active_session_template = Some(index);
+        match self.delete_active_session_template() {
+            Ok(_) => {
+                self.planner_template_selection_index = self.active_session_template.unwrap_or(0);
+                self.set_planner_feedback(
+                    PlannerFeedbackLevel::Success,
+                    format!("Deleted session template `{removed}`"),
+                );
+            }
+            Err(error) => {
+                self.set_planner_feedback(PlannerFeedbackLevel::Warning, error);
+            }
+        }
     }
 
     fn select_recent_planner_label(&mut self, index: usize) {
@@ -471,6 +674,28 @@ impl App {
         self.set_planner_feedback(PlannerFeedbackLevel::Success, message);
     }
 
+    fn selected_planner_template_index(&self) -> Option<usize> {
+        self.session_templates
+            .get(self.planner_template_selection_index)
+            .map(|_| self.planner_template_selection_index)
+    }
+
+    fn selected_planner_template_name(&self) -> Option<String> {
+        self.selected_planner_template_index()
+            .and_then(|index| self.session_templates.get(index))
+            .map(|template| template.name.clone())
+    }
+
+    pub(super) fn clamp_planner_template_selection(&mut self) {
+        if self.session_templates.is_empty() {
+            self.planner_template_selection_index = 0;
+        } else {
+            self.planner_template_selection_index = self
+                .planner_template_selection_index
+                .min(self.session_templates.len().saturating_sub(1));
+        }
+    }
+
     pub(super) fn clamp_planner_selection(&mut self) {
         let display_labels = self.planner_labels_for_display();
         if display_labels.is_empty() {
@@ -501,6 +726,9 @@ impl App {
         self.planner_input.clear();
         self.planner_input_active = false;
         self.planner_input_mode = None;
+        self.planner_pane = PlannerPane::Tasks;
+        self.planner_template_selection_index = self.active_session_template.unwrap_or(0);
+        self.clamp_planner_template_selection();
         self.sync_planner_selection_to_selected_label();
     }
 }

--- a/src/app/session_planner.rs
+++ b/src/app/session_planner.rs
@@ -118,11 +118,12 @@ impl App {
     }
 
     fn handle_session_planner_recent_digit_key(&mut self, key: &KeyEvent) -> bool {
+        if self.planner_pane != PlannerPane::Tasks {
+            return false;
+        }
         if let KeyCode::Char(c @ '1'..='9') = key.code {
             let index = (c as usize).saturating_sub('1' as usize);
-            if self.planner_pane == PlannerPane::Tasks {
-                self.select_recent_planner_label(index);
-            }
+            self.select_recent_planner_label(index);
             return true;
         }
         false

--- a/src/app/session_planner.rs
+++ b/src/app/session_planner.rs
@@ -6,22 +6,7 @@ use crate::app::{
 
 impl App {
     pub(super) fn handle_key_session_planner(&mut self, key: KeyEvent) {
-        if self.planner_input_active {
-            match key.code {
-                _ if self.navigation_matches(NavigationAction::Confirm, &key) => {
-                    self.commit_planner_input()
-                }
-                _ if self.navigation_matches(NavigationAction::Cancel, &key) => {
-                    self.cancel_planner_input()
-                }
-                _ if self.navigation_matches(NavigationAction::Backspace, &key) => {
-                    self.planner_input.pop();
-                }
-                KeyCode::Char(c) => {
-                    self.planner_input.push(c);
-                }
-                _ => {}
-            }
+        if self.handle_session_planner_input_key(&key) {
             return;
         }
 
@@ -29,92 +14,134 @@ impl App {
             return;
         }
 
+        if self.handle_session_planner_navigation_key(&key) {
+            return;
+        }
+        if self.handle_session_planner_recent_digit_key(&key) {
+            return;
+        }
+        self.handle_session_planner_shortcuts(&key);
+    }
+
+    fn handle_session_planner_input_key(&mut self, key: &KeyEvent) -> bool {
+        if !self.planner_input_active {
+            return false;
+        }
         match key.code {
-            _ if self.navigation_matches(NavigationAction::Cancel, &key) => {
-                self.mode = AppMode::Timer;
+            _ if self.navigation_matches(NavigationAction::Confirm, key) => {
+                self.commit_planner_input()
             }
-            _ if self.navigation_matches(NavigationAction::MoveUp, &key) => {
-                match self.planner_pane {
-                    PlannerPane::Tasks => {
+            _ if self.navigation_matches(NavigationAction::Cancel, key) => {
+                self.cancel_planner_input()
+            }
+            _ if self.navigation_matches(NavigationAction::Backspace, key) => {
+                self.planner_input.pop();
+            }
+            KeyCode::Char(c) => {
+                self.planner_input.push(c);
+            }
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_session_planner_navigation_key(&mut self, key: &KeyEvent) -> bool {
+        if self.navigation_matches(NavigationAction::Cancel, key) {
+            self.mode = AppMode::Timer;
+            return true;
+        }
+        if self.navigation_matches(NavigationAction::MoveUp, key) {
+            match self.planner_pane {
+                PlannerPane::Tasks => {
+                    self.planner_selection_index = self.planner_selection_index.saturating_sub(1);
+                }
+                PlannerPane::Templates => {
+                    self.planner_template_selection_index =
+                        self.planner_template_selection_index.saturating_sub(1);
+                }
+            }
+            return true;
+        }
+        if self.navigation_matches(NavigationAction::MoveDown, key) {
+            match self.planner_pane {
+                PlannerPane::Tasks => {
+                    let labels = self.planner_labels_for_display();
+                    if !labels.is_empty() {
                         self.planner_selection_index =
-                            self.planner_selection_index.saturating_sub(1);
+                            (self.planner_selection_index + 1).min(labels.len().saturating_sub(1));
                     }
-                    PlannerPane::Templates => {
+                }
+                PlannerPane::Templates => {
+                    if !self.session_templates.is_empty() {
                         self.planner_template_selection_index =
-                            self.planner_template_selection_index.saturating_sub(1);
+                            (self.planner_template_selection_index + 1)
+                                .min(self.session_templates.len().saturating_sub(1));
                     }
                 }
             }
-            _ if self.navigation_matches(NavigationAction::MoveDown, &key) => {
-                match self.planner_pane {
-                    PlannerPane::Tasks => {
-                        let labels = self.planner_labels_for_display();
-                        if !labels.is_empty() {
-                            self.planner_selection_index = (self.planner_selection_index + 1)
-                                .min(labels.len().saturating_sub(1));
-                        }
-                    }
-                    PlannerPane::Templates => {
-                        if !self.session_templates.is_empty() {
-                            self.planner_template_selection_index =
-                                (self.planner_template_selection_index + 1)
-                                    .min(self.session_templates.len().saturating_sub(1));
-                        }
-                    }
-                }
+            return true;
+        }
+        if self.navigation_matches(NavigationAction::MoveLeft, key) {
+            self.planner_pane = PlannerPane::Tasks;
+            return true;
+        }
+        if self.navigation_matches(NavigationAction::MoveRight, key) {
+            self.planner_pane = PlannerPane::Templates;
+            return true;
+        }
+        if self.navigation_matches(NavigationAction::Confirm, key) {
+            match self.planner_pane {
+                PlannerPane::Tasks => self.select_planner_label(),
+                PlannerPane::Templates => self.apply_planner_template(),
             }
-            _ if self.navigation_matches(NavigationAction::MoveLeft, &key) => {
-                self.planner_pane = PlannerPane::Tasks;
+            return true;
+        }
+        false
+    }
+
+    fn handle_session_planner_recent_digit_key(&mut self, key: &KeyEvent) -> bool {
+        if let KeyCode::Char(c @ '1'..='9') = key.code {
+            let index = (c as usize).saturating_sub('1' as usize);
+            if self.planner_pane == PlannerPane::Tasks {
+                self.select_recent_planner_label(index);
             }
-            _ if self.navigation_matches(NavigationAction::MoveRight, &key) => {
-                self.planner_pane = PlannerPane::Templates;
+            return true;
+        }
+        false
+    }
+
+    fn handle_session_planner_shortcuts(&mut self, key: &KeyEvent) {
+        if self.shortcut_matches(ShortcutAction::BackSessionPlanner, key) {
+            self.mode = AppMode::Timer;
+        } else if self.shortcut_matches(ShortcutAction::PlannerAdd, key) {
+            match self.planner_pane {
+                PlannerPane::Tasks => self.start_planner_input(),
+                PlannerPane::Templates => self.start_planner_template_create_input(),
             }
-            KeyCode::Char(c @ '1'..='9') => {
-                let index = (c as usize).saturating_sub('1' as usize);
-                if self.planner_pane == PlannerPane::Tasks {
-                    self.select_recent_planner_label(index);
-                }
+        } else if self.shortcut_matches(ShortcutAction::PlannerRename, key) {
+            match self.planner_pane {
+                PlannerPane::Tasks => self.start_planner_rename_input(),
+                PlannerPane::Templates => self.start_planner_template_rename_input(),
             }
-            _ if self.navigation_matches(NavigationAction::Confirm, &key) => {
-                match self.planner_pane {
-                    PlannerPane::Tasks => self.select_planner_label(),
-                    PlannerPane::Templates => self.apply_planner_template(),
-                }
+        } else if self.shortcut_matches(ShortcutAction::PlannerFavorite, key) {
+            if self.planner_pane == PlannerPane::Tasks {
+                self.toggle_planner_favorite();
             }
-            _ => {
-                if self.shortcut_matches(ShortcutAction::BackSessionPlanner, &key) {
-                    self.mode = AppMode::Timer;
-                } else if self.shortcut_matches(ShortcutAction::PlannerAdd, &key) {
-                    match self.planner_pane {
-                        PlannerPane::Tasks => self.start_planner_input(),
-                        PlannerPane::Templates => self.start_planner_template_create_input(),
-                    }
-                } else if self.shortcut_matches(ShortcutAction::PlannerRename, &key) {
-                    match self.planner_pane {
-                        PlannerPane::Tasks => self.start_planner_rename_input(),
-                        PlannerPane::Templates => self.start_planner_template_rename_input(),
-                    }
-                } else if self.shortcut_matches(ShortcutAction::PlannerFavorite, &key) {
-                    if self.planner_pane == PlannerPane::Tasks {
-                        self.toggle_planner_favorite();
-                    }
-                } else if self.shortcut_matches(ShortcutAction::PlannerArchive, &key) {
-                    if self.planner_pane == PlannerPane::Tasks {
-                        self.toggle_planner_archive();
-                    }
-                } else if self.navigation_matches(NavigationAction::Delete, &key)
-                    || self.shortcut_matches(ShortcutAction::PlannerDelete, &key)
-                {
-                    match self.planner_pane {
-                        PlannerPane::Tasks => self.remove_planner_label(),
-                        PlannerPane::Templates => self.remove_planner_template(),
-                    }
-                } else if self.shortcut_matches(ShortcutAction::PlannerSelectRecent, &key)
-                    && self.planner_pane == PlannerPane::Tasks
-                {
-                    self.select_recent_planner_label(0);
-                }
+        } else if self.shortcut_matches(ShortcutAction::PlannerArchive, key) {
+            if self.planner_pane == PlannerPane::Tasks {
+                self.toggle_planner_archive();
             }
+        } else if self.navigation_matches(NavigationAction::Delete, key)
+            || self.shortcut_matches(ShortcutAction::PlannerDelete, key)
+        {
+            match self.planner_pane {
+                PlannerPane::Tasks => self.remove_planner_label(),
+                PlannerPane::Templates => self.remove_planner_template(),
+            }
+        } else if self.shortcut_matches(ShortcutAction::PlannerSelectRecent, key)
+            && self.planner_pane == PlannerPane::Tasks
+        {
+            self.select_recent_planner_label(0);
         }
     }
 

--- a/src/app/session_planner.rs
+++ b/src/app/session_planner.rs
@@ -129,38 +129,98 @@ impl App {
     }
 
     fn handle_session_planner_shortcuts(&mut self, key: &KeyEvent) {
-        if self.shortcut_matches(ShortcutAction::BackSessionPlanner, key) {
-            self.mode = AppMode::Timer;
-        } else if self.shortcut_matches(ShortcutAction::PlannerAdd, key) {
-            match self.planner_pane {
-                PlannerPane::Tasks => self.start_planner_input(),
-                PlannerPane::Templates => self.start_planner_template_create_input(),
-            }
-        } else if self.shortcut_matches(ShortcutAction::PlannerRename, key) {
-            match self.planner_pane {
-                PlannerPane::Tasks => self.start_planner_rename_input(),
-                PlannerPane::Templates => self.start_planner_template_rename_input(),
-            }
-        } else if self.shortcut_matches(ShortcutAction::PlannerFavorite, key) {
-            if self.planner_pane == PlannerPane::Tasks {
-                self.toggle_planner_favorite();
-            }
-        } else if self.shortcut_matches(ShortcutAction::PlannerArchive, key) {
-            if self.planner_pane == PlannerPane::Tasks {
-                self.toggle_planner_archive();
-            }
-        } else if self.navigation_matches(NavigationAction::Delete, key)
-            || self.shortcut_matches(ShortcutAction::PlannerDelete, key)
-        {
-            match self.planner_pane {
-                PlannerPane::Tasks => self.remove_planner_label(),
-                PlannerPane::Templates => self.remove_planner_template(),
-            }
-        } else if self.shortcut_matches(ShortcutAction::PlannerSelectRecent, key)
-            && self.planner_pane == PlannerPane::Tasks
-        {
-            self.select_recent_planner_label(0);
+        if self.handle_session_planner_back_shortcut(key) {
+            return;
         }
+        if self.handle_session_planner_add_shortcut(key) {
+            return;
+        }
+        if self.handle_session_planner_rename_shortcut(key) {
+            return;
+        }
+        if self.handle_session_planner_favorite_shortcut(key) {
+            return;
+        }
+        if self.handle_session_planner_archive_shortcut(key) {
+            return;
+        }
+        if self.handle_session_planner_delete_shortcut(key) {
+            return;
+        }
+        let _ = self.handle_session_planner_select_recent_shortcut(key);
+    }
+
+    fn handle_session_planner_back_shortcut(&mut self, key: &KeyEvent) -> bool {
+        if !self.shortcut_matches(ShortcutAction::BackSessionPlanner, key) {
+            return false;
+        }
+        self.mode = AppMode::Timer;
+        true
+    }
+
+    fn handle_session_planner_add_shortcut(&mut self, key: &KeyEvent) -> bool {
+        if !self.shortcut_matches(ShortcutAction::PlannerAdd, key) {
+            return false;
+        }
+        match self.planner_pane {
+            PlannerPane::Tasks => self.start_planner_input(),
+            PlannerPane::Templates => self.start_planner_template_create_input(),
+        }
+        true
+    }
+
+    fn handle_session_planner_rename_shortcut(&mut self, key: &KeyEvent) -> bool {
+        if !self.shortcut_matches(ShortcutAction::PlannerRename, key) {
+            return false;
+        }
+        match self.planner_pane {
+            PlannerPane::Tasks => self.start_planner_rename_input(),
+            PlannerPane::Templates => self.start_planner_template_rename_input(),
+        }
+        true
+    }
+
+    fn handle_session_planner_favorite_shortcut(&mut self, key: &KeyEvent) -> bool {
+        if !self.shortcut_matches(ShortcutAction::PlannerFavorite, key) {
+            return false;
+        }
+        if self.planner_pane == PlannerPane::Tasks {
+            self.toggle_planner_favorite();
+        }
+        true
+    }
+
+    fn handle_session_planner_archive_shortcut(&mut self, key: &KeyEvent) -> bool {
+        if !self.shortcut_matches(ShortcutAction::PlannerArchive, key) {
+            return false;
+        }
+        if self.planner_pane == PlannerPane::Tasks {
+            self.toggle_planner_archive();
+        }
+        true
+    }
+
+    fn handle_session_planner_delete_shortcut(&mut self, key: &KeyEvent) -> bool {
+        if !(self.navigation_matches(NavigationAction::Delete, key)
+            || self.shortcut_matches(ShortcutAction::PlannerDelete, key))
+        {
+            return false;
+        }
+        match self.planner_pane {
+            PlannerPane::Tasks => self.remove_planner_label(),
+            PlannerPane::Templates => self.remove_planner_template(),
+        }
+        true
+    }
+
+    fn handle_session_planner_select_recent_shortcut(&mut self, key: &KeyEvent) -> bool {
+        if !(self.shortcut_matches(ShortcutAction::PlannerSelectRecent, key)
+            && self.planner_pane == PlannerPane::Tasks)
+        {
+            return false;
+        }
+        self.select_recent_planner_label(0);
+        true
     }
 
     fn start_planner_input(&mut self) {

--- a/src/app/session_templates.rs
+++ b/src/app/session_templates.rs
@@ -1,0 +1,190 @@
+use crate::app::{App, normalize_task_label, task_label_index};
+use crate::config::{ProfileAutomationConfig, SessionTemplateConfig};
+
+impl App {
+    pub(super) fn apply_selected_session_template_before_start(&mut self) -> Result<(), String> {
+        let Some(index) = self.active_session_template else {
+            return Ok(());
+        };
+        self.apply_session_template_by_index(index)?;
+        Ok(())
+    }
+
+    pub(super) fn select_session_template(&mut self, name: Option<&str>) -> Result<bool, String> {
+        let Some(name) = name.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(false);
+        };
+        let Some(index) = self.session_template_index_by_name(name) else {
+            return Err(format!("Unknown session template `{name}`."));
+        };
+        if self.active_session_template == Some(index) {
+            return Ok(false);
+        }
+        self.active_session_template = Some(index);
+        self.save_config();
+        Ok(true)
+    }
+
+    pub(super) fn capture_session_template(&mut self, name: &str) -> Result<bool, String> {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err("Template name cannot be empty.".to_string());
+        }
+        if self.session_template_index_by_name(name).is_some() {
+            return Err(format!("Template `{name}` already exists."));
+        }
+        let Some(task_label) = self
+            .selected_task_label
+            .as_ref()
+            .and_then(|value| normalize_task_label(value))
+        else {
+            return Err("Cannot create template: select a task label first.".to_string());
+        };
+        let template = SessionTemplateConfig {
+            name: name.to_string(),
+            task_label,
+            profile: self.selected_profile,
+            blocklist_profile: self.active_blocklist_profile_name().to_string(),
+            schedule: self.selected_profile_automation().recurring_schedule,
+        };
+        self.session_templates.push(template);
+        self.active_session_template = Some(self.session_templates.len().saturating_sub(1));
+        self.save_config();
+        Ok(true)
+    }
+
+    pub(super) fn rename_active_session_template(&mut self, name: &str) -> Result<bool, String> {
+        let Some(active_index) = self.active_session_template else {
+            return Err("No active session template selected.".to_string());
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            return Err("Template name cannot be empty.".to_string());
+        }
+        let Some(current_name) = self
+            .session_templates
+            .get(active_index)
+            .map(|template| template.name.clone())
+        else {
+            return Err("No active session template selected.".to_string());
+        };
+        if current_name == name {
+            return Ok(false);
+        }
+        let duplicate = self
+            .session_templates
+            .iter()
+            .enumerate()
+            .any(|(index, template)| {
+                index != active_index && template.name.eq_ignore_ascii_case(name)
+            });
+        if duplicate {
+            return Err(format!("Template `{name}` already exists."));
+        }
+        if let Some(template) = self.session_templates.get_mut(active_index) {
+            template.name = name.to_string();
+        }
+        self.save_config();
+        Ok(true)
+    }
+
+    pub(super) fn delete_active_session_template(&mut self) -> Result<bool, String> {
+        let Some(active_index) = self.active_session_template else {
+            return Err("No active session template selected.".to_string());
+        };
+        if active_index >= self.session_templates.len() {
+            return Err("No active session template selected.".to_string());
+        }
+        self.session_templates.remove(active_index);
+        if self.session_templates.is_empty() {
+            self.active_session_template = None;
+        } else {
+            self.active_session_template =
+                Some(active_index.min(self.session_templates.len().saturating_sub(1)));
+        }
+        self.save_config();
+        Ok(true)
+    }
+
+    pub(super) fn apply_session_template(&mut self, name: Option<&str>) -> Result<bool, String> {
+        let index = if let Some(name) = name.map(str::trim).filter(|value| !value.is_empty()) {
+            self.session_template_index_by_name(name)
+                .ok_or_else(|| format!("Unknown session template `{name}`."))?
+        } else {
+            self.active_session_template
+                .ok_or_else(|| "No active session template selected.".to_string())?
+        };
+        self.apply_session_template_by_index(index)
+    }
+
+    fn apply_session_template_by_index(&mut self, index: usize) -> Result<bool, String> {
+        let Some(template) = self.session_templates.get(index).cloned() else {
+            return Err("Session template selection is invalid.".to_string());
+        };
+        if self.strict_mode_enforced_for_focus() {
+            return Err("Cannot apply template while strict focus is active.".to_string());
+        }
+        let Some(blocklist_index) = self.blocklist_profiles.iter().position(|profile| {
+            profile
+                .name
+                .eq_ignore_ascii_case(&template.blocklist_profile)
+        }) else {
+            return Err(format!(
+                "Template `{}` references missing blocklist profile `{}`.",
+                template.name, template.blocklist_profile
+            ));
+        };
+        let task_label = self.resolve_template_task_label(&template.task_label)?;
+
+        let mut automation = self
+            .profile_automation
+            .for_profile(template.profile, &ProfileAutomationConfig::default());
+        automation.recurring_schedule = template.schedule.normalized();
+        self.profile_automation
+            .set_for_profile(template.profile, automation);
+
+        if !self.apply_profile(template.profile) {
+            let reason = self
+                .phase_notification
+                .clone()
+                .unwrap_or_else(|| "Failed to apply profile from template.".to_string());
+            return Err(reason);
+        }
+
+        self.active_blocklist_profile = blocklist_index;
+        self.recompute_blocker_sites_from_active_profile();
+        self.selected_task_label = Some(task_label.clone());
+        self.sync_planner_selection_to_selected_label();
+        self.sync_task_planner_state();
+        self.sync_recovery_snapshot();
+        self.active_session_template = Some(index);
+        self.save_config();
+        self.phase_notification = Some(format!("Applied session template `{}`.", template.name));
+        Ok(true)
+    }
+
+    fn resolve_template_task_label(&mut self, task_label: &str) -> Result<String, String> {
+        let Some(normalized_label) = normalize_task_label(task_label) else {
+            return Err("Template task label is empty.".to_string());
+        };
+        if let Some(index) = task_label_index(&self.task_labels, &normalized_label) {
+            let Some(existing_label) = self.task_labels.get(index).cloned() else {
+                return Err("Template task label lookup failed.".to_string());
+            };
+            if self.is_task_label_archived(&existing_label) {
+                return Err(format!(
+                    "Template task label `{existing_label}` is archived and cannot be selected."
+                ));
+            }
+            return Ok(existing_label);
+        }
+        self.task_labels.push(normalized_label.clone());
+        Ok(normalized_label)
+    }
+
+    pub(super) fn session_template_index_by_name(&self, name: &str) -> Option<usize> {
+        self.session_templates
+            .iter()
+            .position(|template| template.name.eq_ignore_ascii_case(name.trim()))
+    }
+}

--- a/src/app/session_templates.rs
+++ b/src/app/session_templates.rs
@@ -57,16 +57,27 @@ impl App {
         let Some(active_index) = self.active_session_template else {
             return Err("No active session template selected.".to_string());
         };
+        self.rename_session_template_at(active_index, name)
+    }
+
+    pub(super) fn rename_session_template_at(
+        &mut self,
+        template_index: usize,
+        name: &str,
+    ) -> Result<bool, String> {
+        if template_index >= self.session_templates.len() {
+            return Err("Session template selection is invalid.".to_string());
+        }
         let name = name.trim();
         if name.is_empty() {
             return Err("Template name cannot be empty.".to_string());
         }
         let Some(current_name) = self
             .session_templates
-            .get(active_index)
+            .get(template_index)
             .map(|template| template.name.clone())
         else {
-            return Err("No active session template selected.".to_string());
+            return Err("Session template selection is invalid.".to_string());
         };
         if current_name == name {
             return Ok(false);
@@ -76,12 +87,12 @@ impl App {
             .iter()
             .enumerate()
             .any(|(index, template)| {
-                index != active_index && template.name.eq_ignore_ascii_case(name)
+                index != template_index && template.name.eq_ignore_ascii_case(name)
             });
         if duplicate {
             return Err(format!("Template `{name}` already exists."));
         }
-        if let Some(template) = self.session_templates.get_mut(active_index) {
+        if let Some(template) = self.session_templates.get_mut(template_index) {
             template.name = name.to_string();
         }
         self.save_config();
@@ -92,15 +103,26 @@ impl App {
         let Some(active_index) = self.active_session_template else {
             return Err("No active session template selected.".to_string());
         };
-        if active_index >= self.session_templates.len() {
-            return Err("No active session template selected.".to_string());
+        self.delete_session_template_at(active_index)
+    }
+
+    pub(super) fn delete_session_template_at(&mut self, index: usize) -> Result<bool, String> {
+        if index >= self.session_templates.len() {
+            return Err("Session template selection is invalid.".to_string());
         }
-        self.session_templates.remove(active_index);
+        self.session_templates.remove(index);
         if self.session_templates.is_empty() {
             self.active_session_template = None;
         } else {
-            self.active_session_template =
-                Some(active_index.min(self.session_templates.len().saturating_sub(1)));
+            self.active_session_template = self.active_session_template.map(|active_index| {
+                if active_index == index {
+                    index.min(self.session_templates.len().saturating_sub(1))
+                } else if active_index > index {
+                    active_index.saturating_sub(1)
+                } else {
+                    active_index.min(self.session_templates.len().saturating_sub(1))
+                }
+            });
         }
         self.save_config();
         Ok(true)

--- a/src/app/shortcuts.rs
+++ b/src/app/shortcuts.rs
@@ -137,9 +137,11 @@ const SITE_INPUT_NAV_ACTIONS: [NavigationAction; 3] = [
     NavigationAction::Backspace,
 ];
 
-const SESSION_PLANNER_NAV_ACTIONS: [NavigationAction; 5] = [
+const SESSION_PLANNER_NAV_ACTIONS: [NavigationAction; 7] = [
     NavigationAction::MoveDown,
     NavigationAction::MoveUp,
+    NavigationAction::MoveLeft,
+    NavigationAction::MoveRight,
     NavigationAction::Confirm,
     NavigationAction::Cancel,
     NavigationAction::Delete,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -128,6 +128,8 @@ fn selected_builtin_profile_is_applied_on_startup() {
             },
         ],
         selected_break_template: "Classic".to_string(),
+        session_templates: Vec::new(),
+        selected_session_template: String::new(),
         notifications: NotificationConfig::default(),
         auto_start: AutoStartConfig::default(),
         recurring_schedule: RecurringScheduleConfig::default(),
@@ -4879,6 +4881,66 @@ fn session_planner_renames_highlighted_label_and_updates_selection() {
             .as_ref()
             .is_some_and(|feedback| feedback.message.contains("Renamed"))
     );
+}
+
+#[test]
+fn session_planner_template_create_and_apply_updates_bundle() {
+    let mut app = App::default();
+    app.task_labels = vec!["Docs".to_string(), "Review".to_string()];
+    app.selected_task_label = Some("Docs".to_string());
+
+    app.handle_key(key(KeyCode::Char('t')));
+    app.handle_key(key(KeyCode::Right));
+    app.handle_key(key(KeyCode::Char('a')));
+    for c in "Deep Flow".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+
+    assert_eq!(app.active_session_template_name(), Some("Deep Flow"));
+    assert_eq!(app.session_templates.len(), 1);
+    assert!(
+        app.planner_feedback
+            .as_ref()
+            .is_some_and(|feedback| { feedback.message.contains("Created session template") })
+    );
+
+    app.selected_task_label = Some("Review".to_string());
+    app.handle_key(key(KeyCode::Enter));
+
+    assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
+    assert!(
+        app.planner_feedback
+            .as_ref()
+            .is_some_and(|feedback| { feedback.message.contains("Applied session template") })
+    );
+}
+
+#[test]
+fn session_planner_template_rename_and_delete_manage_templates() {
+    let mut app = App::default();
+    app.task_labels = vec!["Docs".to_string()];
+    app.selected_task_label = Some("Docs".to_string());
+    app.handle_key(key(KeyCode::Char('t')));
+    app.handle_key(key(KeyCode::Right));
+    app.handle_key(key(KeyCode::Char('a')));
+    for c in "Template A".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+
+    app.handle_key(key(KeyCode::Char('e')));
+    assert_eq!(
+        app.planner_input_mode,
+        Some(PlannerInputMode::RenameTemplate)
+    );
+    app.planner_input = "Template B".to_string();
+    app.handle_key(key(KeyCode::Enter));
+    assert_eq!(app.active_session_template_name(), Some("Template B"));
+
+    app.handle_key(key(KeyCode::Char('d')));
+    assert!(app.session_templates.is_empty());
+    assert_eq!(app.active_session_template_name(), None);
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4944,6 +4944,75 @@ fn session_planner_template_rename_and_delete_manage_templates() {
 }
 
 #[test]
+fn session_planner_template_rename_non_active_keeps_active_template() {
+    let mut app = App::default();
+    app.task_labels = vec!["Docs".to_string(), "Review".to_string(), "Plan".to_string()];
+
+    app.selected_task_label = Some("Docs".to_string());
+    app.capture_session_template("Template A")
+        .expect("template A should be created");
+    app.selected_task_label = Some("Review".to_string());
+    app.capture_session_template("Template B")
+        .expect("template B should be created");
+    app.selected_task_label = Some("Plan".to_string());
+    app.capture_session_template("Template C")
+        .expect("template C should be created");
+    app.select_session_template(Some("Template A"))
+        .expect("template A should be selected");
+
+    app.handle_key(key(KeyCode::Char('t')));
+    app.handle_key(key(KeyCode::Right));
+    app.planner_template_selection_index = 2;
+    app.handle_key(key(KeyCode::Char('e')));
+    assert_eq!(
+        app.planner_input_mode,
+        Some(PlannerInputMode::RenameTemplate)
+    );
+
+    app.planner_input = "Template C2".to_string();
+    app.handle_key(key(KeyCode::Enter));
+
+    assert_eq!(app.active_session_template_name(), Some("Template A"));
+    let names = app
+        .session_templates
+        .iter()
+        .map(|template| template.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["Template A", "Template B", "Template C2"]);
+}
+
+#[test]
+fn session_planner_template_delete_non_active_keeps_active_template() {
+    let mut app = App::default();
+    app.task_labels = vec!["Docs".to_string(), "Review".to_string(), "Plan".to_string()];
+
+    app.selected_task_label = Some("Docs".to_string());
+    app.capture_session_template("Template A")
+        .expect("template A should be created");
+    app.selected_task_label = Some("Review".to_string());
+    app.capture_session_template("Template B")
+        .expect("template B should be created");
+    app.selected_task_label = Some("Plan".to_string());
+    app.capture_session_template("Template C")
+        .expect("template C should be created");
+    app.select_session_template(Some("Template A"))
+        .expect("template A should be selected");
+
+    app.handle_key(key(KeyCode::Char('t')));
+    app.handle_key(key(KeyCode::Right));
+    app.planner_template_selection_index = 2;
+    app.handle_key(key(KeyCode::Char('d')));
+
+    assert_eq!(app.active_session_template_name(), Some("Template A"));
+    let names = app
+        .session_templates
+        .iter()
+        .map(|template| template.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["Template A", "Template B"]);
+}
+
+#[test]
 fn session_planner_rename_moves_task_goal_target() {
     let mut app = App::default();
     app.task_labels = vec!["Docs".to_string()];

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,10 +49,11 @@ use output::{
     print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
     print_goal_command_output, print_json, print_json_compact, print_profile_output,
     print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
-    print_session_metadata_command_output, print_site_add_command_output,
-    print_site_delete_command_output, print_site_edit_command_output,
-    print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
+    print_session_metadata_command_output, print_session_template_command_output,
+    print_site_add_command_output, print_site_delete_command_output,
+    print_site_edit_command_output, print_site_list_command_output, print_status_output,
+    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
+    print_timer_state_output,
 };
 use parsing::{
     finalize_cli_action, invalid_usage, parse_global_tokens, parse_goal_carry_value,
@@ -106,6 +107,11 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --blocklist-profile-create=PROFILE_NAME [--json]
   focustime --blocklist-profile-rename=PROFILE_NAME [--json]
   focustime --blocklist-profile-delete [--json]
+  focustime --session-template [TEMPLATE_NAME] [--json]
+  focustime --session-template-apply [TEMPLATE_NAME] [--json]
+  focustime --session-template-create=TEMPLATE_NAME [--json]
+  focustime --session-template-rename=TEMPLATE_NAME [--json]
+  focustime --session-template-delete [--json]
   focustime --blocklist-sites [--json]
   focustime --allowlist-sites [--json]
   focustime --blocklist-site-add=HOSTNAMES [--json]
@@ -149,6 +155,11 @@ Options:
   --blocklist-profile-create  Create a blocklist profile and select it
   --blocklist-profile-rename  Rename the active blocklist profile
   --blocklist-profile-delete  Delete the active blocklist profile
+  --session-template         Show active session template, or set active template
+  --session-template-apply   Apply a template by name (or apply active template)
+  --session-template-create  Capture current task/profile/blocklist/schedule as a template
+  --session-template-rename  Rename the active session template
+  --session-template-delete  Delete the active session template
   --blocklist-sites           List blocklist sites in active profile
   --allowlist-sites           List allowlist sites in active profile
   --blocklist-site-add        Add/import blocklist hostnames in active profile
@@ -287,6 +298,9 @@ pub enum CommandKind {
         target: SiteListTarget,
         command: BlocklistSiteCommandKind,
     },
+    SessionTemplate {
+        command: SessionTemplateCommandKind,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -340,6 +354,11 @@ enum PrimaryCommand {
     BlocklistProfileCreate(String),
     BlocklistProfileRename(String),
     BlocklistProfileDelete,
+    SessionTemplate(Option<String>),
+    SessionTemplateApply(Option<String>),
+    SessionTemplateCreate(String),
+    SessionTemplateRename(String),
+    SessionTemplateDelete,
     BlocklistSites,
     AllowlistSites,
     BlocklistSiteAdd(String),
@@ -391,6 +410,11 @@ enum ParsedToken {
     BlocklistProfileCreate(String),
     BlocklistProfileRename(String),
     BlocklistProfileDelete,
+    SessionTemplate(Option<String>),
+    SessionTemplateApply(Option<String>),
+    SessionTemplateCreate(String),
+    SessionTemplateRename(String),
+    SessionTemplateDelete,
     BlocklistSites,
     AllowlistSites,
     BlocklistSiteAdd(String),
@@ -442,6 +466,15 @@ pub enum BlocklistSiteCommandKind {
     Add { input: String },
     Edit { value: SiteEditValue },
     Delete { site: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionTemplateCommandKind {
+    Select { name: Option<String> },
+    Apply { name: Option<String> },
+    Create { name: String },
+    Rename { name: String },
+    Delete,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -751,6 +784,24 @@ struct BlocklistProfileCommandOutput {
     updated: bool,
     selected_blocklist_profile: String,
     profiles: Vec<BlocklistProfileSummaryOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SessionTemplateSummaryOutput {
+    name: String,
+    active: bool,
+    task_label: String,
+    profile: &'static str,
+    blocklist_profile: String,
+    schedule_windows_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct SessionTemplateCommandOutput {
+    action: &'static str,
+    updated: bool,
+    selected_session_template: Option<String>,
+    templates: Vec<SessionTemplateSummaryOutput>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -55,7 +55,7 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 27] = [
+    let parsers: [(&str, ValueArgParser); 31] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
         ("--focus-intention", classify_focus_intention_arg),
@@ -82,6 +82,19 @@ fn classify_value_arg(
         (
             "--blocklist-profile-rename",
             classify_blocklist_profile_rename_arg,
+        ),
+        ("--session-template", classify_session_template_arg),
+        (
+            "--session-template-apply",
+            classify_session_template_apply_arg,
+        ),
+        (
+            "--session-template-create",
+            classify_session_template_create_arg,
+        ),
+        (
+            "--session-template-rename",
+            classify_session_template_rename_arg,
         ),
         ("--blocklist-site-add", classify_blocklist_site_add_arg),
         ("--allowlist-site-add", classify_allowlist_site_add_arg),
@@ -123,6 +136,7 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "--diagnostics" => Some(ParsedToken::Diagnostics),
         "--blocking-preview" => Some(ParsedToken::BlockingPreview),
         "--blocklist-profile-delete" => Some(ParsedToken::BlocklistProfileDelete),
+        "--session-template-delete" => Some(ParsedToken::SessionTemplateDelete),
         "--blocklist-sites" => Some(ParsedToken::BlocklistSites),
         "--allowlist-sites" => Some(ParsedToken::AllowlistSites),
         _ => None,
@@ -307,6 +321,71 @@ fn classify_blocklist_profile_rename_arg(
     }
     Err(invalid_usage(
         "`--blocklist-profile-rename` requires a profile name. Use `--blocklist-profile-rename=NAME` or `--blocklist-profile-rename NAME`.",
+    ))
+}
+
+fn classify_session_template_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value =
+            require_nonempty_key_value(next, "`--session-template` requires a template name.")?;
+        return Ok((ParsedToken::SessionTemplate(Some(value.to_string())), 2));
+    }
+    Ok((ParsedToken::SessionTemplate(None), 1))
+}
+
+fn classify_session_template_apply_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value = require_nonempty_key_value(
+            next,
+            "`--session-template-apply` requires a template name when a value is provided.",
+        )?;
+        return Ok((
+            ParsedToken::SessionTemplateApply(Some(value.to_string())),
+            2,
+        ));
+    }
+    Ok((ParsedToken::SessionTemplateApply(None), 1))
+}
+
+fn classify_session_template_create_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value =
+            require_nonempty_key_value(next, "`--session-template-create` requires a name.")?;
+        return Ok((ParsedToken::SessionTemplateCreate(value.to_string()), 2));
+    }
+    Err(invalid_usage(
+        "`--session-template-create` requires a template name. Use `--session-template-create=NAME` or `--session-template-create NAME`.",
+    ))
+}
+
+fn classify_session_template_rename_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value =
+            require_nonempty_key_value(next, "`--session-template-rename` requires a name.")?;
+        return Ok((ParsedToken::SessionTemplateRename(value.to_string()), 2));
+    }
+    Err(invalid_usage(
+        "`--session-template-rename` requires a template name. Use `--session-template-rename=NAME` or `--session-template-rename NAME`.",
     ))
 }
 
@@ -510,7 +589,7 @@ fn classify_schedule_set_arg(
 }
 
 pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 27] = [
+    let parsers: [KeyValueParser; 31] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
         parse_focus_intention_key_value_arg,
@@ -532,6 +611,10 @@ pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, S
         parse_blocklist_profile_key_value_arg,
         parse_blocklist_profile_create_key_value_arg,
         parse_blocklist_profile_rename_key_value_arg,
+        parse_session_template_key_value_arg,
+        parse_session_template_apply_key_value_arg,
+        parse_session_template_create_key_value_arg,
+        parse_session_template_rename_key_value_arg,
         parse_blocklist_site_add_key_value_arg,
         parse_allowlist_site_add_key_value_arg,
         parse_blocklist_site_edit_key_value_arg,
@@ -756,6 +839,46 @@ fn parse_blocklist_profile_rename_key_value_arg(arg: &str) -> Result<Option<Pars
             "`--blocklist-profile-rename=` requires a profile name.",
         )?;
         return Ok(Some(ParsedToken::BlocklistProfileRename(value.to_string())));
+    }
+    Ok(None)
+}
+
+fn parse_session_template_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--session-template=") {
+        let value =
+            require_nonempty_key_value(value, "`--session-template=` requires a template name.")?;
+        return Ok(Some(ParsedToken::SessionTemplate(Some(value.to_string()))));
+    }
+    Ok(None)
+}
+
+fn parse_session_template_apply_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--session-template-apply=") {
+        let value = require_nonempty_key_value(
+            value,
+            "`--session-template-apply=` requires a template name.",
+        )?;
+        return Ok(Some(ParsedToken::SessionTemplateApply(Some(
+            value.to_string(),
+        ))));
+    }
+    Ok(None)
+}
+
+fn parse_session_template_create_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--session-template-create=") {
+        let value =
+            require_nonempty_key_value(value, "`--session-template-create=` requires a name.")?;
+        return Ok(Some(ParsedToken::SessionTemplateCreate(value.to_string())));
+    }
+    Ok(None)
+}
+
+fn parse_session_template_rename_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--session-template-rename=") {
+        let value =
+            require_nonempty_key_value(value, "`--session-template-rename=` requires a name.")?;
+        return Ok(Some(ParsedToken::SessionTemplateRename(value.to_string())));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -18,7 +18,8 @@ use crate::cli::{
     EditSiteResult, ExportOutput, FocusStats, GoalCarryCommandOutput, GoalCommandOutput,
     InvalidSiteEntryOutput, InvalidSiteInput, MonthlyGoalConfig, OutputMode, PathBuf, ProfileId,
     ProfileOutput, ProfileView, RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput,
-    ScheduleDelayCommandOutput, SessionMetadataCommandOutput, SiteAddCommandOutput, SiteBlocker,
+    ScheduleDelayCommandOutput, SessionMetadataCommandOutput, SessionTemplateCommandKind,
+    SessionTemplateCommandOutput, SessionTemplateSummaryOutput, SiteAddCommandOutput, SiteBlocker,
     SiteDeleteCommandOutput, SiteEditCommandOutput, SiteEditValue, SiteListCommandOutput,
     SiteListTarget, StatusOutput, StrictCommandOutput, TaskCommandOutput, TaskGoalCommandOutput,
     TaskGoalOutput, ThemeCommandOutput, ThemePreset, TimerCommandOutput, TimerStateOutput,
@@ -31,11 +32,12 @@ use crate::cli::{
     print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
     print_profile_output, print_restore_output, print_schedule_command_output,
     print_schedule_delay_command_output, print_session_metadata_command_output,
-    print_site_add_command_output, print_site_delete_command_output,
-    print_site_edit_command_output, print_site_list_command_output, print_status_output,
-    print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
-    print_timer_state_output, profile_id, profile_view, selected_break_template_view,
-    theme_preset_view, timer_phase_id, timer_status_id,
+    print_session_template_command_output, print_site_add_command_output,
+    print_site_delete_command_output, print_site_edit_command_output,
+    print_site_list_command_output, print_status_output, print_strict_command_output,
+    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
+    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
+    timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
@@ -94,6 +96,9 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         }
         CommandKind::BlocklistSites { target, command } => {
             execute_blocklist_sites_command(target, command, cli_command.output)
+        }
+        CommandKind::SessionTemplate { command } => {
+            execute_session_template_command(command, cli_command.output)
         }
     }
 }
@@ -305,6 +310,41 @@ fn execute_blocklist_sites_command(
                 OutputMode::Json => print_json(&payload)?,
             }
         }
+    }
+    Ok(())
+}
+
+fn execute_session_template_command(
+    command: SessionTemplateCommandKind,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut app = App::new();
+    let (action, updated) = match command {
+        SessionTemplateCommandKind::Select { name } => (
+            "session-template",
+            app.select_session_template_for_cli(name.as_deref())?,
+        ),
+        SessionTemplateCommandKind::Apply { name } => (
+            "session-template-apply",
+            app.apply_session_template_for_cli(name.as_deref())?,
+        ),
+        SessionTemplateCommandKind::Create { name } => (
+            "session-template-create",
+            app.create_session_template_for_cli(&name)?,
+        ),
+        SessionTemplateCommandKind::Rename { name } => (
+            "session-template-rename",
+            app.rename_active_session_template_for_cli(&name)?,
+        ),
+        SessionTemplateCommandKind::Delete => (
+            "session-template-delete",
+            app.delete_active_session_template_for_cli()?,
+        ),
+    };
+    let payload = build_session_template_command_output(&app, action, updated);
+    match output {
+        OutputMode::Text => print_session_template_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
     }
     Ok(())
 }
@@ -636,6 +676,34 @@ fn build_blocklist_profile_command_output(
         updated,
         selected_blocklist_profile: selected_name,
         profiles,
+    }
+}
+
+fn build_session_template_command_output(
+    app: &App,
+    action: &'static str,
+    updated: bool,
+) -> SessionTemplateCommandOutput {
+    let selected_session_template = app.active_session_template_name().map(str::to_string);
+    let mut templates = Vec::with_capacity(app.session_template_count());
+    templates.extend(app.session_templates.iter().map(|template| {
+        SessionTemplateSummaryOutput {
+            name: template.name.clone(),
+            active: selected_session_template
+                .as_deref()
+                .is_some_and(|selected| selected.eq_ignore_ascii_case(&template.name)),
+            task_label: template.task_label.clone(),
+            profile: profile_id(template.profile),
+            blocklist_profile: template.blocklist_profile.clone(),
+            schedule_windows_count: template.schedule.windows.len()
+                + template.schedule.one_time_windows.len(),
+        }
+    }));
+    SessionTemplateCommandOutput {
+        action,
+        updated,
+        selected_session_template,
+        templates,
     }
 }
 

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -6,11 +6,11 @@ use crate::cli::{
     DiagnosticsCommandOutput, ExportOutput, FocusScoreOutput, GoalCarryCommandOutput,
     GoalCommandOutput, GoalOutput, ProfileOutput, RecurringScheduleConfig, RestoreOutput,
     ScheduleCommandOutput, ScheduleDelayCommandOutput, ScheduleInspectionOutput, Serialize,
-    SessionMetadataCommandOutput, SetupCheck, SetupCheckLevel, SetupCheckOutput, SetupDiagnostics,
-    SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput,
-    StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput, StrictCommandOutput,
-    TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput, TimerStateOutput, Write,
-    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    SessionMetadataCommandOutput, SessionTemplateCommandOutput, SetupCheck, SetupCheckLevel,
+    SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput,
+    SiteEditCommandOutput, SiteListCommandOutput, StatsGrowthSummary, StatsRetentionStatusOutput,
+    StatusOutput, StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
+    TimerStateOutput, Write, format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -102,6 +102,35 @@ pub(super) fn print_blocklist_profile_command_output(payload: &BlocklistProfileC
             profile.blocklist_sites_count,
             profile.allowlist_sites_count,
             profile.effective_blocked_sites_count
+        );
+    }
+}
+
+pub(super) fn print_session_template_command_output(payload: &SessionTemplateCommandOutput) {
+    if payload.updated {
+        println!("Session template updated.");
+    }
+    println!(
+        "Selected session template: {}",
+        payload
+            .selected_session_template
+            .as_deref()
+            .unwrap_or("none")
+    );
+    if payload.templates.is_empty() {
+        println!("Templates: none");
+        return;
+    }
+    println!("Templates:");
+    for template in &payload.templates {
+        let marker = if template.active { "*" } else { " " };
+        println!(
+            "  {marker} {} (task `{}`, profile {}, blocklist `{}`, windows {})",
+            template.name,
+            template.task_label,
+            template.profile,
+            template.blocklist_profile,
+            template.schedule_windows_count
         );
     }
 }

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -2,8 +2,8 @@ use crate::cli::{
     BlocklistProfileCommandKind, BlocklistSiteCommandKind, CliAction, CliCommand, CommandKind,
     DEFAULT_WATCH_INTERVAL_SECS, DailyGoalConfig, MonthlyGoalConfig, NaiveDate,
     OneTimeFocusWindowConfig, OutputMode, ParsedToken, PrimaryCommand, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, SiteEditValue, SiteListTarget,
-    ThemePreset, USAGE_TEXT, WeeklyGoalConfig,
+    RecurringFocusWindowConfig, RecurringScheduleConfig, SessionTemplateCommandKind, SiteEditValue,
+    SiteListTarget, ThemePreset, USAGE_TEXT, WeeklyGoalConfig,
 };
 
 pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), String> {
@@ -61,6 +61,11 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::BlocklistProfileCreate(_)
             | ParsedToken::BlocklistProfileRename(_)
             | ParsedToken::BlocklistProfileDelete
+            | ParsedToken::SessionTemplate(_)
+            | ParsedToken::SessionTemplateApply(_)
+            | ParsedToken::SessionTemplateCreate(_)
+            | ParsedToken::SessionTemplateRename(_)
+            | ParsedToken::SessionTemplateDelete
             | ParsedToken::BlocklistSites
             | ParsedToken::AllowlistSites
             | ParsedToken::BlocklistSiteAdd(_)
@@ -172,6 +177,24 @@ pub(super) fn parse_primary_command(
             )?,
             ParsedToken::BlocklistProfileDelete => {
                 set_primary_command(&mut primary, PrimaryCommand::BlocklistProfileDelete)?
+            }
+            ParsedToken::SessionTemplate(name) => {
+                set_primary_command(&mut primary, PrimaryCommand::SessionTemplate(name.clone()))?
+            }
+            ParsedToken::SessionTemplateApply(name) => set_primary_command(
+                &mut primary,
+                PrimaryCommand::SessionTemplateApply(name.clone()),
+            )?,
+            ParsedToken::SessionTemplateCreate(name) => set_primary_command(
+                &mut primary,
+                PrimaryCommand::SessionTemplateCreate(name.clone()),
+            )?,
+            ParsedToken::SessionTemplateRename(name) => set_primary_command(
+                &mut primary,
+                PrimaryCommand::SessionTemplateRename(name.clone()),
+            )?,
+            ParsedToken::SessionTemplateDelete => {
+                set_primary_command(&mut primary, PrimaryCommand::SessionTemplateDelete)?
             }
             ParsedToken::BlocklistSites => {
                 set_primary_command(&mut primary, PrimaryCommand::BlocklistSites)?
@@ -380,6 +403,40 @@ pub(super) fn finalize_cli_action(
         Some(PrimaryCommand::BlocklistProfileDelete) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::BlocklistProfile {
                 command: BlocklistProfileCommandKind::Delete,
+            },
+            output,
+        })),
+        Some(PrimaryCommand::SessionTemplate(name)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::SessionTemplate {
+                command: SessionTemplateCommandKind::Select { name },
+            },
+            output,
+        })),
+        Some(PrimaryCommand::SessionTemplateApply(name)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::SessionTemplate {
+                command: SessionTemplateCommandKind::Apply { name },
+            },
+            output,
+        })),
+        Some(PrimaryCommand::SessionTemplateCreate(name)) => {
+            Ok(CliAction::RunCommand(CliCommand {
+                kind: CommandKind::SessionTemplate {
+                    command: SessionTemplateCommandKind::Create { name },
+                },
+                output,
+            }))
+        }
+        Some(PrimaryCommand::SessionTemplateRename(name)) => {
+            Ok(CliAction::RunCommand(CliCommand {
+                kind: CommandKind::SessionTemplate {
+                    command: SessionTemplateCommandKind::Rename { name },
+                },
+                output,
+            }))
+        }
+        Some(PrimaryCommand::SessionTemplateDelete) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::SessionTemplate {
+                command: SessionTemplateCommandKind::Delete,
             },
             output,
         })),
@@ -755,6 +812,11 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::BlocklistProfileCreate(_) => "--blocklist-profile-create",
         PrimaryCommand::BlocklistProfileRename(_) => "--blocklist-profile-rename",
         PrimaryCommand::BlocklistProfileDelete => "--blocklist-profile-delete",
+        PrimaryCommand::SessionTemplate(_) => "--session-template",
+        PrimaryCommand::SessionTemplateApply(_) => "--session-template-apply",
+        PrimaryCommand::SessionTemplateCreate(_) => "--session-template-create",
+        PrimaryCommand::SessionTemplateRename(_) => "--session-template-rename",
+        PrimaryCommand::SessionTemplateDelete => "--session-template-delete",
         PrimaryCommand::BlocklistSites => "--blocklist-sites",
         PrimaryCommand::AllowlistSites => "--allowlist-sites",
         PrimaryCommand::BlocklistSiteAdd(_) => "--blocklist-site-add",

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -849,6 +849,96 @@ fn parse_blocklist_profile_delete_runs_command() {
 }
 
 #[test]
+fn parse_session_template_without_value_reads_current_template() {
+    let parsed = parse(&["--session-template"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::SessionTemplate {
+                command: SessionTemplateCommandKind::Select { name: None }
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_session_template_with_value_selects_template() {
+    let parsed = parse(&["--session-template", "Deep Flow"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::SessionTemplate {
+                command: SessionTemplateCommandKind::Select {
+                    name: Some("Deep Flow".to_string())
+                }
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_session_template_apply_without_value_uses_active_template() {
+    let parsed = parse(&["--session-template-apply"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::SessionTemplate {
+                command: SessionTemplateCommandKind::Apply { name: None }
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_session_template_create_with_equals() {
+    let parsed = parse(&["--session-template-create=Deep Flow"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::SessionTemplate {
+                command: SessionTemplateCommandKind::Create {
+                    name: "Deep Flow".to_string()
+                }
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_session_template_rename_with_value() {
+    let parsed = parse(&["--session-template-rename", "Sprint Focus"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::SessionTemplate {
+                command: SessionTemplateCommandKind::Rename {
+                    name: "Sprint Focus".to_string()
+                }
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_session_template_delete_runs_command() {
+    let parsed = parse(&["--session-template-delete"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::SessionTemplate {
+                command: SessionTemplateCommandKind::Delete
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
 fn parse_blocklist_site_add_with_equals() {
     let parsed = parse(&["--blocklist-site-add=github.com,news.ycombinator.com"]).unwrap();
     assert_eq!(
@@ -1077,6 +1167,44 @@ fn classify_key_value_arg_accepts_schedule_set_equals_value() {
 }
 
 #[test]
+fn classify_key_value_arg_accepts_session_template_equals_value() {
+    let parsed = classify_key_value_arg("--session-template=Deep Flow").unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::SessionTemplate(Some("Deep Flow".to_string())))
+    );
+}
+
+#[test]
+fn classify_key_value_arg_accepts_session_template_apply_equals_value() {
+    let parsed = classify_key_value_arg("--session-template-apply=Deep Flow").unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::SessionTemplateApply(Some(
+            "Deep Flow".to_string()
+        )))
+    );
+}
+
+#[test]
+fn classify_key_value_arg_accepts_session_template_create_equals_value() {
+    let parsed = classify_key_value_arg("--session-template-create=Deep Flow").unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::SessionTemplateCreate("Deep Flow".to_string()))
+    );
+}
+
+#[test]
+fn classify_key_value_arg_accepts_session_template_rename_equals_value() {
+    let parsed = classify_key_value_arg("--session-template-rename=Deep Flow").unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::SessionTemplateRename("Deep Flow".to_string()))
+    );
+}
+
+#[test]
 fn classify_key_value_arg_rejects_empty_export_equals_value() {
     let error = classify_key_value_arg("--export=").unwrap_err();
     assert!(error.contains("`--export=` requires a target directory."));
@@ -1140,6 +1268,30 @@ fn classify_key_value_arg_rejects_empty_goal_carry_monthly_equals_value() {
 fn classify_key_value_arg_rejects_empty_schedule_set_equals_value() {
     let error = classify_key_value_arg("--schedule-set=").unwrap_err();
     assert!(error.contains("`--schedule-set=` requires a JSON payload."));
+}
+
+#[test]
+fn classify_key_value_arg_rejects_empty_session_template_equals_value() {
+    let error = classify_key_value_arg("--session-template=").unwrap_err();
+    assert!(error.contains("`--session-template=` requires a template name."));
+}
+
+#[test]
+fn classify_key_value_arg_rejects_empty_session_template_apply_equals_value() {
+    let error = classify_key_value_arg("--session-template-apply=").unwrap_err();
+    assert!(error.contains("`--session-template-apply=` requires a template name."));
+}
+
+#[test]
+fn classify_key_value_arg_rejects_empty_session_template_create_equals_value() {
+    let error = classify_key_value_arg("--session-template-create=").unwrap_err();
+    assert!(error.contains("`--session-template-create=` requires a name."));
+}
+
+#[test]
+fn classify_key_value_arg_rejects_empty_session_template_rename_equals_value() {
+    let error = classify_key_value_arg("--session-template-rename=").unwrap_err();
+    assert!(error.contains("`--session-template-rename=` requires a name."));
 }
 
 #[test]
@@ -1242,6 +1394,18 @@ fn parse_rejects_schedule_set_without_payload() {
 fn parse_rejects_blocklist_profile_create_without_value() {
     let error = parse(&["--blocklist-profile-create"]).unwrap_err();
     assert!(error.contains("`--blocklist-profile-create` requires a profile name"));
+}
+
+#[test]
+fn parse_rejects_session_template_create_without_value() {
+    let error = parse(&["--session-template-create"]).unwrap_err();
+    assert!(error.contains("`--session-template-create` requires a template name"));
+}
+
+#[test]
+fn parse_rejects_session_template_rename_without_value() {
+    let error = parse(&["--session-template-rename"]).unwrap_err();
+    assert!(error.contains("`--session-template-rename` requires a template name"));
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,12 @@ pub struct AppConfig {
     /// Name of the active break template.
     #[serde(default)]
     pub selected_break_template: String,
+    /// Reusable session templates bundling task/profile/blocklist/schedule settings.
+    #[serde(default)]
+    pub session_templates: Vec<SessionTemplateConfig>,
+    /// Name of the active session template (empty = none selected).
+    #[serde(default)]
+    pub selected_session_template: String,
     /// Selected UI theme preset.
     #[serde(default)]
     pub selected_theme_preset: ThemePreset,
@@ -1099,6 +1105,10 @@ fn default_break_template_name() -> String {
     "Classic".to_string()
 }
 
+fn default_session_template_name() -> String {
+    "Template".to_string()
+}
+
 fn default_shortcut_quit() -> String {
     "q".to_string()
 }
@@ -1476,6 +1486,40 @@ impl BreakTemplateConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionTemplateConfig {
+    #[serde(default = "default_session_template_name")]
+    pub name: String,
+    #[serde(default)]
+    pub task_label: String,
+    #[serde(default)]
+    pub profile: ProfileId,
+    #[serde(default = "default_blocklist_profile_name")]
+    pub blocklist_profile: String,
+    #[serde(default)]
+    pub schedule: RecurringScheduleConfig,
+}
+
+impl SessionTemplateConfig {
+    pub fn normalized_with_blocklists(
+        &self,
+        blocklist_profiles: &[BlocklistProfileConfig],
+    ) -> Option<Self> {
+        let name =
+            normalize_nonempty_or_default_string(&self.name, &default_session_template_name());
+        let task_label = normalize_optional_nonempty_string(Some(&self.task_label))?;
+        let blocklist_profile =
+            normalize_selected_blocklist_profile(&self.blocklist_profile, blocklist_profiles);
+        Some(Self {
+            name,
+            task_label,
+            profile: self.profile,
+            blocklist_profile,
+            schedule: self.schedule.normalized(),
+        })
+    }
+}
+
 impl Default for BreakTemplateConfig {
     fn default() -> Self {
         Self {
@@ -1518,6 +1562,8 @@ impl Default for AppConfig {
             custom_profile: None,
             break_templates: default_break_templates(),
             selected_break_template: default_break_template_name(),
+            session_templates: Vec::new(),
+            selected_session_template: String::new(),
             selected_theme_preset: ThemePreset::default(),
             notifications: NotificationConfig::default(),
             auto_start: AutoStartConfig::default(),
@@ -1716,6 +1762,12 @@ impl AppConfig {
         self.selected_blocklist_profile = normalize_selected_blocklist_profile(
             &self.selected_blocklist_profile,
             &self.blocklist_profiles,
+        );
+        self.session_templates =
+            normalize_session_templates(&self.session_templates, &self.blocklist_profiles);
+        self.selected_session_template = normalize_selected_session_template(
+            &self.selected_session_template,
+            &self.session_templates,
         );
         self.blocking_backend = self.blocking_backend.normalized();
         self.schedule_runtime = self.schedule_runtime.normalized();
@@ -2096,6 +2148,40 @@ fn normalize_selected_break_template(
             .map(|template| template.name.clone())
             .unwrap_or_default()
     }
+}
+
+fn normalize_session_templates(
+    templates: &[SessionTemplateConfig],
+    blocklist_profiles: &[BlocklistProfileConfig],
+) -> Vec<SessionTemplateConfig> {
+    let mut normalized = Vec::new();
+    let mut seen_names = HashSet::new();
+
+    for template in templates {
+        let Some(template) = template.normalized_with_blocklists(blocklist_profiles) else {
+            continue;
+        };
+        let name = make_unique_profile_name(&template.name, &mut seen_names);
+        normalized.push(SessionTemplateConfig { name, ..template });
+    }
+
+    normalized
+}
+
+fn normalize_selected_session_template(
+    selected_name: &str,
+    templates: &[SessionTemplateConfig],
+) -> String {
+    let selected_name = selected_name.trim();
+    if selected_name.is_empty() {
+        return String::new();
+    }
+
+    templates
+        .iter()
+        .find(|template| template.name.eq_ignore_ascii_case(selected_name))
+        .map(|template| template.name.clone())
+        .unwrap_or_default()
 }
 
 fn break_template_matches_custom_profile(

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -28,6 +28,8 @@ fn default_values_are_canonical_pomodoro() {
     assert_eq!(cfg.selected_profile, ProfileId::Custom);
     assert!(cfg.custom_profile.is_none());
     assert_eq!(cfg.selected_break_template, "Classic");
+    assert!(cfg.session_templates.is_empty());
+    assert!(cfg.selected_session_template.is_empty());
     assert_eq!(cfg.selected_theme_preset, ThemePreset::Classic);
     assert_eq!(cfg.break_templates.len(), 2);
     assert!(cfg.blocked_sites.is_empty());
@@ -137,6 +139,26 @@ fn round_trip_full_config() {
             },
         ],
         selected_break_template: "Recovery".to_string(),
+        session_templates: vec![SessionTemplateConfig {
+            name: "Morning deep work".to_string(),
+            task_label: "Docs".to_string(),
+            profile: ProfileId::DeepWork,
+            blocklist_profile: "Work".to_string(),
+            schedule: RecurringScheduleConfig {
+                windows: vec![RecurringFocusWindowConfig {
+                    days: vec!["mon".to_string(), "wed".to_string()],
+                    start: "09:15".to_string(),
+                    end: "11:00".to_string(),
+                }],
+                exception_dates: vec!["2026-04-27".to_string()],
+                one_time_windows: vec![OneTimeFocusWindowConfig {
+                    date: "2026-05-10".to_string(),
+                    start: "14:00".to_string(),
+                    end: "15:00".to_string(),
+                }],
+            },
+        }],
+        selected_session_template: "Morning deep work".to_string(),
         selected_theme_preset: ThemePreset::HighContrast,
         notifications: NotificationConfig {
             enabled: true,
@@ -292,6 +314,11 @@ fn round_trip_full_config() {
         parsed.selected_break_template,
         original.selected_break_template
     );
+    assert_eq!(parsed.session_templates, original.session_templates);
+    assert_eq!(
+        parsed.selected_session_template,
+        original.selected_session_template
+    );
     assert_eq!(parsed.selected_theme_preset, original.selected_theme_preset);
     assert_eq!(parsed.notifications, NotificationConfig::default());
     assert_eq!(parsed.auto_start, AutoStartConfig::default());
@@ -328,6 +355,8 @@ fn missing_fields_fall_back_to_defaults() {
     assert_eq!(cfg.selected_profile, ProfileId::Custom);
     assert!(cfg.custom_profile.is_none());
     assert_eq!(cfg.selected_break_template, "");
+    assert!(cfg.session_templates.is_empty());
+    assert_eq!(cfg.selected_session_template, "");
     assert_eq!(cfg.selected_theme_preset, ThemePreset::Classic);
     assert_eq!(cfg.break_templates.len(), 2);
     assert!(cfg.blocked_sites.is_empty());
@@ -414,6 +443,77 @@ fn normalize_break_templates_deduplicates_names_and_clamps_values() {
     );
     assert_eq!(cfg.break_templates[1].name, "recovery (2)");
     assert_eq!(cfg.selected_break_template, "Recovery");
+}
+
+#[test]
+fn normalize_session_templates_deduplicates_and_filters_invalid_entries() {
+    let cfg = AppConfig {
+        blocklist_profiles: vec![
+            BlocklistProfileConfig {
+                name: "Work".to_string(),
+                sites: vec!["youtube.com".to_string()],
+                allowlist_sites: Vec::new(),
+            },
+            BlocklistProfileConfig {
+                name: "Study".to_string(),
+                sites: vec!["reddit.com".to_string()],
+                allowlist_sites: Vec::new(),
+            },
+        ],
+        session_templates: vec![
+            SessionTemplateConfig {
+                name: "Morning".to_string(),
+                task_label: "  Docs  ".to_string(),
+                profile: ProfileId::DeepWork,
+                blocklist_profile: "work".to_string(),
+                schedule: RecurringScheduleConfig::default(),
+            },
+            SessionTemplateConfig {
+                name: "morning".to_string(),
+                task_label: "Code".to_string(),
+                profile: ProfileId::Classic,
+                blocklist_profile: "missing".to_string(),
+                schedule: RecurringScheduleConfig::default(),
+            },
+            SessionTemplateConfig {
+                name: "No Task".to_string(),
+                task_label: "   ".to_string(),
+                profile: ProfileId::Custom,
+                blocklist_profile: "Study".to_string(),
+                schedule: RecurringScheduleConfig::default(),
+            },
+        ],
+        selected_session_template: "MORNING".to_string(),
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    assert_eq!(cfg.session_templates.len(), 2);
+    assert_eq!(cfg.session_templates[0].name, "Morning");
+    assert_eq!(cfg.session_templates[0].task_label, "Docs");
+    assert_eq!(cfg.session_templates[0].blocklist_profile, "Work");
+    assert_eq!(cfg.session_templates[1].name, "morning (2)");
+    assert_eq!(cfg.session_templates[1].task_label, "Code");
+    assert_eq!(cfg.session_templates[1].blocklist_profile, "Work");
+    assert_eq!(cfg.selected_session_template, "Morning");
+}
+
+#[test]
+fn normalize_selected_session_template_clears_unknown_value() {
+    let cfg = AppConfig {
+        session_templates: vec![SessionTemplateConfig {
+            name: "Morning".to_string(),
+            task_label: "Docs".to_string(),
+            profile: ProfileId::DeepWork,
+            blocklist_profile: "Default".to_string(),
+            schedule: RecurringScheduleConfig::default(),
+        }],
+        selected_session_template: "Missing".to_string(),
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    assert_eq!(cfg.selected_session_template, "");
 }
 
 #[test]
@@ -814,6 +914,8 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
         }),
         break_templates: default_break_templates(),
         selected_break_template: default_break_template_name(),
+        session_templates: Vec::new(),
+        selected_session_template: String::new(),
         selected_theme_preset: ThemePreset::Classic,
         notifications: NotificationConfig::default(),
         auto_start: AutoStartConfig::default(),

--- a/src/ui/session_planner.rs
+++ b/src/ui/session_planner.rs
@@ -1,3 +1,4 @@
+use crate::app::PlannerPane;
 use crate::ui::{
     Alignment, App, Block, Borders, Color, Constraint, Direction, Frame, Layout, Line, List,
     ListItem, ListState, Modifier, NavigationAction, PLANNER_RECENT_LABEL_LIMIT, Paragraph,
@@ -21,25 +22,34 @@ pub(super) fn render_session_planner(frame: &mut Frame, app: &App) {
         .margin(2)
         .constraints([
             Constraint::Length(1), // current task
-            Constraint::Min(4),    // task labels list
+            Constraint::Min(4),    // task/template lists
             Constraint::Length(3), // task label input
             Constraint::Length(1), // feedback
             Constraint::Length(3), // hints
         ])
         .split(outer);
+    let lists = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
+        .split(inner[1]);
 
     render_session_planner_selected_task(frame, app, inner[0]);
-    render_session_planner_labels(frame, app, inner[1]);
+    render_session_planner_labels(frame, app, lists[0]);
+    render_session_planner_templates(frame, app, lists[1]);
     render_session_planner_input(frame, app, inner[2]);
     render_session_planner_feedback(frame, app, inner[3]);
     render_session_planner_hints(frame, app, inner[4]);
 }
 
 fn render_session_planner_selected_task(frame: &mut Frame, app: &App, area: Rect) {
-    let selected_text = app.selected_task_label.as_ref().map_or_else(
+    let selected_task = app.selected_task_label.as_ref().map_or_else(
         || "Selected task: none (required before focus starts)".to_string(),
         |label| format!("Selected task: {label}"),
     );
+    let selected_template = app
+        .active_session_template_name()
+        .map_or_else(|| "none".to_string(), str::to_string);
+    let selected_text = format!("{selected_task}   |   Active template: {selected_template}");
     frame.render_widget(
         Paragraph::new(Line::from(selected_text))
             .style(Style::default().fg(app_color(app, Color::White)))
@@ -49,6 +59,11 @@ fn render_session_planner_selected_task(frame: &mut Frame, app: &App, area: Rect
 }
 
 fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {
+    let title = if app.planner_pane == PlannerPane::Tasks {
+        " Task Labels * "
+    } else {
+        " Task Labels "
+    };
     if app.task_labels.is_empty() {
         frame.render_widget(
             Paragraph::new(format!(
@@ -56,11 +71,7 @@ fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {
                 app.shortcut_hint(ShortcutAction::PlannerAdd)
             ))
             .style(Style::default().fg(app_color(app, Color::DarkGray)))
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" Task Labels "),
-            ),
+            .block(Block::default().borders(Borders::ALL).title(title)),
             area,
         );
         return;
@@ -95,11 +106,7 @@ fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {
         })
         .collect();
     let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Task Labels "),
-        )
+        .block(Block::default().borders(Borders::ALL).title(title))
         .highlight_style(
             Style::default()
                 .fg(app_color(app, Color::Black))
@@ -115,33 +122,113 @@ fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_stateful_widget(list, area, &mut state);
 }
 
+fn render_session_planner_templates(frame: &mut Frame, app: &App, area: Rect) {
+    let title = if app.planner_pane == PlannerPane::Templates {
+        " Session Templates * "
+    } else {
+        " Session Templates "
+    };
+    if app.session_templates.is_empty() {
+        frame.render_widget(
+            Paragraph::new(format!(
+                "No templates yet. Press {} to capture current task/profile/blocklist/schedule.",
+                app.shortcut_hint(ShortcutAction::PlannerAdd)
+            ))
+            .style(Style::default().fg(app_color(app, Color::DarkGray)))
+            .wrap(Wrap { trim: true })
+            .block(Block::default().borders(Borders::ALL).title(title)),
+            area,
+        );
+        return;
+    }
+
+    let items: Vec<ListItem> = app
+        .session_templates
+        .iter()
+        .map(|template| {
+            let marker = if app
+                .active_session_template_name()
+                .is_some_and(|active| active.eq_ignore_ascii_case(&template.name))
+            {
+                "✓"
+            } else {
+                " "
+            };
+            let schedule_windows =
+                template.schedule.windows.len() + template.schedule.one_time_windows.len();
+            ListItem::new(format!(
+                " {marker} {} ({}, {}, {}, {}w)",
+                template.name,
+                template.profile.label(),
+                template.task_label,
+                template.blocklist_profile,
+                schedule_windows
+            ))
+        })
+        .collect();
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .highlight_style(
+            Style::default()
+                .fg(app_color(app, Color::Black))
+                .bg(app_color(app, Color::White))
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+    let mut state = ListState::default();
+    state.select(Some(
+        app.planner_template_selection_index
+            .min(app.session_templates.len().saturating_sub(1)),
+    ));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
 fn render_session_planner_input(frame: &mut Frame, app: &App, area: Rect) {
     let input_title = if app.planner_input_active {
         match app.planner_input_mode {
             Some(PlannerInputMode::Rename) => " Rename task label ".to_string(),
+            Some(PlannerInputMode::CreateTemplate) => " Create session template ".to_string(),
+            Some(PlannerInputMode::RenameTemplate) => " Rename session template ".to_string(),
             _ => " Add task label ".to_string(),
         }
     } else {
-        format!(
-            " Task label input ({} add / {} rename / {} favorite / {} archive) ",
-            app.shortcut_hint(ShortcutAction::PlannerAdd),
-            app.shortcut_hint(ShortcutAction::PlannerRename),
-            app.shortcut_hint(ShortcutAction::PlannerFavorite),
-            app.shortcut_hint(ShortcutAction::PlannerArchive),
-        )
+        match app.planner_pane {
+            PlannerPane::Tasks => format!(
+                " Task input ({} add / {} rename / {} favorite / {} archive) ",
+                app.shortcut_hint(ShortcutAction::PlannerAdd),
+                app.shortcut_hint(ShortcutAction::PlannerRename),
+                app.shortcut_hint(ShortcutAction::PlannerFavorite),
+                app.shortcut_hint(ShortcutAction::PlannerArchive),
+            ),
+            PlannerPane::Templates => format!(
+                " Template input ({} create / {} rename) ",
+                app.shortcut_hint(ShortcutAction::PlannerAdd),
+                app.shortcut_hint(ShortcutAction::PlannerRename),
+            ),
+        }
     };
     let input_text = if app.planner_input_active {
         format!("{}|", app.planner_input)
     } else {
-        format!(
-            "Use {} add, {} rename, {} favorite, {} archive, {}/{} delete highlighted",
-            app.shortcut_hint(ShortcutAction::PlannerAdd),
-            app.shortcut_hint(ShortcutAction::PlannerRename),
-            app.shortcut_hint(ShortcutAction::PlannerFavorite),
-            app.shortcut_hint(ShortcutAction::PlannerArchive),
-            app.shortcut_hint(ShortcutAction::PlannerDelete),
-            app.navigation_hint(NavigationAction::Delete),
-        )
+        match app.planner_pane {
+            PlannerPane::Tasks => format!(
+                "Use {} add, {} rename, {} favorite, {} archive, {}/{} delete highlighted",
+                app.shortcut_hint(ShortcutAction::PlannerAdd),
+                app.shortcut_hint(ShortcutAction::PlannerRename),
+                app.shortcut_hint(ShortcutAction::PlannerFavorite),
+                app.shortcut_hint(ShortcutAction::PlannerArchive),
+                app.shortcut_hint(ShortcutAction::PlannerDelete),
+                app.navigation_hint(NavigationAction::Delete),
+            ),
+            PlannerPane::Templates => format!(
+                "Use {} apply, {} create, {} rename, {}/{} delete highlighted",
+                app.navigation_hint(NavigationAction::Confirm),
+                app.shortcut_hint(ShortcutAction::PlannerAdd),
+                app.shortcut_hint(ShortcutAction::PlannerRename),
+                app.shortcut_hint(ShortcutAction::PlannerDelete),
+                app.navigation_hint(NavigationAction::Delete),
+            ),
+        }
     };
     frame.render_widget(
         Paragraph::new(input_text)
@@ -198,6 +285,14 @@ fn render_session_planner_hints(frame: &mut Frame, app: &App, area: Rect) {
                 "Input: rename label, then {}",
                 app.navigation_hint(NavigationAction::Confirm)
             ),
+            Some(PlannerInputMode::CreateTemplate) => format!(
+                "Input: type template name, then {}",
+                app.navigation_hint(NavigationAction::Confirm)
+            ),
+            Some(PlannerInputMode::RenameTemplate) => format!(
+                "Input: rename template, then {}",
+                app.navigation_hint(NavigationAction::Confirm)
+            ),
             _ => format!(
                 "Input: type task label, then {}",
                 app.navigation_hint(NavigationAction::Confirm)
@@ -222,11 +317,13 @@ fn render_session_planner_hints(frame: &mut Frame, app: &App, area: Rect) {
             }),
         ]
     } else {
-        vec![
-            Line::from(format!(
-                "Planner: {}/{} Move  {} Select  {} Add  {} Rename  {} Favorite  {} Archive  {}/{} Delete",
+        let planner_line = match app.planner_pane {
+            PlannerPane::Tasks => format!(
+                "Planner: {}/{} Move  {}/{} Pane  {} Select  {} Add  {} Rename  {} Favorite  {} Archive  {}/{} Delete",
                 app.navigation_hint(NavigationAction::MoveUp),
                 app.navigation_hint(NavigationAction::MoveDown),
+                app.navigation_hint(NavigationAction::MoveLeft),
+                app.navigation_hint(NavigationAction::MoveRight),
                 app.navigation_hint(NavigationAction::Confirm),
                 app.shortcut_hint(ShortcutAction::PlannerAdd),
                 app.shortcut_hint(ShortcutAction::PlannerRename),
@@ -234,11 +331,32 @@ fn render_session_planner_hints(frame: &mut Frame, app: &App, area: Rect) {
                 app.shortcut_hint(ShortcutAction::PlannerArchive),
                 app.shortcut_hint(ShortcutAction::PlannerDelete),
                 app.navigation_hint(NavigationAction::Delete),
-            )),
-            Line::from(format!(
+            ),
+            PlannerPane::Templates => format!(
+                "Planner: {}/{} Move  {}/{} Pane  {} Apply  {} Create  {} Rename  {}/{} Delete",
+                app.navigation_hint(NavigationAction::MoveUp),
+                app.navigation_hint(NavigationAction::MoveDown),
+                app.navigation_hint(NavigationAction::MoveLeft),
+                app.navigation_hint(NavigationAction::MoveRight),
+                app.navigation_hint(NavigationAction::Confirm),
+                app.shortcut_hint(ShortcutAction::PlannerAdd),
+                app.shortcut_hint(ShortcutAction::PlannerRename),
+                app.shortcut_hint(ShortcutAction::PlannerDelete),
+                app.navigation_hint(NavigationAction::Delete),
+            ),
+        };
+        let detail_line = match app.planner_pane {
+            PlannerPane::Tasks => format!(
                 "{}  |  Archived labels stay visible and cannot be selected",
                 planner_recent_quick_pick_text(app)
-            )),
+            ),
+            PlannerPane::Templates => {
+                "Templates apply task + profile + blocklist + schedule together".to_string()
+            }
+        };
+        vec![
+            Line::from(planner_line),
+            Line::from(detail_line),
             Line::from(if app.strict_mode_enforced_for_focus() {
                 format!(
                     "View: [{}/{}] Back  [{}/Ctrl-C] Quit (Locked)",

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -1,4 +1,7 @@
-use crate::config::{AppConfig, ShortcutConfig, ThemePreset};
+use crate::config::{
+    AppConfig, ProfileId, RecurringScheduleConfig, SessionTemplateConfig, ShortcutConfig,
+    ThemePreset,
+};
 use crate::ui::*;
 use chrono::{Datelike, Duration, NaiveDate};
 use ratatui::style::Color;
@@ -817,6 +820,53 @@ fn session_planner_view_renders_rename_input_title() {
 
     let text = terminal_text(&terminal, width, height);
     assert!(text.contains("Rename task label"));
+}
+
+#[test]
+fn session_planner_view_renders_template_panel() {
+    let width = 120;
+    let height = 28;
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    let mut app = App::default();
+    app.mode = AppMode::SessionPlanner;
+    app.task_labels = vec!["Docs".to_string()];
+    app.selected_task_label = Some("Docs".to_string());
+    app.session_templates = vec![SessionTemplateConfig {
+        name: "Deep Flow".to_string(),
+        task_label: "Docs".to_string(),
+        profile: ProfileId::Classic,
+        blocklist_profile: "Default".to_string(),
+        schedule: RecurringScheduleConfig::default(),
+    }];
+
+    terminal
+        .draw(|frame| render(frame, &app))
+        .expect("render should succeed");
+
+    let text = terminal_text(&terminal, width, height);
+    assert!(text.contains("Session Templates"));
+    assert!(text.contains("Deep Flow"));
+}
+
+#[test]
+fn session_planner_view_renders_template_rename_input_title() {
+    let width = 120;
+    let height = 28;
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    let mut app = App::default();
+    app.mode = AppMode::SessionPlanner;
+    app.planner_input_active = true;
+    app.planner_input_mode = Some(PlannerInputMode::RenameTemplate);
+    app.planner_input = "Deep Flow".to_string();
+
+    terminal
+        .draw(|frame| render(frame, &app))
+        .expect("render should succeed");
+
+    let text = terminal_text(&terminal, width, height);
+    assert!(text.contains("Rename session template"));
 }
 
 #[test]


### PR DESCRIPTION
## What

Add reusable session templates that bundle task label, profile, blocklist profile, and schedule settings, then apply them consistently across startup flows.

This PR adds:
- Config/runtime schema and normalization for session templates
- Atomic template apply/capture/rename/delete/select helpers in app runtime
- Auto-apply of the active template on focus start paths (TUI start, CLI start, schedule-triggered start)
- Full CLI command surface for template management and application
- Session Planner TUI template pane with create/rename/delete/apply flows
- Updated tests and README documentation

## Why

Issue #314 requests reusable bundles for task/profile/blocklist/schedule so users can switch focus contexts quickly and consistently, without partial state updates.

Closes #314.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session templates: create/select/apply/rename/delete; persisted selection, auto-apply before start or scheduled windows, and Templates pane with pane switching (←/→) and template-specific shortcuts (create/rename/apply/delete; a/e/d, save/cancel).

* **CLI**
  * New --session-template subcommands (select/apply/create/rename/delete) with JSON/text summary output.

* **Documentation**
  * README updated with CLI usage, example config (selected_session_template), and planner shortcut/behavior details.

* **Tests**
  * Added tests covering session templates, planner UI, and CLI parsing/output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->