### PR TITLE
Temporary allowlist timer with auto-expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ cargo run -- --blocklist-sites
 cargo run -- --allowlist-sites --json
 cargo run -- --blocklist-site-add="youtube.com, reddit.com"
 cargo run -- --allowlist-site-add "reddit.com"
+cargo run -- --allowlist-site-add-temporary "reddit.com=30m,news.ycombinator.com=10m"
 cargo run -- --blocklist-site-edit "youtube.com=news.ycombinator.com"
 cargo run -- --allowlist-site-delete reddit.com
 
@@ -191,7 +192,7 @@ cargo run -- --diagnostics --json
 cargo run -- --blocking-preview
 cargo run -- --blocking-preview --json
 
-# Show status (text or JSON, including growth/retention signals, live timer/session fields, latest interruption summary, and `selected_task_goal` in JSON)
+# Show status (text or JSON, including growth/retention signals, live timer/session fields, active temporary allowlist entries, latest interruption summary, and `selected_task_goal` in JSON)
 cargo run -- --status
 cargo run -- --status --json
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,10 @@ use crate::stats::{
     current_day_key,
 };
 use crate::task_labels::{normalize_task_label, task_label_index};
+use crate::temporary_allowlist::{
+    ActiveTemporaryAllowlistEntry, TemporaryAllowlistEntry,
+    active_temporary_allowlist_status_entries_for_profile,
+};
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
     DEFAULT_SHORT_BREAK_SECS, TimerPhase, TimerState, TimerStatus,
@@ -61,6 +65,7 @@ mod session_planner;
 mod session_templates;
 mod shortcuts;
 mod site_manager;
+mod temporary_allowlist;
 mod timer_flow;
 mod weekday_rules;
 use shortcuts::ShortcutBindings;
@@ -708,6 +713,7 @@ pub struct App {
     pub strict_mode: bool,
     break_glass_duration_secs: u64,
     break_glass_expires_at: Option<Instant>,
+    temporary_allowlist_entries: Vec<TemporaryAllowlistEntry>,
     daily_goal: DailyGoalConfig,
     weekly_goal: WeeklyGoalConfig,
     monthly_goal: MonthlyGoalConfig,
@@ -924,6 +930,7 @@ impl App {
             strict_mode,
             break_glass_duration_secs,
             break_glass_expires_at: None,
+            temporary_allowlist_entries: Vec::new(),
             daily_goal,
             weekly_goal,
             monthly_goal,
@@ -974,6 +981,7 @@ impl App {
         self.current_frame_now = now;
         self.sync_today_goal_snapshot();
         self.wakatime.poll_events();
+        self.sync_temporary_allowlist_entries(now);
         self.sync_break_glass_override();
         self.sync_weekday_profile_rules(now);
         self.sync_recurring_schedule(now);
@@ -1324,6 +1332,24 @@ impl App {
 
     pub fn effective_blocked_site_count(&self) -> usize {
         self.blocker.sites.len()
+    }
+
+    pub fn active_temporary_allowlist_entries(&self) -> Vec<ActiveTemporaryAllowlistEntry> {
+        active_temporary_allowlist_status_entries_for_profile(
+            &self.temporary_allowlist_entries,
+            self.active_blocklist_profile_name(),
+            self.current_frame_now.timestamp(),
+        )
+    }
+
+    pub fn active_temporary_allowlist_count(&self) -> usize {
+        self.active_temporary_allowlist_entries().len()
+    }
+
+    pub fn next_temporary_allowlist_expiry_remaining_secs(&self) -> Option<u64> {
+        self.active_temporary_allowlist_entries()
+            .first()
+            .map(|entry| entry.remaining_secs)
     }
 
     pub fn blocklist_profile_input_mode(&self) -> Option<BlocklistProfileInputMode> {

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -90,6 +90,13 @@ impl App {
         self.sync_cli_workflow_state()
     }
 
+    pub fn add_temporary_allowlist_for_cli(
+        &mut self,
+        input: &str,
+    ) -> Result<(usize, usize), String> {
+        self.add_temporary_allowlist_entries_for_active_profile_from_input(input)
+    }
+
     pub fn blocking_preview_for_cli(&self) -> Result<BlockingPreview, String> {
         self.compute_blocking_preview()
             .map_err(|error| format!("Failed to generate blocking preview: {error}"))
@@ -129,6 +136,10 @@ impl App {
 
     pub fn selected_profile_id(&self) -> ProfileId {
         self.selected_profile
+    }
+
+    pub fn selected_blocklist_profile_name_for_cli(&self) -> String {
+        self.active_blocklist_profile_name().to_string()
     }
 
     pub fn selected_task_label_for_cli(&self) -> Option<String> {

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -4,7 +4,12 @@ use crate::app::{
     blocking_backend_config_for_persistence, format_duration_label, occurrence_key, profile_index,
     profile_spec_for, task_label_index,
 };
-use crate::session_recovery::{self, InProgressSessionSnapshot, WorkflowStateSnapshot};
+use crate::session_recovery::{
+    self, InProgressSessionSnapshot, WorkflowStateSnapshot, WorkflowTemporaryAllowlistEntrySnapshot,
+};
+use crate::temporary_allowlist::{
+    TemporaryAllowlistEntry, prune_expired_temporary_allowlist_entries,
+};
 use chrono::{LocalResult, TimeZone};
 use std::time::Instant;
 
@@ -69,6 +74,7 @@ impl App {
             break_glass_expires_at_epoch_secs,
             break_glass_confirmation_pending,
             strict_reset_confirmation_pending,
+            temporary_allowlist_entries,
         } = snapshot;
 
         self.reset_cli_workflow_runtime_state_for_restore();
@@ -93,6 +99,11 @@ impl App {
             break_glass_confirmation_pending,
             &mut ignored_runtime_artifacts,
         );
+        self.restore_temporary_allowlist_runtime_state(
+            temporary_allowlist_entries,
+            &mut ignored_runtime_artifacts,
+        );
+        self.recompute_blocker_sites_from_active_profile();
         self.restore_strict_reset_runtime_state(
             strict_reset_confirmation_pending,
             &mut ignored_runtime_artifacts,
@@ -124,6 +135,7 @@ impl App {
         self.last_schedule_occurrence_key = None;
         self.pending_timer_action = None;
         self.break_glass_expires_at = None;
+        self.temporary_allowlist_entries.clear();
     }
 
     fn restore_schedule_delay_runtime_state(
@@ -221,6 +233,35 @@ impl App {
             self.pending_timer_action = Some(PendingTimerAction::Reset);
         } else {
             push_ignored_artifact(ignored_runtime_artifacts, "strict reset confirmation");
+        }
+    }
+
+    fn restore_temporary_allowlist_runtime_state(
+        &mut self,
+        temporary_allowlist_entries: Vec<WorkflowTemporaryAllowlistEntrySnapshot>,
+        ignored_runtime_artifacts: &mut Vec<&'static str>,
+    ) {
+        let mut restored = Vec::new();
+        let mut ignored_count = 0usize;
+        for entry in temporary_allowlist_entries {
+            let profile = entry.profile.trim().to_string();
+            let site = entry.site.trim().to_string();
+            if profile.is_empty()
+                || site.is_empty()
+                || entry.expires_at_epoch_secs <= self.current_frame_now.timestamp()
+            {
+                ignored_count += 1;
+                continue;
+            }
+            restored.push(TemporaryAllowlistEntry {
+                profile,
+                site,
+                expires_at_epoch_secs: entry.expires_at_epoch_secs,
+            });
+        }
+        self.temporary_allowlist_entries = restored;
+        if ignored_count > 0 {
+            push_ignored_artifact(ignored_runtime_artifacts, "temporary allowlist entries");
         }
     }
 
@@ -358,6 +399,10 @@ impl App {
 
     pub(super) fn sync_cli_workflow_state(&mut self) -> Result<(), String> {
         let now = Local::now();
+        prune_expired_temporary_allowlist_entries(
+            &mut self.temporary_allowlist_entries,
+            now.timestamp(),
+        );
         let focus_active = self.focus_session_active_for_current_state();
         let active_occurrence_key = self
             .active_schedule_occurrence_at(now)
@@ -382,6 +427,20 @@ impl App {
             self.break_glass_confirmation_pending() && focus_active;
         let strict_reset_confirmation_pending =
             self.strict_reset_confirmation_pending() && self.strict_mode_enforced_for_focus();
+        let temporary_allowlist_entries = self
+            .temporary_allowlist_entries
+            .iter()
+            .filter(|entry| {
+                !entry.profile.trim().is_empty()
+                    && !entry.site.trim().is_empty()
+                    && entry.expires_at_epoch_secs > now.timestamp()
+            })
+            .map(|entry| WorkflowTemporaryAllowlistEntrySnapshot {
+                profile: entry.profile.clone(),
+                site: entry.site.clone(),
+                expires_at_epoch_secs: entry.expires_at_epoch_secs,
+            })
+            .collect::<Vec<_>>();
         let schedule_armed_occurrence_key = if !focus_active {
             self.schedule_armed_occurrence_key
                 .clone()
@@ -411,6 +470,7 @@ impl App {
             break_glass_expires_at_epoch_secs,
             break_glass_confirmation_pending,
             strict_reset_confirmation_pending,
+            temporary_allowlist_entries,
         };
 
         let should_persist = snapshot.schedule_delayed_occurrence_key.is_some()
@@ -418,7 +478,8 @@ impl App {
             || snapshot.last_schedule_occurrence_key.is_some()
             || snapshot.break_glass_expires_at_epoch_secs.is_some()
             || snapshot.break_glass_confirmation_pending
-            || snapshot.strict_reset_confirmation_pending;
+            || snapshot.strict_reset_confirmation_pending
+            || !snapshot.temporary_allowlist_entries.is_empty();
         if should_persist {
             session_recovery::save_workflow_state(&snapshot)
                 .map_err(|error| format!("workflow state save failed: {error}"))

--- a/src/app/site_manager.rs
+++ b/src/app/site_manager.rs
@@ -216,6 +216,17 @@ impl App {
     fn commit_site_input(&mut self) {
         let input = self.site_input.clone();
         let mode = self.site_list_mode;
+        if self.site_edit_index.is_none()
+            && mode == SiteListMode::Allowlist
+            && temporary_allowlist_syntax_used(&input)
+        {
+            let committed = self.apply_temporary_allowlist_add_input(&input);
+            if committed {
+                self.cancel_site_input();
+            }
+            return;
+        }
+
         let mut working = SiteBlocker::new();
         for site in self.active_profile_sites_for_mode(mode).iter().cloned() {
             working.add_site(site);
@@ -237,6 +248,37 @@ impl App {
 
         if committed {
             self.cancel_site_input();
+        }
+    }
+
+    fn apply_temporary_allowlist_add_input(&mut self, input: &str) -> bool {
+        match self.add_temporary_allowlist_entries_for_active_profile_from_input(input) {
+            Ok((added, refreshed)) => {
+                let mut parts = Vec::new();
+                if added > 0 {
+                    parts.push(format!(
+                        "Added {}",
+                        format_count(added, "temporary exception", "temporary exceptions")
+                    ));
+                }
+                if refreshed > 0 {
+                    parts.push(format!(
+                        "Refreshed {}",
+                        format_count(refreshed, "existing exception", "existing exceptions")
+                    ));
+                }
+                let message = if parts.is_empty() {
+                    "No temporary allowlist changes applied".to_string()
+                } else {
+                    parts.join(" • ")
+                };
+                self.set_site_feedback(SiteFeedbackLevel::Success, message);
+                added > 0 || refreshed > 0
+            }
+            Err(error) => {
+                self.set_site_feedback(SiteFeedbackLevel::Warning, error);
+                false
+            }
         }
     }
 
@@ -549,7 +591,12 @@ impl App {
         self.clamp_blocklist_profile_selection();
         self.blocker.sites.clear();
         if let Some(active_profile) = self.blocklist_profiles.get(self.active_blocklist_profile) {
+            let temporary_allowlist =
+                self.active_temporary_allowlist_site_set_for_profile(&active_profile.name);
             for site in effective_blocked_sites_for_profile(active_profile) {
+                if temporary_allowlist.contains(&site.to_ascii_lowercase()) {
+                    continue;
+                }
                 self.blocker.add_site(site);
             }
         }
@@ -593,4 +640,11 @@ impl App {
     pub(super) fn should_resync_blocking_after_site_mutation(&self) -> bool {
         self.should_block_for_current_state() || self.blocker.is_blocking
     }
+}
+
+fn temporary_allowlist_syntax_used(input: &str) -> bool {
+    input
+        .split([',', '\n', '\r'])
+        .map(str::trim)
+        .any(|token| !token.is_empty() && token.contains('='))
 }

--- a/src/app/temporary_allowlist.rs
+++ b/src/app/temporary_allowlist.rs
@@ -44,7 +44,7 @@ impl App {
     ) -> Result<(usize, usize), String> {
         let specs = parse_temporary_allowlist_specs(input)?;
         self.current_frame_now = Local::now();
-        prune_expired_temporary_allowlist_entries(
+        let pruned = prune_expired_temporary_allowlist_entries(
             &mut self.temporary_allowlist_entries,
             self.current_frame_now.timestamp(),
         );
@@ -56,7 +56,7 @@ impl App {
             &specs,
             self.current_frame_now.timestamp(),
         );
-        if added == 0 && refreshed == 0 {
+        if added == 0 && refreshed == 0 && pruned == 0 {
             return Ok((0, 0));
         }
 

--- a/src/app/temporary_allowlist.rs
+++ b/src/app/temporary_allowlist.rs
@@ -1,0 +1,84 @@
+use std::collections::HashSet;
+
+use crate::app::{App, Local};
+use crate::temporary_allowlist::{
+    active_temporary_allowlist_sites_for_profile, parse_temporary_allowlist_specs,
+    prune_expired_temporary_allowlist_entries, upsert_temporary_allowlist_entries,
+};
+
+impl App {
+    pub(super) fn sync_temporary_allowlist_entries(&mut self, now: chrono::DateTime<Local>) {
+        let expired_count = prune_expired_temporary_allowlist_entries(
+            &mut self.temporary_allowlist_entries,
+            now.timestamp(),
+        );
+        if expired_count == 0 {
+            return;
+        }
+
+        self.recompute_blocker_sites_from_active_profile();
+        self.apply_blocking_for_phase();
+        self.append_temporary_allowlist_expiry_notice(expired_count);
+        if let Err(error) = self.sync_cli_workflow_state() {
+            self.config_error = Some(error);
+        }
+    }
+
+    pub(super) fn active_temporary_allowlist_site_set_for_profile(
+        &self,
+        profile_name: &str,
+    ) -> HashSet<String> {
+        active_temporary_allowlist_sites_for_profile(
+            &self.temporary_allowlist_entries,
+            profile_name,
+            self.current_frame_now.timestamp(),
+        )
+        .into_iter()
+        .map(|site| site.to_ascii_lowercase())
+        .collect()
+    }
+
+    pub(super) fn add_temporary_allowlist_entries_for_active_profile_from_input(
+        &mut self,
+        input: &str,
+    ) -> Result<(usize, usize), String> {
+        let specs = parse_temporary_allowlist_specs(input)?;
+        self.current_frame_now = Local::now();
+        prune_expired_temporary_allowlist_entries(
+            &mut self.temporary_allowlist_entries,
+            self.current_frame_now.timestamp(),
+        );
+
+        let profile_name = self.active_blocklist_profile_name().to_string();
+        let (added, refreshed) = upsert_temporary_allowlist_entries(
+            &mut self.temporary_allowlist_entries,
+            &profile_name,
+            &specs,
+            self.current_frame_now.timestamp(),
+        );
+        if added == 0 && refreshed == 0 {
+            return Ok((0, 0));
+        }
+
+        self.recompute_blocker_sites_from_active_profile();
+        self.apply_blocking_for_phase();
+        if let Err(error) = self.sync_cli_workflow_state() {
+            self.config_error = Some(error);
+        }
+        Ok((added, refreshed))
+    }
+
+    fn append_temporary_allowlist_expiry_notice(&mut self, expired_count: usize) {
+        let notice = if expired_count == 1 {
+            "1 temporary allowlist entry expired.".to_string()
+        } else {
+            format!("{expired_count} temporary allowlist entries expired.")
+        };
+        if let Some(existing) = self.phase_notification.as_mut() {
+            existing.push(' ');
+            existing.push_str(&notice);
+        } else {
+            self.phase_notification = Some(notice);
+        }
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4869,6 +4869,7 @@ fn app_restores_cli_workflow_state_from_snapshot() {
         break_glass_expires_at_epoch_secs: None,
         break_glass_confirmation_pending: true,
         strict_reset_confirmation_pending: false,
+        temporary_allowlist_entries: Vec::new(),
     }));
 
     let app = App::default();
@@ -4912,6 +4913,7 @@ fn app_restores_schedule_arming_continuity_from_workflow_snapshot() {
         break_glass_expires_at_epoch_secs: None,
         break_glass_confirmation_pending: false,
         strict_reset_confirmation_pending: false,
+        temporary_allowlist_entries: Vec::new(),
     }));
 
     let app = App::from_config(config);
@@ -4943,6 +4945,7 @@ fn app_restores_strict_reset_confirmation_from_workflow_snapshot() {
         break_glass_expires_at_epoch_secs: None,
         break_glass_confirmation_pending: false,
         strict_reset_confirmation_pending: true,
+        temporary_allowlist_entries: Vec::new(),
     }));
 
     let app = App::from_config(AppConfig {
@@ -4965,6 +4968,7 @@ fn app_reports_partial_runtime_recovery_notice_for_ignored_workflow_artifacts() 
         break_glass_expires_at_epoch_secs: None,
         break_glass_confirmation_pending: true,
         strict_reset_confirmation_pending: true,
+        temporary_allowlist_entries: Vec::new(),
     }));
 
     let app = App::default();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,8 +54,8 @@ use output::{
     print_session_template_command_output, print_site_add_command_output,
     print_site_delete_command_output, print_site_edit_command_output,
     print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
-    print_weekday_rules_command_output,
+    print_task_goal_command_output, print_temporary_site_add_command_output,
+    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
 };
 use parsing::{
     finalize_cli_action, invalid_usage, parse_automation_triggers_value, parse_global_tokens,
@@ -123,6 +123,7 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --allowlist-sites [--json]
   focustime --blocklist-site-add=HOSTNAMES [--json]
   focustime --allowlist-site-add=HOSTNAMES [--json]
+  focustime --allowlist-site-add-temporary=HOST_DURATIONS [--json]
   focustime --blocklist-site-edit=OLD=NEW [--json]
   focustime --allowlist-site-edit=OLD=NEW [--json]
   focustime --blocklist-site-delete=HOSTNAME [--json]
@@ -175,6 +176,7 @@ Options:
   --allowlist-sites           List allowlist sites in active profile
   --blocklist-site-add        Add/import blocklist hostnames in active profile
   --allowlist-site-add        Add/import allowlist hostnames in active profile
+  --allowlist-site-add-temporary  Add temporary allowlist hostnames with inline duration (HOST=30m,HOST=45s)
   --blocklist-site-edit       Replace blocklist hostname using OLD=NEW
   --allowlist-site-edit       Replace allowlist hostname using OLD=NEW
   --blocklist-site-delete     Delete blocklist hostname in active profile
@@ -315,6 +317,9 @@ pub enum CommandKind {
         target: SiteListTarget,
         command: BlocklistSiteCommandKind,
     },
+    AllowlistSiteAddTemporary {
+        input: String,
+    },
     SessionTemplate {
         command: SessionTemplateCommandKind,
     },
@@ -384,6 +389,7 @@ enum PrimaryCommand {
     AllowlistSites,
     BlocklistSiteAdd(String),
     AllowlistSiteAdd(String),
+    AllowlistSiteAddTemporary(String),
     BlocklistSiteEdit(SiteEditValue),
     AllowlistSiteEdit(SiteEditValue),
     BlocklistSiteDelete(String),
@@ -444,6 +450,7 @@ enum ParsedToken {
     AllowlistSites,
     BlocklistSiteAdd(String),
     AllowlistSiteAdd(String),
+    AllowlistSiteAddTemporary(String),
     BlocklistSiteEdit(SiteEditValue),
     AllowlistSiteEdit(SiteEditValue),
     BlocklistSiteDelete(String),
@@ -602,6 +609,13 @@ struct LiveStatusOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TemporaryAllowlistStatusOutput {
+    site: String,
+    remaining_secs: u64,
+    expires_at_epoch_secs: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct StatusOutput {
     day: String,
     selected_profile: ProfileView,
@@ -613,6 +627,8 @@ struct StatusOutput {
     task_note: Option<String>,
     selected_blocklist_profile: String,
     blocked_sites_count: usize,
+    temporary_allowlist_active_count: usize,
+    temporary_allowlist_active: Vec<TemporaryAllowlistStatusOutput>,
     strict_mode: bool,
     goal: GoalOutput,
     weekly_goal: GoalOutput,
@@ -867,6 +883,16 @@ struct SiteAddCommandOutput {
     invalid: Vec<InvalidSiteEntryOutput>,
     sites: Vec<String>,
     effective_blocked_sites_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TemporarySiteAddCommandOutput {
+    action: &'static str,
+    updated: bool,
+    profile: String,
+    added: usize,
+    refreshed: usize,
+    active: Vec<TemporaryAllowlistStatusOutput>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -55,7 +55,7 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 33] = [
+    let parsers: [(&str, ValueArgParser); 34] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
         ("--focus-intention", classify_focus_intention_arg),
@@ -103,6 +103,10 @@ fn classify_value_arg(
         ),
         ("--blocklist-site-add", classify_blocklist_site_add_arg),
         ("--allowlist-site-add", classify_allowlist_site_add_arg),
+        (
+            "--allowlist-site-add-temporary",
+            classify_allowlist_site_add_temporary_arg,
+        ),
         ("--blocklist-site-edit", classify_blocklist_site_edit_arg),
         ("--allowlist-site-edit", classify_allowlist_site_edit_arg),
         (
@@ -428,6 +432,24 @@ fn classify_allowlist_site_add_arg(
     ))
 }
 
+fn classify_allowlist_site_add_temporary_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value = require_nonempty_key_value(
+            next,
+            "`--allowlist-site-add-temporary` requires HOST=30m style input.",
+        )?;
+        return Ok((ParsedToken::AllowlistSiteAddTemporary(value.to_string()), 2));
+    }
+    Err(invalid_usage(
+        "`--allowlist-site-add-temporary` requires HOST=30m style input. Use `--allowlist-site-add-temporary=HOST_DURATIONS` or `--allowlist-site-add-temporary HOST_DURATIONS`.",
+    ))
+}
+
 fn classify_blocklist_site_edit_arg(
     args: &[String],
     index: usize,
@@ -630,7 +652,7 @@ fn classify_automation_triggers_set_arg(
 }
 
 pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 33] = [
+    let parsers: [KeyValueParser; 34] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
         parse_focus_intention_key_value_arg,
@@ -660,6 +682,7 @@ pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, S
         parse_session_template_rename_key_value_arg,
         parse_blocklist_site_add_key_value_arg,
         parse_allowlist_site_add_key_value_arg,
+        parse_allowlist_site_add_temporary_key_value_arg,
         parse_blocklist_site_edit_key_value_arg,
         parse_allowlist_site_edit_key_value_arg,
         parse_blocklist_site_delete_key_value_arg,
@@ -964,6 +987,21 @@ fn parse_allowlist_site_add_key_value_arg(arg: &str) -> Result<Option<ParsedToke
         let value =
             require_nonempty_key_value(value, "`--allowlist-site-add=` requires hostnames input.")?;
         return Ok(Some(ParsedToken::AllowlistSiteAdd(value.to_string())));
+    }
+    Ok(None)
+}
+
+fn parse_allowlist_site_add_temporary_key_value_arg(
+    arg: &str,
+) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--allowlist-site-add-temporary=") {
+        let value = require_nonempty_key_value(
+            value,
+            "`--allowlist-site-add-temporary=` requires HOST=30m style input.",
+        )?;
+        return Ok(Some(ParsedToken::AllowlistSiteAddTemporary(
+            value.to_string(),
+        )));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -24,9 +24,9 @@ use crate::cli::{
     SessionTemplateSummaryOutput, SiteAddCommandOutput, SiteBlocker, SiteDeleteCommandOutput,
     SiteEditCommandOutput, SiteEditValue, SiteListCommandOutput, SiteListTarget, StatusOutput,
     StrictCommandOutput, TaskCommandOutput, TaskGoalCommandOutput, TaskGoalOutput,
-    ThemeCommandOutput, ThemePreset, TimerCommandOutput, TimerStateOutput,
-    WeekdayProfileRuleConfig, WeekdayRulesCommandOutput, WeeklyGoalConfig,
-    available_break_template_views, available_theme_preset_views,
+    TemporaryAllowlistStatusOutput, TemporarySiteAddCommandOutput, ThemeCommandOutput, ThemePreset,
+    TimerCommandOutput, TimerStateOutput, WeekdayProfileRuleConfig, WeekdayRulesCommandOutput,
+    WeeklyGoalConfig, available_break_template_views, available_theme_preset_views,
     build_blocking_preview_command_output, build_diagnostics_command_output,
     build_schedule_inspection_output, build_status_output, build_task_goal_output,
     display_input_value, effective_blocked_sites_for_profile, flush_stdout,
@@ -39,9 +39,10 @@ use crate::cli::{
     print_session_template_command_output, print_site_add_command_output,
     print_site_delete_command_output, print_site_edit_command_output,
     print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_theme_command_output, print_timer_state_output,
-    print_weekday_rules_command_output, profile_id, profile_view, selected_break_template_view,
-    theme_preset_view, timer_phase_id, timer_status_id,
+    print_task_goal_command_output, print_temporary_site_add_command_output,
+    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
+    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
+    timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
@@ -106,6 +107,9 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         }
         CommandKind::BlocklistSites { target, command } => {
             execute_blocklist_sites_command(target, command, cli_command.output)
+        }
+        CommandKind::AllowlistSiteAddTemporary { input } => {
+            execute_allowlist_site_add_temporary_command(input, cli_command.output)
         }
         CommandKind::SessionTemplate { command } => {
             execute_session_template_command(command, cli_command.output)
@@ -320,6 +324,35 @@ fn execute_blocklist_sites_command(
                 OutputMode::Json => print_json(&payload)?,
             }
         }
+    }
+    Ok(())
+}
+
+fn execute_allowlist_site_add_temporary_command(
+    input: String,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut app = App::new();
+    let (added, refreshed) = app.add_temporary_allowlist_for_cli(&input)?;
+    let payload = TemporarySiteAddCommandOutput {
+        action: "allowlist-site-add-temporary",
+        updated: added > 0 || refreshed > 0,
+        profile: app.selected_blocklist_profile_name_for_cli(),
+        added,
+        refreshed,
+        active: app
+            .active_temporary_allowlist_entries()
+            .into_iter()
+            .map(|entry| TemporaryAllowlistStatusOutput {
+                site: entry.site,
+                remaining_secs: entry.remaining_secs,
+                expires_at_epoch_secs: entry.expires_at_epoch_secs,
+            })
+            .collect(),
+    };
+    match output {
+        OutputMode::Text => print_temporary_site_add_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
     }
     Ok(())
 }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -10,8 +10,9 @@ use crate::cli::{
     SetupCheckLevel, SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput,
     SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput, StatsGrowthSummary,
     StatsRetentionStatusOutput, StatusOutput, StrictCommandOutput, TaskGoalCommandOutput,
-    TaskGoalOutput, ThemeCommandOutput, TimerStateOutput, WeekdayRulesCommandOutput, Write,
-    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    TaskGoalOutput, TemporarySiteAddCommandOutput, ThemeCommandOutput, TimerStateOutput,
+    WeekdayRulesCommandOutput, Write, format_schedule_conflict,
+    inspect_schedule_conflicts_from_config, io,
 };
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
@@ -191,6 +192,32 @@ pub(super) fn print_site_add_command_output(payload: &SiteAddCommandOutput) {
     );
 }
 
+pub(super) fn print_temporary_site_add_command_output(payload: &TemporarySiteAddCommandOutput) {
+    if payload.updated {
+        println!(
+            "Temporary allowlist updated in profile `{}`: added {}, refreshed {}.",
+            payload.profile, payload.added, payload.refreshed
+        );
+    } else {
+        println!(
+            "No temporary allowlist changes were applied in profile `{}`.",
+            payload.profile
+        );
+    }
+    if payload.active.is_empty() {
+        println!("Active temporary exceptions: none");
+        return;
+    }
+    println!("Active temporary exceptions ({}):", payload.active.len());
+    for entry in &payload.active {
+        println!(
+            "  - {} (expires in {})",
+            entry.site,
+            format_duration(entry.remaining_secs)
+        );
+    }
+}
+
 pub(super) fn print_site_edit_command_output(payload: &SiteEditCommandOutput) {
     if payload.updated {
         println!(
@@ -287,6 +314,17 @@ pub(super) fn print_status_output(payload: &StatusOutput) {
         "Blocklist profile: {} ({} sites)",
         payload.selected_blocklist_profile, payload.blocked_sites_count
     );
+    println!(
+        "Temporary allowlist active: {}",
+        payload.temporary_allowlist_active_count
+    );
+    for entry in &payload.temporary_allowlist_active {
+        println!(
+            "  - {} (expires in {})",
+            entry.site,
+            format_duration(entry.remaining_secs)
+        );
+    }
     println!(
         "Strict mode: {}",
         if payload.strict_mode { "on" } else { "off" }

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -74,6 +74,7 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::AllowlistSites
             | ParsedToken::BlocklistSiteAdd(_)
             | ParsedToken::AllowlistSiteAdd(_)
+            | ParsedToken::AllowlistSiteAddTemporary(_)
             | ParsedToken::BlocklistSiteEdit(_)
             | ParsedToken::AllowlistSiteEdit(_)
             | ParsedToken::BlocklistSiteDelete(_)
@@ -226,6 +227,10 @@ pub(super) fn parse_primary_command(
             ParsedToken::AllowlistSiteAdd(input) => set_primary_command(
                 &mut primary,
                 PrimaryCommand::AllowlistSiteAdd(input.clone()),
+            )?,
+            ParsedToken::AllowlistSiteAddTemporary(input) => set_primary_command(
+                &mut primary,
+                PrimaryCommand::AllowlistSiteAddTemporary(input.clone()),
             )?,
             ParsedToken::BlocklistSiteEdit(value) => set_primary_command(
                 &mut primary,
@@ -503,6 +508,12 @@ pub(super) fn finalize_cli_action(
             },
             output,
         })),
+        Some(PrimaryCommand::AllowlistSiteAddTemporary(input)) => {
+            Ok(CliAction::RunCommand(CliCommand {
+                kind: CommandKind::AllowlistSiteAddTemporary { input },
+                output,
+            }))
+        }
         Some(PrimaryCommand::BlocklistSiteEdit(value)) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::BlocklistSites {
                 target: SiteListTarget::Blocklist,
@@ -906,6 +917,7 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::AllowlistSites => "--allowlist-sites",
         PrimaryCommand::BlocklistSiteAdd(_) => "--blocklist-site-add",
         PrimaryCommand::AllowlistSiteAdd(_) => "--allowlist-site-add",
+        PrimaryCommand::AllowlistSiteAddTemporary(_) => "--allowlist-site-add-temporary",
         PrimaryCommand::BlocklistSiteEdit(_) => "--blocklist-site-edit",
         PrimaryCommand::AllowlistSiteEdit(_) => "--allowlist-site-edit",
         PrimaryCommand::BlocklistSiteDelete(_) => "--blocklist-site-delete",

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -3,9 +3,9 @@ use crate::cli::{
     DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS, DEFAULT_SHORT_BREAK_SECS,
     DailyGoalSnapshot, Datelike, FocusScoreOutput, FocusStats, GoalOutput, LiveStatusOutput,
     NaiveDate, ProfileId, ProfileSpec, ProfileView, SessionOutput, StatsRetentionStatusOutput,
-    StatusOutput, TaskGoalOutput, ThemePreset, ThemePresetView, TimerPhase, TimerStatus,
-    TodayOutput, carry_over_goal_target, current_day_key, effective_blocked_sites_for_profile,
-    session_recovery,
+    StatusOutput, TaskGoalOutput, TemporaryAllowlistStatusOutput, ThemePreset, ThemePresetView,
+    TimerPhase, TimerStatus, TodayOutput, carry_over_goal_target, current_day_key,
+    effective_blocked_sites_for_profile, session_recovery,
 };
 use crate::timer::TimerState;
 
@@ -36,6 +36,8 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
         .map(|profile| effective_blocked_sites_for_profile(profile).len())
         .unwrap_or_default();
     let selected_automation = config.profile_automation_for(config.selected_profile);
+    let temporary_allowlist_active = active_temporary_allowlist_status(config);
+    let temporary_allowlist_active_count = temporary_allowlist_active.len();
     let live = build_live_status_output(config, selected_task_label.clone());
     let session = build_session_output(&live);
     let latest_interruption = stats.latest_session_interruption();
@@ -69,6 +71,8 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
         task_note,
         selected_blocklist_profile: config.selected_blocklist_profile.clone(),
         blocked_sites_count: active_sites_count,
+        temporary_allowlist_active_count,
+        temporary_allowlist_active,
         strict_mode: selected_automation.strict_mode,
         goal: GoalOutput {
             configured: goal_snapshot.has_any_target(),
@@ -120,6 +124,45 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
         },
         live,
     }
+}
+
+fn active_temporary_allowlist_status(config: &AppConfig) -> Vec<TemporaryAllowlistStatusOutput> {
+    let now_epoch_secs = chrono::Local::now().timestamp();
+    let selected_profile = config.selected_blocklist_profile.trim();
+    if selected_profile.is_empty() {
+        return Vec::new();
+    }
+    let Ok(Some(workflow_state)) = session_recovery::load_workflow_state() else {
+        return Vec::new();
+    };
+
+    let mut active = workflow_state
+        .temporary_allowlist_entries
+        .into_iter()
+        .filter(|entry| entry.profile.eq_ignore_ascii_case(selected_profile))
+        .filter(|entry| entry.expires_at_epoch_secs > now_epoch_secs)
+        .filter_map(|entry| {
+            let site = entry.site.trim().to_string();
+            if site.is_empty() {
+                return None;
+            }
+            Some(TemporaryAllowlistStatusOutput {
+                site,
+                remaining_secs: (entry.expires_at_epoch_secs - now_epoch_secs) as u64,
+                expires_at_epoch_secs: entry.expires_at_epoch_secs,
+            })
+        })
+        .collect::<Vec<_>>();
+    active.sort_by(|left, right| {
+        left.remaining_secs
+            .cmp(&right.remaining_secs)
+            .then_with(|| {
+                left.site
+                    .to_ascii_lowercase()
+                    .cmp(&right.site.to_ascii_lowercase())
+            })
+    });
+    active
 }
 
 fn build_session_output(live: &LiveStatusOutput) -> SessionOutput {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2,6 +2,7 @@ use crate::cli::*;
 use crate::config::{AutomationTriggerActionConfig, AutomationTriggerConditionConfig};
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
+    WorkflowStateSnapshot, WorkflowTemporaryAllowlistEntrySnapshot,
 };
 use chrono::{Datelike, Duration};
 #[cfg(unix)]
@@ -1024,6 +1025,20 @@ fn parse_blocklist_site_add_with_equals() {
                 command: BlocklistSiteCommandKind::Add {
                     input: "github.com,news.ycombinator.com".to_string()
                 }
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_allowlist_site_add_temporary_with_equals() {
+    let parsed = parse(&["--allowlist-site-add-temporary=reddit.com=30m,docs.rs=45s"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::AllowlistSiteAddTemporary {
+                input: "reddit.com=30m,docs.rs=45s".to_string()
             },
             output: OutputMode::Text
         })
@@ -2074,6 +2089,43 @@ fn build_status_output_excludes_allowlist_from_blocked_sites_count() {
     let output = build_status_output(&config, &stats);
 
     assert_eq!(output.blocked_sites_count, 1);
+}
+
+#[test]
+fn build_status_output_includes_active_temporary_allowlist_entries() {
+    let now_epoch_secs = chrono::Local::now().timestamp();
+    session_recovery::set_test_load_workflow_state(Some(WorkflowStateSnapshot {
+        temporary_allowlist_entries: vec![
+            WorkflowTemporaryAllowlistEntrySnapshot {
+                profile: "Work".to_string(),
+                site: "reddit.com".to_string(),
+                expires_at_epoch_secs: now_epoch_secs + 120,
+            },
+            WorkflowTemporaryAllowlistEntrySnapshot {
+                profile: "Work".to_string(),
+                site: "expired.com".to_string(),
+                expires_at_epoch_secs: now_epoch_secs - 1,
+            },
+            WorkflowTemporaryAllowlistEntrySnapshot {
+                profile: "Personal".to_string(),
+                site: "youtube.com".to_string(),
+                expires_at_epoch_secs: now_epoch_secs + 120,
+            },
+        ],
+        ..WorkflowStateSnapshot::default()
+    }));
+
+    let config = AppConfig {
+        selected_blocklist_profile: "Work".to_string(),
+        ..AppConfig::default()
+    };
+    let output = build_status_output(&config, &FocusStats::default());
+    session_recovery::set_test_load_workflow_state(None);
+
+    assert_eq!(output.temporary_allowlist_active_count, 1);
+    assert_eq!(output.temporary_allowlist_active[0].site, "reddit.com");
+    assert!(output.temporary_allowlist_active[0].remaining_secs <= 120);
+    assert!(output.temporary_allowlist_active[0].remaining_secs > 0);
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod schedule;
 mod session_recovery;
 mod stats;
 mod task_labels;
+mod temporary_allowlist;
 mod timer;
 mod ui;
 mod wakatime;

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -110,6 +110,18 @@ pub struct WorkflowStateSnapshot {
     pub break_glass_confirmation_pending: bool,
     #[serde(default)]
     pub strict_reset_confirmation_pending: bool,
+    #[serde(default)]
+    pub temporary_allowlist_entries: Vec<WorkflowTemporaryAllowlistEntrySnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct WorkflowTemporaryAllowlistEntrySnapshot {
+    #[serde(default)]
+    pub profile: String,
+    #[serde(default)]
+    pub site: String,
+    #[serde(default)]
+    pub expires_at_epoch_secs: i64,
 }
 
 impl InProgressSessionSnapshot {
@@ -705,6 +717,7 @@ selected_profile = "classic"
             break_glass_expires_at_epoch_secs: None,
             break_glass_confirmation_pending: true,
             strict_reset_confirmation_pending: false,
+            temporary_allowlist_entries: Vec::new(),
         })
         .expect("save should succeed");
 

--- a/src/temporary_allowlist.rs
+++ b/src/temporary_allowlist.rs
@@ -1,0 +1,338 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::blocker::SiteBlocker;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TemporaryAllowlistEntry {
+    #[serde(default)]
+    pub profile: String,
+    #[serde(default)]
+    pub site: String,
+    #[serde(default)]
+    pub expires_at_epoch_secs: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedTemporaryAllowlistSpec {
+    pub site: String,
+    pub duration_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ActiveTemporaryAllowlistEntry {
+    pub site: String,
+    pub remaining_secs: u64,
+    pub expires_at_epoch_secs: i64,
+}
+
+pub fn parse_temporary_allowlist_specs(
+    input: &str,
+) -> Result<Vec<ParsedTemporaryAllowlistSpec>, String> {
+    let mut parsed: Vec<ParsedTemporaryAllowlistSpec> = Vec::new();
+    let mut site_index_by_key: HashMap<String, usize> = HashMap::new();
+
+    for raw_token in input.split([',', '\n', '\r']) {
+        let token = raw_token.trim();
+        if token.is_empty() {
+            continue;
+        }
+        let (site_token, duration_token) = token.rsplit_once('=').ok_or_else(|| {
+            format!(
+                "Invalid temporary allowlist entry `{}`. Use `HOST=30m` format.",
+                display_input_value(token)
+            )
+        })?;
+        let site = normalize_single_site(site_token)?;
+        let duration_secs = parse_duration_secs(duration_token).map_err(|reason| {
+            format!(
+                "Invalid duration in `{}` ({reason}).",
+                display_input_value(token)
+            )
+        })?;
+
+        let key = site.to_ascii_lowercase();
+        if let Some(index) = site_index_by_key.get(&key).copied() {
+            parsed[index].duration_secs = duration_secs;
+        } else {
+            site_index_by_key.insert(key, parsed.len());
+            parsed.push(ParsedTemporaryAllowlistSpec {
+                site,
+                duration_secs,
+            });
+        }
+    }
+
+    if parsed.is_empty() {
+        return Err(
+            "No temporary allowlist entries were provided. Use `HOST=30m` tokens.".to_string(),
+        );
+    }
+
+    Ok(parsed)
+}
+
+pub fn prune_expired_temporary_allowlist_entries(
+    entries: &mut Vec<TemporaryAllowlistEntry>,
+    now_epoch_secs: i64,
+) -> usize {
+    let original_len = entries.len();
+    entries.retain(|entry| {
+        !entry.profile.trim().is_empty()
+            && !entry.site.trim().is_empty()
+            && entry.expires_at_epoch_secs > now_epoch_secs
+    });
+    original_len.saturating_sub(entries.len())
+}
+
+pub fn upsert_temporary_allowlist_entries(
+    entries: &mut Vec<TemporaryAllowlistEntry>,
+    profile: &str,
+    specs: &[ParsedTemporaryAllowlistSpec],
+    now_epoch_secs: i64,
+) -> (usize, usize) {
+    let profile = profile.trim();
+    if profile.is_empty() || specs.is_empty() {
+        return (0, 0);
+    }
+
+    let mut added = 0usize;
+    let mut refreshed = 0usize;
+    for spec in specs {
+        let expires_at_epoch_secs = now_epoch_secs
+            .saturating_add(i64::try_from(spec.duration_secs).unwrap_or(i64::MAX).max(1));
+
+        if let Some(existing) = entries.iter_mut().find(|entry| {
+            entry.profile.eq_ignore_ascii_case(profile)
+                && entry.site.eq_ignore_ascii_case(&spec.site)
+        }) {
+            existing.profile = profile.to_string();
+            existing.site = spec.site.clone();
+            if existing.expires_at_epoch_secs != expires_at_epoch_secs {
+                existing.expires_at_epoch_secs = expires_at_epoch_secs;
+                refreshed += 1;
+            }
+            continue;
+        }
+
+        entries.push(TemporaryAllowlistEntry {
+            profile: profile.to_string(),
+            site: spec.site.clone(),
+            expires_at_epoch_secs,
+        });
+        added += 1;
+    }
+
+    entries.sort_by(|left, right| {
+        left.profile
+            .to_ascii_lowercase()
+            .cmp(&right.profile.to_ascii_lowercase())
+            .then(
+                left.site
+                    .to_ascii_lowercase()
+                    .cmp(&right.site.to_ascii_lowercase()),
+            )
+            .then(left.expires_at_epoch_secs.cmp(&right.expires_at_epoch_secs))
+    });
+
+    (added, refreshed)
+}
+
+pub fn active_temporary_allowlist_sites_for_profile(
+    entries: &[TemporaryAllowlistEntry],
+    profile: &str,
+    now_epoch_secs: i64,
+) -> Vec<String> {
+    active_temporary_allowlist_status_entries_for_profile(entries, profile, now_epoch_secs)
+        .into_iter()
+        .map(|entry| entry.site)
+        .collect()
+}
+
+pub fn active_temporary_allowlist_status_entries_for_profile(
+    entries: &[TemporaryAllowlistEntry],
+    profile: &str,
+    now_epoch_secs: i64,
+) -> Vec<ActiveTemporaryAllowlistEntry> {
+    let mut latest_by_site: HashMap<String, ActiveTemporaryAllowlistEntry> = HashMap::new();
+
+    for entry in entries {
+        let profile_name = entry.profile.trim();
+        let site = entry.site.trim();
+        if profile_name.is_empty()
+            || site.is_empty()
+            || entry.expires_at_epoch_secs <= now_epoch_secs
+            || !profile_name.eq_ignore_ascii_case(profile)
+        {
+            continue;
+        }
+
+        let remaining_secs = (entry.expires_at_epoch_secs - now_epoch_secs) as u64;
+        let key = site.to_ascii_lowercase();
+        match latest_by_site.get(&key) {
+            Some(existing) if existing.expires_at_epoch_secs >= entry.expires_at_epoch_secs => {}
+            _ => {
+                latest_by_site.insert(
+                    key,
+                    ActiveTemporaryAllowlistEntry {
+                        site: site.to_string(),
+                        remaining_secs,
+                        expires_at_epoch_secs: entry.expires_at_epoch_secs,
+                    },
+                );
+            }
+        }
+    }
+
+    let mut active = latest_by_site.into_values().collect::<Vec<_>>();
+    active.sort_by(|left, right| {
+        left.remaining_secs.cmp(&right.remaining_secs).then(
+            left.site
+                .to_ascii_lowercase()
+                .cmp(&right.site.to_ascii_lowercase()),
+        )
+    });
+    active
+}
+
+fn normalize_single_site(input: &str) -> Result<String, String> {
+    let mut blocker = SiteBlocker::new();
+    let result = blocker.add_sites_from_input(input);
+    if let Some(invalid) = result.invalid.first() {
+        return Err(format!(
+            "Invalid hostname `{}` ({})",
+            display_input_value(&invalid.input),
+            invalid.reason.message()
+        ));
+    }
+    if let Some(site) = result.added.first() {
+        return Ok(site.clone());
+    }
+    Err(format!("Invalid hostname `{}`", display_input_value(input)))
+}
+
+fn parse_duration_secs(input: &str) -> Result<u64, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("duration is empty".to_string());
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let (number_part, multiplier) = match lower.chars().last() {
+        Some('s') => (&lower[..lower.len() - 1], 1u64),
+        Some('m') => (&lower[..lower.len() - 1], 60u64),
+        Some('h') => (&lower[..lower.len() - 1], 60u64 * 60),
+        Some('d') => (&lower[..lower.len() - 1], 60u64 * 60 * 24),
+        Some(last) if last.is_ascii_digit() => (lower.as_str(), 1u64),
+        _ => {
+            return Err(
+                "unsupported unit; use seconds (`s`), minutes (`m`), hours (`h`), or days (`d`)"
+                    .to_string(),
+            );
+        }
+    };
+
+    if number_part.trim().is_empty() {
+        return Err("duration value is missing".to_string());
+    }
+
+    let value = number_part
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| "duration must be a whole number".to_string())?;
+    if value == 0 {
+        return Err("duration must be greater than 0".to_string());
+    }
+    value
+        .checked_mul(multiplier)
+        .ok_or_else(|| "duration is too large".to_string())
+}
+
+fn display_input_value(input: &str) -> String {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        "<empty>".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_temporary_allowlist_specs_accepts_inline_durations() {
+        let parsed = parse_temporary_allowlist_specs("reddit.com=30m, youtube.com=45s").unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].site, "reddit.com");
+        assert_eq!(parsed[0].duration_secs, 1800);
+        assert_eq!(parsed[1].site, "youtube.com");
+        assert_eq!(parsed[1].duration_secs, 45);
+    }
+
+    #[test]
+    fn parse_temporary_allowlist_specs_rejects_missing_duration() {
+        let error = parse_temporary_allowlist_specs("reddit.com").unwrap_err();
+        assert!(error.contains("HOST=30m"));
+    }
+
+    #[test]
+    fn active_temporary_allowlist_status_entries_filter_by_profile_and_expiry() {
+        let entries = vec![
+            TemporaryAllowlistEntry {
+                profile: "Work".to_string(),
+                site: "reddit.com".to_string(),
+                expires_at_epoch_secs: 200,
+            },
+            TemporaryAllowlistEntry {
+                profile: "work".to_string(),
+                site: "news.ycombinator.com".to_string(),
+                expires_at_epoch_secs: 150,
+            },
+            TemporaryAllowlistEntry {
+                profile: "Study".to_string(),
+                site: "x.com".to_string(),
+                expires_at_epoch_secs: 200,
+            },
+            TemporaryAllowlistEntry {
+                profile: "Work".to_string(),
+                site: "expired.com".to_string(),
+                expires_at_epoch_secs: 50,
+            },
+        ];
+
+        let active = active_temporary_allowlist_status_entries_for_profile(&entries, "WORK", 100);
+        assert_eq!(active.len(), 2);
+        assert_eq!(active[0].site, "news.ycombinator.com");
+        assert_eq!(active[0].remaining_secs, 50);
+        assert_eq!(active[1].site, "reddit.com");
+        assert_eq!(active[1].remaining_secs, 100);
+    }
+
+    #[test]
+    fn upsert_temporary_allowlist_entries_adds_and_refreshes_entries() {
+        let mut entries = vec![TemporaryAllowlistEntry {
+            profile: "Work".to_string(),
+            site: "reddit.com".to_string(),
+            expires_at_epoch_secs: 100,
+        }];
+        let specs = vec![
+            ParsedTemporaryAllowlistSpec {
+                site: "reddit.com".to_string(),
+                duration_secs: 120,
+            },
+            ParsedTemporaryAllowlistSpec {
+                site: "youtube.com".to_string(),
+                duration_secs: 60,
+            },
+        ];
+
+        let (added, refreshed) =
+            upsert_temporary_allowlist_entries(&mut entries, "Work", &specs, 1000);
+        assert_eq!(added, 1);
+        assert_eq!(refreshed, 1);
+        assert_eq!(entries.len(), 2);
+    }
+}

--- a/src/ui/site_manager.rs
+++ b/src/ui/site_manager.rs
@@ -163,7 +163,7 @@ fn site_manager_copy_for_mode(app: &App, site_list_mode: SiteListMode) -> (Strin
                 app.shortcut_hint(ShortcutAction::SiteAdd)
             ),
             format!(
-                "Press {} to add/import allowlist exceptions or {} to edit selected",
+                "Press {} to add allowlist exceptions (HOST=30m for temporary) or {} to edit selected",
                 app.shortcut_hint(ShortcutAction::SiteAdd),
                 app.shortcut_hint(ShortcutAction::SiteEdit)
             ),
@@ -226,7 +226,7 @@ fn render_site_manager_input(
     let input_title = match input_mode {
         SiteInputMode::Add => match site_list_mode {
             SiteListMode::Blocklist => " Add / Import Blocklist Sites ",
-            SiteListMode::Allowlist => " Add / Import Allowlist Sites ",
+            SiteListMode::Allowlist => " Add Allowlist Sites / Temporary Exceptions ",
         },
         SiteInputMode::Edit => match site_list_mode {
             SiteListMode::Blocklist => " Edit Blocklist Site ",
@@ -356,7 +356,7 @@ fn site_manager_hint_lines(
             }),
             Line::from(match input_mode {
                 SiteInputMode::Add => format!(
-                    "Tip: paste comma/newline hostnames, then press {}",
+                    "Tip: comma/newline entries. In Allowlist mode, use HOST=30m for temporary exceptions, then press {}",
                     app.navigation_hint(NavigationAction::Confirm)
                 ),
                 SiteInputMode::Edit => format!(

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -367,7 +367,7 @@ fn timer_status_text_shows_active_break_glass_state() {
         crossterm::event::KeyModifiers::NONE,
     ));
 
-    let (_, _, break_glass_status) = timer_status_text(&app);
+    let (_, _, break_glass_status, _) = timer_status_text(&app);
     assert!(break_glass_status.contains("Break-glass: active"));
 }
 

--- a/src/ui/timer.rs
+++ b/src/ui/timer.rs
@@ -123,7 +123,8 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let (status_text, strict_status_text, break_glass_status_text) = timer_status_text(app);
+    let (status_text, strict_status_text, break_glass_status_text, temporary_allowlist_status_text) =
+        timer_status_text(app);
     let profile_line = format!(
         "🗂  Profile: {} ({})",
         app.selected_profile_name(),
@@ -167,7 +168,9 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
     let goal_text = readable_goal_streak_text(&format_timer_goal_streak_line(app));
     let (waka_text, waka_color) = wakatime_status_line(app);
     let (schedule_next_text, schedule_status_text) = app.recurring_schedule_display_texts();
-    let strict_and_break_glass = format!("{strict_status_text} · {break_glass_status_text}");
+    let strict_and_break_glass = format!(
+        "{strict_status_text} · {break_glass_status_text} · {temporary_allowlist_status_text}"
+    );
 
     let mut lines = vec![
         Line::styled(task_text, task_style),
@@ -214,7 +217,7 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
 
-pub(super) fn timer_status_text(app: &App) -> (String, String, String) {
+pub(super) fn timer_status_text(app: &App) -> (String, String, String, String) {
     let status_text = match app.timer.status {
         TimerStatus::Running => "📍 Status: ▶ Running".to_string(),
         TimerStatus::Paused => "📍 Status: ⏸ Paused".to_string(),
@@ -245,7 +248,22 @@ pub(super) fn timer_status_text(app: &App) -> (String, String, String) {
     } else {
         "🚨 Break-glass: off".to_string()
     };
-    (status_text, strict_text, break_glass_text)
+    let temporary_allowlist_text =
+        if let Some(next_expiry_secs) = app.next_temporary_allowlist_expiry_remaining_secs() {
+            format!(
+                "⏳ Temp allowlist: {} active (next {})",
+                app.active_temporary_allowlist_count(),
+                format_duration_label(next_expiry_secs)
+            )
+        } else {
+            "⏳ Temp allowlist: off".to_string()
+        };
+    (
+        status_text,
+        strict_text,
+        break_glass_text,
+        temporary_allowlist_text,
+    )
 }
 
 fn render_timer_phase_notice(frame: &mut Frame, app: &App, area: Rect) {

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -189,6 +189,8 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload.get("goal").is_some());
     assert!(payload.get("weekly_goal").is_some());
     assert!(payload.get("monthly_goal").is_some());
+    assert!(payload.get("temporary_allowlist_active_count").is_some());
+    assert!(payload.get("temporary_allowlist_active").is_some());
     assert!(payload["goal"].get("carry_over").is_some());
     assert!(payload["weekly_goal"].get("carry_over").is_some());
     assert!(payload["monthly_goal"].get("carry_over").is_some());
@@ -205,6 +207,30 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload.get("live").is_some());
     assert!(payload["live"].get("focus_intention").is_some());
     assert!(payload["live"].get("task_note").is_some());
+}
+
+#[test]
+fn temporary_allowlist_add_json_is_reflected_in_status_json() {
+    let env = TestEnv::new("temporary-allowlist-json");
+
+    let add_output = env.run(&["--allowlist-site-add-temporary=reddit.com=120s", "--json"]);
+    assert_eq!(add_output.status.code(), Some(0));
+    assert!(stderr_text(&add_output).trim().is_empty());
+    let add_payload: Value = serde_json::from_slice(&add_output.stdout).expect("stdout JSON");
+    assert_eq!(add_payload["action"], "allowlist-site-add-temporary");
+    assert_eq!(add_payload["updated"], true);
+    assert_eq!(add_payload["added"], 1);
+    assert_eq!(add_payload["active"][0]["site"], "reddit.com");
+
+    let status_output = env.run(&["--status", "--json"]);
+    assert_eq!(status_output.status.code(), Some(0));
+    assert!(stderr_text(&status_output).trim().is_empty());
+    let status_payload: Value = serde_json::from_slice(&status_output.stdout).expect("stdout JSON");
+    assert_eq!(status_payload["temporary_allowlist_active_count"], 1);
+    assert_eq!(
+        status_payload["temporary_allowlist_active"][0]["site"],
+        "reddit.com"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Add temporary allowlist exceptions with inline per-host durations (for both CLI and TUI), auto-expire them at runtime, and surface active temporary exceptions in status views.

## Why

Issue #317 requests a way to temporarily allow specific sites without permanently changing policy, with automatic expiry and visibility so behavior is predictable during focus sessions.

Closes #317.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --allowlist-site-add-temporary CLI flag to temporarily allowlist sites with durations (e.g., HOST=30m)
  * CLI site-add reports added/refreshed counts and lists active temporary exceptions
  * Status output (text & JSON) now shows active temporary allowlist entries with remaining expiry times; entries persist and expire automatically

* **Documentation**
  * Updated CLI docs with examples for temporary allowlist usage

* **UI Improvements**
  * Timer display shows temporary allowlist status and next expiry countdown

* **Tests**
  * Added coverage for parsing, CLI flag, and status JSON behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->