### PR TITLE
Wildcard matching edge-case correctness fixes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,8 +9,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crate::blocker::{
     BlockingBackendKind, BlockingBackendPolicy, BlockingIntent, BlockingPreview,
     BlockingPreviewAction, BulkAddResult, CommandBlockingBackend, EditSiteResult,
-    HostsFileDiagnostics, InvalidSiteInput, SiteBlocker, domain_rule_matches_host,
-    normalize_domain_rule,
+    HostsFileDiagnostics, InvalidSiteInput, SiteBlocker,
 };
 use crate::config::{
     AppConfig, AutoStartConfig, AutomationTriggerRuleConfig, BlockingBackendConfig,
@@ -1828,63 +1827,7 @@ fn display_input_value(input: &str) -> String {
 }
 
 fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
-    let allowlist_rules: Vec<String> = all_allowlist_rules_for_profile(profile)
-        .iter()
-        .filter_map(|rule| normalize_domain_rule(rule).ok())
-        .collect();
-    let mut seen = HashSet::new();
-    all_blocklist_rules_for_profile(profile)
-        .into_iter()
-        .filter_map(|site| normalize_domain_rule(&site).ok())
-        .filter(|site| !block_rule_excluded_by_allowlist(site, &allowlist_rules))
-        .filter(|site| seen.insert(site.to_ascii_lowercase()))
-        .collect()
-}
-
-fn block_rule_excluded_by_allowlist(block_rule: &str, allowlist_rules: &[String]) -> bool {
-    if block_rule.starts_with("*.") {
-        return allowlist_rules
-            .iter()
-            .any(|allow_rule| allow_rule.eq_ignore_ascii_case(block_rule));
-    }
-    allowlist_rules
-        .iter()
-        .any(|allow_rule| domain_rule_matches_host(allow_rule, block_rule))
-}
-
-fn all_blocklist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
-    if profile.categories.is_empty() {
-        return dedup_case_insensitive(profile.sites.iter().cloned());
-    }
-    dedup_case_insensitive(
-        profile
-            .categories
-            .iter()
-            .flat_map(|category| category.sites.iter().cloned()),
-    )
-}
-
-fn all_allowlist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
-    if profile.categories.is_empty() {
-        return dedup_case_insensitive(profile.allowlist_sites.iter().cloned());
-    }
-    dedup_case_insensitive(
-        profile
-            .categories
-            .iter()
-            .flat_map(|category| category.allowlist_sites.iter().cloned()),
-    )
-}
-
-fn dedup_case_insensitive<I>(values: I) -> Vec<String>
-where
-    I: IntoIterator<Item = String>,
-{
-    let mut seen = HashSet::new();
-    values
-        .into_iter()
-        .filter(|value| seen.insert(value.to_ascii_lowercase()))
-        .collect()
+    crate::config::effective_blocked_sites_for_profile(profile)
 }
 
 fn permission_remediation_guidance() -> &'static str {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2368,6 +2368,30 @@ fn wildcard_rules_are_kept_in_effective_blocking() {
 }
 
 #[test]
+fn runtime_effective_blocking_canonicalizes_dotted_and_punycode_rules() {
+    let config = AppConfig {
+        blocklist_profiles: vec![BlocklistProfileConfig {
+            name: "Work".to_string(),
+            sites: vec![
+                ".Example.com".to_string(),
+                "*.xn--bcher-kva.example.".to_string(),
+                "api.example.com.".to_string(),
+            ],
+            allowlist_sites: vec![".example.com".to_string()],
+            ..BlocklistProfileConfig::default()
+        }],
+        selected_blocklist_profile: "Work".to_string(),
+        ..AppConfig::default()
+    };
+    let app = App::from_config(config);
+
+    assert_eq!(
+        app.blocker.sites,
+        vec!["*.xn--bcher-kva.example".to_string()]
+    );
+}
+
+#[test]
 fn site_manager_allowlist_mode_updates_effective_blocked_sites() {
     let config = AppConfig {
         blocklist_profiles: vec![BlocklistProfileConfig {

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -124,7 +124,7 @@ fn normalize_domain_like_input(
 ) -> Result<String, SiteValidationError> {
     let hostname = extract_hostname_candidate(input)?;
     let (hostname, wildcard_prefix) = extract_wildcard_prefix(hostname, allow_wildcard_prefix)?;
-    let hostname = strip_numeric_port(hostname)?;
+    let hostname = strip_trailing_root_dots(strip_numeric_port(hostname)?);
     if hostname.is_empty() {
         return Err(SiteValidationError::MissingHostname);
     }
@@ -166,6 +166,9 @@ fn extract_wildcard_prefix(
         }
         return Ok((stripped.to_string(), true));
     }
+    if let Some(stripped) = hostname.strip_prefix('.') {
+        return Ok((stripped.to_string(), allow_wildcard_prefix));
+    }
     Ok((hostname, false))
 }
 
@@ -178,6 +181,13 @@ fn strip_numeric_port(mut hostname: String) -> Result<String, SiteValidationErro
         hostname.truncate(colon_pos);
     }
     Ok(hostname)
+}
+
+fn strip_trailing_root_dots(mut hostname: String) -> String {
+    while hostname.ends_with('.') {
+        hostname.pop();
+    }
+    hostname
 }
 
 fn validate_domain_host(hostname: &str) -> Result<(), SiteValidationError> {
@@ -1486,6 +1496,47 @@ mod tests {
             normalize_domain_rule("https://*.example.com/path").unwrap(),
             "*.example.com"
         );
+    }
+
+    #[test]
+    fn normalize_domain_rule_canonicalizes_dotted_forms() {
+        assert_eq!(
+            normalize_domain_rule(".Example.com").unwrap(),
+            "*.example.com"
+        );
+        assert_eq!(
+            normalize_domain_rule("example.com.").unwrap(),
+            "example.com"
+        );
+        assert_eq!(
+            normalize_domain_rule("https://.Example.com./path").unwrap(),
+            "*.example.com"
+        );
+        assert_eq!(
+            normalize_domain_rule(".com").unwrap_err(),
+            SiteValidationError::InvalidLabel
+        );
+    }
+
+    #[test]
+    fn normalize_domain_host_canonicalizes_root_dot_forms() {
+        assert_eq!(
+            normalize_domain_host(".WWW.Example.com.").unwrap(),
+            "www.example.com"
+        );
+    }
+
+    #[test]
+    fn wildcard_matching_handles_punycode_and_dotted_forms() {
+        assert!(domain_rule_matches_host(
+            ".xn--bcher-kva.example",
+            "shop.xn--bcher-kva.example."
+        ));
+        assert!(domain_rule_matches_host(
+            "*.example.com.",
+            "service.example.com"
+        ));
+        assert!(!domain_rule_matches_host("*.example.com.", "example.com."));
     }
 
     #[test]

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,4 +1,3 @@
-use crate::blocker::{domain_rule_matches_host, normalize_domain_rule};
 use crate::cli::{
     AutomationTriggersCommandOutput, BackupOutput, BlockingPreviewAction,
     BlockingPreviewCommandOutput, BlocklistCategoryCommandOutput, BlocklistProfileCommandOutput,
@@ -906,64 +905,7 @@ pub(super) fn display_input_value(value: &str) -> String {
 }
 
 pub(super) fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
-    let allowlist_rules: Vec<String> = all_allowlist_rules_for_profile(profile)
-        .iter()
-        .filter_map(|rule| normalize_domain_rule(rule).ok())
-        .collect();
-
-    let mut seen = std::collections::HashSet::new();
-    all_blocklist_rules_for_profile(profile)
-        .into_iter()
-        .filter_map(|site| normalize_domain_rule(&site).ok())
-        .filter(|site| !block_rule_excluded_by_allowlist(site, &allowlist_rules))
-        .filter(|site| seen.insert(site.to_ascii_lowercase()))
-        .collect()
-}
-
-fn block_rule_excluded_by_allowlist(block_rule: &str, allowlist_rules: &[String]) -> bool {
-    if block_rule.starts_with("*.") {
-        return allowlist_rules
-            .iter()
-            .any(|allow_rule| allow_rule.eq_ignore_ascii_case(block_rule));
-    }
-    allowlist_rules
-        .iter()
-        .any(|allow_rule| domain_rule_matches_host(allow_rule, block_rule))
-}
-
-fn all_blocklist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
-    if profile.categories.is_empty() {
-        return dedup_case_insensitive(profile.sites.iter().cloned());
-    }
-    dedup_case_insensitive(
-        profile
-            .categories
-            .iter()
-            .flat_map(|category| category.sites.iter().cloned()),
-    )
-}
-
-fn all_allowlist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
-    if profile.categories.is_empty() {
-        return dedup_case_insensitive(profile.allowlist_sites.iter().cloned());
-    }
-    dedup_case_insensitive(
-        profile
-            .categories
-            .iter()
-            .flat_map(|category| category.allowlist_sites.iter().cloned()),
-    )
-}
-
-fn dedup_case_insensitive<I>(values: I) -> Vec<String>
-where
-    I: IntoIterator<Item = String>,
-{
-    let mut seen = std::collections::HashSet::new();
-    values
-        .into_iter()
-        .filter(|value| seen.insert(value.to_ascii_lowercase()))
-        .collect()
+    crate::config::effective_blocked_sites_for_profile(profile)
 }
 
 #[cfg(test)]
@@ -1020,6 +962,24 @@ mod tests {
         assert_eq!(
             effective_blocked_sites_for_profile(&profile),
             vec!["*.example.com".to_string(), "forum.example.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn effective_blocked_sites_canonicalizes_dotted_and_punycode_rules() {
+        let profile = crate::config::BlocklistProfileConfig {
+            sites: vec![
+                ".Example.com".to_string(),
+                "*.xn--bcher-kva.example.".to_string(),
+                "api.example.com.".to_string(),
+            ],
+            allowlist_sites: vec![".example.com".to_string()],
+            ..crate::config::BlocklistProfileConfig::default()
+        };
+
+        assert_eq!(
+            effective_blocked_sites_for_profile(&profile),
+            vec!["*.xn--bcher-kva.example".to_string()]
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -619,10 +619,18 @@ pub fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> 
 }
 
 fn block_rule_excluded_by_allowlist(block_rule: &str, allowlist_rules: &[String]) -> bool {
-    if block_rule.starts_with("*.") {
-        return allowlist_rules
-            .iter()
-            .any(|allow_rule| allow_rule.eq_ignore_ascii_case(block_rule));
+    if let Some(block_suffix) = block_rule.strip_prefix("*.") {
+        let block_suffix = block_suffix.to_ascii_lowercase();
+        return allowlist_rules.iter().any(|allow_rule| {
+            if allow_rule.eq_ignore_ascii_case(block_rule) {
+                return true;
+            }
+            let Some(allow_suffix) = allow_rule.strip_prefix("*.") else {
+                return false;
+            };
+            let allow_suffix = allow_suffix.to_ascii_lowercase();
+            block_suffix == allow_suffix || block_suffix.ends_with(&format!(".{allow_suffix}"))
+        });
     }
     allowlist_rules
         .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
+use crate::blocker::{domain_rule_matches_host, normalize_domain_rule};
 use chrono::{Local, NaiveDate};
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -600,6 +601,67 @@ impl Default for BlocklistCategoryConfig {
             allowlist_sites: Vec::new(),
         }
     }
+}
+
+pub fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+    let allowlist_rules: Vec<String> = all_allowlist_rules_for_profile(profile)
+        .iter()
+        .filter_map(|rule| normalize_domain_rule(rule).ok())
+        .collect();
+
+    let mut seen = HashSet::new();
+    all_blocklist_rules_for_profile(profile)
+        .into_iter()
+        .filter_map(|site| normalize_domain_rule(&site).ok())
+        .filter(|site| !block_rule_excluded_by_allowlist(site, &allowlist_rules))
+        .filter(|site| seen.insert(site.to_ascii_lowercase()))
+        .collect()
+}
+
+fn block_rule_excluded_by_allowlist(block_rule: &str, allowlist_rules: &[String]) -> bool {
+    if block_rule.starts_with("*.") {
+        return allowlist_rules
+            .iter()
+            .any(|allow_rule| allow_rule.eq_ignore_ascii_case(block_rule));
+    }
+    allowlist_rules
+        .iter()
+        .any(|allow_rule| domain_rule_matches_host(allow_rule, block_rule))
+}
+
+fn all_blocklist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+    if profile.categories.is_empty() {
+        return dedup_case_insensitive(profile.sites.iter().cloned());
+    }
+    dedup_case_insensitive(
+        profile
+            .categories
+            .iter()
+            .flat_map(|category| category.sites.iter().cloned()),
+    )
+}
+
+fn all_allowlist_rules_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+    if profile.categories.is_empty() {
+        return dedup_case_insensitive(profile.allowlist_sites.iter().cloned());
+    }
+    dedup_case_insensitive(
+        profile
+            .categories
+            .iter()
+            .flat_map(|category| category.allowlist_sites.iter().cloned()),
+    )
+}
+
+fn dedup_case_insensitive<I>(values: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut seen = HashSet::new();
+    values
+        .into_iter()
+        .filter(|value| seen.insert(value.to_ascii_lowercase()))
+        .collect()
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2106,3 +2106,35 @@ fn normalize_merges_legacy_profile_lists_when_categories_exist() {
                 .any(|site| site.eq_ignore_ascii_case("legacy-allow.com"))
     }));
 }
+
+#[test]
+fn effective_blocked_sites_wildcard_allowlist_covers_narrower_wildcard_blocks() {
+    let profile = BlocklistProfileConfig {
+        sites: vec![
+            "*.api.example.com".to_string(),
+            "*.deep.api.example.com".to_string(),
+            "*.other.com".to_string(),
+        ],
+        allowlist_sites: vec!["*.example.com".to_string()],
+        ..BlocklistProfileConfig::default()
+    };
+
+    assert_eq!(
+        effective_blocked_sites_for_profile(&profile),
+        vec!["*.other.com".to_string()]
+    );
+}
+
+#[test]
+fn effective_blocked_sites_exact_allowlist_does_not_cancel_wildcard_block() {
+    let profile = BlocklistProfileConfig {
+        sites: vec!["*.api.example.com".to_string()],
+        allowlist_sites: vec!["api.example.com".to_string()],
+        ..BlocklistProfileConfig::default()
+    };
+
+    assert_eq!(
+        effective_blocked_sites_for_profile(&profile),
+        vec!["*.api.example.com".to_string()]
+    );
+}


### PR DESCRIPTION
## What

Improve wildcard/domain matching correctness for dotted and punycode-style edge cases, and ensure runtime blocking and CLI diagnostics compute effective blocked sites through the same shared logic.

## Why

Issue #321 called out correctness drift risk around wildcard matching semantics across normalization, runtime behavior, and diagnostics output. This change removes duplicated matching code paths and adds targeted regressions so the same domain rules produce the same results everywhere.

Closes #321.

## Checklist

### Required

- [ ] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blocklist resolution and canonicalization: leading/trailing dots, punycode, and wildcard forms are handled consistently; allowlist entries correctly override matching blocked patterns and results are deduplicated case-insensitively.

* **Tests**
  * Added tests validating canonicalization, wildcard/allowlist interaction, and blocking behavior across dotted and punycode variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->