### PR TITLE
Day-of-week smart profile switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,11 @@ cargo run -- --allowlist-site-delete reddit.com
 # Show/set schedule for the selected profile (including overlap/conflict inspection)
 cargo run -- --schedule
 cargo run -- --schedule-set='{"windows":[{"days":["mon","tue"],"start":"09:00","end":"11:00"}],"exception_dates":["2026-12-25"],"one_time_windows":[{"date":"2026-05-02","start":"14:00","end":"16:00"}]}'
+cargo run -- --weekday-rules
+cargo run -- --weekday-rules-set='[{"day":"mon","profile":"deep-work","blocklist_profile":"Work","session_template":"Deep Flow"}]'
 cargo run -- --schedule-delay
 cargo run -- --schedule --json
+cargo run -- --weekday-rules --json
 
 # Break-glass workflow controls from CLI (first call arms, second confirms)
 cargo run -- --break-glass-trigger
@@ -387,7 +390,7 @@ Saved notes are reflected in live status metadata (`task_note`), recovery state,
 and interruption/completed-session history export fields.
 
 CLI parity is available via `--focus-intention`, `--task-note`, `--schedule-delay`,
-`--session-template*`, `--break-glass-trigger`, and `--break-glass-cancel` for
+`--weekday-rules*`, `--session-template*`, `--break-glass-trigger`, and `--break-glass-cancel` for
 non-interactive inspection and in-session workflow control.
 
 ### Example config
@@ -632,6 +635,8 @@ Recurring schedule windows can also trigger focus behavior at wall-clock times:
 - recurring exception dates only skip recurring windows; one-time windows still apply on their configured date
 - if multiple windows overlap, the most recently started active window takes precedence; windows with the same start time are resolved deterministically
 - `--schedule` (text and JSON) reports detected schedule conflicts/overlaps without rejecting the schedule
+- `weekday_profile_rules[]` can bind weekday (`day`) to a profile (`profile`), blocklist profile (`blocklist_profile`), and optional session template (`session_template`)
+- weekday profile rules apply at startup and day boundaries; they do not continuously re-assert during the same day
 - the timer session overview shows the current/next scheduled window
 
 You can configure notification and auto-start settings directly from the TUI:
@@ -654,6 +659,9 @@ You can configure notification and auto-start settings directly from the TUI:
   - **One-time date**: `←/→` moves selected one-time window date backward/forward by 1 day
   - **One-time start/end**: adjust one-time window times in `[schedule_runtime].time_step_minutes` steps (default `15`, clamped `1..60`)
   - **One-time add/remove**: `→` adds a one-time window (starting from today), `←` removes selected window
+  - **Weekday rule**: `←/→` changes which weekday rule entry is selected
+  - **Weekday day/profile/blocklist/template**: tune target weekday and linked profile/blocklist/session-template values
+  - **Weekday add/remove**: `→` adds a rule for an unused day, `←` removes selected rule
   - **Conflict inspector**: read-only summary of detected schedule overlaps/conflicts
 
 ## Session recovery

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,8 @@ use crate::config::{
     NotificationConfig, OneTimeFocusWindowConfig, ProfileAutomationConfig,
     ProfileAutomationSettingsConfig, ProfileId, RecurringFocusWindowConfig,
     RecurringScheduleConfig, ScheduleRuntimeConfig, SessionTemplateConfig, StatsRetentionConfig,
-    ThemePreset, WakatimeMetadataConfig, WakatimeRuntimeConfig, WeeklyGoalConfig,
+    ThemePreset, WakatimeMetadataConfig, WakatimeRuntimeConfig, WeekdayProfileRuleConfig,
+    WeeklyGoalConfig,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -59,12 +60,13 @@ mod session_templates;
 mod shortcuts;
 mod site_manager;
 mod timer_flow;
+mod weekday_rules;
 use shortcuts::ShortcutBindings;
 pub use shortcuts::{NavigationAction, ShortcutAction};
 
 pub const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
-pub const PROFILE_EDIT_FIELD_LABELS: [&str; 36] = [
+pub const PROFILE_EDIT_FIELD_LABELS: [&str; 42] = [
     "Focus",
     "Short Break",
     "Long Break",
@@ -100,6 +102,12 @@ pub const PROFILE_EDIT_FIELD_LABELS: [&str; 36] = [
     "One-time end",
     "One-time add/remove",
     "Schedule conflicts",
+    "Weekday rule",
+    "Weekday rule day",
+    "Weekday rule profile",
+    "Weekday rule blocklist",
+    "Weekday rule template",
+    "Weekday rule add/remove",
     "Theme preset",
 ];
 const PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX: usize = 9;
@@ -128,7 +136,13 @@ const PROFILE_EDIT_ONE_TIME_START_INDEX: usize = 31;
 const PROFILE_EDIT_ONE_TIME_END_INDEX: usize = 32;
 const PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX: usize = 33;
 const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 34;
-const PROFILE_EDIT_THEME_PRESET_INDEX: usize = 35;
+const PROFILE_EDIT_WEEKDAY_RULE_INDEX: usize = 35;
+const PROFILE_EDIT_WEEKDAY_RULE_DAY_INDEX: usize = 36;
+const PROFILE_EDIT_WEEKDAY_RULE_PROFILE_INDEX: usize = 37;
+const PROFILE_EDIT_WEEKDAY_RULE_BLOCKLIST_INDEX: usize = 38;
+const PROFILE_EDIT_WEEKDAY_RULE_TEMPLATE_INDEX: usize = 39;
+const PROFILE_EDIT_WEEKDAY_RULE_ADD_REMOVE_INDEX: usize = 40;
+const PROFILE_EDIT_THEME_PRESET_INDEX: usize = 41;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
@@ -319,6 +333,7 @@ struct ProfileEditSnapshot {
     notification_settings: NotificationConfig,
     auto_start: AutoStartConfig,
     recurring_schedule: RecurringScheduleConfig,
+    weekday_profile_rules: Vec<WeekdayProfileRuleConfig>,
     strict_mode: bool,
     daily_goal: DailyGoalConfig,
     weekly_goal: WeeklyGoalConfig,
@@ -638,6 +653,7 @@ pub struct App {
     feature_flags: FeatureFlagsConfig,
     config_deprecation_warnings: Vec<String>,
     profile_automation: ProfileAutomationSettingsConfig,
+    weekday_profile_rules: Vec<WeekdayProfileRuleConfig>,
     pub custom_profile: CustomProfileConfig,
     pub profile_selection_index: usize,
     pub profile_edit_active: bool,
@@ -646,6 +662,7 @@ pub struct App {
     profile_edit_schedule_day: usize,
     profile_edit_schedule_exception: usize,
     profile_edit_one_time_window: usize,
+    profile_edit_weekday_rule: usize,
     profile_edit_snapshot: Option<ProfileEditSnapshot>,
     notification_settings: NotificationConfig,
     auto_start: AutoStartConfig,
@@ -658,6 +675,7 @@ pub struct App {
     schedule_delayed_occurrence_key: Option<String>,
     schedule_delay_until: Option<DateTime<Local>>,
     last_schedule_occurrence_key: Option<String>,
+    last_weekday_profile_sync_day: Option<NaiveDate>,
     current_frame_now: DateTime<Local>,
     pub strict_mode: bool,
     break_glass_duration_secs: u64,
@@ -706,6 +724,7 @@ impl App {
         let setup_deprecation_warnings = setup_deprecation_warnings(&config_deprecation_warnings);
         let custom_profile = config.effective_custom_profile();
         let profile_automation = config.profile_automation.clone().unwrap_or_default();
+        let weekday_profile_rules = config.weekday_profile_rules.clone();
         let selected_automation = config.profile_automation_for(selected_profile);
         let notification_settings = selected_automation.notifications;
         let auto_start = selected_automation.auto_start;
@@ -830,6 +849,7 @@ impl App {
             feature_flags,
             config_deprecation_warnings,
             profile_automation,
+            weekday_profile_rules,
             custom_profile,
             profile_selection_index: profile_index(selected_profile),
             profile_edit_active: false,
@@ -838,6 +858,7 @@ impl App {
             profile_edit_schedule_day: 0,
             profile_edit_schedule_exception: 0,
             profile_edit_one_time_window: 0,
+            profile_edit_weekday_rule: 0,
             profile_edit_snapshot: None,
             notification_settings,
             auto_start,
@@ -850,6 +871,7 @@ impl App {
             schedule_delayed_occurrence_key: None,
             schedule_delay_until: None,
             last_schedule_occurrence_key: None,
+            last_weekday_profile_sync_day: None,
             current_frame_now: Local::now(),
             strict_mode,
             break_glass_duration_secs,
@@ -872,6 +894,7 @@ impl App {
         app.recompute_blocker_sites_from_active_profile();
         app.restore_in_progress_session();
         app.restore_cli_workflow_state();
+        app.sync_weekday_profile_rules(Local::now());
         app.sync_planner_selection_to_selected_label();
         app.sync_recovery_snapshot();
         app.apply_blocking_for_phase();
@@ -904,6 +927,7 @@ impl App {
         self.sync_today_goal_snapshot();
         self.wakatime.poll_events();
         self.sync_break_glass_override();
+        self.sync_weekday_profile_rules(now);
         self.sync_recurring_schedule(now);
     }
 
@@ -1131,7 +1155,7 @@ impl App {
     }
 
     pub fn profile_edit_field_value(&self, field_index: usize) -> String {
-        if (PROFILE_EDIT_SCHEDULE_WINDOW_INDEX..=PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX)
+        if (PROFILE_EDIT_SCHEDULE_WINDOW_INDEX..=PROFILE_EDIT_WEEKDAY_RULE_ADD_REMOVE_INDEX)
             .contains(&field_index)
         {
             return self.profile_edit_schedule_field_value(field_index);

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -469,6 +469,7 @@ impl App {
             custom_profile: Some(custom_profile),
             break_templates: self.break_templates.clone(),
             selected_break_template: self.selected_break_template_for_persistence(),
+            weekday_profile_rules: self.weekday_profile_rules.clone(),
             session_templates: self.session_templates.clone(),
             selected_session_template: self.selected_session_template_for_persistence(),
             selected_theme_preset: self.selected_theme_preset,

--- a/src/app/profile_management.rs
+++ b/src/app/profile_management.rs
@@ -12,6 +12,9 @@ use crate::app::{
     PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX, PROFILE_EDIT_SCHEDULE_START_INDEX,
     PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, PROFILE_EDIT_THEME_PRESET_INDEX,
     PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX, PROFILE_EDIT_WAKATIME_PROJECT_INDEX,
+    PROFILE_EDIT_WEEKDAY_RULE_ADD_REMOVE_INDEX, PROFILE_EDIT_WEEKDAY_RULE_BLOCKLIST_INDEX,
+    PROFILE_EDIT_WEEKDAY_RULE_DAY_INDEX, PROFILE_EDIT_WEEKDAY_RULE_INDEX,
+    PROFILE_EDIT_WEEKDAY_RULE_PROFILE_INDEX, PROFILE_EDIT_WEEKDAY_RULE_TEMPLATE_INDEX,
     PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX, PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX,
     PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX, PROFILE_IDS, ProfileAutomationConfig,
     ProfileEditSnapshot, ProfileId, ShortcutAction, TimerState, WakatimeHeartbeatMetadata,
@@ -93,6 +96,7 @@ impl App {
         self.selected_profile = profile;
         self.profile_selection_index = profile_index(profile);
         self.apply_automation_for_profile(profile);
+        self.last_weekday_profile_sync_day = Some(Local::now().date_naive());
         self.pending_timer_action = None;
         self.save_config();
         self.apply_blocking_for_phase();
@@ -118,6 +122,7 @@ impl App {
         self.profile_edit_schedule_day = 0;
         self.profile_edit_schedule_exception = 0;
         self.profile_edit_one_time_window = 0;
+        self.profile_edit_weekday_rule = 0;
         self.profile_edit_snapshot = None;
         self.profile_selection_index = profile_index(self.selected_profile);
         self.clamp_profile_selection();
@@ -224,6 +229,7 @@ impl App {
             notification_settings: self.notification_settings,
             auto_start: self.auto_start,
             recurring_schedule: self.recurring_schedule.clone(),
+            weekday_profile_rules: self.weekday_profile_rules.clone(),
             strict_mode: self.strict_mode,
             daily_goal: self.daily_goal,
             weekly_goal: self.weekly_goal,
@@ -238,6 +244,7 @@ impl App {
         self.profile_edit_schedule_day = 0;
         self.profile_edit_schedule_exception = 0;
         self.profile_edit_one_time_window = 0;
+        self.profile_edit_weekday_rule = 0;
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -247,6 +254,7 @@ impl App {
             self.notification_settings = snapshot.notification_settings;
             self.auto_start = snapshot.auto_start;
             self.recurring_schedule = snapshot.recurring_schedule;
+            self.weekday_profile_rules = snapshot.weekday_profile_rules;
             self.strict_mode = snapshot.strict_mode;
             self.daily_goal = snapshot.daily_goal;
             self.weekly_goal = snapshot.weekly_goal;
@@ -264,6 +272,7 @@ impl App {
         self.profile_edit_schedule_day = 0;
         self.profile_edit_schedule_exception = 0;
         self.profile_edit_one_time_window = 0;
+        self.profile_edit_weekday_rule = 0;
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -275,6 +284,10 @@ impl App {
         let schedule_changed = self.profile_edit_snapshot.as_ref().is_some_and(|snapshot| {
             snapshot.recurring_schedule.normalized() != normalized_schedule
         });
+        let weekday_rules_changed = self
+            .profile_edit_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.weekday_profile_rules != self.weekday_profile_rules);
         let daily_goal_changed = self
             .profile_edit_snapshot
             .as_ref()
@@ -322,6 +335,12 @@ impl App {
             self.current_frame_now = now;
             self.sync_recurring_schedule(now);
         }
+        if weekday_rules_changed {
+            self.last_weekday_profile_sync_day = None;
+            let now = Local::now();
+            self.current_frame_now = now;
+            self.sync_weekday_profile_rules(now);
+        }
         if daily_goal_changed
             || weekly_goal_changed
             || monthly_goal_changed
@@ -335,6 +354,7 @@ impl App {
         self.profile_edit_schedule_day = 0;
         self.profile_edit_schedule_exception = 0;
         self.profile_edit_one_time_window = 0;
+        self.profile_edit_weekday_rule = 0;
         self.clamp_profile_edit_schedule_selection();
         self.profile_edit_snapshot = None;
     }
@@ -449,6 +469,24 @@ impl App {
             }
             PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX => {
                 self.adjust_one_time_windows_collection(increase);
+            }
+            PROFILE_EDIT_WEEKDAY_RULE_INDEX => {
+                self.cycle_weekday_profile_rule(increase);
+            }
+            PROFILE_EDIT_WEEKDAY_RULE_DAY_INDEX => {
+                self.cycle_weekday_profile_rule_day(increase);
+            }
+            PROFILE_EDIT_WEEKDAY_RULE_PROFILE_INDEX => {
+                self.cycle_weekday_profile_rule_profile(increase);
+            }
+            PROFILE_EDIT_WEEKDAY_RULE_BLOCKLIST_INDEX => {
+                self.cycle_weekday_profile_rule_blocklist(increase);
+            }
+            PROFILE_EDIT_WEEKDAY_RULE_TEMPLATE_INDEX => {
+                self.cycle_weekday_profile_rule_template(increase);
+            }
+            PROFILE_EDIT_WEEKDAY_RULE_ADD_REMOVE_INDEX => {
+                self.adjust_weekday_profile_rules_collection(increase);
             }
             PROFILE_EDIT_WAKATIME_PROJECT_INDEX | PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX => {}
             _ => {}

--- a/src/app/schedule_editor.rs
+++ b/src/app/schedule_editor.rs
@@ -635,26 +635,28 @@ impl App {
             return;
         };
         let total = SCHEDULE_DAY_TOKENS.len();
-        let next_index = if increase {
-            (current_index + 1) % total
-        } else if current_index == 0 {
-            total - 1
-        } else {
-            current_index - 1
-        };
-        let next_day = SCHEDULE_DAY_TOKENS[next_index];
-        if self
-            .weekday_profile_rules
-            .iter()
-            .enumerate()
-            .any(|(index, rule)| {
-                index != self.profile_edit_weekday_rule && rule.day.eq_ignore_ascii_case(next_day)
-            })
-        {
+        for step in 1..=total {
+            let candidate_index = if increase {
+                (current_index + step) % total
+            } else {
+                (current_index + total - (step % total)) % total
+            };
+            let candidate_day = SCHEDULE_DAY_TOKENS[candidate_index];
+            let occupied = self
+                .weekday_profile_rules
+                .iter()
+                .enumerate()
+                .any(|(index, rule)| {
+                    index != self.profile_edit_weekday_rule
+                        && rule.day.eq_ignore_ascii_case(candidate_day)
+                });
+            if occupied {
+                continue;
+            }
+            if let Some(rule) = self.selected_weekday_profile_rule_mut() {
+                rule.day = candidate_day.to_string();
+            }
             return;
-        }
-        if let Some(rule) = self.selected_weekday_profile_rule_mut() {
-            rule.day = next_day.to_string();
         }
     }
 

--- a/src/app/schedule_editor.rs
+++ b/src/app/schedule_editor.rs
@@ -7,10 +7,14 @@ use crate::app::{
     PROFILE_EDIT_SCHEDULE_END_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX,
     PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX,
     PROFILE_EDIT_SCHEDULE_START_INDEX, PROFILE_EDIT_SCHEDULE_WINDOW_INDEX,
+    PROFILE_EDIT_WEEKDAY_RULE_ADD_REMOVE_INDEX, PROFILE_EDIT_WEEKDAY_RULE_BLOCKLIST_INDEX,
+    PROFILE_EDIT_WEEKDAY_RULE_DAY_INDEX, PROFILE_EDIT_WEEKDAY_RULE_INDEX,
+    PROFILE_EDIT_WEEKDAY_RULE_PROFILE_INDEX, PROFILE_EDIT_WEEKDAY_RULE_TEMPLATE_INDEX, PROFILE_IDS,
     RecurringFocusWindowConfig, SCHEDULE_DAY_LABELS, SCHEDULE_DAY_TOKENS, bool_label, format_hhmm,
     format_schedule_conflict, format_schedule_days_for_display,
     inspect_schedule_conflicts_from_config, parse_hhmm_minutes, parse_schedule_exception_date,
-    sort_one_time_windows, sort_schedule_days, sort_schedule_exception_dates,
+    profile_for_index, profile_index, sort_one_time_windows, sort_schedule_days,
+    sort_schedule_exception_dates,
 };
 
 impl App {
@@ -54,6 +58,12 @@ impl App {
                 .unwrap_or_else(|| "n/a".to_string()),
             PROFILE_EDIT_ONE_TIME_ADD_REMOVE_INDEX => self.one_time_window_collection_value(),
             PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX => self.schedule_conflict_summary_value(),
+            PROFILE_EDIT_WEEKDAY_RULE_INDEX => self.weekday_rule_selector_value(),
+            PROFILE_EDIT_WEEKDAY_RULE_DAY_INDEX => self.weekday_rule_day_value(),
+            PROFILE_EDIT_WEEKDAY_RULE_PROFILE_INDEX => self.weekday_rule_profile_value(),
+            PROFILE_EDIT_WEEKDAY_RULE_BLOCKLIST_INDEX => self.weekday_rule_blocklist_value(),
+            PROFILE_EDIT_WEEKDAY_RULE_TEMPLATE_INDEX => self.weekday_rule_template_value(),
+            PROFILE_EDIT_WEEKDAY_RULE_ADD_REMOVE_INDEX => self.weekday_rule_collection_value(),
             _ => String::new(),
         }
     }
@@ -144,6 +154,58 @@ impl App {
         }
     }
 
+    fn weekday_rule_selector_value(&self) -> String {
+        if self.weekday_profile_rules.is_empty() {
+            "none".to_string()
+        } else {
+            format!(
+                "{}/{}",
+                self.profile_edit_weekday_rule.saturating_add(1),
+                self.weekday_profile_rules.len()
+            )
+        }
+    }
+
+    fn weekday_rule_day_value(&self) -> String {
+        self.selected_weekday_profile_rule()
+            .map(|rule| {
+                let day_index = SCHEDULE_DAY_TOKENS
+                    .iter()
+                    .position(|token| token.eq_ignore_ascii_case(rule.day.as_str()))
+                    .unwrap_or(0);
+                SCHEDULE_DAY_LABELS[day_index].to_string()
+            })
+            .unwrap_or_else(|| "n/a".to_string())
+    }
+
+    fn weekday_rule_profile_value(&self) -> String {
+        self.selected_weekday_profile_rule()
+            .map(|rule| rule.profile.label().to_string())
+            .unwrap_or_else(|| "n/a".to_string())
+    }
+
+    fn weekday_rule_blocklist_value(&self) -> String {
+        self.selected_weekday_profile_rule()
+            .map(|rule| rule.blocklist_profile.clone())
+            .unwrap_or_else(|| "n/a".to_string())
+    }
+
+    fn weekday_rule_template_value(&self) -> String {
+        self.selected_weekday_profile_rule()
+            .and_then(|rule| rule.session_template.clone())
+            .unwrap_or_else(|| "none".to_string())
+    }
+
+    fn weekday_rule_collection_value(&self) -> String {
+        if self.weekday_profile_rules.is_empty() {
+            "→ Add rule".to_string()
+        } else if self.weekday_profile_rules.len() >= SCHEDULE_DAY_TOKENS.len() {
+            "← Remove".to_string()
+        } else {
+            "← Remove · → Add".to_string()
+        }
+    }
+
     fn selected_schedule_window(&self) -> Option<&RecurringFocusWindowConfig> {
         self.recurring_schedule
             .windows
@@ -166,6 +228,18 @@ impl App {
         self.recurring_schedule
             .one_time_windows
             .get(self.profile_edit_one_time_window)
+    }
+
+    fn selected_weekday_profile_rule(&self) -> Option<&crate::config::WeekdayProfileRuleConfig> {
+        self.weekday_profile_rules
+            .get(self.profile_edit_weekday_rule)
+    }
+
+    fn selected_weekday_profile_rule_mut(
+        &mut self,
+    ) -> Option<&mut crate::config::WeekdayProfileRuleConfig> {
+        self.weekday_profile_rules
+            .get_mut(self.profile_edit_weekday_rule)
     }
 
     fn selected_schedule_day_token(&self) -> &'static str {
@@ -220,6 +294,13 @@ impl App {
                     .len()
                     .saturating_sub(1),
             );
+        }
+        if self.weekday_profile_rules.is_empty() {
+            self.profile_edit_weekday_rule = 0;
+        } else {
+            self.profile_edit_weekday_rule = self
+                .profile_edit_weekday_rule
+                .min(self.weekday_profile_rules.len().saturating_sub(1));
         }
     }
 
@@ -524,6 +605,170 @@ impl App {
         {
             self.profile_edit_one_time_window = position;
         }
+    }
+
+    pub(super) fn cycle_weekday_profile_rule(&mut self, increase: bool) {
+        if self.weekday_profile_rules.is_empty() {
+            return;
+        }
+        let total = self.weekday_profile_rules.len();
+        if increase {
+            self.profile_edit_weekday_rule = (self.profile_edit_weekday_rule + 1) % total;
+        } else if self.profile_edit_weekday_rule == 0 {
+            self.profile_edit_weekday_rule = total - 1;
+        } else {
+            self.profile_edit_weekday_rule = self.profile_edit_weekday_rule.saturating_sub(1);
+        }
+    }
+
+    pub(super) fn cycle_weekday_profile_rule_day(&mut self, increase: bool) {
+        let Some(current_day) = self
+            .selected_weekday_profile_rule()
+            .map(|rule| rule.day.clone())
+        else {
+            return;
+        };
+        let Some(current_index) = SCHEDULE_DAY_TOKENS
+            .iter()
+            .position(|token| token.eq_ignore_ascii_case(&current_day))
+        else {
+            return;
+        };
+        let total = SCHEDULE_DAY_TOKENS.len();
+        let next_index = if increase {
+            (current_index + 1) % total
+        } else if current_index == 0 {
+            total - 1
+        } else {
+            current_index - 1
+        };
+        let next_day = SCHEDULE_DAY_TOKENS[next_index];
+        if self
+            .weekday_profile_rules
+            .iter()
+            .enumerate()
+            .any(|(index, rule)| {
+                index != self.profile_edit_weekday_rule && rule.day.eq_ignore_ascii_case(next_day)
+            })
+        {
+            return;
+        }
+        if let Some(rule) = self.selected_weekday_profile_rule_mut() {
+            rule.day = next_day.to_string();
+        }
+    }
+
+    pub(super) fn cycle_weekday_profile_rule_profile(&mut self, increase: bool) {
+        let Some(rule) = self.selected_weekday_profile_rule_mut() else {
+            return;
+        };
+        let current_index = profile_index(rule.profile);
+        let total = PROFILE_IDS.len();
+        let next_index = if increase {
+            (current_index + 1) % total
+        } else if current_index == 0 {
+            total - 1
+        } else {
+            current_index - 1
+        };
+        rule.profile = profile_for_index(next_index);
+    }
+
+    pub(super) fn cycle_weekday_profile_rule_blocklist(&mut self, increase: bool) {
+        if self.blocklist_profiles.is_empty() {
+            return;
+        }
+        let Some(current_name) = self
+            .selected_weekday_profile_rule()
+            .map(|rule| rule.blocklist_profile.clone())
+        else {
+            return;
+        };
+        let current_index = self
+            .blocklist_profiles
+            .iter()
+            .position(|profile| profile.name.eq_ignore_ascii_case(current_name.as_str()))
+            .unwrap_or(0);
+        let total = self.blocklist_profiles.len();
+        let next_index = if increase {
+            (current_index + 1) % total
+        } else if current_index == 0 {
+            total - 1
+        } else {
+            current_index - 1
+        };
+        let next_name = self.blocklist_profiles[next_index].name.clone();
+        if let Some(rule) = self.selected_weekday_profile_rule_mut() {
+            rule.blocklist_profile = next_name;
+        }
+    }
+
+    pub(super) fn cycle_weekday_profile_rule_template(&mut self, increase: bool) {
+        if self.session_templates.is_empty() {
+            if let Some(rule) = self.selected_weekday_profile_rule_mut() {
+                rule.session_template = None;
+            }
+            return;
+        }
+
+        let current_name = self
+            .selected_weekday_profile_rule()
+            .and_then(|rule| rule.session_template.clone());
+        let none_index = self.session_templates.len();
+        let current_index = current_name
+            .as_deref()
+            .and_then(|name| self.session_template_index_by_name(name))
+            .unwrap_or(none_index);
+        let total = none_index + 1;
+        let next_index = if increase {
+            (current_index + 1) % total
+        } else if current_index == 0 {
+            total - 1
+        } else {
+            current_index - 1
+        };
+        let next_template = if next_index == none_index {
+            None
+        } else {
+            self.session_templates
+                .get(next_index)
+                .map(|template| template.name.clone())
+        };
+        if let Some(rule) = self.selected_weekday_profile_rule_mut() {
+            rule.session_template = next_template;
+        }
+    }
+
+    pub(super) fn adjust_weekday_profile_rules_collection(&mut self, increase: bool) {
+        if increase {
+            if self.weekday_profile_rules.len() >= SCHEDULE_DAY_TOKENS.len() {
+                return;
+            }
+            let Some(next_day) = SCHEDULE_DAY_TOKENS.iter().find(|token| {
+                !self
+                    .weekday_profile_rules
+                    .iter()
+                    .any(|rule| rule.day.eq_ignore_ascii_case(token))
+            }) else {
+                return;
+            };
+            self.weekday_profile_rules
+                .push(crate::config::WeekdayProfileRuleConfig {
+                    day: (*next_day).to_string(),
+                    profile: self.selected_profile,
+                    blocklist_profile: self.active_blocklist_profile_name().to_string(),
+                    session_template: self.active_session_template_name().map(ToString::to_string),
+                });
+            self.profile_edit_weekday_rule = self.weekday_profile_rules.len().saturating_sub(1);
+            return;
+        }
+
+        if self.weekday_profile_rules.is_empty() {
+            return;
+        }
+        self.weekday_profile_rules
+            .remove(self.profile_edit_weekday_rule);
+        self.clamp_profile_edit_schedule_selection();
     }
 
     pub(super) fn adjust_schedule_windows_collection(&mut self, increase: bool) {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -130,6 +130,7 @@ fn selected_builtin_profile_is_applied_on_startup() {
         selected_break_template: "Classic".to_string(),
         session_templates: Vec::new(),
         selected_session_template: String::new(),
+        weekday_profile_rules: Vec::new(),
         notifications: NotificationConfig::default(),
         auto_start: AutoStartConfig::default(),
         recurring_schedule: RecurringScheduleConfig::default(),
@@ -3595,6 +3596,7 @@ fn strict_mode_blocks_custom_profile_commit_during_active_focus() {
         weekly_goal: app.weekly_goal,
         monthly_goal: app.monthly_goal,
         goal_carry_over: app.goal_carry_over,
+        weekday_profile_rules: app.weekday_profile_rules.clone(),
         selected_theme_preset: app.selected_theme_preset,
         wakatime_metadata: app.wakatime_metadata.clone(),
     });
@@ -3649,6 +3651,7 @@ fn enabling_strict_mode_saves_during_active_focus_for_custom_profile_without_res
         weekly_goal: app.weekly_goal,
         monthly_goal: app.monthly_goal,
         goal_carry_over: app.goal_carry_over,
+        weekday_profile_rules: app.weekday_profile_rules.clone(),
         selected_theme_preset: app.selected_theme_preset,
         wakatime_metadata: app.wakatime_metadata.clone(),
     });

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,6 +1,8 @@
 use crate::app::*;
 use crate::blocker;
-use crate::config::{FeatureFlagsConfig, ShortcutConfig, StatsRetentionConfig};
+use crate::config::{
+    FeatureFlagsConfig, ShortcutConfig, StatsRetentionConfig, WeekdayProfileRuleConfig,
+};
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
 };
@@ -850,6 +852,38 @@ fn editing_one_time_schedule_fields_updates_and_persists_settings() {
         persisted.recurring_schedule.one_time_windows,
         app.recurring_schedule.one_time_windows
     );
+}
+
+#[test]
+fn weekday_rule_day_cycle_skips_occupied_days() {
+    let mut app = App::default();
+    app.weekday_profile_rules = vec![
+        WeekdayProfileRuleConfig {
+            day: "mon".to_string(),
+            profile: ProfileId::Classic,
+            blocklist_profile: "Default".to_string(),
+            session_template: None,
+        },
+        WeekdayProfileRuleConfig {
+            day: "tue".to_string(),
+            profile: ProfileId::Classic,
+            blocklist_profile: "Default".to_string(),
+            session_template: None,
+        },
+        WeekdayProfileRuleConfig {
+            day: "wed".to_string(),
+            profile: ProfileId::Classic,
+            blocklist_profile: "Default".to_string(),
+            session_template: None,
+        },
+    ];
+    app.profile_edit_weekday_rule = 0;
+
+    app.cycle_weekday_profile_rule_day(true);
+    assert_eq!(app.weekday_profile_rules[0].day, "thu");
+
+    app.cycle_weekday_profile_rule_day(false);
+    assert_eq!(app.weekday_profile_rules[0].day, "mon");
 }
 
 #[test]

--- a/src/app/weekday_rules.rs
+++ b/src/app/weekday_rules.rs
@@ -1,0 +1,101 @@
+use crate::app::{App, Local, TimerStatus};
+use crate::config::WeekdayProfileRuleConfig;
+use chrono::{DateTime, Datelike};
+
+impl App {
+    pub(super) fn sync_weekday_profile_rules(&mut self, now: DateTime<Local>) {
+        let today = now.date_naive();
+        if self.last_weekday_profile_sync_day == Some(today) {
+            return;
+        }
+
+        // Avoid resetting an in-progress timer session at day rollover.
+        if self.timer.status != TimerStatus::Idle {
+            return;
+        }
+
+        let day = weekday_token(now.weekday());
+        let Some(rule) = self
+            .weekday_profile_rules
+            .iter()
+            .find(|rule| rule.day.eq_ignore_ascii_case(day))
+            .cloned()
+        else {
+            self.last_weekday_profile_sync_day = Some(today);
+            return;
+        };
+
+        if let Err(error) = self.apply_weekday_profile_rule(&rule) {
+            self.config_error = Some(error);
+        }
+        self.last_weekday_profile_sync_day = Some(today);
+    }
+
+    fn apply_weekday_profile_rule(
+        &mut self,
+        rule: &WeekdayProfileRuleConfig,
+    ) -> Result<(), String> {
+        let mut changed_after_profile_apply = false;
+        let profile_changed = self.selected_profile != rule.profile;
+        if profile_changed && !self.apply_profile(rule.profile) {
+            return Err(self
+                .config_error
+                .clone()
+                .or_else(|| self.phase_notification.clone())
+                .unwrap_or_else(|| "failed to apply profile from weekday rule".to_string()));
+        }
+
+        let Some(blocklist_index) = self.blocklist_profiles.iter().position(|profile| {
+            profile
+                .name
+                .eq_ignore_ascii_case(rule.blocklist_profile.as_str())
+        }) else {
+            return Err(format!(
+                "weekday rule for `{}` references missing blocklist profile `{}`",
+                rule.day, rule.blocklist_profile
+            ));
+        };
+        if self.active_blocklist_profile != blocklist_index {
+            self.active_blocklist_profile = blocklist_index;
+            self.recompute_blocker_sites_from_active_profile();
+            self.clamp_selection();
+            changed_after_profile_apply = true;
+        }
+
+        let target_template = match rule.session_template.as_deref() {
+            Some(name) => Some(self.session_template_index_by_name(name).ok_or_else(|| {
+                format!(
+                    "weekday rule for `{}` references missing session template `{}`",
+                    rule.day, name
+                )
+            })?),
+            None => None,
+        };
+
+        if self.active_session_template != target_template {
+            self.active_session_template = target_template;
+            self.planner_template_selection_index = self.active_session_template.unwrap_or(0);
+            changed_after_profile_apply = true;
+        }
+
+        if changed_after_profile_apply {
+            self.save_config();
+            self.apply_blocking_for_phase();
+            self.sync_recovery_snapshot();
+        }
+
+        Ok(())
+    }
+}
+
+fn weekday_token(day: chrono::Weekday) -> &'static str {
+    match day {
+        chrono::Weekday::Mon => "mon",
+        chrono::Weekday::Tue => "tue",
+        chrono::Weekday::Wed => "wed",
+        chrono::Weekday::Thu => "thu",
+        chrono::Weekday::Fri => "fri",
+        chrono::Weekday::Sat => "sat",
+        chrono::Weekday::Sun => "sun",
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ use crate::blocker::{BlockingPreviewAction, EditSiteResult, InvalidSiteInput, Si
 use crate::config::{
     AppConfig, BlocklistProfileConfig, BreakTemplateConfig, CustomProfileConfig, DailyGoalConfig,
     MonthlyGoalConfig, OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig,
-    RecurringScheduleConfig, ThemePreset, WeeklyGoalConfig,
+    RecurringScheduleConfig, ThemePreset, WeekdayProfileRuleConfig, WeeklyGoalConfig,
 };
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
@@ -53,14 +53,14 @@ use output::{
     print_site_add_command_output, print_site_delete_command_output,
     print_site_edit_command_output, print_site_list_command_output, print_status_output,
     print_strict_command_output, print_task_goal_command_output, print_theme_command_output,
-    print_timer_state_output,
+    print_timer_state_output, print_weekday_rules_command_output,
 };
 use parsing::{
     finalize_cli_action, invalid_usage, parse_global_tokens, parse_goal_carry_value,
     parse_goal_value, parse_monthly_goal_value, parse_primary_command, parse_profile_id,
     parse_schedule_value, parse_site_edit_value, parse_strict_value, parse_task_goal_value,
     parse_theme_preset, parse_watch_interval_option, parse_watch_interval_secs,
-    parse_weekly_goal_value, require_nonempty_key_value,
+    parse_weekday_rules_value, parse_weekly_goal_value, require_nonempty_key_value,
 };
 use status::{
     available_break_template_views, available_theme_preset_views, build_status_output,
@@ -100,6 +100,8 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --strict=on|off [--json]
   focustime --schedule [--json]
   focustime --schedule-set=JSON_PAYLOAD [--json]
+  focustime --weekday-rules [--json]
+  focustime --weekday-rules-set=JSON_PAYLOAD [--json]
   focustime --schedule-delay [--json]
   focustime --break-glass-trigger [--json]
   focustime --break-glass-cancel [--json]
@@ -148,6 +150,8 @@ Options:
   --strict        Show strict mode for selected profile, or set on/off
   --schedule      Show selected profile schedule with overlap/conflict inspection
   --schedule-set  Replace selected profile schedule (recurring + one-time) from JSON payload
+  --weekday-rules      Show weekday smart-switch rules
+  --weekday-rules-set  Replace weekday smart-switch rules from JSON payload
   --schedule-delay  Delay the current active schedule window start by 10 minutes
   --break-glass-trigger  Trigger break-glass workflow (first call arms, second confirms)
   --break-glass-cancel   Cancel a pending break-glass confirmation
@@ -274,6 +278,9 @@ pub enum CommandKind {
     Schedule {
         schedule: Option<RecurringScheduleConfig>,
     },
+    WeekdayRules {
+        rules: Option<Vec<WeekdayProfileRuleConfig>>,
+    },
     ScheduleDelay,
     BreakGlassTrigger,
     BreakGlassCancel,
@@ -341,6 +348,8 @@ enum PrimaryCommand {
     Strict(Option<bool>),
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
+    WeekdayRules,
+    WeekdayRulesSet(Vec<WeekdayProfileRuleConfig>),
     ScheduleDelay,
     BreakGlassTrigger,
     BreakGlassCancel,
@@ -398,6 +407,8 @@ enum ParsedToken {
     Strict(Option<bool>),
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
+    WeekdayRules,
+    WeekdayRulesSet(Vec<WeekdayProfileRuleConfig>),
     ScheduleDelay,
     BreakGlassTrigger,
     BreakGlassCancel,
@@ -734,6 +745,12 @@ struct ScheduleCommandOutput {
 struct ScheduleInspectionOutput {
     conflict_count: usize,
     conflicts: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct WeekdayRulesCommandOutput {
+    updated: bool,
+    rules: Vec<WeekdayProfileRuleConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,8 +2,8 @@ use crate::cli::{
     KeyValueParser, OsString, OutputMode, ParsedToken, PathBuf, ValueArgParser, invalid_usage,
     parse_goal_carry_value, parse_goal_value, parse_monthly_goal_value, parse_profile_id,
     parse_schedule_value, parse_site_edit_value, parse_strict_value, parse_task_goal_value,
-    parse_theme_preset, parse_watch_interval_secs, parse_weekly_goal_value,
-    require_nonempty_key_value,
+    parse_theme_preset, parse_watch_interval_secs, parse_weekday_rules_value,
+    parse_weekly_goal_value, require_nonempty_key_value,
 };
 
 pub(super) fn infer_output_mode_from_os_args(args: &[OsString]) -> OutputMode {
@@ -55,7 +55,7 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 31] = [
+    let parsers: [(&str, ValueArgParser); 32] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
         ("--focus-intention", classify_focus_intention_arg),
@@ -70,6 +70,7 @@ fn classify_value_arg(
         ("--goal-carry-monthly", classify_goal_carry_monthly_arg),
         ("--strict", classify_strict_arg),
         ("--schedule-set", classify_schedule_set_arg),
+        ("--weekday-rules-set", classify_weekday_rules_set_arg),
         ("--watch", classify_watch_arg),
         ("--backup", classify_backup_arg),
         ("--restore", classify_restore_arg),
@@ -130,6 +131,7 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "--next" => Some(ParsedToken::Next),
         "--status" => Some(ParsedToken::Status),
         "--schedule" => Some(ParsedToken::Schedule),
+        "--weekday-rules" => Some(ParsedToken::WeekdayRules),
         "--schedule-delay" => Some(ParsedToken::ScheduleDelay),
         "--break-glass-trigger" => Some(ParsedToken::BreakGlassTrigger),
         "--break-glass-cancel" => Some(ParsedToken::BreakGlassCancel),
@@ -588,8 +590,25 @@ fn classify_schedule_set_arg(
     ))
 }
 
+fn classify_weekday_rules_set_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        return Ok((
+            ParsedToken::WeekdayRulesSet(parse_weekday_rules_value(next)?),
+            2,
+        ));
+    }
+    Err(invalid_usage(
+        "`--weekday-rules-set` requires a JSON payload. Use `--weekday-rules-set='[{\"day\":\"mon\",\"profile\":\"deep-work\",\"blocklist_profile\":\"Work\",\"session_template\":\"Deep Flow\"}]'`.",
+    ))
+}
+
 pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 31] = [
+    let parsers: [KeyValueParser; 32] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
         parse_focus_intention_key_value_arg,
@@ -604,6 +623,7 @@ pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, S
         parse_goal_carry_monthly_key_value_arg,
         parse_strict_key_value_arg,
         parse_schedule_set_key_value_arg,
+        parse_weekday_rules_set_key_value_arg,
         parse_watch_key_value_arg,
         parse_backup_key_value_arg,
         parse_restore_key_value_arg,
@@ -771,6 +791,17 @@ fn parse_schedule_set_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, St
         let value =
             require_nonempty_key_value(value, "`--schedule-set=` requires a JSON payload.")?;
         return Ok(Some(ParsedToken::ScheduleSet(parse_schedule_value(value)?)));
+    }
+    Ok(None)
+}
+
+fn parse_weekday_rules_set_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--weekday-rules-set=") {
+        let value =
+            require_nonempty_key_value(value, "`--weekday-rules-set=` requires a JSON payload.")?;
+        return Ok(Some(ParsedToken::WeekdayRulesSet(
+            parse_weekday_rules_value(value)?,
+        )));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -23,7 +23,8 @@ use crate::cli::{
     SiteDeleteCommandOutput, SiteEditCommandOutput, SiteEditValue, SiteListCommandOutput,
     SiteListTarget, StatusOutput, StrictCommandOutput, TaskCommandOutput, TaskGoalCommandOutput,
     TaskGoalOutput, ThemeCommandOutput, ThemePreset, TimerCommandOutput, TimerStateOutput,
-    WeeklyGoalConfig, available_break_template_views, available_theme_preset_views,
+    WeekdayProfileRuleConfig, WeekdayRulesCommandOutput, WeeklyGoalConfig,
+    available_break_template_views, available_theme_preset_views,
     build_blocking_preview_command_output, build_diagnostics_command_output,
     build_schedule_inspection_output, build_status_output, build_task_goal_output,
     display_input_value, effective_blocked_sites_for_profile, flush_stdout, print_backup_output,
@@ -36,8 +37,8 @@ use crate::cli::{
     print_site_delete_command_output, print_site_edit_command_output,
     print_site_list_command_output, print_status_output, print_strict_command_output,
     print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
-    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
-    timer_status_id,
+    print_weekday_rules_command_output, profile_id, profile_view, selected_break_template_view,
+    theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
@@ -79,6 +80,9 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         CommandKind::Strict { enabled } => execute_strict_command(enabled, cli_command.output),
         CommandKind::Schedule { schedule } => {
             execute_schedule_command(schedule, cli_command.output)
+        }
+        CommandKind::WeekdayRules { rules } => {
+            execute_weekday_rules_command(rules, cli_command.output)
         }
         CommandKind::ScheduleDelay => execute_schedule_delay_command(cli_command.output),
         CommandKind::BreakGlassTrigger => execute_break_glass_trigger_command(cli_command.output),
@@ -1014,6 +1018,33 @@ fn execute_schedule_command(
 
     match output {
         OutputMode::Text => print_schedule_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_weekday_rules_command(
+    rules: Option<Vec<WeekdayProfileRuleConfig>>,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let mut updated = false;
+    if let Some(rules) = rules {
+        config.weekday_profile_rules = rules;
+        config = config.normalized();
+        config
+            .save()
+            .map_err(|error| format!("Failed to save weekday rules: {error}"))?;
+        updated = true;
+    }
+
+    let payload = WeekdayRulesCommandOutput {
+        updated,
+        rules: config.weekday_profile_rules.clone(),
+    };
+
+    match output {
+        OutputMode::Text => print_weekday_rules_command_output(&payload),
         OutputMode::Json => print_json(&payload)?,
     }
     Ok(())

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -10,7 +10,8 @@ use crate::cli::{
     SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput,
     SiteEditCommandOutput, SiteListCommandOutput, StatsGrowthSummary, StatsRetentionStatusOutput,
     StatusOutput, StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, ThemeCommandOutput,
-    TimerStateOutput, Write, format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    TimerStateOutput, WeekdayRulesCommandOutput, Write, format_schedule_conflict,
+    inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -630,6 +631,27 @@ pub(super) fn print_schedule_command_output(payload: &ScheduleCommandOutput) {
         for conflict in &payload.inspection.conflicts {
             println!("  - {conflict}");
         }
+    }
+}
+
+pub(super) fn print_weekday_rules_command_output(payload: &WeekdayRulesCommandOutput) {
+    if payload.updated {
+        println!("Weekday rules updated.");
+    }
+    if payload.rules.is_empty() {
+        println!("Weekday rules: none");
+        return;
+    }
+    println!("Weekday rules:");
+    for rule in &payload.rules {
+        let template = rule.session_template.as_deref().unwrap_or("none");
+        println!(
+            "  - {} -> profile {}, blocklist {}, template {}",
+            rule.day,
+            rule.profile.label(),
+            rule.blocklist_profile,
+            template
+        );
     }
 }
 

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -3,7 +3,7 @@ use crate::cli::{
     DEFAULT_WATCH_INTERVAL_SECS, DailyGoalConfig, MonthlyGoalConfig, NaiveDate,
     OneTimeFocusWindowConfig, OutputMode, ParsedToken, PrimaryCommand, ProfileId,
     RecurringFocusWindowConfig, RecurringScheduleConfig, SessionTemplateCommandKind, SiteEditValue,
-    SiteListTarget, ThemePreset, USAGE_TEXT, WeeklyGoalConfig,
+    SiteListTarget, ThemePreset, USAGE_TEXT, WeekdayProfileRuleConfig, WeeklyGoalConfig,
 };
 
 pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), String> {
@@ -49,6 +49,8 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::Strict(_)
             | ParsedToken::Schedule
             | ParsedToken::ScheduleSet(_)
+            | ParsedToken::WeekdayRules
+            | ParsedToken::WeekdayRulesSet(_)
             | ParsedToken::ScheduleDelay
             | ParsedToken::BreakGlassTrigger
             | ParsedToken::BreakGlassCancel
@@ -138,6 +140,12 @@ pub(super) fn parse_primary_command(
             ParsedToken::Schedule => set_primary_command(&mut primary, PrimaryCommand::Schedule)?,
             ParsedToken::ScheduleSet(schedule) => {
                 set_primary_command(&mut primary, PrimaryCommand::ScheduleSet(schedule.clone()))?
+            }
+            ParsedToken::WeekdayRules => {
+                set_primary_command(&mut primary, PrimaryCommand::WeekdayRules)?
+            }
+            ParsedToken::WeekdayRulesSet(rules) => {
+                set_primary_command(&mut primary, PrimaryCommand::WeekdayRulesSet(rules.clone()))?
             }
             ParsedToken::ScheduleDelay => {
                 set_primary_command(&mut primary, PrimaryCommand::ScheduleDelay)?
@@ -306,6 +314,14 @@ pub(super) fn finalize_cli_action(
             kind: CommandKind::Schedule {
                 schedule: Some(schedule),
             },
+            output,
+        })),
+        Some(PrimaryCommand::WeekdayRules) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::WeekdayRules { rules: None },
+            output,
+        })),
+        Some(PrimaryCommand::WeekdayRulesSet(rules)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::WeekdayRules { rules: Some(rules) },
             output,
         })),
         Some(PrimaryCommand::ScheduleDelay) => Ok(CliAction::RunCommand(CliCommand {
@@ -633,6 +649,18 @@ pub(super) fn parse_schedule_value(value: &str) -> Result<RecurringScheduleConfi
     Ok(schedule)
 }
 
+pub(super) fn parse_weekday_rules_value(
+    value: &str,
+) -> Result<Vec<WeekdayProfileRuleConfig>, String> {
+    let rules = serde_json::from_str::<Vec<WeekdayProfileRuleConfig>>(value).map_err(|error| {
+        invalid_usage(&format!(
+            "Invalid weekday-rules JSON payload: {error}. Use `--weekday-rules-set='[{{\"day\":\"mon\",\"profile\":\"deep-work\",\"blocklist_profile\":\"Work\",\"session_template\":\"Deep Flow\"}}]'`."
+        ))
+    })?;
+    validate_weekday_rules_value(&rules)?;
+    Ok(rules)
+}
+
 fn validate_schedule_value(schedule: &RecurringScheduleConfig) -> Result<(), String> {
     for (index, window) in schedule.windows.iter().enumerate() {
         validate_schedule_window(window, index)?;
@@ -726,6 +754,30 @@ fn validate_one_time_schedule_window(
     Ok(())
 }
 
+fn validate_weekday_rules_value(rules: &[WeekdayProfileRuleConfig]) -> Result<(), String> {
+    for (index, rule) in rules.iter().enumerate() {
+        if !is_valid_schedule_weekday(&rule.day) {
+            return Err(invalid_usage(&format!(
+                "Invalid weekday rule at index {index}: unknown day `{}`.",
+                rule.day
+            )));
+        }
+        if rule.blocklist_profile.trim().is_empty() {
+            return Err(invalid_usage(&format!(
+                "Invalid weekday rule at index {index}: `blocklist_profile` cannot be empty."
+            )));
+        }
+        if let Some(template) = rule.session_template.as_deref()
+            && template.trim().is_empty()
+        {
+            return Err(invalid_usage(&format!(
+                "Invalid weekday rule at index {index}: `session_template` cannot be empty when provided."
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn is_valid_schedule_weekday(value: &str) -> bool {
     matches!(
         value.trim().to_ascii_lowercase().as_str(),
@@ -799,6 +851,8 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Strict(_) => "--strict",
         PrimaryCommand::Schedule => "--schedule",
         PrimaryCommand::ScheduleSet(_) => "--schedule-set",
+        PrimaryCommand::WeekdayRules => "--weekday-rules",
+        PrimaryCommand::WeekdayRulesSet(_) => "--weekday-rules-set",
         PrimaryCommand::ScheduleDelay => "--schedule-delay",
         PrimaryCommand::BreakGlassTrigger => "--break-glass-trigger",
         PrimaryCommand::BreakGlassCancel => "--break-glass-cancel",

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -506,6 +506,18 @@ fn parse_schedule_reads_current_schedule() {
 }
 
 #[test]
+fn parse_weekday_rules_reads_current_rules() {
+    let parsed = parse(&["--weekday-rules"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::WeekdayRules { rules: None },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
 fn parse_schedule_delay_supports_json_mode() {
     let parsed = parse(&["--schedule-delay", "--json"]).unwrap();
     assert_eq!(
@@ -581,6 +593,30 @@ fn parse_schedule_set_accepts_one_time_windows_payload() {
                         end: "15:30".to_string(),
                     }],
                 }),
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_weekday_rules_set_accepts_json_payload() {
+    let payload = r#"[{"day":"monday","profile":"deep-work","blocklist_profile":"Work","session_template":"Deep Flow"}]"#;
+    let parsed = parse_args([
+        OsString::from("--weekday-rules-set"),
+        OsString::from(payload),
+    ])
+    .unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::WeekdayRules {
+                rules: Some(vec![WeekdayProfileRuleConfig {
+                    day: "monday".to_string(),
+                    profile: ProfileId::DeepWork,
+                    blocklist_profile: "Work".to_string(),
+                    session_template: Some("Deep Flow".to_string()),
+                }]),
             },
             output: OutputMode::Text
         })
@@ -1167,6 +1203,23 @@ fn classify_key_value_arg_accepts_schedule_set_equals_value() {
 }
 
 #[test]
+fn classify_key_value_arg_accepts_weekday_rules_set_equals_value() {
+    let payload = "--weekday-rules-set=[{\"day\":\"fri\",\"profile\":\"classic\",\"blocklist_profile\":\"Default\"}]";
+    let parsed = classify_key_value_arg(payload).unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::WeekdayRulesSet(vec![
+            WeekdayProfileRuleConfig {
+                day: "fri".to_string(),
+                profile: ProfileId::Classic,
+                blocklist_profile: "Default".to_string(),
+                session_template: None,
+            }
+        ]))
+    );
+}
+
+#[test]
 fn classify_key_value_arg_accepts_session_template_equals_value() {
     let parsed = classify_key_value_arg("--session-template=Deep Flow").unwrap();
     assert_eq!(
@@ -1268,6 +1321,12 @@ fn classify_key_value_arg_rejects_empty_goal_carry_monthly_equals_value() {
 fn classify_key_value_arg_rejects_empty_schedule_set_equals_value() {
     let error = classify_key_value_arg("--schedule-set=").unwrap_err();
     assert!(error.contains("`--schedule-set=` requires a JSON payload."));
+}
+
+#[test]
+fn classify_key_value_arg_rejects_empty_weekday_rules_set_equals_value() {
+    let error = classify_key_value_arg("--weekday-rules-set=").unwrap_err();
+    assert!(error.contains("`--weekday-rules-set=` requires a JSON payload."));
 }
 
 #[test]
@@ -1391,6 +1450,12 @@ fn parse_rejects_schedule_set_without_payload() {
 }
 
 #[test]
+fn parse_rejects_weekday_rules_set_without_payload() {
+    let error = parse(&["--weekday-rules-set"]).unwrap_err();
+    assert!(error.contains("`--weekday-rules-set` requires a JSON payload"));
+}
+
+#[test]
 fn parse_rejects_blocklist_profile_create_without_value() {
     let error = parse(&["--blocklist-profile-create"]).unwrap_err();
     assert!(error.contains("`--blocklist-profile-create` requires a profile name"));
@@ -1421,6 +1486,17 @@ fn parse_rejects_schedule_set_with_invalid_weekday() {
     let error =
         parse_args([OsString::from("--schedule-set"), OsString::from(payload)]).unwrap_err();
     assert!(error.contains("unknown weekday"));
+}
+
+#[test]
+fn parse_rejects_weekday_rules_set_with_invalid_weekday() {
+    let payload = r#"[{"day":"funday","profile":"classic","blocklist_profile":"Default"}]"#;
+    let error = parse_args([
+        OsString::from("--weekday-rules-set"),
+        OsString::from(payload),
+    ])
+    .unwrap_err();
+    assert!(error.contains("unknown day"));
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,9 @@ pub struct AppConfig {
     /// Name of the active break template.
     #[serde(default)]
     pub selected_break_template: String,
+    /// Weekday smart-switch rules for profile and planning defaults.
+    #[serde(default)]
+    pub weekday_profile_rules: Vec<WeekdayProfileRuleConfig>,
     /// Reusable session templates bundling task/profile/blocklist/schedule settings.
     #[serde(default)]
     pub session_templates: Vec<SessionTemplateConfig>,
@@ -750,6 +753,51 @@ impl ProfileAutomationSettingsConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WeekdayProfileRuleConfig {
+    #[serde(default = "default_weekday_profile_rule_day")]
+    pub day: String,
+    #[serde(default)]
+    pub profile: ProfileId,
+    #[serde(default = "default_blocklist_profile_name")]
+    pub blocklist_profile: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_template: Option<String>,
+}
+
+impl WeekdayProfileRuleConfig {
+    fn normalized_with_context(
+        &self,
+        blocklist_profiles: &[BlocklistProfileConfig],
+        session_templates: &[SessionTemplateConfig],
+    ) -> Option<Self> {
+        let day = normalize_weekday_token(&self.day)?;
+        let blocklist_profile =
+            normalize_selected_blocklist_profile(&self.blocklist_profile, blocklist_profiles);
+        let session_template = normalize_optional_selected_session_template(
+            self.session_template.as_deref(),
+            session_templates,
+        );
+        Some(Self {
+            day,
+            profile: self.profile,
+            blocklist_profile,
+            session_template,
+        })
+    }
+}
+
+impl Default for WeekdayProfileRuleConfig {
+    fn default() -> Self {
+        Self {
+            day: default_weekday_profile_rule_day(),
+            profile: ProfileId::default(),
+            blocklist_profile: default_blocklist_profile_name(),
+            session_template: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RecurringFocusWindowConfig {
     #[serde(default = "default_schedule_window_days")]
     pub days: Vec<String>,
@@ -1079,6 +1127,10 @@ fn default_schedule_window_days() -> Vec<String> {
         "thu".to_string(),
         "fri".to_string(),
     ]
+}
+
+fn default_weekday_profile_rule_day() -> String {
+    "mon".to_string()
 }
 
 fn default_schedule_window_start() -> String {
@@ -1562,6 +1614,7 @@ impl Default for AppConfig {
             custom_profile: None,
             break_templates: default_break_templates(),
             selected_break_template: default_break_template_name(),
+            weekday_profile_rules: Vec::new(),
             session_templates: Vec::new(),
             selected_session_template: String::new(),
             selected_theme_preset: ThemePreset::default(),
@@ -1767,6 +1820,11 @@ impl AppConfig {
             normalize_session_templates(&self.session_templates, &self.blocklist_profiles);
         self.selected_session_template = normalize_selected_session_template(
             &self.selected_session_template,
+            &self.session_templates,
+        );
+        self.weekday_profile_rules = normalize_weekday_profile_rules(
+            &self.weekday_profile_rules,
+            &self.blocklist_profiles,
             &self.session_templates,
         );
         self.blocking_backend = self.blocking_backend.normalized();
@@ -2182,6 +2240,67 @@ fn normalize_selected_session_template(
         .find(|template| template.name.eq_ignore_ascii_case(selected_name))
         .map(|template| template.name.clone())
         .unwrap_or_default()
+}
+
+fn normalize_optional_selected_session_template(
+    value: Option<&str>,
+    session_templates: &[SessionTemplateConfig],
+) -> Option<String> {
+    let normalized = normalize_optional_nonempty_string(value)?;
+    session_templates
+        .iter()
+        .find(|template| template.name.eq_ignore_ascii_case(&normalized))
+        .map(|template| template.name.clone())
+}
+
+fn normalize_weekday_profile_rules(
+    rules: &[WeekdayProfileRuleConfig],
+    blocklist_profiles: &[BlocklistProfileConfig],
+    session_templates: &[SessionTemplateConfig],
+) -> Vec<WeekdayProfileRuleConfig> {
+    let mut normalized_by_day: [Option<WeekdayProfileRuleConfig>; 7] =
+        std::array::from_fn(|_| None);
+    for rule in rules {
+        let Some(normalized) = rule.normalized_with_context(blocklist_profiles, session_templates)
+        else {
+            continue;
+        };
+        let Some(day_index) = weekday_token_to_index(&normalized.day) else {
+            continue;
+        };
+        normalized_by_day[day_index] = Some(normalized);
+    }
+    normalized_by_day.into_iter().flatten().collect()
+}
+
+fn normalize_weekday_token(value: &str) -> Option<String> {
+    weekday_token_to_index(value).map(|index| weekday_token_from_index(index).to_string())
+}
+
+fn weekday_token_to_index(value: &str) -> Option<usize> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "mon" | "monday" => Some(0),
+        "tue" | "tues" | "tuesday" => Some(1),
+        "wed" | "wednesday" => Some(2),
+        "thu" | "thurs" | "thursday" => Some(3),
+        "fri" | "friday" => Some(4),
+        "sat" | "saturday" => Some(5),
+        "sun" | "sunday" => Some(6),
+        _ => None,
+    }
+}
+
+fn weekday_token_from_index(index: usize) -> &'static str {
+    match index {
+        0 => "mon",
+        1 => "tue",
+        2 => "wed",
+        3 => "thu",
+        4 => "fri",
+        5 => "sat",
+        6 => "sun",
+        _ => "mon",
+    }
 }
 
 fn break_template_matches_custom_profile(

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -159,6 +159,7 @@ fn round_trip_full_config() {
             },
         }],
         selected_session_template: "Morning deep work".to_string(),
+        weekday_profile_rules: Vec::new(),
         selected_theme_preset: ThemePreset::HighContrast,
         notifications: NotificationConfig {
             enabled: true,
@@ -916,6 +917,7 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
         selected_break_template: default_break_template_name(),
         session_templates: Vec::new(),
         selected_session_template: String::new(),
+        weekday_profile_rules: Vec::new(),
         selected_theme_preset: ThemePreset::Classic,
         notifications: NotificationConfig::default(),
         auto_start: AutoStartConfig::default(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -47,9 +47,10 @@ const PROFILE_EDIT_GROUP_TIMER: [usize; 4] = [0, 1, 2, 3];
 const PROFILE_EDIT_GROUP_AUTOMATION: [usize; 5] = [4, 5, 6, 7, 8];
 const PROFILE_EDIT_GROUP_GOALS: [usize; 9] = [9, 10, 11, 12, 13, 14, 15, 16, 17];
 const PROFILE_EDIT_GROUP_WAKATIME: [usize; 2] = [18, 19];
-const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 15] =
-    [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34];
-const PROFILE_EDIT_GROUP_APPEARANCE: [usize; 1] = [35];
+const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 21] = [
+    20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+];
+const PROFILE_EDIT_GROUP_APPEARANCE: [usize; 1] = [41];
 const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 6] = [
     ("Timer", &PROFILE_EDIT_GROUP_TIMER),
     ("Automation", &PROFILE_EDIT_GROUP_AUTOMATION),

--- a/src/ui/profile_manager.rs
+++ b/src/ui/profile_manager.rs
@@ -288,7 +288,13 @@ fn profile_edit_field_display_label(field_index: usize) -> &'static str {
         32 => "One-time end",
         33 => "One-time add/remove",
         34 => "Conflict inspector",
-        35 => "Theme preset",
+        35 => "Rule selector",
+        36 => "Rule day",
+        37 => "Rule profile",
+        38 => "Rule blocklist",
+        39 => "Rule template",
+        40 => "Rule add/remove",
+        41 => "Theme preset",
         _ => "",
     }
 }


### PR DESCRIPTION
## What

Add day-of-week smart profile switching so configured weekday rules can automatically apply the runtime context. This includes switching the active profile, blocklist profile, and optional active session template.

The implementation covers config normalization/persistence, runtime day-boundary/startup application, profile editor controls in the TUI, and CLI management commands (`--weekday-rules`, `--weekday-rules-set`).

## Why

Users need weekday-based defaults that reduce manual setup while keeping behavior predictable. Rules apply at startup and day boundaries (not continuously during the same day), and runtime application is guarded to avoid resetting active sessions.

Closes #315.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekday profile rules: auto-switch profile, blocklist profile, and optional session template at startup and day boundaries; persisted in configuration.
  * CLI: manage rules with --weekday-rules and --weekday-rules-set (JSON), with readable text/JSON output.

* **UI**
  * Profile editor: weekday-rules editor with keyboard navigation, add/remove, and field cycling.

* **Tests**
  * Added CLI and unit tests for parsing, validation, and weekday-rule behavior.

* **Documentation**
  * Updated README with CLI examples and TUI guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->