### PR TITLE
Template edit/rename/duplicate reliability fixes

### DIFF
--- a/src/app/session_templates.rs
+++ b/src/app/session_templates.rs
@@ -1,5 +1,7 @@
 use crate::app::{App, normalize_task_label, task_label_index};
-use crate::config::{ProfileAutomationConfig, SessionTemplateConfig};
+use crate::config::{
+    AutomationTriggerActionConfig, ProfileAutomationConfig, SessionTemplateConfig,
+};
 
 impl App {
     pub(super) fn apply_selected_session_template_before_start(&mut self) -> Result<(), String> {
@@ -95,6 +97,7 @@ impl App {
         if let Some(template) = self.session_templates.get_mut(template_index) {
             template.name = name.to_string();
         }
+        self.rename_session_template_references(&current_name, name);
         self.save_config();
         Ok(true)
     }
@@ -110,6 +113,11 @@ impl App {
         if index >= self.session_templates.len() {
             return Err("Session template selection is invalid.".to_string());
         }
+        let removed_name = self
+            .session_templates
+            .get(index)
+            .map(|template| template.name.clone())
+            .ok_or_else(|| "Session template selection is invalid.".to_string())?;
         self.session_templates.remove(index);
         if self.session_templates.is_empty() {
             self.active_session_template = None;
@@ -124,6 +132,7 @@ impl App {
                 }
             });
         }
+        self.clear_session_template_references(&removed_name);
         self.save_config();
         Ok(true)
     }
@@ -208,5 +217,41 @@ impl App {
         self.session_templates
             .iter()
             .position(|template| template.name.eq_ignore_ascii_case(name.trim()))
+    }
+
+    fn rename_session_template_references(&mut self, previous_name: &str, next_name: &str) {
+        self.rewrite_session_template_references(previous_name, Some(next_name));
+    }
+
+    fn clear_session_template_references(&mut self, removed_name: &str) {
+        self.rewrite_session_template_references(removed_name, None);
+    }
+
+    fn rewrite_session_template_references(
+        &mut self,
+        target_name: &str,
+        replacement: Option<&str>,
+    ) {
+        let replacement = replacement.map(str::to_string);
+
+        for rule in &mut self.weekday_profile_rules {
+            if let Some(name) = rule.session_template.as_deref()
+                && name.eq_ignore_ascii_case(target_name)
+            {
+                rule.session_template = replacement.clone();
+            }
+        }
+
+        for trigger in &mut self.automation_triggers {
+            if let AutomationTriggerActionConfig::ApplyDefaults {
+                session_template, ..
+            } = &mut trigger.action
+                && session_template
+                    .as_deref()
+                    .is_some_and(|name| name.eq_ignore_ascii_case(target_name))
+            {
+                *session_template = replacement.clone();
+            }
+        }
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5272,6 +5272,156 @@ fn session_planner_template_delete_non_active_keeps_active_template() {
 }
 
 #[test]
+fn session_template_rename_updates_weekday_and_automation_references() {
+    let mut app = App::default();
+    app.task_labels = vec!["Docs".to_string()];
+    app.selected_task_label = Some("Docs".to_string());
+    app.capture_session_template("Template A")
+        .expect("template A should be created");
+
+    app.weekday_profile_rules = vec![WeekdayProfileRuleConfig {
+        day: "mon".to_string(),
+        profile: ProfileId::Classic,
+        blocklist_profile: "Default".to_string(),
+        session_template: Some("template a".to_string()),
+    }];
+    app.automation_triggers = vec![AutomationTriggerRuleConfig {
+        trigger: AutomationTriggerConditionConfig::FocusStarted,
+        action: AutomationTriggerActionConfig::ApplyDefaults {
+            profile: ProfileId::Classic,
+            blocklist_profile: "Default".to_string(),
+            session_template: Some("TEMPLATE A".to_string()),
+        },
+    }];
+
+    let updated = app
+        .rename_session_template_at(0, "Template B")
+        .expect("rename should succeed");
+
+    assert!(updated);
+    assert_eq!(
+        app.weekday_profile_rules[0].session_template.as_deref(),
+        Some("Template B")
+    );
+    let Some(AutomationTriggerRuleConfig {
+        action:
+            AutomationTriggerActionConfig::ApplyDefaults {
+                session_template, ..
+            },
+        ..
+    }) = app.automation_triggers.first()
+    else {
+        panic!("expected apply-defaults trigger");
+    };
+    assert_eq!(session_template.as_deref(), Some("Template B"));
+}
+
+#[test]
+fn session_template_delete_clears_weekday_and_automation_references() {
+    let mut app = App::default();
+    app.task_labels = vec!["Docs".to_string(), "Review".to_string()];
+
+    app.selected_task_label = Some("Docs".to_string());
+    app.capture_session_template("Template A")
+        .expect("template A should be created");
+    app.selected_task_label = Some("Review".to_string());
+    app.capture_session_template("Template B")
+        .expect("template B should be created");
+
+    app.weekday_profile_rules = vec![
+        WeekdayProfileRuleConfig {
+            day: "mon".to_string(),
+            profile: ProfileId::Classic,
+            blocklist_profile: "Default".to_string(),
+            session_template: Some("template a".to_string()),
+        },
+        WeekdayProfileRuleConfig {
+            day: "tue".to_string(),
+            profile: ProfileId::Classic,
+            blocklist_profile: "Default".to_string(),
+            session_template: Some("Template B".to_string()),
+        },
+    ];
+    app.automation_triggers = vec![
+        AutomationTriggerRuleConfig {
+            trigger: AutomationTriggerConditionConfig::FocusStarted,
+            action: AutomationTriggerActionConfig::ApplyDefaults {
+                profile: ProfileId::Classic,
+                blocklist_profile: "Default".to_string(),
+                session_template: Some("TEMPLATE A".to_string()),
+            },
+        },
+        AutomationTriggerRuleConfig {
+            trigger: AutomationTriggerConditionConfig::FocusCompleted,
+            action: AutomationTriggerActionConfig::ApplyDefaults {
+                profile: ProfileId::Classic,
+                blocklist_profile: "Default".to_string(),
+                session_template: Some("Template B".to_string()),
+            },
+        },
+    ];
+
+    app.delete_session_template_at(0)
+        .expect("delete should succeed");
+
+    assert_eq!(app.session_templates.len(), 1);
+    assert_eq!(app.session_templates[0].name, "Template B");
+    assert_eq!(app.weekday_profile_rules[0].session_template, None);
+    assert_eq!(
+        app.weekday_profile_rules[1].session_template.as_deref(),
+        Some("Template B")
+    );
+    let Some(AutomationTriggerRuleConfig {
+        action:
+            AutomationTriggerActionConfig::ApplyDefaults {
+                session_template, ..
+            },
+        ..
+    }) = app.automation_triggers.first()
+    else {
+        panic!("expected apply-defaults trigger");
+    };
+    assert!(session_template.is_none());
+    let Some(AutomationTriggerRuleConfig {
+        action:
+            AutomationTriggerActionConfig::ApplyDefaults {
+                session_template, ..
+            },
+        ..
+    }) = app.automation_triggers.get(1)
+    else {
+        panic!("expected second apply-defaults trigger");
+    };
+    assert_eq!(session_template.as_deref(), Some("Template B"));
+}
+
+#[test]
+fn session_template_chained_rename_and_create_preserves_duplicate_validation() {
+    let mut app = App::default();
+    app.task_labels = vec!["Docs".to_string()];
+    app.selected_task_label = Some("Docs".to_string());
+
+    app.capture_session_template("Template A")
+        .expect("template A should be created");
+    app.rename_session_template_at(0, "Template B")
+        .expect("rename should succeed");
+    app.capture_session_template("Template A")
+        .expect("template A should be creatable again");
+
+    let names = app
+        .session_templates
+        .iter()
+        .map(|template| template.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["Template B", "Template A"]);
+
+    let err = app
+        .rename_session_template_at(1, "Template B")
+        .expect_err("rename to duplicate should fail");
+    assert!(err.contains("Template `Template B` already exists."));
+}
+
+#[test]
 fn session_planner_rename_moves_task_goal_target() {
     let mut app = App::default();
     app.task_labels = vec!["Docs".to_string()];


### PR DESCRIPTION
## What

- Keep session template references consistent when templates are renamed or deleted.
- Add regression tests for rename/delete reference rewrites and chained rename/create duplicate validation.

## Why

Template mutations previously updated only the template list and active selection. Weekday rules and automation trigger defaults could still point to stale template names after rename/delete, creating reliability gaps in chained operations.

Closes #319.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session templates now automatically update all internal references when renamed or deleted, ensuring consistency across rules and automation triggers throughout the application.

* **Tests**
  * Added comprehensive unit tests covering session template rename, delete, and duplicate-name validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->