### PR TITLE
Prepare v0.12.1 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.12.0 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.12.1 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -116,7 +116,7 @@ When preparing a release update, keep these files aligned:
 - `README.md` release automation and latest-release references
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
-- Release tag examples in docs use the current target release version (for example, `v0.12.0`)
+- Release tag examples in docs use the current target release version (for example, `v0.12.1`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.12.1] - 2026-05-21
+
+### Changed
+
+- **Temporary allowlist visibility improvements (#353):** improved temporary allowlist status visibility across CLI status output and timer UI layouts, including narrow terminal widths.
+
+### Fixed
+
+- **Wildcard matching edge-case correctness fixes (#352):** normalized wildcard-domain matching and effective blocked-site computation so broader allowlist coverage is honored consistently.
+- **Automation rule conflict validation clarity (#351):** strengthened pre-save validation and clearer diagnostics for conflicting automation trigger rules in CLI and TUI flows.
+- **Template action reference integrity (#350):** preserved template references during rename/delete operations to avoid broken template links.
+
 ## [0.12.0] - 2026-05-20
 
 ### Added
@@ -300,7 +312,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/utilForever/focustime/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/utilForever/focustime/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/utilForever/focustime/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/utilForever/focustime/compare/v0.10.1...v0.11.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ The project uses Conventional Commit-style release commits:
 
 Before preparing a release commit, make sure all CI jobs pass for the release changes.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.12.0`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.12.1`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -849,12 +849,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.12.0`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.12.1`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.12.0](https://github.com/utilForever/focustime/releases/tag/v0.12.0).
+The latest stable release is [v0.12.1](https://github.com/utilForever/focustime/releases/tag/v0.12.1).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the v0.12.1 release update by aligning package metadata and release-facing documentation, and add release notes for changes delivered after v0.12.0.

## Why

The release branch needs synchronized versioning and docs before tagging so users and contributors see accurate release guidance and history.

Closes #354.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues with CLI/TUI visibility, wildcard matching accuracy, input validation, and template-reference integrity.

* **Documentation**
  * Updated release notes, guidance documentation, and version references to reflect v0.12.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->