### PR TITLE
Blocklist categories and wildcard domain rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Blocklist categories and wildcard domain rules (#318):** added per-profile blocklist category management across CLI and TUI, plus wildcard subdomain rule support (`*.example.com`) in blocklist/allowlist matching with consistent effective-blocking computation.
+
 ## [0.11.1] - 2026-05-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ cargo run -- --blocklist-profile-create Study
 cargo run -- --blocklist-profile-rename "Deep Work"
 cargo run -- --blocklist-profile-delete --json
 
+# Manage categories within the active blocklist profile
+cargo run -- --blocklist-category
+cargo run -- --blocklist-category Social
+cargo run -- --blocklist-category-create "Work Chat"
+cargo run -- --blocklist-category-rename "Deep Focus"
+cargo run -- --blocklist-category-delete --json
+
 # Manage session templates (task/profile/blocklist/schedule bundles)
 cargo run -- --session-template
 cargo run -- --session-template "Deep Flow"
@@ -163,7 +170,8 @@ cargo run -- --session-template-delete --json
 # Manage blocklist/allowlist sites for the active blocklist profile
 cargo run -- --blocklist-sites
 cargo run -- --allowlist-sites --json
-cargo run -- --blocklist-site-add="youtube.com, reddit.com"
+cargo run -- --blocklist-category Social
+cargo run -- --blocklist-site-add="youtube.com, *.facebook.com"
 cargo run -- --allowlist-site-add "reddit.com"
 cargo run -- --allowlist-site-add-temporary "reddit.com=30m,news.ycombinator.com=10m"
 cargo run -- --blocklist-site-edit "youtube.com=news.ycombinator.com"
@@ -394,6 +402,10 @@ CLI parity is available via `--focus-intention`, `--task-note`, `--schedule-dela
 `--weekday-rules*`, `--session-template*`, `--break-glass-trigger`, and `--break-glass-cancel` for
 non-interactive inspection and in-session workflow control.
 
+Blocklist rules support exact hosts and wildcard subdomain rules. `*.example.com`
+matches `docs.example.com` and `api.example.com`, but does **not** match
+`example.com`.
+
 ### Example config
 
 ```toml
@@ -438,11 +450,24 @@ long_break_interval = 3
 
 [[blocklist_profiles]]
 name = "Work"
-sites = ["youtube.com", "reddit.com"]
+selected_category = "Social"
+
+[[blocklist_profiles.categories]]
+name = "Social"
+sites = ["youtube.com", "*.facebook.com", "reddit.com"]
 allowlist_sites = ["reddit.com"]
+
+[[blocklist_profiles.categories]]
+name = "News"
+sites = ["news.ycombinator.com"]
+allowlist_sites = []
 
 [[blocklist_profiles]]
 name = "Study"
+selected_category = "General"
+
+[[blocklist_profiles.categories]]
+name = "General"
 sites = ["x.com", "news.ycombinator.com"]
 allowlist_sites = []
 
@@ -559,9 +584,13 @@ Open the site manager from timer view with **`b`**.
 - `d` or `Delete`: remove the selected hostname
 - `m`: toggle between editing blocklist sites and allowlist exceptions
 - `[` / `]`: switch active blocklist profile
+- `←` / `→`: switch active category in the current profile
 - `n`: create a blocklist profile
 - `r`: rename the active blocklist profile
 - `x`: delete the active blocklist profile
+- `Ctrl+n`: create a blocklist category
+- `Ctrl+r`: rename the active blocklist category
+- `Ctrl+x`: delete the active blocklist category
 - `↑/↓` (default `navigate_up`/`navigate_down`): move selection
 - `b`: return to timer view
 - `Esc` (default `cancel`): return to timer view only when add/edit mode is not active
@@ -569,13 +598,16 @@ Open the site manager from timer view with **`b`**.
 Add/import input supports:
 
 - single hostnames (`youtube.com`)
+- wildcard subdomain rules (`*.example.com`; subdomains only)
 - comma-separated lists (`youtube.com, reddit.com`)
 - newline-separated lists (paste multi-line blocklists, then press `Enter`)
 - while add/import or edit mode is active, `Enter` (default `confirm`) commits and `Esc` (default `cancel`) cancels the current draft
 
 Invalid and duplicate entries are reported inline so you can fix them without leaving the view.
 
-Allowlist entries act as explicit exceptions: effective focus blocking is computed as **blocklist sites minus allowlist sites** for the active profile.
+Allowlist entries act as explicit exceptions: effective focus blocking is computed as
+**blocklist sites minus allowlist sites** for the active profile, using exact and
+wildcard rule matching.
 
 For hosts-based blocking to apply reliably, keep DNS-over-HTTPS disabled in your browser.
 If you configure the command backend, ensure your custom commands enforce equivalent restrictions.

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,14 +9,15 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crate::blocker::{
     BlockingBackendKind, BlockingBackendPolicy, BlockingIntent, BlockingPreview,
     BlockingPreviewAction, BulkAddResult, CommandBlockingBackend, EditSiteResult,
-    HostsFileDiagnostics, InvalidSiteInput, SiteBlocker,
+    HostsFileDiagnostics, InvalidSiteInput, SiteBlocker, domain_rule_matches_host,
+    normalize_domain_rule,
 };
 use crate::config::{
     AppConfig, AutoStartConfig, AutomationTriggerRuleConfig, BlockingBackendConfig,
-    BlockingBackendPolicyConfig, BlocklistProfileConfig, BreakTemplateConfig,
-    CommandBlockingBackendConfig, CustomProfileConfig, DailyGoalConfig, FeatureFlagsConfig,
-    GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig, OneTimeFocusWindowConfig,
-    ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
+    BlockingBackendPolicyConfig, BlocklistCategoryConfig, BlocklistProfileConfig,
+    BreakTemplateConfig, CommandBlockingBackendConfig, CustomProfileConfig, DailyGoalConfig,
+    FeatureFlagsConfig, GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig,
+    OneTimeFocusWindowConfig, ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
     RecurringFocusWindowConfig, RecurringScheduleConfig, ScheduleRuntimeConfig,
     SessionTemplateConfig, StatsRetentionConfig, ThemePreset, WakatimeMetadataConfig,
     WakatimeRuntimeConfig, WeekdayProfileRuleConfig, WeeklyGoalConfig,
@@ -173,6 +174,7 @@ const PROFILE_EDIT_AUTOMATION_TRIGGER_ADD_REMOVE_INDEX: usize = 51;
 const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
+const DEFAULT_BLOCKLIST_CATEGORY_NAME: &str = "General";
 const UNLINKED_BREAK_TEMPLATE_NAME: &str = "Custom";
 #[cfg(not(test))]
 const STATS_FILE_NAME: &str = "stats.toml";
@@ -250,6 +252,13 @@ fn blocklist_profile_index(profiles: &[BlocklistProfileConfig], selected_name: &
     profiles
         .iter()
         .position(|profile| profile.name.eq_ignore_ascii_case(selected_name))
+        .unwrap_or(0)
+}
+
+fn blocklist_category_index(categories: &[BlocklistCategoryConfig], selected_name: &str) -> usize {
+    categories
+        .iter()
+        .position(|category| category.name.eq_ignore_ascii_case(selected_name))
         .unwrap_or(0)
 }
 
@@ -434,6 +443,8 @@ impl SiteListMode {
 pub enum BlocklistProfileInputMode {
     Create,
     Rename,
+    CreateCategory,
+    RenameCategory,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1371,6 +1382,42 @@ impl App {
         self.blocklist_profiles.len()
     }
 
+    pub fn active_blocklist_category_name(&self) -> &str {
+        let Some(profile) = self.blocklist_profiles.get(self.active_blocklist_profile) else {
+            return DEFAULT_BLOCKLIST_CATEGORY_NAME;
+        };
+        if profile.categories.is_empty() {
+            if profile.selected_category.trim().is_empty() {
+                return DEFAULT_BLOCKLIST_CATEGORY_NAME;
+            }
+            return profile.selected_category.as_str();
+        }
+        let index = blocklist_category_index(&profile.categories, &profile.selected_category)
+            .min(profile.categories.len().saturating_sub(1));
+        profile
+            .categories
+            .get(index)
+            .map(|category| category.name.as_str())
+            .unwrap_or(DEFAULT_BLOCKLIST_CATEGORY_NAME)
+    }
+
+    pub fn active_blocklist_category_position(&self) -> usize {
+        let Some(profile) = self.blocklist_profiles.get(self.active_blocklist_profile) else {
+            return 1;
+        };
+        if profile.categories.is_empty() {
+            return 1;
+        }
+        blocklist_category_index(&profile.categories, &profile.selected_category).saturating_add(1)
+    }
+
+    pub fn blocklist_category_count(&self) -> usize {
+        self.blocklist_profiles
+            .get(self.active_blocklist_profile)
+            .map(|profile| profile.categories.len().max(1))
+            .unwrap_or(1)
+    }
+
     pub fn active_break_template_name(&self) -> &str {
         self.active_break_template
             .and_then(|index| self.break_templates.get(index))
@@ -1781,16 +1828,56 @@ fn display_input_value(input: &str) -> String {
 }
 
 fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
-    let allowlist: HashSet<String> = profile
-        .allowlist_sites
+    let allowlist_rules: Vec<String> = all_allowlist_rules_for_profile(profile)
         .iter()
-        .map(|site| site.to_ascii_lowercase())
+        .filter_map(|rule| normalize_domain_rule(rule).ok())
         .collect();
-    profile
-        .sites
-        .iter()
-        .filter(|site| !allowlist.contains(&site.to_ascii_lowercase()))
-        .cloned()
+    let mut seen = HashSet::new();
+    all_blocklist_rules_for_profile(profile)
+        .into_iter()
+        .filter_map(|site| normalize_domain_rule(&site).ok())
+        .filter(|site| !site.starts_with("*."))
+        .filter(|site| {
+            !allowlist_rules
+                .iter()
+                .any(|allow_rule| domain_rule_matches_host(allow_rule, site))
+        })
+        .filter(|site| seen.insert(site.to_ascii_lowercase()))
+        .collect()
+}
+
+fn all_blocklist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+    if profile.categories.is_empty() {
+        return dedup_case_insensitive(profile.sites.iter().cloned());
+    }
+    dedup_case_insensitive(
+        profile
+            .categories
+            .iter()
+            .flat_map(|category| category.sites.iter().cloned()),
+    )
+}
+
+fn all_allowlist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+    if profile.categories.is_empty() {
+        return dedup_case_insensitive(profile.allowlist_sites.iter().cloned());
+    }
+    dedup_case_insensitive(
+        profile
+            .categories
+            .iter()
+            .flat_map(|category| category.allowlist_sites.iter().cloned()),
+    )
+}
+
+fn dedup_case_insensitive<I>(values: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut seen = HashSet::new();
+    values
+        .into_iter()
+        .filter(|value| seen.insert(value.to_ascii_lowercase()))
         .collect()
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1836,14 +1836,20 @@ fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<
     all_blocklist_rules_for_profile(profile)
         .into_iter()
         .filter_map(|site| normalize_domain_rule(&site).ok())
-        .filter(|site| !site.starts_with("*."))
-        .filter(|site| {
-            !allowlist_rules
-                .iter()
-                .any(|allow_rule| domain_rule_matches_host(allow_rule, site))
-        })
+        .filter(|site| !block_rule_excluded_by_allowlist(site, &allowlist_rules))
         .filter(|site| seen.insert(site.to_ascii_lowercase()))
         .collect()
+}
+
+fn block_rule_excluded_by_allowlist(block_rule: &str, allowlist_rules: &[String]) -> bool {
+    if block_rule.starts_with("*.") {
+        return allowlist_rules
+            .iter()
+            .any(|allow_rule| allow_rule.eq_ignore_ascii_case(block_rule));
+    }
+    allowlist_rules
+        .iter()
+        .any(|allow_rule| domain_rule_matches_host(allow_rule, block_rule))
 }
 
 fn all_blocklist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -1,6 +1,6 @@
 use crate::app::{
-    App, AppConfig, BlocklistProfileConfig, DEFAULT_BLOCKLIST_PROFILE_NAME, Local,
-    PendingTimerAction, TimerPhase, TimerState, TimerStatus,
+    App, AppConfig, BlocklistCategoryConfig, BlocklistProfileConfig,
+    DEFAULT_BLOCKLIST_PROFILE_NAME, Local, PendingTimerAction, TimerPhase, TimerState, TimerStatus,
     blocking_backend_config_for_persistence, format_duration_label, occurrence_key, profile_index,
     profile_spec_for, task_label_index,
 };
@@ -494,11 +494,21 @@ impl App {
     pub(super) fn persisted_config(&self) -> AppConfig {
         let custom_profile = self.custom_profile.normalized();
         let mut blocklist_profiles = self.blocklist_profiles.clone();
+        for profile in &mut blocklist_profiles {
+            ensure_profile_categories_for_persistence(profile);
+            sync_profile_site_mirrors_for_persistence(profile);
+        }
         if blocklist_profiles.is_empty() {
             blocklist_profiles.push(BlocklistProfileConfig {
                 name: DEFAULT_BLOCKLIST_PROFILE_NAME.to_string(),
                 sites: self.blocker.sites.clone(),
                 allowlist_sites: Vec::new(),
+                categories: vec![BlocklistCategoryConfig {
+                    name: "General".to_string(),
+                    sites: self.blocker.sites.clone(),
+                    allowlist_sites: Vec::new(),
+                }],
+                selected_category: "General".to_string(),
             });
         }
         let active_index = self
@@ -607,6 +617,59 @@ impl App {
             self.stats_has_unsaved_elapsed = false;
         }
     }
+}
+
+fn ensure_profile_categories_for_persistence(profile: &mut BlocklistProfileConfig) {
+    if profile.categories.is_empty() {
+        profile.categories.push(BlocklistCategoryConfig {
+            name: "General".to_string(),
+            sites: profile.sites.clone(),
+            allowlist_sites: profile.allowlist_sites.clone(),
+        });
+    }
+    let selected = profile.selected_category.trim().to_string();
+    if selected.is_empty() {
+        if let Some(first) = profile.categories.first() {
+            profile.selected_category = first.name.clone();
+        } else {
+            profile.selected_category = "General".to_string();
+        }
+    } else if let Some(category) = profile
+        .categories
+        .iter()
+        .find(|category| category.name.eq_ignore_ascii_case(&selected))
+    {
+        profile.selected_category = category.name.clone();
+    } else if let Some(first) = profile.categories.first() {
+        profile.selected_category = first.name.clone();
+    } else {
+        profile.selected_category = "General".to_string();
+    }
+}
+
+fn sync_profile_site_mirrors_for_persistence(profile: &mut BlocklistProfileConfig) {
+    let mut sites: Vec<String> = Vec::new();
+    let mut allowlist_sites: Vec<String> = Vec::new();
+    for category in &profile.categories {
+        for site in &category.sites {
+            if !sites
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(site))
+            {
+                sites.push(site.clone());
+            }
+        }
+        for site in &category.allowlist_sites {
+            if !allowlist_sites
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(site))
+            {
+                allowlist_sites.push(site.clone());
+            }
+        }
+    }
+    profile.sites = sites;
+    profile.allowlist_sites = allowlist_sites;
 }
 
 fn local_datetime_from_epoch_secs(epoch_secs: i64) -> Option<chrono::DateTime<Local>> {

--- a/src/app/site_manager.rs
+++ b/src/app/site_manager.rs
@@ -343,161 +343,142 @@ impl App {
             return;
         }
 
-        match mode {
-            BlocklistProfileInputMode::Create => {
-                let has_duplicate = self
-                    .blocklist_profiles
-                    .iter()
-                    .any(|profile| profile.name.eq_ignore_ascii_case(&name));
-                if has_duplicate {
-                    self.set_site_feedback(
-                        SiteFeedbackLevel::Warning,
-                        format!("Profile `{name}` already exists"),
-                    );
-                    return;
-                }
-                self.blocklist_profiles.push(BlocklistProfileConfig {
-                    name: name.clone(),
-                    sites: Vec::new(),
-                    allowlist_sites: Vec::new(),
-                    categories: Vec::new(),
-                    selected_category: default_blocklist_category_name(),
-                });
-                self.active_blocklist_profile = self.blocklist_profiles.len().saturating_sub(1);
-                self.recompute_blocker_sites_from_active_profile();
-                self.clamp_selection();
-                self.cancel_blocklist_profile_input();
-                self.save_config();
-                self.sync_blocking_after_site_mutation();
-                self.set_site_feedback(
-                    SiteFeedbackLevel::Success,
-                    format!("Created profile `{name}`"),
-                );
-            }
-            BlocklistProfileInputMode::Rename => {
-                let old_name = self.active_blocklist_profile_name().to_string();
-                if old_name == name {
-                    self.set_site_feedback(
-                        SiteFeedbackLevel::Warning,
-                        format!("No change for profile `{name}`"),
-                    );
-                    return;
-                }
-                let has_duplicate =
-                    self.blocklist_profiles
-                        .iter()
-                        .enumerate()
-                        .any(|(index, profile)| {
-                            index != self.active_blocklist_profile
-                                && profile.name.eq_ignore_ascii_case(&name)
-                        });
-                if has_duplicate {
-                    self.set_site_feedback(
-                        SiteFeedbackLevel::Warning,
-                        format!("Profile `{name}` already exists"),
-                    );
-                    return;
-                }
-                if let Some(profile) = self
-                    .blocklist_profiles
-                    .get_mut(self.active_blocklist_profile)
-                {
-                    profile.name = name.clone();
-                }
-                self.cancel_blocklist_profile_input();
-                self.save_config();
-                self.set_site_feedback(
-                    SiteFeedbackLevel::Success,
-                    format!("Renamed profile `{old_name}` -> `{name}`"),
-                );
-            }
-            BlocklistProfileInputMode::CreateCategory => {
-                let Some(profile) = self
-                    .blocklist_profiles
-                    .get_mut(self.active_blocklist_profile)
-                else {
-                    return;
-                };
-                ensure_profile_categories(profile);
-                let has_duplicate = profile
-                    .categories
-                    .iter()
-                    .any(|category| category.name.eq_ignore_ascii_case(&name));
-                if has_duplicate {
-                    self.set_site_feedback(
-                        SiteFeedbackLevel::Warning,
-                        format!("Category `{name}` already exists"),
-                    );
-                    return;
-                }
-                profile.categories.push(BlocklistCategoryConfig {
-                    name: name.clone(),
-                    sites: Vec::new(),
-                    allowlist_sites: Vec::new(),
-                });
-                profile.selected_category = name.clone();
-                sync_profile_site_mirrors(profile);
-                self.cancel_blocklist_profile_input();
-                self.clamp_selection();
-                self.save_config();
-                self.set_site_feedback(
-                    SiteFeedbackLevel::Success,
-                    format!("Created category `{name}`"),
-                );
-            }
-            BlocklistProfileInputMode::RenameCategory => {
-                let Some(profile) = self
-                    .blocklist_profiles
-                    .get_mut(self.active_blocklist_profile)
-                else {
-                    return;
-                };
-                ensure_profile_categories(profile);
-                let index =
-                    blocklist_category_index(&profile.categories, &profile.selected_category)
-                        .min(profile.categories.len().saturating_sub(1));
-                let Some(current) = profile
-                    .categories
-                    .get(index)
-                    .map(|category| category.name.clone())
-                else {
-                    return;
-                };
-                if current.eq_ignore_ascii_case(&name) {
-                    self.set_site_feedback(
-                        SiteFeedbackLevel::Warning,
-                        format!("No change for category `{current}`"),
-                    );
-                    return;
-                }
-                let has_duplicate =
-                    profile
-                        .categories
-                        .iter()
-                        .enumerate()
-                        .any(|(candidate_index, category)| {
-                            candidate_index != index && category.name.eq_ignore_ascii_case(&name)
-                        });
-                if has_duplicate {
-                    self.set_site_feedback(
-                        SiteFeedbackLevel::Warning,
-                        format!("Category `{name}` already exists"),
-                    );
-                    return;
-                }
-                if let Some(category) = profile.categories.get_mut(index) {
-                    category.name = name.clone();
-                }
-                profile.selected_category = name.clone();
-                sync_profile_site_mirrors(profile);
-                self.cancel_blocklist_profile_input();
-                self.save_config();
-                self.set_site_feedback(
-                    SiteFeedbackLevel::Success,
-                    format!("Renamed category `{current}` -> `{name}`"),
-                );
-            }
+        let outcome = match mode {
+            BlocklistProfileInputMode::Create => self.commit_create_blocklist_profile(name),
+            BlocklistProfileInputMode::Rename => self.commit_rename_blocklist_profile(name),
+            BlocklistProfileInputMode::CreateCategory => self.commit_create_blocklist_category(name),
+            BlocklistProfileInputMode::RenameCategory => self.commit_rename_blocklist_category(name),
+        };
+
+        if let Err(message) = outcome {
+            self.set_site_feedback(SiteFeedbackLevel::Warning, message);
         }
+    }
+
+    fn commit_create_blocklist_profile(&mut self, name: String) -> Result<(), String> {
+        let has_duplicate = self
+            .blocklist_profiles
+            .iter()
+            .any(|profile| profile.name.eq_ignore_ascii_case(&name));
+        if has_duplicate {
+            return Err(format!("Profile `{name}` already exists"));
+        }
+
+        self.blocklist_profiles.push(BlocklistProfileConfig {
+            name: name.clone(),
+            sites: Vec::new(),
+            allowlist_sites: Vec::new(),
+            categories: Vec::new(),
+            selected_category: default_blocklist_category_name(),
+        });
+        self.active_blocklist_profile = self.blocklist_profiles.len().saturating_sub(1);
+        self.recompute_blocker_sites_from_active_profile();
+        self.clamp_selection();
+        self.cancel_blocklist_profile_input();
+        self.save_config();
+        self.sync_blocking_after_site_mutation();
+        self.set_site_feedback(SiteFeedbackLevel::Success, format!("Created profile `{name}`"));
+        Ok(())
+    }
+
+    fn commit_rename_blocklist_profile(&mut self, name: String) -> Result<(), String> {
+        let old_name = self.active_blocklist_profile_name().to_string();
+        if old_name == name {
+            return Err(format!("No change for profile `{name}`"));
+        }
+
+        let has_duplicate = self
+            .blocklist_profiles
+            .iter()
+            .enumerate()
+            .any(|(index, profile)| {
+                index != self.active_blocklist_profile && profile.name.eq_ignore_ascii_case(&name)
+            });
+        if has_duplicate {
+            return Err(format!("Profile `{name}` already exists"));
+        }
+
+        if let Some(profile) = self.blocklist_profiles.get_mut(self.active_blocklist_profile) {
+            profile.name = name.clone();
+        }
+        self.cancel_blocklist_profile_input();
+        self.save_config();
+        self.set_site_feedback(
+            SiteFeedbackLevel::Success,
+            format!("Renamed profile `{old_name}` -> `{name}`"),
+        );
+        Ok(())
+    }
+
+    fn commit_create_blocklist_category(&mut self, name: String) -> Result<(), String> {
+        {
+            let Some(profile) = self.blocklist_profiles.get_mut(self.active_blocklist_profile) else {
+                return Ok(());
+            };
+            ensure_profile_categories(profile);
+            let has_duplicate = profile
+                .categories
+                .iter()
+                .any(|category| category.name.eq_ignore_ascii_case(&name));
+            if has_duplicate {
+                return Err(format!("Category `{name}` already exists"));
+            }
+            profile.categories.push(BlocklistCategoryConfig {
+                name: name.clone(),
+                sites: Vec::new(),
+                allowlist_sites: Vec::new(),
+            });
+            profile.selected_category = name.clone();
+            sync_profile_site_mirrors(profile);
+        }
+
+        self.cancel_blocklist_profile_input();
+        self.clamp_selection();
+        self.save_config();
+        self.set_site_feedback(SiteFeedbackLevel::Success, format!("Created category `{name}`"));
+        Ok(())
+    }
+
+    fn commit_rename_blocklist_category(&mut self, name: String) -> Result<(), String> {
+        let current_name = {
+            let Some(profile) = self.blocklist_profiles.get_mut(self.active_blocklist_profile) else {
+                return Ok(());
+            };
+            ensure_profile_categories(profile);
+            let index = blocklist_category_index(&profile.categories, &profile.selected_category)
+                .min(profile.categories.len().saturating_sub(1));
+            let Some(current) = profile.categories.get(index).map(|category| category.name.clone())
+            else {
+                return Ok(());
+            };
+            if current.eq_ignore_ascii_case(&name) {
+                return Err(format!("No change for category `{current}`"));
+            }
+            let has_duplicate = profile
+                .categories
+                .iter()
+                .enumerate()
+                .any(|(candidate_index, category)| {
+                    candidate_index != index && category.name.eq_ignore_ascii_case(&name)
+                });
+            if has_duplicate {
+                return Err(format!("Category `{name}` already exists"));
+            }
+            if let Some(category) = profile.categories.get_mut(index) {
+                category.name = name.clone();
+            }
+            profile.selected_category = name.clone();
+            sync_profile_site_mirrors(profile);
+            current
+        };
+
+        self.cancel_blocklist_profile_input();
+        self.save_config();
+        self.set_site_feedback(
+            SiteFeedbackLevel::Success,
+            format!("Renamed category `{current_name}` -> `{name}`"),
+        );
+        Ok(())
     }
 
     fn apply_bulk_add_result(&mut self, result: BulkAddResult) -> bool {

--- a/src/app/site_manager.rs
+++ b/src/app/site_manager.rs
@@ -346,8 +346,12 @@ impl App {
         let outcome = match mode {
             BlocklistProfileInputMode::Create => self.commit_create_blocklist_profile(name),
             BlocklistProfileInputMode::Rename => self.commit_rename_blocklist_profile(name),
-            BlocklistProfileInputMode::CreateCategory => self.commit_create_blocklist_category(name),
-            BlocklistProfileInputMode::RenameCategory => self.commit_rename_blocklist_category(name),
+            BlocklistProfileInputMode::CreateCategory => {
+                self.commit_create_blocklist_category(name)
+            }
+            BlocklistProfileInputMode::RenameCategory => {
+                self.commit_rename_blocklist_category(name)
+            }
         };
 
         if let Err(message) = outcome {
@@ -377,7 +381,10 @@ impl App {
         self.cancel_blocklist_profile_input();
         self.save_config();
         self.sync_blocking_after_site_mutation();
-        self.set_site_feedback(SiteFeedbackLevel::Success, format!("Created profile `{name}`"));
+        self.set_site_feedback(
+            SiteFeedbackLevel::Success,
+            format!("Created profile `{name}`"),
+        );
         Ok(())
     }
 
@@ -398,7 +405,10 @@ impl App {
             return Err(format!("Profile `{name}` already exists"));
         }
 
-        if let Some(profile) = self.blocklist_profiles.get_mut(self.active_blocklist_profile) {
+        if let Some(profile) = self
+            .blocklist_profiles
+            .get_mut(self.active_blocklist_profile)
+        {
             profile.name = name.clone();
         }
         self.cancel_blocklist_profile_input();
@@ -412,7 +422,10 @@ impl App {
 
     fn commit_create_blocklist_category(&mut self, name: String) -> Result<(), String> {
         {
-            let Some(profile) = self.blocklist_profiles.get_mut(self.active_blocklist_profile) else {
+            let Some(profile) = self
+                .blocklist_profiles
+                .get_mut(self.active_blocklist_profile)
+            else {
                 return Ok(());
             };
             ensure_profile_categories(profile);
@@ -435,32 +448,42 @@ impl App {
         self.cancel_blocklist_profile_input();
         self.clamp_selection();
         self.save_config();
-        self.set_site_feedback(SiteFeedbackLevel::Success, format!("Created category `{name}`"));
+        self.set_site_feedback(
+            SiteFeedbackLevel::Success,
+            format!("Created category `{name}`"),
+        );
         Ok(())
     }
 
     fn commit_rename_blocklist_category(&mut self, name: String) -> Result<(), String> {
         let current_name = {
-            let Some(profile) = self.blocklist_profiles.get_mut(self.active_blocklist_profile) else {
+            let Some(profile) = self
+                .blocklist_profiles
+                .get_mut(self.active_blocklist_profile)
+            else {
                 return Ok(());
             };
             ensure_profile_categories(profile);
             let index = blocklist_category_index(&profile.categories, &profile.selected_category)
                 .min(profile.categories.len().saturating_sub(1));
-            let Some(current) = profile.categories.get(index).map(|category| category.name.clone())
+            let Some(current) = profile
+                .categories
+                .get(index)
+                .map(|category| category.name.clone())
             else {
                 return Ok(());
             };
             if current.eq_ignore_ascii_case(&name) {
                 return Err(format!("No change for category `{current}`"));
             }
-            let has_duplicate = profile
-                .categories
-                .iter()
-                .enumerate()
-                .any(|(candidate_index, category)| {
-                    candidate_index != index && category.name.eq_ignore_ascii_case(&name)
-                });
+            let has_duplicate =
+                profile
+                    .categories
+                    .iter()
+                    .enumerate()
+                    .any(|(candidate_index, category)| {
+                        candidate_index != index && category.name.eq_ignore_ascii_case(&name)
+                    });
             if has_duplicate {
                 return Err(format!("Category `{name}` already exists"));
             }

--- a/src/app/site_manager.rs
+++ b/src/app/site_manager.rs
@@ -1,8 +1,9 @@
 use crate::app::{
-    App, AppMode, BlocklistProfileConfig, BlocklistProfileInputMode, BulkAddResult, EditSiteResult,
-    KeyCode, KeyEvent, KeyModifiers, NavigationAction, ShortcutAction, SiteBlocker,
-    SiteFeedbackLevel, SiteInputMode, SiteListMode, display_input_value,
-    effective_blocked_sites_for_profile, format_count, summarize_invalid_inputs,
+    App, AppMode, BlocklistCategoryConfig, BlocklistProfileConfig, BlocklistProfileInputMode,
+    BulkAddResult, EditSiteResult, KeyCode, KeyEvent, KeyModifiers, NavigationAction,
+    ShortcutAction, SiteBlocker, SiteFeedbackLevel, SiteInputMode, SiteListMode,
+    blocklist_category_index, display_input_value, effective_blocked_sites_for_profile,
+    format_count, summarize_invalid_inputs,
 };
 
 const SITE_MANAGER_SHORTCUT_ACTIONS: [ShortcutAction; 10] = [
@@ -33,6 +34,10 @@ impl App {
         }
 
         if self.handle_site_manager_navigation_key(&key) {
+            return;
+        }
+
+        if self.handle_blocklist_category_hotkey(&key) {
             return;
         }
 
@@ -111,8 +116,37 @@ impl App {
                 self.selected_site = self.selected_site.saturating_sub(1);
                 true
             }
+            _ if self.navigation_matches(NavigationAction::MoveLeft, key) => {
+                self.select_previous_blocklist_category();
+                true
+            }
+            _ if self.navigation_matches(NavigationAction::MoveRight, key) => {
+                self.select_next_blocklist_category();
+                true
+            }
             _ if self.navigation_matches(NavigationAction::Cancel, key) => {
                 self.mode = AppMode::Timer;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn handle_blocklist_category_hotkey(&mut self, key: &KeyEvent) -> bool {
+        if !key.modifiers.contains(KeyModifiers::CONTROL) {
+            return false;
+        }
+        match key.code {
+            KeyCode::Char('n') => {
+                self.start_blocklist_profile_input(BlocklistProfileInputMode::CreateCategory);
+                true
+            }
+            KeyCode::Char('r') => {
+                self.start_blocklist_profile_input(BlocklistProfileInputMode::RenameCategory);
+                true
+            }
+            KeyCode::Char('x') => {
+                self.delete_active_blocklist_category();
                 true
             }
             _ => false,
@@ -204,6 +238,12 @@ impl App {
             BlocklistProfileInputMode::Rename => {
                 self.blocklist_profile_input = self.active_blocklist_profile_name().to_string();
             }
+            BlocklistProfileInputMode::CreateCategory => {
+                self.blocklist_profile_input.clear();
+            }
+            BlocklistProfileInputMode::RenameCategory => {
+                self.blocklist_profile_input = self.active_blocklist_category_name().to_string();
+            }
         }
     }
 
@@ -236,12 +276,14 @@ impl App {
             let edit_result = working.edit_site_from_input(index, &input);
             if let Some(target_sites) = self.active_profile_sites_for_mode_mut(mode) {
                 *target_sites = working.sites.clone();
+                self.sync_active_profile_site_mirrors();
             }
             self.apply_edit_site_result(edit_result)
         } else {
             let add_result = working.add_sites_from_input(&input);
             if let Some(target_sites) = self.active_profile_sites_for_mode_mut(mode) {
                 *target_sites = working.sites.clone();
+                self.sync_active_profile_site_mirrors();
             }
             self.apply_bulk_add_result(add_result)
         };
@@ -289,33 +331,37 @@ impl App {
 
         let name = self.blocklist_profile_input.trim().to_string();
         if name.is_empty() {
-            self.set_site_feedback(SiteFeedbackLevel::Warning, "Profile name cannot be empty");
-            return;
-        }
-
-        let has_duplicate = self
-            .blocklist_profiles
-            .iter()
-            .enumerate()
-            .any(|(index, profile)| {
-                let is_current = mode == BlocklistProfileInputMode::Rename
-                    && index == self.active_blocklist_profile;
-                !is_current && profile.name.eq_ignore_ascii_case(&name)
-            });
-        if has_duplicate {
+            let label = match mode {
+                BlocklistProfileInputMode::Create | BlocklistProfileInputMode::Rename => "Profile",
+                BlocklistProfileInputMode::CreateCategory
+                | BlocklistProfileInputMode::RenameCategory => "Category",
+            };
             self.set_site_feedback(
                 SiteFeedbackLevel::Warning,
-                format!("Profile `{name}` already exists"),
+                format!("{label} name cannot be empty"),
             );
             return;
         }
 
         match mode {
             BlocklistProfileInputMode::Create => {
+                let has_duplicate = self
+                    .blocklist_profiles
+                    .iter()
+                    .any(|profile| profile.name.eq_ignore_ascii_case(&name));
+                if has_duplicate {
+                    self.set_site_feedback(
+                        SiteFeedbackLevel::Warning,
+                        format!("Profile `{name}` already exists"),
+                    );
+                    return;
+                }
                 self.blocklist_profiles.push(BlocklistProfileConfig {
                     name: name.clone(),
                     sites: Vec::new(),
                     allowlist_sites: Vec::new(),
+                    categories: Vec::new(),
+                    selected_category: default_blocklist_category_name(),
                 });
                 self.active_blocklist_profile = self.blocklist_profiles.len().saturating_sub(1);
                 self.recompute_blocker_sites_from_active_profile();
@@ -337,6 +383,21 @@ impl App {
                     );
                     return;
                 }
+                let has_duplicate =
+                    self.blocklist_profiles
+                        .iter()
+                        .enumerate()
+                        .any(|(index, profile)| {
+                            index != self.active_blocklist_profile
+                                && profile.name.eq_ignore_ascii_case(&name)
+                        });
+                if has_duplicate {
+                    self.set_site_feedback(
+                        SiteFeedbackLevel::Warning,
+                        format!("Profile `{name}` already exists"),
+                    );
+                    return;
+                }
                 if let Some(profile) = self
                     .blocklist_profiles
                     .get_mut(self.active_blocklist_profile)
@@ -348,6 +409,92 @@ impl App {
                 self.set_site_feedback(
                     SiteFeedbackLevel::Success,
                     format!("Renamed profile `{old_name}` -> `{name}`"),
+                );
+            }
+            BlocklistProfileInputMode::CreateCategory => {
+                let Some(profile) = self
+                    .blocklist_profiles
+                    .get_mut(self.active_blocklist_profile)
+                else {
+                    return;
+                };
+                ensure_profile_categories(profile);
+                let has_duplicate = profile
+                    .categories
+                    .iter()
+                    .any(|category| category.name.eq_ignore_ascii_case(&name));
+                if has_duplicate {
+                    self.set_site_feedback(
+                        SiteFeedbackLevel::Warning,
+                        format!("Category `{name}` already exists"),
+                    );
+                    return;
+                }
+                profile.categories.push(BlocklistCategoryConfig {
+                    name: name.clone(),
+                    sites: Vec::new(),
+                    allowlist_sites: Vec::new(),
+                });
+                profile.selected_category = name.clone();
+                sync_profile_site_mirrors(profile);
+                self.cancel_blocklist_profile_input();
+                self.clamp_selection();
+                self.save_config();
+                self.set_site_feedback(
+                    SiteFeedbackLevel::Success,
+                    format!("Created category `{name}`"),
+                );
+            }
+            BlocklistProfileInputMode::RenameCategory => {
+                let Some(profile) = self
+                    .blocklist_profiles
+                    .get_mut(self.active_blocklist_profile)
+                else {
+                    return;
+                };
+                ensure_profile_categories(profile);
+                let index =
+                    blocklist_category_index(&profile.categories, &profile.selected_category)
+                        .min(profile.categories.len().saturating_sub(1));
+                let Some(current) = profile
+                    .categories
+                    .get(index)
+                    .map(|category| category.name.clone())
+                else {
+                    return;
+                };
+                if current.eq_ignore_ascii_case(&name) {
+                    self.set_site_feedback(
+                        SiteFeedbackLevel::Warning,
+                        format!("No change for category `{current}`"),
+                    );
+                    return;
+                }
+                let has_duplicate =
+                    profile
+                        .categories
+                        .iter()
+                        .enumerate()
+                        .any(|(candidate_index, category)| {
+                            candidate_index != index && category.name.eq_ignore_ascii_case(&name)
+                        });
+                if has_duplicate {
+                    self.set_site_feedback(
+                        SiteFeedbackLevel::Warning,
+                        format!("Category `{name}` already exists"),
+                    );
+                    return;
+                }
+                if let Some(category) = profile.categories.get_mut(index) {
+                    category.name = name.clone();
+                }
+                profile.selected_category = name.clone();
+                sync_profile_site_mirrors(profile);
+                self.cancel_blocklist_profile_input();
+                self.save_config();
+                self.set_site_feedback(
+                    SiteFeedbackLevel::Success,
+                    format!("Renamed category `{current}` -> `{name}`"),
                 );
             }
         }
@@ -460,6 +607,7 @@ impl App {
         let removed = working.remove_site(selected_site);
         if let Some(target_sites) = self.active_profile_sites_for_mode_mut(mode) {
             *target_sites = working.sites.clone();
+            self.sync_active_profile_site_mirrors();
         }
 
         if let Some(removed) = removed {
@@ -493,6 +641,46 @@ impl App {
         self.switch_blocklist_profile(next);
     }
 
+    fn select_previous_blocklist_category(&mut self) {
+        let next = {
+            let Some(profile) = self
+                .blocklist_profiles
+                .get_mut(self.active_blocklist_profile)
+            else {
+                return;
+            };
+            ensure_profile_categories(profile);
+            if profile.categories.len() <= 1 {
+                return;
+            }
+            let current = blocklist_category_index(&profile.categories, &profile.selected_category);
+            if current == 0 {
+                profile.categories.len().saturating_sub(1)
+            } else {
+                current.saturating_sub(1)
+            }
+        };
+        self.switch_blocklist_category(next);
+    }
+
+    fn select_next_blocklist_category(&mut self) {
+        let next = {
+            let Some(profile) = self
+                .blocklist_profiles
+                .get_mut(self.active_blocklist_profile)
+            else {
+                return;
+            };
+            ensure_profile_categories(profile);
+            if profile.categories.len() <= 1 {
+                return;
+            }
+            let current = blocklist_category_index(&profile.categories, &profile.selected_category);
+            (current + 1) % profile.categories.len()
+        };
+        self.switch_blocklist_category(next);
+    }
+
     fn switch_blocklist_profile(&mut self, next_index: usize) {
         if next_index >= self.blocklist_profiles.len()
             || next_index == self.active_blocklist_profile
@@ -510,6 +698,79 @@ impl App {
             format!(
                 "Switched to profile `{}`",
                 self.active_blocklist_profile_name()
+            ),
+        );
+    }
+
+    fn switch_blocklist_category(&mut self, next_index: usize) {
+        let Some(profile) = self
+            .blocklist_profiles
+            .get_mut(self.active_blocklist_profile)
+        else {
+            return;
+        };
+        ensure_profile_categories(profile);
+        if next_index >= profile.categories.len() {
+            return;
+        }
+        let Some(next_name) = profile
+            .categories
+            .get(next_index)
+            .map(|category| category.name.clone())
+        else {
+            return;
+        };
+        if next_name.eq_ignore_ascii_case(&profile.selected_category) {
+            return;
+        }
+        profile.selected_category = next_name.clone();
+        self.recompute_blocker_sites_from_active_profile();
+        self.clamp_selection();
+        self.save_config();
+        self.sync_blocking_after_site_mutation();
+        self.set_site_feedback(
+            SiteFeedbackLevel::Success,
+            format!("Switched to category `{next_name}`"),
+        );
+    }
+
+    fn delete_active_blocklist_category(&mut self) {
+        let Some(profile) = self
+            .blocklist_profiles
+            .get_mut(self.active_blocklist_profile)
+        else {
+            return;
+        };
+        ensure_profile_categories(profile);
+        if profile.categories.len() <= 1 {
+            self.set_site_feedback(
+                SiteFeedbackLevel::Warning,
+                "At least one blocklist category is required",
+            );
+            return;
+        }
+        let index = blocklist_category_index(&profile.categories, &profile.selected_category)
+            .min(profile.categories.len().saturating_sub(1));
+        let removed = profile.categories.remove(index);
+        let next_index = index.min(profile.categories.len().saturating_sub(1));
+        if let Some(next_name) = profile
+            .categories
+            .get(next_index)
+            .map(|category| category.name.clone())
+        {
+            profile.selected_category = next_name;
+        }
+        sync_profile_site_mirrors(profile);
+        self.recompute_blocker_sites_from_active_profile();
+        self.clamp_selection();
+        self.save_config();
+        self.sync_blocking_after_site_mutation();
+        self.set_site_feedback(
+            SiteFeedbackLevel::Success,
+            format!(
+                "Deleted category `{}` (active: `{}`)",
+                removed.name,
+                self.active_blocklist_category_name()
             ),
         );
     }
@@ -561,16 +822,25 @@ impl App {
         self.active_blocklist_profile = self
             .active_blocklist_profile
             .min(self.blocklist_profiles.len().saturating_sub(1));
+        if let Some(profile) = self
+            .blocklist_profiles
+            .get_mut(self.active_blocklist_profile)
+        {
+            ensure_profile_categories(profile);
+        }
     }
 
     pub(super) fn active_profile_sites_for_mode(&self, mode: SiteListMode) -> &[String] {
         self.blocklist_profiles
             .get(self.active_blocklist_profile)
             .map(|profile| match mode {
-                SiteListMode::Blocklist => &profile.sites,
-                SiteListMode::Allowlist => &profile.allowlist_sites,
+                SiteListMode::Blocklist => active_profile_category(profile)
+                    .map(|category| category.sites.as_slice())
+                    .unwrap_or(profile.sites.as_slice()),
+                SiteListMode::Allowlist => active_profile_category(profile)
+                    .map(|category| category.allowlist_sites.as_slice())
+                    .unwrap_or(profile.allowlist_sites.as_slice()),
             })
-            .map(Vec::as_slice)
             .unwrap_or(&[])
     }
 
@@ -579,12 +849,17 @@ impl App {
         mode: SiteListMode,
     ) -> Option<&mut Vec<String>> {
         self.clamp_blocklist_profile_selection();
-        self.blocklist_profiles
-            .get_mut(self.active_blocklist_profile)
-            .map(|profile| match mode {
-                SiteListMode::Blocklist => &mut profile.sites,
-                SiteListMode::Allowlist => &mut profile.allowlist_sites,
-            })
+        let profile = self
+            .blocklist_profiles
+            .get_mut(self.active_blocklist_profile)?;
+        ensure_profile_categories(profile);
+        let index = blocklist_category_index(&profile.categories, &profile.selected_category)
+            .min(profile.categories.len().saturating_sub(1));
+        let category = profile.categories.get_mut(index)?;
+        match mode {
+            SiteListMode::Blocklist => Some(&mut category.sites),
+            SiteListMode::Allowlist => Some(&mut category.allowlist_sites),
+        }
     }
 
     pub(super) fn recompute_blocker_sites_from_active_profile(&mut self) {
@@ -619,6 +894,16 @@ impl App {
         self.sync_blocking_after_site_mutation();
     }
 
+    fn sync_active_profile_site_mirrors(&mut self) {
+        if let Some(profile) = self
+            .blocklist_profiles
+            .get_mut(self.active_blocklist_profile)
+        {
+            ensure_profile_categories(profile);
+            sync_profile_site_mirrors(profile);
+        }
+    }
+
     fn sync_blocking_after_site_mutation(&mut self) {
         if !self.should_resync_blocking_after_site_mutation() {
             return;
@@ -647,4 +932,71 @@ fn temporary_allowlist_syntax_used(input: &str) -> bool {
         .split([',', '\n', '\r'])
         .map(str::trim)
         .any(|token| !token.is_empty() && token.contains('='))
+}
+
+fn active_profile_category(profile: &BlocklistProfileConfig) -> Option<&BlocklistCategoryConfig> {
+    if profile.categories.is_empty() {
+        return None;
+    }
+    let index = blocklist_category_index(&profile.categories, &profile.selected_category)
+        .min(profile.categories.len().saturating_sub(1));
+    profile.categories.get(index)
+}
+
+fn ensure_profile_categories(profile: &mut BlocklistProfileConfig) {
+    if profile.categories.is_empty() {
+        profile.categories.push(BlocklistCategoryConfig {
+            name: default_blocklist_category_name(),
+            sites: profile.sites.clone(),
+            allowlist_sites: profile.allowlist_sites.clone(),
+        });
+    }
+
+    let selected = profile.selected_category.trim().to_string();
+    if selected.is_empty() {
+        if let Some(first) = profile.categories.first() {
+            profile.selected_category = first.name.clone();
+        } else {
+            profile.selected_category = default_blocklist_category_name();
+        }
+    } else if let Some(category) = profile
+        .categories
+        .iter()
+        .find(|category| category.name.eq_ignore_ascii_case(&selected))
+    {
+        profile.selected_category = category.name.clone();
+    } else if let Some(first) = profile.categories.first() {
+        profile.selected_category = first.name.clone();
+    } else {
+        profile.selected_category = default_blocklist_category_name();
+    }
+}
+
+fn sync_profile_site_mirrors(profile: &mut BlocklistProfileConfig) {
+    let mut sites: Vec<String> = Vec::new();
+    let mut allowlist_sites: Vec<String> = Vec::new();
+    for category in &profile.categories {
+        for site in &category.sites {
+            if !sites
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(site))
+            {
+                sites.push(site.clone());
+            }
+        }
+        for site in &category.allowlist_sites {
+            if !allowlist_sites
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(site))
+            {
+                allowlist_sites.push(site.clone());
+            }
+        }
+    }
+    profile.sites = sites;
+    profile.allowlist_sites = allowlist_sites;
+}
+
+fn default_blocklist_category_name() -> String {
+    "General".to_string()
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2351,6 +2351,23 @@ fn allowlist_excludes_sites_from_effective_blocking() {
 }
 
 #[test]
+fn wildcard_rules_are_kept_in_effective_blocking() {
+    let config = AppConfig {
+        blocklist_profiles: vec![BlocklistProfileConfig {
+            name: "Work".to_string(),
+            sites: vec!["*.example.com".to_string()],
+            allowlist_sites: Vec::new(),
+            ..BlocklistProfileConfig::default()
+        }],
+        selected_blocklist_profile: "Work".to_string(),
+        ..AppConfig::default()
+    };
+    let app = App::from_config(config);
+
+    assert_eq!(app.blocker.sites, vec!["*.example.com".to_string()]);
+}
+
+#[test]
 fn site_manager_allowlist_mode_updates_effective_blocked_sites() {
     let config = AppConfig {
         blocklist_profiles: vec![BlocklistProfileConfig {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2269,11 +2269,13 @@ fn site_manager_switches_between_blocklist_profiles() {
                 name: "Work".to_string(),
                 sites: vec!["a.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..BlocklistProfileConfig::default()
             },
             BlocklistProfileConfig {
                 name: "Study".to_string(),
                 sites: vec!["b.com".to_string(), "c.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..BlocklistProfileConfig::default()
             },
         ],
         selected_blocklist_profile: "Work".to_string(),
@@ -2302,11 +2304,13 @@ fn site_manager_allowlist_mode_clamps_selection_on_profile_switch() {
                 name: "Study".to_string(),
                 sites: vec!["study.com".to_string()],
                 allowlist_sites: vec!["allow-a.com".to_string(), "allow-b.com".to_string()],
+                ..BlocklistProfileConfig::default()
             },
             BlocklistProfileConfig {
                 name: "Work".to_string(),
                 sites: vec!["work.com".to_string(), "news.com".to_string()],
                 allowlist_sites: vec!["news.com".to_string()],
+                ..BlocklistProfileConfig::default()
             },
         ],
         selected_blocklist_profile: "Study".to_string(),
@@ -2336,6 +2340,7 @@ fn allowlist_excludes_sites_from_effective_blocking() {
             name: "Work".to_string(),
             sites: vec!["a.com".to_string(), "b.com".to_string()],
             allowlist_sites: vec!["b.com".to_string()],
+            ..BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Work".to_string(),
         ..AppConfig::default()
@@ -2352,6 +2357,7 @@ fn site_manager_allowlist_mode_updates_effective_blocked_sites() {
             name: "Default".to_string(),
             sites: vec!["a.com".to_string(), "b.com".to_string()],
             allowlist_sites: vec!["b.com".to_string()],
+            ..BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Default".to_string(),
         ..AppConfig::default()

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -122,36 +122,54 @@ fn normalize_domain_like_input(
     input: &str,
     allow_wildcard_prefix: bool,
 ) -> Result<String, SiteValidationError> {
-    let mut hostname = input.trim().to_lowercase();
+    let hostname = extract_hostname_candidate(input)?;
+    let (hostname, wildcard_prefix) = extract_wildcard_prefix(hostname, allow_wildcard_prefix)?;
+    let hostname = strip_numeric_port(hostname)?;
+    if hostname.is_empty() {
+        return Err(SiteValidationError::MissingHostname);
+    }
+    validate_domain_host(&hostname)?;
+    if wildcard_prefix && !hostname.contains('.') {
+        return Err(SiteValidationError::InvalidLabel);
+    }
+    if wildcard_prefix {
+        Ok(format!("*.{hostname}"))
+    } else {
+        Ok(hostname)
+    }
+}
 
+fn extract_hostname_candidate(input: &str) -> Result<String, SiteValidationError> {
+    let mut hostname = input.trim().to_lowercase();
     if hostname.is_empty() {
         return Err(SiteValidationError::EmptyHostname);
     }
-
-    // Strip URI scheme (e.g. "https://example.com" → "example.com").
     if let Some(sep) = hostname.find("://") {
         hostname = hostname[sep + 3..].to_string();
     }
-
-    // Remove path, query, or fragment after the hostname.
     if let Some(pos) = hostname.find(['/', '?', '#']) {
         hostname.truncate(pos);
     }
-
     if let Some(at_pos) = hostname.rfind('@') {
         hostname = hostname[at_pos + 1..].to_string();
     }
+    Ok(hostname)
+}
 
-    let mut wildcard_prefix = false;
+fn extract_wildcard_prefix(
+    hostname: String,
+    allow_wildcard_prefix: bool,
+) -> Result<(String, bool), SiteValidationError> {
     if let Some(stripped) = hostname.strip_prefix("*.") {
         if !allow_wildcard_prefix {
             return Err(SiteValidationError::InvalidCharacter);
         }
-        wildcard_prefix = true;
-        hostname = stripped.to_string();
+        return Ok((stripped.to_string(), true));
     }
+    Ok((hostname, false))
+}
 
-    // Strip a port suffix from host:port forms when the suffix is numeric.
+fn strip_numeric_port(mut hostname: String) -> Result<String, SiteValidationError> {
     if let Some(colon_pos) = hostname.rfind(':') {
         let port = &hostname[colon_pos + 1..];
         if hostname[..colon_pos].contains(':') || !port.chars().all(|c| c.is_ascii_digit()) {
@@ -159,24 +177,19 @@ fn normalize_domain_like_input(
         }
         hostname.truncate(colon_pos);
     }
+    Ok(hostname)
+}
 
-    if hostname.is_empty() {
-        return Err(SiteValidationError::MissingHostname);
-    }
-
-    // Reject anything with internal whitespace (would produce multi-hostname lines).
+fn validate_domain_host(hostname: &str) -> Result<(), SiteValidationError> {
     if hostname.chars().any(char::is_whitespace) {
         return Err(SiteValidationError::ContainsWhitespace);
     }
-
-    // Allow only ASCII letters, digits, dots, and hyphens.
     if !hostname
         .chars()
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-')
     {
         return Err(SiteValidationError::InvalidCharacter);
     }
-
     if hostname.starts_with('.')
         || hostname.ends_with('.')
         || hostname.contains("..")
@@ -184,21 +197,12 @@ fn normalize_domain_like_input(
     {
         return Err(SiteValidationError::InvalidLabel);
     }
-
     for label in hostname.split('.') {
         if label.is_empty() || label.len() > 63 || label.starts_with('-') || label.ends_with('-') {
             return Err(SiteValidationError::InvalidLabel);
         }
     }
-
-    if wildcard_prefix {
-        if !hostname.contains('.') {
-            return Err(SiteValidationError::InvalidLabel);
-        }
-        Ok(format!("*.{hostname}"))
-    } else {
-        Ok(hostname)
-    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -128,15 +128,6 @@ fn normalize_domain_like_input(
         return Err(SiteValidationError::EmptyHostname);
     }
 
-    let mut wildcard_prefix = false;
-    if let Some(stripped) = hostname.strip_prefix("*.") {
-        if !allow_wildcard_prefix {
-            return Err(SiteValidationError::InvalidCharacter);
-        }
-        wildcard_prefix = true;
-        hostname = stripped.to_string();
-    }
-
     // Strip URI scheme (e.g. "https://example.com" → "example.com").
     if let Some(sep) = hostname.find("://") {
         hostname = hostname[sep + 3..].to_string();
@@ -149,6 +140,15 @@ fn normalize_domain_like_input(
 
     if let Some(at_pos) = hostname.rfind('@') {
         hostname = hostname[at_pos + 1..].to_string();
+    }
+
+    let mut wildcard_prefix = false;
+    if let Some(stripped) = hostname.strip_prefix("*.") {
+        if !allow_wildcard_prefix {
+            return Err(SiteValidationError::InvalidCharacter);
+        }
+        wildcard_prefix = true;
+        hostname = stripped.to_string();
     }
 
     // Strip a port suffix from host:port forms when the suffix is numeric.
@@ -1453,6 +1453,14 @@ mod tests {
             "*.example.com",
             "example.com.bad"
         ));
+    }
+
+    #[test]
+    fn normalize_domain_rule_supports_wildcards_after_url_prefix_stripping() {
+        assert_eq!(
+            normalize_domain_rule("https://*.example.com/path").unwrap(),
+            "*.example.com"
+        );
     }
 
     #[test]

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -717,8 +717,18 @@ impl SiteBlocker {
     }
 
     fn apply_hosts_block_to_path(&self, hosts_path: &Path) -> io::Result<()> {
+        let hosts_sites = self.hosts_renderable_sites();
         let changed = atomic_write_hosts_to_path(hosts_path, |snapshot_content| {
-            Some(self.build_blocked_hosts_content(snapshot_content))
+            if hosts_sites.is_empty() {
+                let cleaned = Self::strip_block_section(snapshot_content);
+                if cleaned == snapshot_content {
+                    None
+                } else {
+                    Some(cleaned)
+                }
+            } else {
+                Some(self.build_blocked_hosts_content(snapshot_content, &hosts_sites))
+            }
         })?;
         if changed {
             flush_dns_cache();
@@ -806,8 +816,11 @@ impl SiteBlocker {
     ) -> BlockingPreview {
         let nl = line_ending_for(original);
         let current_section = Self::extract_block_sections(original);
+        let hosts_sites = self.hosts_renderable_sites();
         let next_section = match intent {
-            BlockingIntent::Block if !self.sites.is_empty() => Some(self.render_block_section(nl)),
+            BlockingIntent::Block if !hosts_sites.is_empty() => {
+                Some(self.render_block_section(nl, &hosts_sites))
+            }
             BlockingIntent::Block | BlockingIntent::Unblock => None,
         };
         let next_content = match next_section.as_deref() {
@@ -823,7 +836,7 @@ impl SiteBlocker {
             BlockingPreviewAction::Unblock
         };
         let effective_blocked_sites = if next_section.is_some() {
-            self.sites.clone()
+            hosts_sites
         } else {
             Vec::new()
         };
@@ -842,9 +855,9 @@ impl SiteBlocker {
         }
     }
 
-    fn build_blocked_hosts_content(&self, original: &str) -> String {
+    fn build_blocked_hosts_content(&self, original: &str, hosts_sites: &[String]) -> String {
         let nl = line_ending_for(original);
-        let section = self.render_block_section(nl);
+        let section = self.render_block_section(nl, hosts_sites);
         Self::build_hosts_content_with_section(original, &section, nl)
     }
 
@@ -860,16 +873,24 @@ impl SiteBlocker {
         content
     }
 
-    fn render_block_section(&self, nl: &str) -> String {
+    fn render_block_section(&self, nl: &str, hosts_sites: &[String]) -> String {
         let mut section = String::new();
         section.push_str(BLOCK_MARKER_START);
         section.push_str(nl);
-        for site in &self.sites {
+        for site in hosts_sites {
             append_site_entries(&mut section, site, nl);
         }
         section.push_str(BLOCK_MARKER_END);
         section.push_str(nl);
         section
+    }
+
+    fn hosts_renderable_sites(&self) -> Vec<String> {
+        self.sites
+            .iter()
+            .filter(|site| !site.starts_with("*."))
+            .cloned()
+            .collect()
     }
 
     fn extract_block_sections(content: &str) -> Option<String> {
@@ -1576,6 +1597,24 @@ mod tests {
     }
 
     #[test]
+    fn preview_block_skips_wildcard_entries_for_hosts_backend() {
+        let mut blocker = SiteBlocker::new();
+        blocker.add_site("*.example.com".to_string());
+        blocker.add_site("api.example.com".to_string());
+        let original = "127.0.0.1 localhost\n";
+
+        let preview = blocker.preview_from_hosts_content("hosts", original, BlockingIntent::Block);
+        let section = preview
+            .next_section
+            .as_deref()
+            .expect("block preview should include next section");
+
+        assert_eq!(preview.effective_blocked_sites, vec!["api.example.com"]);
+        assert!(!section.contains("*.example.com"));
+        assert!(section.contains("127.0.0.1 api.example.com"));
+    }
+
+    #[test]
     fn preview_unblock_reports_current_section_and_change() {
         let blocker = SiteBlocker::new();
         let original = "127.0.0.1 localhost\n# focustime-block-start\n127.0.0.1 example.com\n# focustime-block-end\n";
@@ -1624,7 +1663,8 @@ mod tests {
     fn preview_block_no_change_when_hosts_already_match() {
         let mut blocker = SiteBlocker::new();
         blocker.add_site("example.com".to_string());
-        let original = blocker.build_blocked_hosts_content("127.0.0.1 localhost\n");
+        let original = blocker
+            .build_blocked_hosts_content("127.0.0.1 localhost\n", &["example.com".to_string()]);
 
         let preview = blocker.preview_from_hosts_content("hosts", &original, BlockingIntent::Block);
 

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -97,6 +97,110 @@ impl SiteValidationError {
     }
 }
 
+pub fn normalize_domain_rule(input: &str) -> Result<String, SiteValidationError> {
+    normalize_domain_like_input(input, true)
+}
+
+pub fn normalize_domain_host(input: &str) -> Result<String, SiteValidationError> {
+    normalize_domain_like_input(input, false)
+}
+
+pub fn domain_rule_matches_host(rule: &str, host: &str) -> bool {
+    let Ok(rule) = normalize_domain_rule(rule) else {
+        return false;
+    };
+    let Ok(host) = normalize_domain_host(host) else {
+        return false;
+    };
+    if let Some(suffix) = rule.strip_prefix("*.") {
+        return host.ends_with(&format!(".{suffix}"));
+    }
+    host == rule
+}
+
+fn normalize_domain_like_input(
+    input: &str,
+    allow_wildcard_prefix: bool,
+) -> Result<String, SiteValidationError> {
+    let mut hostname = input.trim().to_lowercase();
+
+    if hostname.is_empty() {
+        return Err(SiteValidationError::EmptyHostname);
+    }
+
+    let mut wildcard_prefix = false;
+    if let Some(stripped) = hostname.strip_prefix("*.") {
+        if !allow_wildcard_prefix {
+            return Err(SiteValidationError::InvalidCharacter);
+        }
+        wildcard_prefix = true;
+        hostname = stripped.to_string();
+    }
+
+    // Strip URI scheme (e.g. "https://example.com" → "example.com").
+    if let Some(sep) = hostname.find("://") {
+        hostname = hostname[sep + 3..].to_string();
+    }
+
+    // Remove path, query, or fragment after the hostname.
+    if let Some(pos) = hostname.find(['/', '?', '#']) {
+        hostname.truncate(pos);
+    }
+
+    if let Some(at_pos) = hostname.rfind('@') {
+        hostname = hostname[at_pos + 1..].to_string();
+    }
+
+    // Strip a port suffix from host:port forms when the suffix is numeric.
+    if let Some(colon_pos) = hostname.rfind(':') {
+        let port = &hostname[colon_pos + 1..];
+        if hostname[..colon_pos].contains(':') || !port.chars().all(|c| c.is_ascii_digit()) {
+            return Err(SiteValidationError::InvalidLabel);
+        }
+        hostname.truncate(colon_pos);
+    }
+
+    if hostname.is_empty() {
+        return Err(SiteValidationError::MissingHostname);
+    }
+
+    // Reject anything with internal whitespace (would produce multi-hostname lines).
+    if hostname.chars().any(char::is_whitespace) {
+        return Err(SiteValidationError::ContainsWhitespace);
+    }
+
+    // Allow only ASCII letters, digits, dots, and hyphens.
+    if !hostname
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-')
+    {
+        return Err(SiteValidationError::InvalidCharacter);
+    }
+
+    if hostname.starts_with('.')
+        || hostname.ends_with('.')
+        || hostname.contains("..")
+        || hostname.len() > 253
+    {
+        return Err(SiteValidationError::InvalidLabel);
+    }
+
+    for label in hostname.split('.') {
+        if label.is_empty() || label.len() > 63 || label.starts_with('-') || label.ends_with('-') {
+            return Err(SiteValidationError::InvalidLabel);
+        }
+    }
+
+    if wildcard_prefix {
+        if !hostname.contains('.') {
+            return Err(SiteValidationError::InvalidLabel);
+        }
+        Ok(format!("*.{hostname}"))
+    } else {
+        Ok(hostname)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidSiteInput {
     pub input: String,
@@ -381,71 +485,7 @@ impl SiteBlocker {
 
     /// Validate and normalise a user-supplied hostname.
     fn sanitize_hostname_with_reason(input: &str) -> Result<String, SiteValidationError> {
-        let mut hostname = input.trim().to_lowercase();
-
-        if hostname.is_empty() {
-            return Err(SiteValidationError::EmptyHostname);
-        }
-
-        // Strip URI scheme (e.g. "https://example.com" → "example.com").
-        if let Some(sep) = hostname.find("://") {
-            hostname = hostname[sep + 3..].to_string();
-        }
-
-        // Remove path, query, or fragment after the hostname.
-        if let Some(pos) = hostname.find(['/', '?', '#']) {
-            hostname.truncate(pos);
-        }
-
-        if let Some(at_pos) = hostname.rfind('@') {
-            hostname = hostname[at_pos + 1..].to_string();
-        }
-
-        // Strip a port suffix from host:port forms when the suffix is numeric.
-        if let Some(colon_pos) = hostname.rfind(':') {
-            let port = &hostname[colon_pos + 1..];
-            if hostname[..colon_pos].contains(':') || !port.chars().all(|c| c.is_ascii_digit()) {
-                return Err(SiteValidationError::InvalidLabel);
-            }
-            hostname.truncate(colon_pos);
-        }
-
-        if hostname.is_empty() {
-            return Err(SiteValidationError::MissingHostname);
-        }
-
-        // Reject anything with internal whitespace (would produce multi-hostname lines).
-        if hostname.chars().any(char::is_whitespace) {
-            return Err(SiteValidationError::ContainsWhitespace);
-        }
-
-        // Allow only ASCII letters, digits, dots, and hyphens.
-        if !hostname
-            .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-')
-        {
-            return Err(SiteValidationError::InvalidCharacter);
-        }
-
-        if hostname.starts_with('.')
-            || hostname.ends_with('.')
-            || hostname.contains("..")
-            || hostname.len() > 253
-        {
-            return Err(SiteValidationError::InvalidLabel);
-        }
-
-        for label in hostname.split('.') {
-            if label.is_empty()
-                || label.len() > 63
-                || label.starts_with('-')
-                || label.ends_with('-')
-            {
-                return Err(SiteValidationError::InvalidLabel);
-            }
-        }
-
-        Ok(hostname)
+        normalize_domain_rule(input)
     }
 
     pub fn remove_site(&mut self, index: usize) -> Option<String> {
@@ -1308,6 +1348,20 @@ mod tests {
     }
 
     #[test]
+    fn add_site_accepts_wildcard_rules() {
+        let mut b = SiteBlocker::new();
+        b.add_site("*.Docs.Example.com".to_string());
+        assert_eq!(b.sites, vec!["*.docs.example.com"]);
+    }
+
+    #[test]
+    fn add_site_rejects_mid_label_wildcard() {
+        let mut b = SiteBlocker::new();
+        b.add_site("foo*bar.example.com".to_string());
+        assert!(b.sites.is_empty());
+    }
+
+    #[test]
     fn bulk_add_accepts_comma_and_newline_separators() {
         let mut b = SiteBlocker::new();
         let result = b.add_sites_from_input("example.com, github.com\nhttps://rust-lang.org/docs");
@@ -1383,6 +1437,28 @@ mod tests {
                 reason: SiteValidationError::MultipleHostnames,
             })
         );
+    }
+
+    #[test]
+    fn wildcard_rule_matches_subdomains_only() {
+        assert!(domain_rule_matches_host("*.example.com", "www.example.com"));
+        assert!(domain_rule_matches_host("*.example.com", "a.b.example.com"));
+        assert!(!domain_rule_matches_host("*.example.com", "example.com"));
+    }
+
+    #[test]
+    fn wildcard_rule_respects_label_boundaries() {
+        assert!(!domain_rule_matches_host("*.example.com", "badexample.com"));
+        assert!(!domain_rule_matches_host(
+            "*.example.com",
+            "example.com.bad"
+        ));
+    }
+
+    #[test]
+    fn exact_rule_matches_only_exact_hostname() {
+        assert!(domain_rule_matches_host("example.com", "example.com"));
+        assert!(!domain_rule_matches_host("example.com", "www.example.com"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -181,15 +181,15 @@ Options:
   --session-template-create  Capture current task/profile/blocklist/schedule as a template
   --session-template-rename  Rename the active session template
   --session-template-delete  Delete the active session template
-  --blocklist-sites           List blocklist sites in active profile
-  --allowlist-sites           List allowlist sites in active profile
-  --blocklist-site-add        Add/import blocklist hostnames in active profile
-  --allowlist-site-add        Add/import allowlist hostnames in active profile
+  --blocklist-sites           List blocklist sites in active category within active profile
+  --allowlist-sites           List allowlist sites in active category within active profile
+  --blocklist-site-add        Add/import blocklist hostnames in active category within active profile
+  --allowlist-site-add        Add/import allowlist hostnames in active category within active profile
   --allowlist-site-add-temporary  Add temporary allowlist hostnames with inline duration (HOST=30m,HOST=45s)
-  --blocklist-site-edit       Replace blocklist hostname using OLD=NEW
-  --allowlist-site-edit       Replace allowlist hostname using OLD=NEW
-  --blocklist-site-delete     Delete blocklist hostname in active profile
-  --allowlist-site-delete     Delete allowlist hostname in active profile
+  --blocklist-site-edit       Replace blocklist hostname in active category using OLD=NEW
+  --allowlist-site-edit       Replace allowlist hostname in active category using OLD=NEW
+  --blocklist-site-delete     Delete blocklist hostname in active category within active profile
+  --allowlist-site-delete     Delete allowlist hostname in active category within active profile
   --diagnostics   Show setup diagnostics checks
   --blocking-preview  Preview backend-selected blocking changes without writing
   --status        Print status summary (includes live timer/session fields and latest interruption)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,16 +46,17 @@ use output::{
     build_blocking_preview_command_output, build_diagnostics_command_output,
     build_schedule_inspection_output, display_input_value, effective_blocked_sites_for_profile,
     flush_stdout, print_automation_triggers_command_output, print_backup_output,
-    print_blocking_preview_command_output, print_blocklist_profile_command_output,
-    print_break_glass_command_output, print_diagnostics_command_output, print_export_output,
-    print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
-    print_profile_output, print_restore_output, print_schedule_command_output,
-    print_schedule_delay_command_output, print_session_metadata_command_output,
-    print_session_template_command_output, print_site_add_command_output,
-    print_site_delete_command_output, print_site_edit_command_output,
-    print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_temporary_site_add_command_output,
-    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
+    print_blocking_preview_command_output, print_blocklist_category_command_output,
+    print_blocklist_profile_command_output, print_break_glass_command_output,
+    print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
+    print_goal_command_output, print_json, print_json_compact, print_profile_output,
+    print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
+    print_session_metadata_command_output, print_session_template_command_output,
+    print_site_add_command_output, print_site_delete_command_output,
+    print_site_edit_command_output, print_site_list_command_output, print_status_output,
+    print_strict_command_output, print_task_goal_command_output,
+    print_temporary_site_add_command_output, print_theme_command_output, print_timer_state_output,
+    print_weekday_rules_command_output,
 };
 use parsing::{
     finalize_cli_action, invalid_usage, parse_automation_triggers_value, parse_global_tokens,
@@ -114,6 +115,10 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --blocklist-profile-create=PROFILE_NAME [--json]
   focustime --blocklist-profile-rename=PROFILE_NAME [--json]
   focustime --blocklist-profile-delete [--json]
+  focustime --blocklist-category [CATEGORY_NAME] [--json]
+  focustime --blocklist-category-create=CATEGORY_NAME [--json]
+  focustime --blocklist-category-rename=CATEGORY_NAME [--json]
+  focustime --blocklist-category-delete [--json]
   focustime --session-template [TEMPLATE_NAME] [--json]
   focustime --session-template-apply [TEMPLATE_NAME] [--json]
   focustime --session-template-create=TEMPLATE_NAME [--json]
@@ -167,6 +172,10 @@ Options:
   --blocklist-profile-create  Create a blocklist profile and select it
   --blocklist-profile-rename  Rename the active blocklist profile
   --blocklist-profile-delete  Delete the active blocklist profile
+  --blocklist-category         Show active blocklist category, or set active category
+  --blocklist-category-create  Create a blocklist category in active profile and select it
+  --blocklist-category-rename  Rename the active blocklist category
+  --blocklist-category-delete  Delete the active blocklist category
   --session-template         Show active session template, or set active template
   --session-template-apply   Apply a template by name (or apply active template)
   --session-template-create  Capture current task/profile/blocklist/schedule as a template
@@ -313,6 +322,9 @@ pub enum CommandKind {
     BlocklistProfile {
         command: BlocklistProfileCommandKind,
     },
+    BlocklistCategory {
+        command: BlocklistCategoryCommandKind,
+    },
     BlocklistSites {
         target: SiteListTarget,
         command: BlocklistSiteCommandKind,
@@ -380,6 +392,10 @@ enum PrimaryCommand {
     BlocklistProfileCreate(String),
     BlocklistProfileRename(String),
     BlocklistProfileDelete,
+    BlocklistCategory(Option<String>),
+    BlocklistCategoryCreate(String),
+    BlocklistCategoryRename(String),
+    BlocklistCategoryDelete,
     SessionTemplate(Option<String>),
     SessionTemplateApply(Option<String>),
     SessionTemplateCreate(String),
@@ -441,6 +457,10 @@ enum ParsedToken {
     BlocklistProfileCreate(String),
     BlocklistProfileRename(String),
     BlocklistProfileDelete,
+    BlocklistCategory(Option<String>),
+    BlocklistCategoryCreate(String),
+    BlocklistCategoryRename(String),
+    BlocklistCategoryDelete,
     SessionTemplate(Option<String>),
     SessionTemplateApply(Option<String>),
     SessionTemplateCreate(String),
@@ -487,6 +507,14 @@ pub struct SiteEditValue {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BlocklistProfileCommandKind {
     Select { profile: Option<String> },
+    Create { name: String },
+    Rename { name: String },
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BlocklistCategoryCommandKind {
+    Select { category: Option<String> },
     Create { name: String },
     Rename { name: String },
     Delete,
@@ -840,6 +868,23 @@ struct BlocklistProfileCommandOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct BlocklistCategorySummaryOutput {
+    name: String,
+    active: bool,
+    blocklist_sites_count: usize,
+    allowlist_sites_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct BlocklistCategoryCommandOutput {
+    action: &'static str,
+    updated: bool,
+    selected_blocklist_profile: String,
+    selected_blocklist_category: String,
+    categories: Vec<BlocklistCategorySummaryOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct SessionTemplateSummaryOutput {
     name: String,
     active: bool,
@@ -861,6 +906,7 @@ struct SessionTemplateCommandOutput {
 struct SiteListCommandOutput {
     action: &'static str,
     profile: String,
+    category: String,
     target: SiteListTarget,
     sites: Vec<String>,
     effective_blocked_sites_count: usize,
@@ -877,6 +923,7 @@ struct SiteAddCommandOutput {
     action: &'static str,
     updated: bool,
     profile: String,
+    category: String,
     target: SiteListTarget,
     added: Vec<String>,
     duplicates: Vec<String>,
@@ -900,6 +947,7 @@ struct SiteEditCommandOutput {
     action: &'static str,
     updated: bool,
     profile: String,
+    category: String,
     target: SiteListTarget,
     previous: String,
     current: String,
@@ -912,6 +960,7 @@ struct SiteDeleteCommandOutput {
     action: &'static str,
     updated: bool,
     profile: String,
+    category: String,
     target: SiteListTarget,
     removed: String,
     sites: Vec<String>,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -55,7 +55,7 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 34] = [
+    let parsers: [(&str, ValueArgParser); 37] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
         ("--focus-intention", classify_focus_intention_arg),
@@ -87,6 +87,15 @@ fn classify_value_arg(
         (
             "--blocklist-profile-rename",
             classify_blocklist_profile_rename_arg,
+        ),
+        ("--blocklist-category", classify_blocklist_category_arg),
+        (
+            "--blocklist-category-create",
+            classify_blocklist_category_create_arg,
+        ),
+        (
+            "--blocklist-category-rename",
+            classify_blocklist_category_rename_arg,
         ),
         ("--session-template", classify_session_template_arg),
         (
@@ -147,6 +156,7 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "--diagnostics" => Some(ParsedToken::Diagnostics),
         "--blocking-preview" => Some(ParsedToken::BlockingPreview),
         "--blocklist-profile-delete" => Some(ParsedToken::BlocklistProfileDelete),
+        "--blocklist-category-delete" => Some(ParsedToken::BlocklistCategoryDelete),
         "--session-template-delete" => Some(ParsedToken::SessionTemplateDelete),
         "--blocklist-sites" => Some(ParsedToken::BlocklistSites),
         "--allowlist-sites" => Some(ParsedToken::AllowlistSites),
@@ -332,6 +342,59 @@ fn classify_blocklist_profile_rename_arg(
     }
     Err(invalid_usage(
         "`--blocklist-profile-rename` requires a profile name. Use `--blocklist-profile-rename=NAME` or `--blocklist-profile-rename NAME`.",
+    ))
+}
+
+fn classify_blocklist_category_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        if next.trim().is_empty() {
+            return Err(invalid_usage(
+                "`--blocklist-category` requires a category name when a value is provided.",
+            ));
+        }
+        return Ok((ParsedToken::BlocklistCategory(Some(next.clone())), 2));
+    }
+    Ok((ParsedToken::BlocklistCategory(None), 1))
+}
+
+fn classify_blocklist_category_create_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value = require_nonempty_key_value(
+            next,
+            "`--blocklist-category-create` requires a category name.",
+        )?;
+        return Ok((ParsedToken::BlocklistCategoryCreate(value.to_string()), 2));
+    }
+    Err(invalid_usage(
+        "`--blocklist-category-create` requires a category name. Use `--blocklist-category-create=NAME` or `--blocklist-category-create NAME`.",
+    ))
+}
+
+fn classify_blocklist_category_rename_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value = require_nonempty_key_value(
+            next,
+            "`--blocklist-category-rename` requires a category name.",
+        )?;
+        return Ok((ParsedToken::BlocklistCategoryRename(value.to_string()), 2));
+    }
+    Err(invalid_usage(
+        "`--blocklist-category-rename` requires a category name. Use `--blocklist-category-rename=NAME` or `--blocklist-category-rename NAME`.",
     ))
 }
 
@@ -652,7 +715,7 @@ fn classify_automation_triggers_set_arg(
 }
 
 pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 34] = [
+    let parsers: [KeyValueParser; 37] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
         parse_focus_intention_key_value_arg,
@@ -676,6 +739,9 @@ pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, S
         parse_blocklist_profile_key_value_arg,
         parse_blocklist_profile_create_key_value_arg,
         parse_blocklist_profile_rename_key_value_arg,
+        parse_blocklist_category_key_value_arg,
+        parse_blocklist_category_create_key_value_arg,
+        parse_blocklist_category_rename_key_value_arg,
         parse_session_template_key_value_arg,
         parse_session_template_apply_key_value_arg,
         parse_session_template_create_key_value_arg,
@@ -929,6 +995,43 @@ fn parse_blocklist_profile_rename_key_value_arg(arg: &str) -> Result<Option<Pars
             "`--blocklist-profile-rename=` requires a profile name.",
         )?;
         return Ok(Some(ParsedToken::BlocklistProfileRename(value.to_string())));
+    }
+    Ok(None)
+}
+
+fn parse_blocklist_category_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--blocklist-category=") {
+        let value =
+            require_nonempty_key_value(value, "`--blocklist-category=` requires a category name.")?;
+        return Ok(Some(ParsedToken::BlocklistCategory(Some(
+            value.to_string(),
+        ))));
+    }
+    Ok(None)
+}
+
+fn parse_blocklist_category_create_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--blocklist-category-create=") {
+        let value = require_nonempty_key_value(
+            value,
+            "`--blocklist-category-create=` requires a category name.",
+        )?;
+        return Ok(Some(ParsedToken::BlocklistCategoryCreate(
+            value.to_string(),
+        )));
+    }
+    Ok(None)
+}
+
+fn parse_blocklist_category_rename_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--blocklist-category-rename=") {
+        let value = require_nonempty_key_value(
+            value,
+            "`--blocklist-category-rename=` requires a category name.",
+        )?;
+        return Ok(Some(ParsedToken::BlocklistCategoryRename(
+            value.to_string(),
+        )));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -448,93 +448,117 @@ pub(super) fn apply_blocklist_category_command(
     ensure_blocklist_profiles(config);
     let profile_index = selected_blocklist_profile_index(config);
     ensure_blocklist_categories(&mut config.blocklist_profiles[profile_index]);
+    let profile = &mut config.blocklist_profiles[profile_index];
 
     let (action, updated) = match command {
-        BlocklistCategoryCommandKind::Select { category } => {
-            let mut updated = false;
-            if let Some(category) = category {
-                let profile = &mut config.blocklist_profiles[profile_index];
-                let index = profile
-                    .categories
-                    .iter()
-                    .position(|candidate| candidate.name.eq_ignore_ascii_case(category.trim()))
-                    .ok_or_else(|| format!("Unknown blocklist category `{category}`."))?;
-                let selected = profile.categories[index].name.clone();
-                if !profile.selected_category.eq_ignore_ascii_case(&selected) {
-                    profile.selected_category = selected;
-                    updated = true;
-                }
-            }
-            ("blocklist-category", updated)
-        }
-        BlocklistCategoryCommandKind::Create { name } => {
-            let profile = &mut config.blocklist_profiles[profile_index];
-            let name = name.trim().to_string();
-            if name.is_empty() {
-                return Err("Category name cannot be empty.".to_string());
-            }
-            if profile
-                .categories
-                .iter()
-                .any(|category| category.name.eq_ignore_ascii_case(&name))
-            {
-                return Err(format!("Category `{name}` already exists."));
-            }
-            profile
-                .categories
-                .push(crate::config::BlocklistCategoryConfig {
-                    name: name.clone(),
-                    sites: Vec::new(),
-                    allowlist_sites: Vec::new(),
-                });
-            profile.selected_category = name;
-            ("blocklist-category-create", true)
-        }
-        BlocklistCategoryCommandKind::Rename { name } => {
-            let profile = &mut config.blocklist_profiles[profile_index];
-            let index = selected_blocklist_category_index(profile);
-            let current = profile.categories[index].name.clone();
-            let name = name.trim().to_string();
-            if name.is_empty() {
-                return Err("Category name cannot be empty.".to_string());
-            }
-            if current.eq_ignore_ascii_case(&name) {
-                ("blocklist-category-rename", false)
-            } else {
-                let duplicate =
-                    profile
-                        .categories
-                        .iter()
-                        .enumerate()
-                        .any(|(candidate_index, category)| {
-                            candidate_index != index && category.name.eq_ignore_ascii_case(&name)
-                        });
-                if duplicate {
-                    return Err(format!("Category `{name}` already exists."));
-                }
-                profile.categories[index].name = name.clone();
-                profile.selected_category = name;
-                ("blocklist-category-rename", true)
-            }
-        }
-        BlocklistCategoryCommandKind::Delete => {
-            let profile = &mut config.blocklist_profiles[profile_index];
-            if profile.categories.len() <= 1 {
-                return Err("At least one blocklist category is required.".to_string());
-            }
-            let index = selected_blocklist_category_index(profile);
-            profile.categories.remove(index);
-            let next_index = index.min(profile.categories.len().saturating_sub(1));
-            profile.selected_category = profile.categories[next_index].name.clone();
-            ("blocklist-category-delete", true)
-        }
+        BlocklistCategoryCommandKind::Select { category } => (
+            "blocklist-category",
+            handle_select_blocklist_category(profile, category)?,
+        ),
+        BlocklistCategoryCommandKind::Create { name } => (
+            "blocklist-category-create",
+            handle_create_blocklist_category(profile, name)?,
+        ),
+        BlocklistCategoryCommandKind::Rename { name } => (
+            "blocklist-category-rename",
+            handle_rename_blocklist_category(profile, name)?,
+        ),
+        BlocklistCategoryCommandKind::Delete => (
+            "blocklist-category-delete",
+            handle_delete_blocklist_category(profile)?,
+        ),
     };
 
-    sync_profile_site_mirrors(&mut config.blocklist_profiles[profile_index]);
+    sync_profile_site_mirrors(profile);
     sync_selected_blocklist_profile(config);
     Ok(build_blocklist_category_command_output(
         config, action, updated,
     ))
+}
+
+fn handle_select_blocklist_category(
+    profile: &mut BlocklistProfileConfig,
+    category: Option<String>,
+) -> Result<bool, String> {
+    let Some(category) = category else {
+        return Ok(false);
+    };
+    let index = profile
+        .categories
+        .iter()
+        .position(|candidate| candidate.name.eq_ignore_ascii_case(category.trim()))
+        .ok_or_else(|| format!("Unknown blocklist category `{category}`."))?;
+    let selected = profile.categories[index].name.clone();
+    if profile.selected_category.eq_ignore_ascii_case(&selected) {
+        return Ok(false);
+    }
+    profile.selected_category = selected;
+    Ok(true)
+}
+
+fn handle_create_blocklist_category(
+    profile: &mut BlocklistProfileConfig,
+    name: String,
+) -> Result<bool, String> {
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err("Category name cannot be empty.".to_string());
+    }
+    if profile
+        .categories
+        .iter()
+        .any(|category| category.name.eq_ignore_ascii_case(&name))
+    {
+        return Err(format!("Category `{name}` already exists."));
+    }
+    profile
+        .categories
+        .push(crate::config::BlocklistCategoryConfig {
+            name: name.clone(),
+            sites: Vec::new(),
+            allowlist_sites: Vec::new(),
+        });
+    profile.selected_category = name;
+    Ok(true)
+}
+
+fn handle_rename_blocklist_category(
+    profile: &mut BlocklistProfileConfig,
+    name: String,
+) -> Result<bool, String> {
+    let index = selected_blocklist_category_index(profile);
+    let current = profile.categories[index].name.clone();
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err("Category name cannot be empty.".to_string());
+    }
+    if current.eq_ignore_ascii_case(&name) {
+        return Ok(false);
+    }
+    let duplicate = profile
+        .categories
+        .iter()
+        .enumerate()
+        .any(|(candidate_index, category)| {
+            candidate_index != index && category.name.eq_ignore_ascii_case(&name)
+        });
+    if duplicate {
+        return Err(format!("Category `{name}` already exists."));
+    }
+    profile.categories[index].name = name.clone();
+    profile.selected_category = name;
+    Ok(true)
+}
+
+fn handle_delete_blocklist_category(profile: &mut BlocklistProfileConfig) -> Result<bool, String> {
+    if profile.categories.len() <= 1 {
+        return Err("At least one blocklist category is required.".to_string());
+    }
+    let index = selected_blocklist_category_index(profile);
+    profile.categories.remove(index);
+    let next_index = index.min(profile.categories.len().saturating_sub(1));
+    profile.selected_category = profile.categories[next_index].name.clone();
+    Ok(true)
 }
 
 fn handle_select_blocklist_profile(

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -14,6 +14,7 @@ use crate::config::validate_automation_trigger_rules;
 
 use crate::cli::{
     AppConfig, AutomationTriggerRuleConfig, AutomationTriggersCommandOutput, BackupOutput,
+    BlocklistCategoryCommandKind, BlocklistCategoryCommandOutput, BlocklistCategorySummaryOutput,
     BlocklistProfileCommandKind, BlocklistProfileCommandOutput, BlocklistProfileConfig,
     BlocklistProfileSummaryOutput, BlocklistSiteCommandKind, BreakGlassCommandOutput, CliCommand,
     CommandKind, DailyGoalConfig, DailyGoalSnapshot, EditSiteResult, ExportOutput, FocusStats,
@@ -31,18 +32,18 @@ use crate::cli::{
     build_schedule_inspection_output, build_status_output, build_task_goal_output,
     display_input_value, effective_blocked_sites_for_profile, flush_stdout,
     print_automation_triggers_command_output, print_backup_output,
-    print_blocking_preview_command_output, print_blocklist_profile_command_output,
-    print_break_glass_command_output, print_diagnostics_command_output, print_export_output,
-    print_goal_carry_command_output, print_goal_command_output, print_json, print_json_compact,
-    print_profile_output, print_restore_output, print_schedule_command_output,
-    print_schedule_delay_command_output, print_session_metadata_command_output,
-    print_session_template_command_output, print_site_add_command_output,
-    print_site_delete_command_output, print_site_edit_command_output,
-    print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_temporary_site_add_command_output,
-    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
-    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
-    timer_status_id,
+    print_blocking_preview_command_output, print_blocklist_category_command_output,
+    print_blocklist_profile_command_output, print_break_glass_command_output,
+    print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
+    print_goal_command_output, print_json, print_json_compact, print_profile_output,
+    print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
+    print_session_metadata_command_output, print_session_template_command_output,
+    print_site_add_command_output, print_site_delete_command_output,
+    print_site_edit_command_output, print_site_list_command_output, print_status_output,
+    print_strict_command_output, print_task_goal_command_output,
+    print_temporary_site_add_command_output, print_theme_command_output, print_timer_state_output,
+    print_weekday_rules_command_output, profile_id, profile_view, selected_break_template_view,
+    theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
@@ -104,6 +105,9 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         CommandKind::Export { dir } => execute_export_command(dir, cli_command.output),
         CommandKind::BlocklistProfile { command } => {
             execute_blocklist_profile_command(command, cli_command.output)
+        }
+        CommandKind::BlocklistCategory { command } => {
+            execute_blocklist_category_command(command, cli_command.output)
         }
         CommandKind::BlocklistSites { target, command } => {
             execute_blocklist_sites_command(target, command, cli_command.output)
@@ -274,6 +278,24 @@ fn execute_blocklist_profile_command(
     Ok(())
 }
 
+fn execute_blocklist_category_command(
+    command: BlocklistCategoryCommandKind,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let payload = apply_blocklist_category_command(&mut config, command)?;
+    if payload.updated {
+        config
+            .save()
+            .map_err(|error| format!("Failed to save blocklist category settings: {error}"))?;
+    }
+    match output {
+        OutputMode::Text => print_blocklist_category_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
 fn execute_blocklist_sites_command(
     target: SiteListTarget,
     command: BlocklistSiteCommandKind,
@@ -419,6 +441,102 @@ pub(super) fn apply_blocklist_profile_command(
     ))
 }
 
+pub(super) fn apply_blocklist_category_command(
+    config: &mut AppConfig,
+    command: BlocklistCategoryCommandKind,
+) -> Result<BlocklistCategoryCommandOutput, String> {
+    ensure_blocklist_profiles(config);
+    let profile_index = selected_blocklist_profile_index(config);
+    ensure_blocklist_categories(&mut config.blocklist_profiles[profile_index]);
+
+    let (action, updated) = match command {
+        BlocklistCategoryCommandKind::Select { category } => {
+            let mut updated = false;
+            if let Some(category) = category {
+                let profile = &mut config.blocklist_profiles[profile_index];
+                let index = profile
+                    .categories
+                    .iter()
+                    .position(|candidate| candidate.name.eq_ignore_ascii_case(category.trim()))
+                    .ok_or_else(|| format!("Unknown blocklist category `{category}`."))?;
+                let selected = profile.categories[index].name.clone();
+                if !profile.selected_category.eq_ignore_ascii_case(&selected) {
+                    profile.selected_category = selected;
+                    updated = true;
+                }
+            }
+            ("blocklist-category", updated)
+        }
+        BlocklistCategoryCommandKind::Create { name } => {
+            let profile = &mut config.blocklist_profiles[profile_index];
+            let name = name.trim().to_string();
+            if name.is_empty() {
+                return Err("Category name cannot be empty.".to_string());
+            }
+            if profile
+                .categories
+                .iter()
+                .any(|category| category.name.eq_ignore_ascii_case(&name))
+            {
+                return Err(format!("Category `{name}` already exists."));
+            }
+            profile
+                .categories
+                .push(crate::config::BlocklistCategoryConfig {
+                    name: name.clone(),
+                    sites: Vec::new(),
+                    allowlist_sites: Vec::new(),
+                });
+            profile.selected_category = name;
+            ("blocklist-category-create", true)
+        }
+        BlocklistCategoryCommandKind::Rename { name } => {
+            let profile = &mut config.blocklist_profiles[profile_index];
+            let index = selected_blocklist_category_index(profile);
+            let current = profile.categories[index].name.clone();
+            let name = name.trim().to_string();
+            if name.is_empty() {
+                return Err("Category name cannot be empty.".to_string());
+            }
+            if current.eq_ignore_ascii_case(&name) {
+                ("blocklist-category-rename", false)
+            } else {
+                let duplicate =
+                    profile
+                        .categories
+                        .iter()
+                        .enumerate()
+                        .any(|(candidate_index, category)| {
+                            candidate_index != index && category.name.eq_ignore_ascii_case(&name)
+                        });
+                if duplicate {
+                    return Err(format!("Category `{name}` already exists."));
+                }
+                profile.categories[index].name = name.clone();
+                profile.selected_category = name;
+                ("blocklist-category-rename", true)
+            }
+        }
+        BlocklistCategoryCommandKind::Delete => {
+            let profile = &mut config.blocklist_profiles[profile_index];
+            if profile.categories.len() <= 1 {
+                return Err("At least one blocklist category is required.".to_string());
+            }
+            let index = selected_blocklist_category_index(profile);
+            profile.categories.remove(index);
+            let next_index = index.min(profile.categories.len().saturating_sub(1));
+            profile.selected_category = profile.categories[next_index].name.clone();
+            ("blocklist-category-delete", true)
+        }
+    };
+
+    sync_profile_site_mirrors(&mut config.blocklist_profiles[profile_index]);
+    sync_selected_blocklist_profile(config);
+    Ok(build_blocklist_category_command_output(
+        config, action, updated,
+    ))
+}
+
 fn handle_select_blocklist_profile(
     config: &mut AppConfig,
     profile: Option<String>,
@@ -454,6 +572,12 @@ fn handle_create_blocklist_profile(
         name: name.clone(),
         sites: Vec::new(),
         allowlist_sites: Vec::new(),
+        categories: vec![crate::config::BlocklistCategoryConfig {
+            name: "General".to_string(),
+            sites: Vec::new(),
+            allowlist_sites: Vec::new(),
+        }],
+        selected_category: "General".to_string(),
     });
     config.selected_blocklist_profile = name;
     Ok(("blocklist-profile-create", true))
@@ -516,6 +640,7 @@ pub(super) fn apply_site_add_command(
     let result = working.add_sites_from_input(input);
     let updated = !result.added.is_empty();
     *active_profile_sites_mut(config, index, target) = working.sites.clone();
+    sync_profile_site_mirrors(&mut config.blocklist_profiles[index]);
     if updated {
         sync_selected_blocklist_profile(config);
     }
@@ -525,6 +650,7 @@ pub(super) fn apply_site_add_command(
         action: "site-add",
         updated,
         profile: active_profile.name.clone(),
+        category: active_profile.selected_category.clone(),
         target,
         added: result.added,
         duplicates: result.duplicates,
@@ -562,12 +688,14 @@ pub(super) fn apply_site_edit_command(
     match result {
         EditSiteResult::Updated { old, new } => {
             *active_profile_sites_mut(config, index, target) = working.sites.clone();
+            sync_profile_site_mirrors(&mut config.blocklist_profiles[index]);
             sync_selected_blocklist_profile(config);
             let active_profile = &config.blocklist_profiles[index];
             Ok(SiteEditCommandOutput {
                 action: "site-edit",
                 updated: true,
                 profile: active_profile.name.clone(),
+                category: active_profile.selected_category.clone(),
                 target,
                 previous: old,
                 current: new,
@@ -582,6 +710,7 @@ pub(super) fn apply_site_edit_command(
                 action: "site-edit",
                 updated: false,
                 profile: active_profile.name.clone(),
+                category: active_profile.selected_category.clone(),
                 target,
                 previous: hostname.clone(),
                 current: hostname,
@@ -624,6 +753,7 @@ pub(super) fn apply_site_delete_command(
         .remove_site(delete_index)
         .ok_or_else(|| format!("Site `{site}` was not found in {}.", target.id()))?;
     *active_profile_sites_mut(config, index, target) = working.sites.clone();
+    sync_profile_site_mirrors(&mut config.blocklist_profiles[index]);
     sync_selected_blocklist_profile(config);
 
     let active_profile = &config.blocklist_profiles[index];
@@ -631,6 +761,7 @@ pub(super) fn apply_site_delete_command(
         action: "site-delete",
         updated: true,
         profile: active_profile.name.clone(),
+        category: active_profile.selected_category.clone(),
         target,
         removed,
         sites: active_profile_sites(config, index, target).to_vec(),
@@ -645,6 +776,8 @@ fn ensure_blocklist_profiles(config: &mut AppConfig) {
             .push(BlocklistProfileConfig::default());
         config.selected_blocklist_profile = config.blocklist_profiles[0].name.clone();
     }
+    let index = selected_blocklist_profile_index(config);
+    ensure_blocklist_categories(&mut config.blocklist_profiles[index]);
 }
 
 fn blocklist_profile_index_by_name(
@@ -669,9 +802,18 @@ fn active_profile_sites(
     profile_index: usize,
     target: SiteListTarget,
 ) -> &[String] {
+    let profile = &config.blocklist_profiles[profile_index];
+    if profile.categories.is_empty() {
+        return match target {
+            SiteListTarget::Blocklist => &profile.sites,
+            SiteListTarget::Allowlist => &profile.allowlist_sites,
+        };
+    }
+    let category_index = selected_blocklist_category_index(profile);
+    let category = &profile.categories[category_index];
     match target {
-        SiteListTarget::Blocklist => &config.blocklist_profiles[profile_index].sites,
-        SiteListTarget::Allowlist => &config.blocklist_profiles[profile_index].allowlist_sites,
+        SiteListTarget::Blocklist => &category.sites,
+        SiteListTarget::Allowlist => &category.allowlist_sites,
     }
 }
 
@@ -680,9 +822,13 @@ fn active_profile_sites_mut(
     profile_index: usize,
     target: SiteListTarget,
 ) -> &mut Vec<String> {
+    ensure_blocklist_categories(&mut config.blocklist_profiles[profile_index]);
+    let category_index =
+        selected_blocklist_category_index(&config.blocklist_profiles[profile_index]);
+    let category = &mut config.blocklist_profiles[profile_index].categories[category_index];
     match target {
-        SiteListTarget::Blocklist => &mut config.blocklist_profiles[profile_index].sites,
-        SiteListTarget::Allowlist => &mut config.blocklist_profiles[profile_index].allowlist_sites,
+        SiteListTarget::Blocklist => &mut category.sites,
+        SiteListTarget::Allowlist => &mut category.allowlist_sites,
     }
 }
 
@@ -719,6 +865,38 @@ fn build_blocklist_profile_command_output(
         updated,
         selected_blocklist_profile: selected_name,
         profiles,
+    }
+}
+
+fn build_blocklist_category_command_output(
+    config: &AppConfig,
+    action: &'static str,
+    updated: bool,
+) -> BlocklistCategoryCommandOutput {
+    let profile_index = selected_blocklist_profile_index(config);
+    let profile = &config.blocklist_profiles[profile_index];
+    let selected_category = if profile.categories.is_empty() {
+        "General".to_string()
+    } else {
+        let index = selected_blocklist_category_index(profile);
+        profile.categories[index].name.clone()
+    };
+    let categories = profile
+        .categories
+        .iter()
+        .map(|category| BlocklistCategorySummaryOutput {
+            name: category.name.clone(),
+            active: category.name.eq_ignore_ascii_case(&selected_category),
+            blocklist_sites_count: category.sites.len(),
+            allowlist_sites_count: category.allowlist_sites.len(),
+        })
+        .collect();
+    BlocklistCategoryCommandOutput {
+        action,
+        updated,
+        selected_blocklist_profile: profile.name.clone(),
+        selected_blocklist_category: selected_category,
+        categories,
     }
 }
 
@@ -764,6 +942,7 @@ fn build_site_list_command_output(
         return SiteListCommandOutput {
             action,
             profile: fallback,
+            category: "General".to_string(),
             target,
             sites: Vec::new(),
             effective_blocked_sites_count: 0,
@@ -774,6 +953,7 @@ fn build_site_list_command_output(
     SiteListCommandOutput {
         action,
         profile: profile.name.clone(),
+        category: profile.selected_category.clone(),
         target,
         sites: active_profile_sites(config, index, target).to_vec(),
         effective_blocked_sites_count: effective_blocked_sites_for_profile(profile).len(),
@@ -788,6 +968,75 @@ fn invalid_site_entries_output(values: &[InvalidSiteInput]) -> Vec<InvalidSiteEn
             reason: invalid.reason.message().to_string(),
         })
         .collect()
+}
+
+fn ensure_blocklist_categories(profile: &mut BlocklistProfileConfig) {
+    if profile.categories.is_empty() {
+        profile
+            .categories
+            .push(crate::config::BlocklistCategoryConfig {
+                name: "General".to_string(),
+                sites: profile.sites.clone(),
+                allowlist_sites: profile.allowlist_sites.clone(),
+            });
+    }
+    let selected = profile.selected_category.trim().to_string();
+    if selected.is_empty() {
+        profile.selected_category = profile
+            .categories
+            .first()
+            .map(|category| category.name.clone())
+            .unwrap_or_else(|| "General".to_string());
+    } else if let Some(category) = profile
+        .categories
+        .iter()
+        .find(|category| category.name.eq_ignore_ascii_case(&selected))
+    {
+        profile.selected_category = category.name.clone();
+    } else {
+        profile.selected_category = profile
+            .categories
+            .first()
+            .map(|category| category.name.clone())
+            .unwrap_or_else(|| "General".to_string());
+    }
+}
+
+fn selected_blocklist_category_index(profile: &BlocklistProfileConfig) -> usize {
+    profile
+        .categories
+        .iter()
+        .position(|category| {
+            category
+                .name
+                .eq_ignore_ascii_case(&profile.selected_category)
+        })
+        .unwrap_or(0)
+}
+
+fn sync_profile_site_mirrors(profile: &mut BlocklistProfileConfig) {
+    let mut sites: Vec<String> = Vec::new();
+    let mut allowlist_sites: Vec<String> = Vec::new();
+    for category in &profile.categories {
+        for site in &category.sites {
+            if !sites
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(site))
+            {
+                sites.push(site.clone());
+            }
+        }
+        for site in &category.allowlist_sites {
+            if !allowlist_sites
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(site))
+            {
+                allowlist_sites.push(site.clone());
+            }
+        }
+    }
+    profile.sites = sites;
+    profile.allowlist_sites = allowlist_sites;
 }
 
 fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Result<(), String> {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -965,3 +965,61 @@ where
         .filter(|value| seen.insert(value.to_ascii_lowercase()))
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::effective_blocked_sites_for_profile;
+    use crate::config::BlocklistCategoryConfig;
+
+    #[test]
+    fn effective_blocked_sites_keeps_wildcard_only_rules() {
+        let profile = crate::config::BlocklistProfileConfig {
+            sites: vec!["*.Example.com".to_string()],
+            ..crate::config::BlocklistProfileConfig::default()
+        };
+
+        assert_eq!(
+            effective_blocked_sites_for_profile(&profile),
+            vec!["*.example.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn effective_blocked_sites_keeps_wildcard_when_allowlist_is_exact_host() {
+        let profile = crate::config::BlocklistProfileConfig {
+            sites: vec!["*.example.com".to_string()],
+            allowlist_sites: vec!["ads.example.com".to_string()],
+            ..crate::config::BlocklistProfileConfig::default()
+        };
+
+        assert_eq!(
+            effective_blocked_sites_for_profile(&profile),
+            vec!["*.example.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn effective_blocked_sites_aggregates_categories_and_dedups_case_insensitively() {
+        let profile = crate::config::BlocklistProfileConfig {
+            sites: vec!["legacy-top-level.com".to_string()],
+            categories: vec![
+                BlocklistCategoryConfig {
+                    name: "Social".to_string(),
+                    sites: vec!["News.com".to_string(), "*.example.com".to_string()],
+                    allowlist_sites: vec!["news.com".to_string()],
+                },
+                BlocklistCategoryConfig {
+                    name: "Work".to_string(),
+                    sites: vec!["*.EXAMPLE.com".to_string(), "forum.example.com".to_string()],
+                    allowlist_sites: Vec::new(),
+                },
+            ],
+            ..crate::config::BlocklistProfileConfig::default()
+        };
+
+        assert_eq!(
+            effective_blocked_sites_for_profile(&profile),
+            vec!["*.example.com".to_string(), "forum.example.com".to_string()]
+        );
+    }
+}

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,17 +1,16 @@
-use std::collections::HashSet;
-
+use crate::blocker::{domain_rule_matches_host, normalize_domain_rule};
 use crate::cli::{
     AutomationTriggersCommandOutput, BackupOutput, BlockingPreviewAction,
-    BlockingPreviewCommandOutput, BlocklistProfileCommandOutput, BlocklistProfileConfig,
-    BreakGlassCommandOutput, DiagnosticsCommandOutput, ExportOutput, FocusScoreOutput,
-    GoalCarryCommandOutput, GoalCommandOutput, GoalOutput, ProfileOutput, RecurringScheduleConfig,
-    RestoreOutput, ScheduleCommandOutput, ScheduleDelayCommandOutput, ScheduleInspectionOutput,
-    Serialize, SessionMetadataCommandOutput, SessionTemplateCommandOutput, SetupCheck,
-    SetupCheckLevel, SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput,
-    SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput, StatsGrowthSummary,
-    StatsRetentionStatusOutput, StatusOutput, StrictCommandOutput, TaskGoalCommandOutput,
-    TaskGoalOutput, TemporarySiteAddCommandOutput, ThemeCommandOutput, TimerStateOutput,
-    WeekdayRulesCommandOutput, Write, format_schedule_conflict,
+    BlockingPreviewCommandOutput, BlocklistCategoryCommandOutput, BlocklistProfileCommandOutput,
+    BlocklistProfileConfig, BreakGlassCommandOutput, DiagnosticsCommandOutput, ExportOutput,
+    FocusScoreOutput, GoalCarryCommandOutput, GoalCommandOutput, GoalOutput, ProfileOutput,
+    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, ScheduleDelayCommandOutput,
+    ScheduleInspectionOutput, Serialize, SessionMetadataCommandOutput,
+    SessionTemplateCommandOutput, SetupCheck, SetupCheckLevel, SetupCheckOutput, SetupDiagnostics,
+    SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput,
+    StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput, StrictCommandOutput,
+    TaskGoalCommandOutput, TaskGoalOutput, TemporarySiteAddCommandOutput, ThemeCommandOutput,
+    TimerStateOutput, WeekdayRulesCommandOutput, Write, format_schedule_conflict,
     inspect_schedule_conflicts_from_config, io,
 };
 
@@ -108,6 +107,28 @@ pub(super) fn print_blocklist_profile_command_output(payload: &BlocklistProfileC
     }
 }
 
+pub(super) fn print_blocklist_category_command_output(payload: &BlocklistCategoryCommandOutput) {
+    if payload.updated {
+        println!("Blocklist category updated.");
+    }
+    println!(
+        "Selected blocklist profile/category: {} / {}",
+        payload.selected_blocklist_profile, payload.selected_blocklist_category
+    );
+    if payload.categories.is_empty() {
+        println!("Categories: none");
+        return;
+    }
+    println!("Categories:");
+    for category in &payload.categories {
+        let marker = if category.active { "*" } else { " " };
+        println!(
+            "  {marker} {} (blocklist {}, allowlist {})",
+            category.name, category.blocklist_sites_count, category.allowlist_sites_count
+        );
+    }
+}
+
 pub(super) fn print_session_template_command_output(payload: &SessionTemplateCommandOutput) {
     if payload.updated {
         println!("Session template updated.");
@@ -139,8 +160,9 @@ pub(super) fn print_session_template_command_output(payload: &SessionTemplateCom
 
 pub(super) fn print_site_list_command_output(payload: &SiteListCommandOutput) {
     println!(
-        "Active profile `{}` {} entries: {}",
+        "Active profile/category `{}` / `{}` {} entries: {}",
         payload.profile,
+        payload.category,
         payload.target.id(),
         payload.sites.len()
     );
@@ -156,16 +178,18 @@ pub(super) fn print_site_list_command_output(payload: &SiteListCommandOutput) {
 pub(super) fn print_site_add_command_output(payload: &SiteAddCommandOutput) {
     if payload.updated {
         println!(
-            "Added {} hostname(s) to {} in profile `{}`.",
+            "Added {} hostname(s) to {} in profile/category `{}` / `{}`.",
             payload.added.len(),
             payload.target.id(),
-            payload.profile
+            payload.profile,
+            payload.category
         );
     } else {
         println!(
-            "No {} hostnames were added in profile `{}`.",
+            "No {} hostnames were added in profile/category `{}` / `{}`.",
             payload.target.id(),
-            payload.profile
+            payload.profile,
+            payload.category
         );
     }
     if !payload.duplicates.is_empty() {
@@ -221,18 +245,20 @@ pub(super) fn print_temporary_site_add_command_output(payload: &TemporarySiteAdd
 pub(super) fn print_site_edit_command_output(payload: &SiteEditCommandOutput) {
     if payload.updated {
         println!(
-            "Updated {} hostname in profile `{}`: {} -> {}",
+            "Updated {} hostname in profile/category `{}` / `{}`: {} -> {}",
             payload.target.id(),
             payload.profile,
+            payload.category,
             payload.previous,
             payload.current
         );
     } else {
         println!(
-            "No change for {} hostname `{}` in profile `{}`.",
+            "No change for {} hostname `{}` in profile/category `{}` / `{}`.",
             payload.target.id(),
             payload.current,
-            payload.profile
+            payload.profile,
+            payload.category
         );
     }
     println!(
@@ -248,10 +274,11 @@ pub(super) fn print_site_edit_command_output(payload: &SiteEditCommandOutput) {
 
 pub(super) fn print_site_delete_command_output(payload: &SiteDeleteCommandOutput) {
     println!(
-        "Deleted {} hostname `{}` from profile `{}`.",
+        "Deleted {} hostname `{}` from profile/category `{}` / `{}`.",
         payload.target.id(),
         payload.removed,
-        payload.profile
+        payload.profile,
+        payload.category
     );
     println!(
         "{} entries now: {}",
@@ -879,15 +906,56 @@ pub(super) fn display_input_value(value: &str) -> String {
 }
 
 pub(super) fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
-    let allowlist: HashSet<String> = profile
-        .allowlist_sites
+    let allowlist_rules: Vec<String> = all_allowlist_rules_for_profile(profile)
         .iter()
-        .map(|site| site.to_ascii_lowercase())
+        .filter_map(|rule| normalize_domain_rule(rule).ok())
         .collect();
-    profile
-        .sites
-        .iter()
-        .filter(|site| !allowlist.contains(&site.to_ascii_lowercase()))
-        .cloned()
+
+    let mut seen = std::collections::HashSet::new();
+    all_blocklist_rules_for_profile(profile)
+        .into_iter()
+        .filter_map(|site| normalize_domain_rule(&site).ok())
+        .filter(|site| !site.starts_with("*."))
+        .filter(|site| {
+            !allowlist_rules
+                .iter()
+                .any(|allow_rule| domain_rule_matches_host(allow_rule, site))
+        })
+        .filter(|site| seen.insert(site.to_ascii_lowercase()))
+        .collect()
+}
+
+fn all_blocklist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+    if profile.categories.is_empty() {
+        return dedup_case_insensitive(profile.sites.iter().cloned());
+    }
+    dedup_case_insensitive(
+        profile
+            .categories
+            .iter()
+            .flat_map(|category| category.sites.iter().cloned()),
+    )
+}
+
+fn all_allowlist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+    if profile.categories.is_empty() {
+        return dedup_case_insensitive(profile.allowlist_sites.iter().cloned());
+    }
+    dedup_case_insensitive(
+        profile
+            .categories
+            .iter()
+            .flat_map(|category| category.allowlist_sites.iter().cloned()),
+    )
+}
+
+fn dedup_case_insensitive<I>(values: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut seen = std::collections::HashSet::new();
+    values
+        .into_iter()
+        .filter(|value| seen.insert(value.to_ascii_lowercase()))
         .collect()
 }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -915,14 +915,20 @@ pub(super) fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConf
     all_blocklist_rules_for_profile(profile)
         .into_iter()
         .filter_map(|site| normalize_domain_rule(&site).ok())
-        .filter(|site| !site.starts_with("*."))
-        .filter(|site| {
-            !allowlist_rules
-                .iter()
-                .any(|allow_rule| domain_rule_matches_host(allow_rule, site))
-        })
+        .filter(|site| !block_rule_excluded_by_allowlist(site, &allowlist_rules))
         .filter(|site| seen.insert(site.to_ascii_lowercase()))
         .collect()
+}
+
+fn block_rule_excluded_by_allowlist(block_rule: &str, allowlist_rules: &[String]) -> bool {
+    if block_rule.starts_with("*.") {
+        return allowlist_rules
+            .iter()
+            .any(|allow_rule| allow_rule.eq_ignore_ascii_case(block_rule));
+    }
+    allowlist_rules
+        .iter()
+        .any(|allow_rule| domain_rule_matches_host(allow_rule, block_rule))
 }
 
 fn all_blocklist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -1,9 +1,10 @@
 use crate::cli::{
-    AutomationTriggerRuleConfig, BlocklistProfileCommandKind, BlocklistSiteCommandKind, CliAction,
-    CliCommand, CommandKind, DEFAULT_WATCH_INTERVAL_SECS, DailyGoalConfig, MonthlyGoalConfig,
-    NaiveDate, OneTimeFocusWindowConfig, OutputMode, ParsedToken, PrimaryCommand, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, SessionTemplateCommandKind, SiteEditValue,
-    SiteListTarget, ThemePreset, USAGE_TEXT, WeekdayProfileRuleConfig, WeeklyGoalConfig,
+    AutomationTriggerRuleConfig, BlocklistCategoryCommandKind, BlocklistProfileCommandKind,
+    BlocklistSiteCommandKind, CliAction, CliCommand, CommandKind, DEFAULT_WATCH_INTERVAL_SECS,
+    DailyGoalConfig, MonthlyGoalConfig, NaiveDate, OneTimeFocusWindowConfig, OutputMode,
+    ParsedToken, PrimaryCommand, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig,
+    SessionTemplateCommandKind, SiteEditValue, SiteListTarget, ThemePreset, USAGE_TEXT,
+    WeekdayProfileRuleConfig, WeeklyGoalConfig,
 };
 
 pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), String> {
@@ -65,6 +66,10 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::BlocklistProfileCreate(_)
             | ParsedToken::BlocklistProfileRename(_)
             | ParsedToken::BlocklistProfileDelete
+            | ParsedToken::BlocklistCategory(_)
+            | ParsedToken::BlocklistCategoryCreate(_)
+            | ParsedToken::BlocklistCategoryRename(_)
+            | ParsedToken::BlocklistCategoryDelete
             | ParsedToken::SessionTemplate(_)
             | ParsedToken::SessionTemplateApply(_)
             | ParsedToken::SessionTemplateCreate(_)
@@ -195,6 +200,21 @@ pub(super) fn parse_primary_command(
             )?,
             ParsedToken::BlocklistProfileDelete => {
                 set_primary_command(&mut primary, PrimaryCommand::BlocklistProfileDelete)?
+            }
+            ParsedToken::BlocklistCategory(category) => set_primary_command(
+                &mut primary,
+                PrimaryCommand::BlocklistCategory(category.clone()),
+            )?,
+            ParsedToken::BlocklistCategoryCreate(name) => set_primary_command(
+                &mut primary,
+                PrimaryCommand::BlocklistCategoryCreate(name.clone()),
+            )?,
+            ParsedToken::BlocklistCategoryRename(name) => set_primary_command(
+                &mut primary,
+                PrimaryCommand::BlocklistCategoryRename(name.clone()),
+            )?,
+            ParsedToken::BlocklistCategoryDelete => {
+                set_primary_command(&mut primary, PrimaryCommand::BlocklistCategoryDelete)?
             }
             ParsedToken::SessionTemplate(name) => {
                 set_primary_command(&mut primary, PrimaryCommand::SessionTemplate(name.clone()))?
@@ -443,6 +463,36 @@ pub(super) fn finalize_cli_action(
         Some(PrimaryCommand::BlocklistProfileDelete) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::BlocklistProfile {
                 command: BlocklistProfileCommandKind::Delete,
+            },
+            output,
+        })),
+        Some(PrimaryCommand::BlocklistCategory(category)) => {
+            Ok(CliAction::RunCommand(CliCommand {
+                kind: CommandKind::BlocklistCategory {
+                    command: BlocklistCategoryCommandKind::Select { category },
+                },
+                output,
+            }))
+        }
+        Some(PrimaryCommand::BlocklistCategoryCreate(name)) => {
+            Ok(CliAction::RunCommand(CliCommand {
+                kind: CommandKind::BlocklistCategory {
+                    command: BlocklistCategoryCommandKind::Create { name },
+                },
+                output,
+            }))
+        }
+        Some(PrimaryCommand::BlocklistCategoryRename(name)) => {
+            Ok(CliAction::RunCommand(CliCommand {
+                kind: CommandKind::BlocklistCategory {
+                    command: BlocklistCategoryCommandKind::Rename { name },
+                },
+                output,
+            }))
+        }
+        Some(PrimaryCommand::BlocklistCategoryDelete) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::BlocklistCategory {
+                command: BlocklistCategoryCommandKind::Delete,
             },
             output,
         })),
@@ -908,6 +958,10 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::BlocklistProfileCreate(_) => "--blocklist-profile-create",
         PrimaryCommand::BlocklistProfileRename(_) => "--blocklist-profile-rename",
         PrimaryCommand::BlocklistProfileDelete => "--blocklist-profile-delete",
+        PrimaryCommand::BlocklistCategory(_) => "--blocklist-category",
+        PrimaryCommand::BlocklistCategoryCreate(_) => "--blocklist-category-create",
+        PrimaryCommand::BlocklistCategoryRename(_) => "--blocklist-category-rename",
+        PrimaryCommand::BlocklistCategoryDelete => "--blocklist-category-delete",
         PrimaryCommand::SessionTemplate(_) => "--session-template",
         PrimaryCommand::SessionTemplateApply(_) => "--session-template-apply",
         PrimaryCommand::SessionTemplateCreate(_) => "--session-template-create",

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1763,11 +1763,13 @@ fn apply_blocklist_profile_select_updates_selection_case_insensitively() {
                 name: "Work".to_string(),
                 sites: vec!["a.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..crate::config::BlocklistProfileConfig::default()
             },
             crate::config::BlocklistProfileConfig {
                 name: "Study".to_string(),
                 sites: vec!["study.com".to_string(), "news.com".to_string()],
                 allowlist_sites: vec!["news.com".to_string()],
+                ..crate::config::BlocklistProfileConfig::default()
             },
         ],
         selected_blocklist_profile: "work".to_string(),
@@ -1797,11 +1799,13 @@ fn apply_blocklist_profile_rename_updates_selection_and_name() {
                 name: "Work".to_string(),
                 sites: vec!["a.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..crate::config::BlocklistProfileConfig::default()
             },
             crate::config::BlocklistProfileConfig {
                 name: "Study".to_string(),
                 sites: vec!["study.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..crate::config::BlocklistProfileConfig::default()
             },
         ],
         selected_blocklist_profile: "Work".to_string(),
@@ -1832,11 +1836,13 @@ fn apply_blocklist_profile_delete_switches_selection() {
                 name: "Work".to_string(),
                 sites: vec!["a.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..crate::config::BlocklistProfileConfig::default()
             },
             crate::config::BlocklistProfileConfig {
                 name: "Study".to_string(),
                 sites: vec!["study.com".to_string(), "news.com".to_string()],
                 allowlist_sites: vec!["news.com".to_string()],
+                ..crate::config::BlocklistProfileConfig::default()
             },
         ],
         selected_blocklist_profile: "Work".to_string(),
@@ -1861,6 +1867,7 @@ fn apply_allowlist_site_add_updates_effective_blocking() {
             name: "Default".to_string(),
             sites: vec!["a.com".to_string(), "b.com".to_string()],
             allowlist_sites: vec!["b.com".to_string()],
+            ..crate::config::BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Default".to_string(),
         ..AppConfig::default()
@@ -1886,6 +1893,7 @@ fn apply_site_edit_command_updates_blocklist_sites() {
             name: "Default".to_string(),
             sites: vec!["a.com".to_string(), "b.com".to_string()],
             allowlist_sites: Vec::new(),
+            ..crate::config::BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Default".to_string(),
         ..AppConfig::default()
@@ -1923,6 +1931,7 @@ fn apply_site_edit_command_handles_duplicate_case_entries() {
                 "b.com".to_string(),
             ],
             allowlist_sites: Vec::new(),
+            ..crate::config::BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Default".to_string(),
         ..AppConfig::default()
@@ -1955,6 +1964,7 @@ fn apply_site_delete_command_updates_allowlist_and_effective_blocking() {
             name: "Default".to_string(),
             sites: vec!["a.com".to_string(), "b.com".to_string()],
             allowlist_sites: vec!["b.com".to_string()],
+            ..crate::config::BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Default".to_string(),
         ..AppConfig::default()
@@ -1982,6 +1992,7 @@ fn apply_site_delete_command_handles_duplicate_case_entries() {
                 "other.com".to_string(),
             ],
             allowlist_sites: Vec::new(),
+            ..crate::config::BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Default".to_string(),
         ..AppConfig::default()
@@ -2007,6 +2018,7 @@ fn build_status_output_matches_blocklist_profile_case_insensitively() {
             name: "Work".to_string(),
             sites: vec!["youtube.com".to_string(), "reddit.com".to_string()],
             allowlist_sites: Vec::new(),
+            ..crate::config::BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "work".to_string(),
         ..AppConfig::default()
@@ -2080,6 +2092,7 @@ fn build_status_output_excludes_allowlist_from_blocked_sites_count() {
             name: "Work".to_string(),
             sites: vec!["youtube.com".to_string(), "reddit.com".to_string()],
             allowlist_sites: vec!["reddit.com".to_string()],
+            ..crate::config::BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Work".to_string(),
         ..AppConfig::default()

--- a/src/config.rs
+++ b/src/config.rs
@@ -2798,14 +2798,20 @@ fn normalize_blocklist_categories(
     }
 
     if !legacy_sites.is_empty() || !legacy_allowlist_sites.is_empty() {
-        let target_index = normalized
-            .iter()
-            .position(|category| {
-                category
-                    .name
-                    .eq_ignore_ascii_case(&default_blocklist_category_name())
-            })
-            .unwrap_or(0);
+        let target_index = if let Some(index) = normalized.iter().position(|category| {
+            category
+                .name
+                .eq_ignore_ascii_case(&default_blocklist_category_name())
+        }) {
+            index
+        } else {
+            normalized.push(BlocklistCategoryConfig {
+                name: default_blocklist_category_name(),
+                sites: Vec::new(),
+                allowlist_sites: Vec::new(),
+            });
+            normalized.len().saturating_sub(1)
+        };
         merge_unique_case_insensitive(&mut normalized[target_index].sites, legacy_sites);
         merge_unique_case_insensitive(
             &mut normalized[target_index].allowlist_sites,

--- a/src/config.rs
+++ b/src/config.rs
@@ -548,11 +548,34 @@ impl Default for ShortcutConfig {
 pub struct BlocklistProfileConfig {
     #[serde(default = "default_blocklist_profile_name")]
     pub name: String,
+    /// Deprecated flat mirror of categorized blocklist rules.
+    ///
+    /// Canonical rules live in `categories[*].sites`; this field is maintained
+    /// for load-time compatibility and helper surfaces still reading flat lists.
     #[serde(default)]
     pub sites: Vec<String>,
+    /// Deprecated flat mirror of categorized allowlist rules.
+    ///
+    /// Canonical rules live in `categories[*].allowlist_sites`.
     /// Sites that are explicitly excluded from blocking.
     ///
     /// Effective focus blocking is computed as `sites - allowlist_sites`.
+    #[serde(default)]
+    pub allowlist_sites: Vec<String>,
+    /// Category-organized block/allow rules.
+    #[serde(default)]
+    pub categories: Vec<BlocklistCategoryConfig>,
+    /// Name of the selected category inside this profile.
+    #[serde(default = "default_blocklist_category_name")]
+    pub selected_category: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlocklistCategoryConfig {
+    #[serde(default = "default_blocklist_category_name")]
+    pub name: String,
+    #[serde(default)]
+    pub sites: Vec<String>,
     #[serde(default)]
     pub allowlist_sites: Vec<String>,
 }
@@ -561,6 +584,18 @@ impl Default for BlocklistProfileConfig {
     fn default() -> Self {
         Self {
             name: default_blocklist_profile_name(),
+            sites: Vec::new(),
+            allowlist_sites: Vec::new(),
+            categories: Vec::new(),
+            selected_category: default_blocklist_category_name(),
+        }
+    }
+}
+
+impl Default for BlocklistCategoryConfig {
+    fn default() -> Self {
+        Self {
+            name: default_blocklist_category_name(),
             sites: Vec::new(),
             allowlist_sites: Vec::new(),
         }
@@ -1255,6 +1290,10 @@ fn default_one_time_schedule_date() -> String {
 
 fn default_blocklist_profile_name() -> String {
     "Default".to_string()
+}
+
+fn default_blocklist_category_name() -> String {
+    "General".to_string()
 }
 
 fn default_break_glass_duration_secs() -> u64 {
@@ -2657,18 +2696,33 @@ fn normalize_blocklist_profiles(
         let base_name =
             normalize_nonempty_or_default_string(&profile.name, &default_blocklist_profile_name());
         let name = make_unique_profile_name(&base_name, &mut seen_names);
+        let categories = normalize_blocklist_categories(
+            &profile.categories,
+            &profile.sites,
+            &profile.allowlist_sites,
+        );
+        let selected_category =
+            normalize_selected_blocklist_category(&profile.selected_category, &categories);
+        let (sites, allowlist_sites) = flatten_blocklist_categories(&categories);
         normalized.push(BlocklistProfileConfig {
             name,
-            sites: profile.sites.clone(),
-            allowlist_sites: profile.allowlist_sites.clone(),
+            sites,
+            allowlist_sites,
+            categories,
+            selected_category,
         });
     }
 
     if normalized.is_empty() {
+        let categories = normalize_blocklist_categories(&[], legacy_blocked_sites, &[]);
+        let selected_category = normalize_selected_blocklist_category("", categories.as_slice());
+        let (sites, allowlist_sites) = flatten_blocklist_categories(&categories);
         return vec![BlocklistProfileConfig {
             name: default_blocklist_profile_name(),
-            sites: legacy_blocked_sites.to_vec(),
-            allowlist_sites: Vec::new(),
+            sites,
+            allowlist_sites,
+            categories,
+            selected_category,
         }];
     }
 
@@ -2713,6 +2767,88 @@ fn make_unique_profile_name(base_name: &str, seen_names: &mut HashSet<String>) -
         }
         suffix += 1;
     }
+}
+
+fn normalize_blocklist_categories(
+    categories: &[BlocklistCategoryConfig],
+    legacy_sites: &[String],
+    legacy_allowlist_sites: &[String],
+) -> Vec<BlocklistCategoryConfig> {
+    let mut normalized = Vec::new();
+    let mut seen_names = HashSet::new();
+    for category in categories {
+        let base_name = normalize_nonempty_or_default_string(
+            &category.name,
+            &default_blocklist_category_name(),
+        );
+        let name = make_unique_profile_name(&base_name, &mut seen_names);
+        normalized.push(BlocklistCategoryConfig {
+            name,
+            sites: category.sites.clone(),
+            allowlist_sites: category.allowlist_sites.clone(),
+        });
+    }
+
+    if normalized.is_empty() {
+        return vec![BlocklistCategoryConfig {
+            name: default_blocklist_category_name(),
+            sites: legacy_sites.to_vec(),
+            allowlist_sites: legacy_allowlist_sites.to_vec(),
+        }];
+    }
+
+    normalized
+}
+
+fn normalize_selected_blocklist_category(
+    selected_name: &str,
+    categories: &[BlocklistCategoryConfig],
+) -> String {
+    let selected_name = selected_name.trim();
+    if selected_name.is_empty() {
+        return categories
+            .first()
+            .map(|category| category.name.clone())
+            .unwrap_or_else(default_blocklist_category_name);
+    }
+
+    if let Some(category) = categories
+        .iter()
+        .find(|category| category.name.eq_ignore_ascii_case(selected_name))
+    {
+        category.name.clone()
+    } else {
+        categories
+            .first()
+            .map(|category| category.name.clone())
+            .unwrap_or_else(default_blocklist_category_name)
+    }
+}
+
+fn flatten_blocklist_categories(
+    categories: &[BlocklistCategoryConfig],
+) -> (Vec<String>, Vec<String>) {
+    let mut sites = Vec::new();
+    let mut allowlist_sites = Vec::new();
+    let mut seen_sites = HashSet::new();
+    let mut seen_allowlist_sites = HashSet::new();
+
+    for category in categories {
+        for site in &category.sites {
+            let key = site.to_ascii_lowercase();
+            if seen_sites.insert(key) {
+                sites.push(site.clone());
+            }
+        }
+        for site in &category.allowlist_sites {
+            let key = site.to_ascii_lowercase();
+            if seen_allowlist_sites.insert(key) {
+                allowlist_sites.push(site.clone());
+            }
+        }
+    }
+
+    (sites, allowlist_sites)
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2797,7 +2797,33 @@ fn normalize_blocklist_categories(
         }];
     }
 
+    if !legacy_sites.is_empty() || !legacy_allowlist_sites.is_empty() {
+        let target_index = normalized
+            .iter()
+            .position(|category| {
+                category
+                    .name
+                    .eq_ignore_ascii_case(&default_blocklist_category_name())
+            })
+            .unwrap_or(0);
+        merge_unique_case_insensitive(&mut normalized[target_index].sites, legacy_sites);
+        merge_unique_case_insensitive(
+            &mut normalized[target_index].allowlist_sites,
+            legacy_allowlist_sites,
+        );
+    }
+
     normalized
+}
+
+fn merge_unique_case_insensitive(target: &mut Vec<String>, source: &[String]) {
+    let mut seen: HashSet<String> = target.iter().map(|value| value.to_ascii_lowercase()).collect();
+    for value in source {
+        let key = value.to_ascii_lowercase();
+        if seen.insert(key) {
+            target.push(value.clone());
+        }
+    }
 }
 
 fn normalize_selected_blocklist_category(

--- a/src/config.rs
+++ b/src/config.rs
@@ -2817,7 +2817,10 @@ fn normalize_blocklist_categories(
 }
 
 fn merge_unique_case_insensitive(target: &mut Vec<String>, source: &[String]) {
-    let mut seen: HashSet<String> = target.iter().map(|value| value.to_ascii_lowercase()).collect();
+    let mut seen: HashSet<String> = target
+        .iter()
+        .map(|value| value.to_ascii_lowercase())
+        .collect();
     for value in source {
         let key = value.to_ascii_lowercase();
         if seen.insert(key) {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2021,7 +2021,11 @@ fn normalize_merges_legacy_profile_lists_when_categories_exist() {
     let profile = &cfg.blocklist_profiles[0];
     assert!(profile.sites.contains(&"youtube.com".to_string()));
     assert!(profile.sites.contains(&"legacy.com".to_string()));
-    assert!(profile.allowlist_sites.contains(&"legacy-allow.com".to_string()));
+    assert!(
+        profile
+            .allowlist_sites
+            .contains(&"legacy-allow.com".to_string())
+    );
     assert!(profile.categories.iter().any(|category| {
         category
             .sites

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -109,11 +109,13 @@ fn round_trip_full_config() {
                 name: "Work".to_string(),
                 sites: vec!["example.com".to_string(), "reddit.com".to_string()],
                 allowlist_sites: vec!["reddit.com".to_string()],
+                ..BlocklistProfileConfig::default()
             },
             BlocklistProfileConfig {
                 name: "Study".to_string(),
                 sites: vec!["x.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..BlocklistProfileConfig::default()
             },
         ],
         selected_blocklist_profile: "Study".to_string(),
@@ -473,11 +475,13 @@ fn normalize_session_templates_deduplicates_and_filters_invalid_entries() {
                 name: "Work".to_string(),
                 sites: vec!["youtube.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..BlocklistProfileConfig::default()
             },
             BlocklistProfileConfig {
                 name: "Study".to_string(),
                 sites: vec!["reddit.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..BlocklistProfileConfig::default()
             },
         ],
         session_templates: vec![
@@ -874,11 +878,13 @@ fn normalize_automation_trigger_apply_defaults_resolves_references() {
                 name: "Default".to_string(),
                 sites: Vec::new(),
                 allowlist_sites: Vec::new(),
+                ..BlocklistProfileConfig::default()
             },
             BlocklistProfileConfig {
                 name: "Work".to_string(),
                 sites: Vec::new(),
                 allowlist_sites: Vec::new(),
+                ..BlocklistProfileConfig::default()
             },
         ],
         session_templates: vec![SessionTemplateConfig {
@@ -989,6 +995,7 @@ fn validate_automation_trigger_rules_accepts_distinct_valid_rules() {
             name: "Work".to_string(),
             sites: Vec::new(),
             allowlist_sites: Vec::new(),
+            ..BlocklistProfileConfig::default()
         },
     ];
     let templates = vec![SessionTemplateConfig {
@@ -1765,11 +1772,13 @@ fn normalize_deduplicates_profile_names_and_fixes_selection() {
                 name: "Work".to_string(),
                 sites: vec!["a.com".to_string()],
                 allowlist_sites: vec!["b.com".to_string()],
+                ..BlocklistProfileConfig::default()
             },
             BlocklistProfileConfig {
                 name: "work".to_string(),
                 sites: vec!["b.com".to_string()],
                 allowlist_sites: Vec::new(),
+                ..BlocklistProfileConfig::default()
             },
         ],
         selected_blocklist_profile: "missing".to_string(),
@@ -1790,6 +1799,7 @@ fn normalize_keeps_legacy_blocked_sites_empty_for_profile_only_config() {
             name: "Work".to_string(),
             sites: vec!["a.com".to_string(), "b.com".to_string()],
             allowlist_sites: vec!["b.com".to_string()],
+            ..BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Work".to_string(),
         ..AppConfig::default()
@@ -1978,6 +1988,7 @@ fn normalize_keeps_legacy_blocked_sites_when_profiles_exist() {
             name: "Work".to_string(),
             sites: vec!["a.com".to_string(), "b.com".to_string()],
             allowlist_sites: vec!["b.com".to_string()],
+            ..BlocklistProfileConfig::default()
         }],
         selected_blocklist_profile: "Work".to_string(),
         ..AppConfig::default()

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1998,3 +1998,34 @@ fn normalize_keeps_legacy_blocked_sites_when_profiles_exist() {
     assert_eq!(cfg.selected_blocklist_profile, "Work");
     assert_eq!(cfg.blocked_sites, vec!["legacy-only.com".to_string()]);
 }
+
+#[test]
+fn normalize_merges_legacy_profile_lists_when_categories_exist() {
+    let cfg = AppConfig {
+        blocklist_profiles: vec![BlocklistProfileConfig {
+            name: "Work".to_string(),
+            sites: vec!["legacy.com".to_string()],
+            allowlist_sites: vec!["legacy-allow.com".to_string()],
+            categories: vec![BlocklistCategoryConfig {
+                name: "Social".to_string(),
+                sites: vec!["youtube.com".to_string()],
+                allowlist_sites: Vec::new(),
+            }],
+            selected_category: "Social".to_string(),
+        }],
+        selected_blocklist_profile: "Work".to_string(),
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    let profile = &cfg.blocklist_profiles[0];
+    assert!(profile.sites.contains(&"youtube.com".to_string()));
+    assert!(profile.sites.contains(&"legacy.com".to_string()));
+    assert!(profile.allowlist_sites.contains(&"legacy-allow.com".to_string()));
+    assert!(profile.categories.iter().any(|category| {
+        category
+            .sites
+            .iter()
+            .any(|site| site.eq_ignore_ascii_case("legacy.com"))
+    }));
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2026,10 +2026,23 @@ fn normalize_merges_legacy_profile_lists_when_categories_exist() {
             .allowlist_sites
             .contains(&"legacy-allow.com".to_string())
     );
+    assert!(profile
+        .categories
+        .iter()
+        .any(|category| category.name.eq_ignore_ascii_case("Social")
+            && category
+                .sites
+                .iter()
+                .any(|site| site.eq_ignore_ascii_case("youtube.com"))));
     assert!(profile.categories.iter().any(|category| {
-        category
-            .sites
-            .iter()
-            .any(|site| site.eq_ignore_ascii_case("legacy.com"))
+        category.name.eq_ignore_ascii_case("General")
+            && category
+                .sites
+                .iter()
+                .any(|site| site.eq_ignore_ascii_case("legacy.com"))
+            && category
+                .allowlist_sites
+                .iter()
+                .any(|site| site.eq_ignore_ascii_case("legacy-allow.com"))
     }));
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2026,14 +2026,13 @@ fn normalize_merges_legacy_profile_lists_when_categories_exist() {
             .allowlist_sites
             .contains(&"legacy-allow.com".to_string())
     );
-    assert!(profile
-        .categories
-        .iter()
-        .any(|category| category.name.eq_ignore_ascii_case("Social")
+    assert!(profile.categories.iter().any(|category| {
+        category.name.eq_ignore_ascii_case("Social")
             && category
                 .sites
                 .iter()
-                .any(|site| site.eq_ignore_ascii_case("youtube.com"))));
+                .any(|site| site.eq_ignore_ascii_case("youtube.com"))
+    }));
     assert!(profile.categories.iter().any(|category| {
         category.name.eq_ignore_ascii_case("General")
             && category

--- a/src/ui/site_manager.rs
+++ b/src/ui/site_manager.rs
@@ -51,10 +51,13 @@ pub(super) fn render_site_manager(frame: &mut Frame, app: &App) {
 
     let site_list_mode = app.site_list_mode();
     let profile_text = format!(
-        "Profile: {} ({}/{}) · List: {} · Effective blocks: {}",
+        "Profile: {} ({}/{}) · Category: {} ({}/{}) · List: {} · Effective blocks: {}",
         app.active_blocklist_profile_name(),
         app.active_blocklist_profile_position(),
         app.blocklist_profile_count(),
+        app.active_blocklist_category_name(),
+        app.active_blocklist_category_position(),
+        app.blocklist_category_count(),
         site_list_mode.label(),
         app.effective_blocked_site_count()
     );
@@ -179,8 +182,9 @@ fn render_site_manager_site_list(
     empty_text: &str,
 ) {
     let list_title = format!(
-        " {list_title_label} · {} ({}) ",
+        " {list_title_label} · {} / {} ({}) ",
         app.active_blocklist_profile_name(),
+        app.active_blocklist_category_name(),
         app.active_policy_site_count()
     );
     let list_block = Block::default()
@@ -266,6 +270,8 @@ fn render_site_manager_profile_input(
     let profile_input_title = match profile_input_mode {
         Some(BlocklistProfileInputMode::Create) => " New Blocklist Profile ",
         Some(BlocklistProfileInputMode::Rename) => " Rename Blocklist Profile ",
+        Some(BlocklistProfileInputMode::CreateCategory) => " New Blocklist Category ",
+        Some(BlocklistProfileInputMode::RenameCategory) => " Rename Blocklist Category ",
         None => " Blocklist Profiles ",
     };
     let active_style = if app.blocklist_profile_input_active {
@@ -277,13 +283,14 @@ fn render_site_manager_profile_input(
         format!("{}_", app.blocklist_profile_input)
     } else {
         format!(
-            "Use {} to toggle blocklist/allowlist, {} create, {} rename, {} delete, [{} {}] switch",
-            app.shortcut_hint(ShortcutAction::ToggleSiteListMode),
+            "Profiles [{} {}] switch · {} create/{} rename/{} delete · Categories [{} {}] switch (Ctrl+N/Ctrl+R/Ctrl+X)",
+            app.shortcut_label(ShortcutAction::SelectPreviousBlocklistProfile),
+            app.shortcut_label(ShortcutAction::SelectNextBlocklistProfile),
             app.shortcut_hint(ShortcutAction::CreateBlocklistProfile),
             app.shortcut_hint(ShortcutAction::RenameBlocklistProfile),
             app.shortcut_hint(ShortcutAction::DeleteBlocklistProfile),
-            app.shortcut_label(ShortcutAction::SelectPreviousBlocklistProfile),
-            app.shortcut_label(ShortcutAction::SelectNextBlocklistProfile),
+            app.navigation_label(NavigationAction::MoveLeft),
+            app.navigation_label(NavigationAction::MoveRight),
         )
     };
     frame.render_widget(
@@ -369,13 +376,20 @@ fn site_manager_hint_lines(
     }
 
     if app.blocklist_profile_input_active {
+        let target = match app.blocklist_profile_input_mode() {
+            Some(
+                BlocklistProfileInputMode::CreateCategory
+                | BlocklistProfileInputMode::RenameCategory,
+            ) => "Category",
+            _ => "Profile",
+        };
         return vec![
             Line::from(format!(
-                "Profile: {} Save  {} Cancel",
+                "{target}: {} Save  {} Cancel",
                 app.navigation_hint(NavigationAction::Confirm),
                 app.navigation_hint(NavigationAction::Cancel)
             )),
-            Line::from("Tip: use descriptive names like Work, Study, or Deep Work"),
+            Line::from("Tip: use descriptive names like Work, Study, Deep Work, or Social Media"),
             Line::from("Tip: disable DNS-over-HTTPS in your browser so blocking can apply"),
         ];
     }
@@ -394,12 +408,14 @@ fn site_manager_hint_lines(
                 app.navigation_hint(NavigationAction::MoveDown),
             )),
             Line::from(format!(
-                "Profiles: [{} {}] Switch  {} New  {} Rename  {} Delete  [{}/{}] Back  [{}] Quit (Locked)",
+                "Profiles: [{} {}] Switch  {} New  {} Rename  {} Delete  Categories: [{}/{}] Switch  [Ctrl+N/Ctrl+R/Ctrl+X] Manage  [{}/{}] Back  [{}] Quit (Locked)",
                 app.shortcut_label(ShortcutAction::SelectPreviousBlocklistProfile),
                 app.shortcut_label(ShortcutAction::SelectNextBlocklistProfile),
                 app.shortcut_hint(ShortcutAction::CreateBlocklistProfile),
                 app.shortcut_hint(ShortcutAction::RenameBlocklistProfile),
                 app.shortcut_hint(ShortcutAction::DeleteBlocklistProfile),
+                app.navigation_label(NavigationAction::MoveLeft),
+                app.navigation_label(NavigationAction::MoveRight),
                 app.shortcut_label(ShortcutAction::BackSiteManager),
                 app.navigation_label(NavigationAction::Cancel),
                 app.shortcut_label(ShortcutAction::Quit),
@@ -421,12 +437,14 @@ fn site_manager_hint_lines(
             app.navigation_hint(NavigationAction::MoveDown),
         )),
         Line::from(format!(
-            "Profiles: [{} {}] Switch  {} New  {} Rename  {} Delete  [{}/{}] Back",
+            "Profiles: [{} {}] Switch  {} New  {} Rename  {} Delete  Categories: [{}/{}] Switch  [Ctrl+N/Ctrl+R/Ctrl+X] Manage  [{}/{}] Back",
             app.shortcut_label(ShortcutAction::SelectPreviousBlocklistProfile),
             app.shortcut_label(ShortcutAction::SelectNextBlocklistProfile),
             app.shortcut_hint(ShortcutAction::CreateBlocklistProfile),
             app.shortcut_hint(ShortcutAction::RenameBlocklistProfile),
             app.shortcut_hint(ShortcutAction::DeleteBlocklistProfile),
+            app.navigation_label(NavigationAction::MoveLeft),
+            app.navigation_label(NavigationAction::MoveRight),
             app.shortcut_label(ShortcutAction::BackSiteManager),
             app.navigation_label(NavigationAction::Cancel),
         )),


### PR DESCRIPTION
## What

Add blocklist categories within each profile and wildcard domain rules (`*.example.com`) across config normalization, effective blocking, TUI workflows, and CLI workflows.

## Why

Issue #318 requires category-based organization for blocklists and wildcard rule support while preserving compatibility with existing profile-level `sites` and `allowlist_sites` data.

Closes #318.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable) - N/A
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable) - N/A
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable) - N/A
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR - N/A (no breaking behavior intended)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocklist category management in profiles (create/rename/delete/select) across CLI and TUI; category appears in CLI/TUI outputs and site commands.

* **Improvements**
  * Wildcard domain rules (e.g., *.example.com) supported as subdomain-only matches; effective blocking computed from normalized, case-insensitive, deduplicated rules.
  * Hosts-file previews/exports omit wildcard-only entries.
  * Config persistence normalizes and preserves category structures while keeping legacy mirrors.

* **Documentation**
  * README and CHANGELOG updated with commands, examples, and wildcard behavior notes.

* **Tests**
  * Added/updated tests for wildcard handling, category aggregation, and effective-blocking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->