### PR TITLE
Temporary allowlist visibility improvements in timer and CLI status

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -656,6 +656,8 @@ struct StatusOutput {
     selected_blocklist_profile: String,
     blocked_sites_count: usize,
     temporary_allowlist_active_count: usize,
+    temporary_allowlist_next_expiry_remaining_secs: Option<u64>,
+    temporary_allowlist_next_expiry_epoch_secs: Option<i64>,
     temporary_allowlist_active: Vec<TemporaryAllowlistStatusOutput>,
     strict_mode: bool,
     goal: GoalOutput,

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -12,6 +12,7 @@ use crate::cli::{
     TimerStateOutput, WeekdayRulesCommandOutput, Write, format_schedule_conflict,
     inspect_schedule_conflicts_from_config, io,
 };
+use chrono::{Local, TimeZone};
 
 pub(super) fn print_profile_output(payload: &ProfileOutput) {
     if payload.updated {
@@ -340,16 +341,39 @@ pub(super) fn print_status_output(payload: &StatusOutput) {
         "Blocklist profile: {} ({} sites)",
         payload.selected_blocklist_profile, payload.blocked_sites_count
     );
-    println!(
-        "Temporary allowlist active: {}",
-        payload.temporary_allowlist_active_count
-    );
-    for entry in &payload.temporary_allowlist_active {
+    if payload.temporary_allowlist_active.is_empty() {
+        println!("Temporary allowlist: off");
+    } else {
+        let next_expiry_text = match (
+            payload.temporary_allowlist_next_expiry_remaining_secs,
+            payload.temporary_allowlist_next_expiry_epoch_secs,
+        ) {
+            (Some(remaining_secs), Some(epoch_secs)) => format!(
+                " (next expiry in {}{})",
+                format_duration(remaining_secs),
+                format_expiry_clock_suffix(epoch_secs)
+            ),
+            (Some(remaining_secs), None) => {
+                format!(" (next expiry in {})", format_duration(remaining_secs))
+            }
+            (None, Some(epoch_secs)) => {
+                format!(" (next expiry{})", format_expiry_clock_suffix(epoch_secs))
+            }
+            (None, None) => String::new(),
+        };
         println!(
-            "  - {} (expires in {})",
-            entry.site,
-            format_duration(entry.remaining_secs)
+            "Temporary allowlist: {} active{}",
+            payload.temporary_allowlist_active_count, next_expiry_text
         );
+        println!("Active temporary exceptions:");
+        for entry in &payload.temporary_allowlist_active {
+            println!(
+                "  - {} (expires in {}{})",
+                entry.site,
+                format_duration(entry.remaining_secs),
+                format_expiry_clock_suffix(entry.expires_at_epoch_secs)
+            );
+        }
     }
     println!(
         "Strict mode: {}",
@@ -893,6 +917,14 @@ pub(super) fn format_duration(secs: u64) -> String {
         (m, 0) => format!("{m}m"),
         (m, s) => format!("{m}m {s}s"),
     }
+}
+
+fn format_expiry_clock_suffix(epoch_secs: i64) -> String {
+    Local
+        .timestamp_opt(epoch_secs, 0)
+        .single()
+        .map(|datetime| format!(" at {}", datetime.format("%H:%M:%S")))
+        .unwrap_or_default()
 }
 
 pub(super) fn display_input_value(value: &str) -> String {

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -38,6 +38,12 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
     let selected_automation = config.profile_automation_for(config.selected_profile);
     let temporary_allowlist_active = active_temporary_allowlist_status(config);
     let temporary_allowlist_active_count = temporary_allowlist_active.len();
+    let temporary_allowlist_next_expiry_remaining_secs = temporary_allowlist_active
+        .first()
+        .map(|entry| entry.remaining_secs);
+    let temporary_allowlist_next_expiry_epoch_secs = temporary_allowlist_active
+        .first()
+        .map(|entry| entry.expires_at_epoch_secs);
     let live = build_live_status_output(config, selected_task_label.clone());
     let session = build_session_output(&live);
     let latest_interruption = stats.latest_session_interruption();
@@ -72,6 +78,8 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
         selected_blocklist_profile: config.selected_blocklist_profile.clone(),
         blocked_sites_count: active_sites_count,
         temporary_allowlist_active_count,
+        temporary_allowlist_next_expiry_remaining_secs,
+        temporary_allowlist_next_expiry_epoch_secs,
         temporary_allowlist_active,
         strict_mode: selected_automation.strict_mode,
         goal: GoalOutput {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2136,6 +2136,14 @@ fn build_status_output_includes_active_temporary_allowlist_entries() {
     session_recovery::set_test_load_workflow_state(None);
 
     assert_eq!(output.temporary_allowlist_active_count, 1);
+    assert_eq!(
+        output.temporary_allowlist_next_expiry_remaining_secs,
+        Some(output.temporary_allowlist_active[0].remaining_secs)
+    );
+    assert_eq!(
+        output.temporary_allowlist_next_expiry_epoch_secs,
+        Some(output.temporary_allowlist_active[0].expires_at_epoch_secs)
+    );
     assert_eq!(output.temporary_allowlist_active[0].site, "reddit.com");
     assert!(output.temporary_allowlist_active[0].remaining_secs <= 120);
     assert!(output.temporary_allowlist_active[0].remaining_secs > 0);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -39,8 +39,9 @@ mod timer;
 use timer::{format_duration_label, format_wakatime_heartbeat_timestamp, render_timer};
 #[cfg(test)]
 use timer::{
-    note_phase_notice_text, timer_primary_hint, timer_secondary_hint, timer_status_text,
-    timer_tertiary_hint, wakatime_status_line,
+    note_phase_notice_text, timer_primary_hint, timer_secondary_hint,
+    timer_session_status_lines_for_width, timer_status_text, timer_tertiary_hint,
+    wakatime_status_line,
 };
 
 const PROFILE_EDIT_GROUP_TIMER: [usize; 4] = [0, 1, 2, 3];

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -372,6 +372,44 @@ fn timer_status_text_shows_active_break_glass_state() {
 }
 
 #[test]
+fn timer_session_status_lines_include_active_temporary_allowlist_entries() {
+    let mut app = App::default();
+    let (added, refreshed) = app
+        .add_temporary_allowlist_for_cli("reddit.com=120s,news.ycombinator.com=180s")
+        .expect("temporary allowlist entries should be accepted");
+    assert_eq!(added, 2);
+    assert_eq!(refreshed, 0);
+
+    let lines = timer_session_status_lines_for_width(&app, 80);
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("Temp allowlist: 2 active"))
+    );
+    assert!(lines.iter().any(|line| line.contains("reddit.com")));
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("news.ycombinator.com"))
+    );
+}
+
+#[test]
+fn timer_session_status_lines_compact_temporary_allowlist_in_narrow_layouts() {
+    let mut app = App::default();
+    let (added, refreshed) = app
+        .add_temporary_allowlist_for_cli("reddit.com=120s,news.ycombinator.com=180s")
+        .expect("temporary allowlist entries should be accepted");
+    assert_eq!(added, 2);
+    assert_eq!(refreshed, 0);
+
+    let lines = timer_session_status_lines_for_width(&app, 50);
+    assert!(lines.iter().any(|line| line.contains("⏳ Temp: 2 active")));
+    assert!(lines.iter().any(|line| line.contains("reddit.com")));
+    assert!(lines.iter().any(|line| line.contains("+1 more")));
+}
+
+#[test]
 fn timer_secondary_hint_includes_setup_shortcut_in_strict_mode() {
     let mut app = App::default();
     app.strict_mode = true;

--- a/src/ui/timer.rs
+++ b/src/ui/timer.rs
@@ -278,63 +278,102 @@ fn timer_session_status_lines(
     app: &App,
     width: u16,
 ) -> Vec<String> {
+    let narrow = is_narrow_timer_status(width);
     let mut lines = vec![strict_status_text, break_glass_status_text];
-
-    if width < 56 {
-        if let Some(next_expiry_secs) = app.next_temporary_allowlist_expiry_remaining_secs() {
-            lines.push(format!(
-                "⏳ Temp: {} active (next {})",
-                app.active_temporary_allowlist_count(),
-                format_duration_label(next_expiry_secs)
-            ));
-        } else {
-            lines.push("⏳ Temp: off".to_string());
-        }
-    } else {
-        lines.push(temporary_allowlist_status_text);
-    }
+    lines.push(timer_temporary_allowlist_summary_line(
+        app,
+        narrow,
+        temporary_allowlist_status_text,
+    ));
 
     let active_entries = app.active_temporary_allowlist_entries();
     if active_entries.is_empty() {
         return lines;
     }
 
-    let max_visible_entries = if width < 56 {
+    let max_visible_entries = max_visible_temporary_allowlist_entries(width);
+
+    for entry in active_entries.iter().take(max_visible_entries) {
+        lines.push(timer_temporary_allowlist_entry_line(
+            &entry.site,
+            entry.remaining_secs,
+            narrow,
+        ));
+    }
+
+    if let Some(more_entries_line) = timer_temporary_allowlist_more_entries_line(
+        active_entries.len(),
+        max_visible_entries,
+        narrow,
+    ) {
+        lines.push(more_entries_line);
+    }
+
+    lines
+}
+
+fn is_narrow_timer_status(width: u16) -> bool {
+    width < 56
+}
+
+fn max_visible_temporary_allowlist_entries(width: u16) -> usize {
+    if width < 56 {
         1
     } else if width < 76 {
         2
     } else {
         3
-    };
+    }
+}
 
-    for entry in active_entries.iter().take(max_visible_entries) {
-        if width < 56 {
-            lines.push(format!(
-                "  • {} ({})",
-                entry.site,
-                format_duration_label(entry.remaining_secs)
-            ));
-        } else {
-            lines.push(format!(
-                "  • {} (expires in {})",
-                entry.site,
-                format_duration_label(entry.remaining_secs)
-            ));
-        }
+fn timer_temporary_allowlist_summary_line(
+    app: &App,
+    narrow: bool,
+    temporary_allowlist_status_text: String,
+) -> String {
+    if !narrow {
+        return temporary_allowlist_status_text;
     }
 
-    let hidden_entries = active_entries.len().saturating_sub(max_visible_entries);
-    if hidden_entries > 0 {
-        if width < 56 {
-            lines.push(format!("  • +{hidden_entries} more"));
-        } else if hidden_entries == 1 {
-            lines.push("  • +1 more active exception".to_string());
-        } else {
-            lines.push(format!("  • +{hidden_entries} more active exceptions"));
-        }
+    match app.next_temporary_allowlist_expiry_remaining_secs() {
+        Some(next_expiry_secs) => format!(
+            "⏳ Temp: {} active (next {})",
+            app.active_temporary_allowlist_count(),
+            format_duration_label(next_expiry_secs)
+        ),
+        None => "⏳ Temp: off".to_string(),
     }
+}
 
-    lines
+fn timer_temporary_allowlist_entry_line(site: &str, remaining_secs: u64, narrow: bool) -> String {
+    if narrow {
+        format!("  • {} ({})", site, format_duration_label(remaining_secs))
+    } else {
+        format!(
+            "  • {} (expires in {})",
+            site,
+            format_duration_label(remaining_secs)
+        )
+    }
+}
+
+fn timer_temporary_allowlist_more_entries_line(
+    total_entries: usize,
+    max_visible_entries: usize,
+    narrow: bool,
+) -> Option<String> {
+    let hidden_entries = total_entries.saturating_sub(max_visible_entries);
+    if hidden_entries == 0 {
+        return None;
+    }
+    if narrow {
+        return Some(format!("  • +{hidden_entries} more"));
+    }
+    if hidden_entries == 1 {
+        Some("  • +1 more active exception".to_string())
+    } else {
+        Some(format!("  • +{hidden_entries} more active exceptions"))
+    }
 }
 
 #[cfg(test)]

--- a/src/ui/timer.rs
+++ b/src/ui/timer.rs
@@ -168,9 +168,6 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
     let goal_text = readable_goal_streak_text(&format_timer_goal_streak_line(app));
     let (waka_text, waka_color) = wakatime_status_line(app);
     let (schedule_next_text, schedule_status_text) = app.recurring_schedule_display_texts();
-    let strict_and_break_glass = format!(
-        "{strict_status_text} · {break_glass_status_text} · {temporary_allowlist_status_text}"
-    );
 
     let mut lines = vec![
         Line::styled(task_text, task_style),
@@ -209,10 +206,18 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
         ));
     }
     lines.push(Line::styled(waka_text, Style::default().fg(waka_color)));
-    lines.push(Line::styled(
-        strict_and_break_glass,
-        Style::default().fg(app_color(app, Color::DarkGray)),
-    ));
+    for status_line in timer_session_status_lines(
+        strict_status_text,
+        break_glass_status_text,
+        temporary_allowlist_status_text,
+        app,
+        inner.width,
+    ) {
+        lines.push(Line::styled(
+            status_line,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ));
+    }
 
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
@@ -263,6 +268,85 @@ pub(super) fn timer_status_text(app: &App) -> (String, String, String, String) {
         strict_text,
         break_glass_text,
         temporary_allowlist_text,
+    )
+}
+
+fn timer_session_status_lines(
+    strict_status_text: String,
+    break_glass_status_text: String,
+    temporary_allowlist_status_text: String,
+    app: &App,
+    width: u16,
+) -> Vec<String> {
+    let mut lines = vec![strict_status_text, break_glass_status_text];
+
+    if width < 56 {
+        if let Some(next_expiry_secs) = app.next_temporary_allowlist_expiry_remaining_secs() {
+            lines.push(format!(
+                "⏳ Temp: {} active (next {})",
+                app.active_temporary_allowlist_count(),
+                format_duration_label(next_expiry_secs)
+            ));
+        } else {
+            lines.push("⏳ Temp: off".to_string());
+        }
+    } else {
+        lines.push(temporary_allowlist_status_text);
+    }
+
+    let active_entries = app.active_temporary_allowlist_entries();
+    if active_entries.is_empty() {
+        return lines;
+    }
+
+    let max_visible_entries = if width < 56 {
+        1
+    } else if width < 76 {
+        2
+    } else {
+        3
+    };
+
+    for entry in active_entries.iter().take(max_visible_entries) {
+        if width < 56 {
+            lines.push(format!(
+                "  • {} ({})",
+                entry.site,
+                format_duration_label(entry.remaining_secs)
+            ));
+        } else {
+            lines.push(format!(
+                "  • {} (expires in {})",
+                entry.site,
+                format_duration_label(entry.remaining_secs)
+            ));
+        }
+    }
+
+    let hidden_entries = active_entries.len().saturating_sub(max_visible_entries);
+    if hidden_entries > 0 {
+        if width < 56 {
+            lines.push(format!("  • +{hidden_entries} more"));
+        } else if hidden_entries == 1 {
+            lines.push("  • +1 more active exception".to_string());
+        } else {
+            lines.push(format!("  • +{hidden_entries} more active exceptions"));
+        }
+    }
+
+    lines
+}
+
+#[cfg(test)]
+pub(super) fn timer_session_status_lines_for_width(app: &App, width: u16) -> Vec<String> {
+    let (_, strict_status_text, break_glass_status_text, temporary_allowlist_status_text) =
+        timer_status_text(app);
+    timer_session_status_lines(
+        strict_status_text,
+        break_glass_status_text,
+        temporary_allowlist_status_text,
+        app,
+        width,
     )
 }
 

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -190,6 +190,16 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload.get("weekly_goal").is_some());
     assert!(payload.get("monthly_goal").is_some());
     assert!(payload.get("temporary_allowlist_active_count").is_some());
+    assert!(
+        payload
+            .get("temporary_allowlist_next_expiry_remaining_secs")
+            .is_some()
+    );
+    assert!(
+        payload
+            .get("temporary_allowlist_next_expiry_epoch_secs")
+            .is_some()
+    );
     assert!(payload.get("temporary_allowlist_active").is_some());
     assert!(payload["goal"].get("carry_over").is_some());
     assert!(payload["weekly_goal"].get("carry_over").is_some());
@@ -227,6 +237,14 @@ fn temporary_allowlist_add_json_is_reflected_in_status_json() {
     assert!(stderr_text(&status_output).trim().is_empty());
     let status_payload: Value = serde_json::from_slice(&status_output.stdout).expect("stdout JSON");
     assert_eq!(status_payload["temporary_allowlist_active_count"], 1);
+    assert_eq!(
+        status_payload["temporary_allowlist_next_expiry_remaining_secs"],
+        status_payload["temporary_allowlist_active"][0]["remaining_secs"]
+    );
+    assert_eq!(
+        status_payload["temporary_allowlist_next_expiry_epoch_secs"],
+        status_payload["temporary_allowlist_active"][0]["expires_at_epoch_secs"]
+    );
     assert_eq!(
         status_payload["temporary_allowlist_active"][0]["site"],
         "reddit.com"


### PR DESCRIPTION
## What

- Improve temporary allowlist visibility in CLI status output and timer session panel.
- Add additive JSON status fields for next temporary allowlist expiry.
- Add regression tests for CLI JSON contract, CLI status model, and timer UI status-line behavior.

## Why

Temporary allowlist state existed but was harder to scan in status surfaces, especially in narrow timer layouts, and it lacked a top-level next-expiry signal for JSON consumers.
This change makes active exceptions and expiry timing immediately visible while keeping existing JSON fields backward compatible.

Closes #322.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI status (text and JSON) now includes next temporary-allowlist expiry info (remaining seconds and epoch timestamp) and shows “off” vs “active” with next-expiry clock time when available.
  * Session panel UI now displays temporary allowlist status responsively (compact on narrow widths, full details and listed entries on wider screens).

* **Tests**
  * Added tests for the new CLI status fields and responsive UI formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->