### PR TITLE
Prepare v0.12.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.11.1 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.12.0 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -116,7 +116,7 @@ When preparing a release update, keep these files aligned:
 - `README.md` release automation and latest-release references
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
-- Release tag examples in docs use the current target release version (for example, `v0.11.1`)
+- Release tag examples in docs use the current target release version (for example, `v0.12.0`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,3 +127,5 @@ sequenceDiagram
   readability and keeps facades focused.
 - Keep platform-specific behavior explicit with `#[cfg(...)]` in the module that
   owns it.
+- For release docs updates, keep architecture-facing terminology aligned with the
+  module names and responsibility language used in `README.md` and release notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Temporary allowlist timer with auto-expiry (#317):** added temporary allowlist entries that automatically expire, including runtime support and CLI/TUI controls.
 - **Blocklist categories and wildcard domain rules (#318):** added per-profile blocklist category management across CLI and TUI, plus wildcard subdomain rule support (`*.example.com`) in blocklist/allowlist matching with consistent effective-blocking computation.
 
+### Removed
+
+- Legacy top-level timer compatibility fields (`focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval`) are retired; configure durations under `[custom_profile]`.
+- Legacy top-level automation compatibility fields (`notifications`, `auto_start`, `strict_mode`, `recurring_schedule`) are retired; configure per-profile automation under `[profile_automation.<profile>]`.
+- Legacy top-level `blocked_sites` compatibility fallback is retired; use `[[blocklist_profiles]]` with `selected_blocklist_profile`.
+
 ## [0.11.1] - 2026-05-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.12.0] - 2026-05-20
+
+### Added
+
+- **Session templates for task/profile/blocklist/schedule bundles (#314):** added reusable session-template bundles with config/runtime wiring plus CLI and planner workflows for selecting and applying templates.
+- **Day-of-week smart profile switching (#315):** added weekday rule configuration and runtime profile switching controls across CLI and TUI profile-management flows.
+- **Rule-based automation triggers (time/schedule/event) (#316):** added explicit automation trigger rules with runtime execution support and CLI/TUI management surfaces.
+- **Temporary allowlist timer with auto-expiry (#317):** added temporary allowlist entries that automatically expire, including runtime support and CLI/TUI controls.
 - **Blocklist categories and wildcard domain rules (#318):** added per-profile blocklist category management across CLI and TUI, plus wildcard subdomain rule support (`*.example.com`) in blocklist/allowlist matching with consistent effective-blocking computation.
 
 ## [0.11.1] - 2026-05-18
@@ -286,7 +294,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/utilForever/focustime/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/utilForever/focustime/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/utilForever/focustime/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/utilForever/focustime/compare/v0.10.0...v0.10.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ The project uses Conventional Commit-style release commits:
 
 Before preparing a release commit, make sure all CI jobs pass for the release changes.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.11.1`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.12.0`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -235,15 +235,15 @@ deprecation warnings when legacy compatibility fields are detected.
 
 | Legacy field/path                                                                    | Canonical replacement                                                                                                                             | Removal milestone |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| Top-level `focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval` | `[custom_profile]`                                                                                                                                | v0.12.0 (planned) |
-| Top-level `notifications`, `auto_start`, `strict_mode`, `recurring_schedule`         | `[profile_automation.<profile>.notifications]`, `[profile_automation.<profile>.auto_start]`, and per-profile `strict_mode` / `recurring_schedule` | v0.12.0 (planned) |
-| Top-level `blocked_sites` (without canonical profiles)                               | `[[blocklist_profiles]]` + `selected_blocklist_profile`                                                                                           | v0.12.0 (planned) |
+| Top-level `focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval` | `[custom_profile]`                                                                                                                                | v0.12.0           |
+| Top-level `notifications`, `auto_start`, `strict_mode`, `recurring_schedule`         | `[profile_automation.<profile>.notifications]`, `[profile_automation.<profile>.auto_start]`, and per-profile `strict_mode` / `recurring_schedule` | v0.12.0           |
+| Top-level `blocked_sites` (without canonical profiles)                               | `[[blocklist_profiles]]` + `selected_blocklist_profile`                                                                                           | v0.12.0           |
 
 Milestone policy:
 
 - **v0.10.x migration window:** warning-only window with migration tooling (`--migrate`, `--backup`, `--restore`)
 - **v0.11.0+:** retired temporary migration-only CLI compatibility flags (`--migrate`, `--dry-run`); `--backup`/`--restore` remain supported.
-- **v0.12.0 (planned):** remove legacy field/path compatibility after the warning window
+- **v0.12.0:** remove legacy field/path compatibility after the warning window
 
 ### CLI JSON/error contract
 
@@ -847,12 +847,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.11.1`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.12.0`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.11.1](https://github.com/utilForever/focustime/releases/tag/v0.11.1).
+The latest stable release is [v0.12.0](https://github.com/utilForever/focustime/releases/tag/v0.12.0).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -425,8 +425,6 @@ block_command = ""
 unblock_command = ""
 diagnostics_command = ""
 
-# Strict mode for the selected profile's automation settings.
-strict_mode = false
 break_glass_duration_secs = 300
 
 [shortcuts]
@@ -487,6 +485,10 @@ focus_secs = 1800
 short_break_secs = 360
 long_break_secs = 900
 long_break_interval = 3
+
+[profile_automation.custom]
+# Strict mode for the selected profile.
+strict_mode = false
 
 [profile_automation.custom.notifications]
 enabled = true


### PR DESCRIPTION
## What

Align the v0.12.0 release branch metadata and release docs, and complete v0.12.0 changelog coverage for merged work in the release window.

## Why

The release update needed consistent version/tag references across docs and package metadata, and the v0.12.0 changelog was missing several merged PR-related entries between `v0.11.1..HEAD`.

Closes #348.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-template bundles, day-of-week smart profile switching, rule-based automation triggers, temporary allowlist timer with auto-expiry, and blocklist categories with wildcard domain rules.

* **Removed**
  * Retired legacy timer/automation compatibility fields and legacy blocklist fallback.

* **Documentation**
  * Updated release/compatibility docs, README guidance, and changelog for v0.12.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->