### PR TITLE
Weekly-to-daily goal auto-allocation planner

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -68,6 +68,7 @@ mod site_manager;
 mod temporary_allowlist;
 mod timer_flow;
 mod weekday_rules;
+pub(crate) use history_goals::weekly_daily_goal_allocation_for_context;
 use shortcuts::ShortcutBindings;
 pub use shortcuts::{NavigationAction, ShortcutAction};
 
@@ -518,6 +519,44 @@ pub struct DailyGoalProgress {
 impl DailyGoalProgress {
     pub fn has_any_target(self) -> bool {
         self.minutes.is_configured() || self.pomodoros.is_configured()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WeeklyDailyAllocationDay {
+    pub day: NaiveDate,
+    pub minutes_target: u64,
+    pub pomodoros_target: u32,
+    pub allocatable: bool,
+    pub weight_minutes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WeeklyDailyGoalAllocation {
+    pub week_target: DailyGoalSnapshot,
+    pub completed_minutes: u64,
+    pub completed_pomodoros: u32,
+    pub remaining_minutes: u64,
+    pub remaining_pomodoros: u32,
+    pub remaining_days_in_week: usize,
+    pub allocatable_days: usize,
+    pub uses_schedule_weights: bool,
+    pub daily_targets: Vec<WeeklyDailyAllocationDay>,
+}
+
+impl WeeklyDailyGoalAllocation {
+    pub fn has_any_target(&self) -> bool {
+        self.week_target.has_any_target()
+    }
+
+    pub fn today_target(&self) -> DailyGoalSnapshot {
+        self.daily_targets
+            .first()
+            .map(|target| DailyGoalSnapshot {
+                minutes: target.minutes_target,
+                pomodoros: target.pomodoros_target,
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/src/app/history_goals.rs
+++ b/src/app/history_goals.rs
@@ -269,7 +269,7 @@ pub(crate) fn weekly_daily_goal_allocation_for_context(
                 .get(index)
                 .copied()
                 .and_then(|value| u32::try_from(value).ok())
-                .unwrap_or(u32::MAX),
+                .unwrap_or(0),
             allocatable: weights.get(index).copied().unwrap_or(0) > 0,
             weight_minutes: weights.get(index).copied().unwrap_or(0),
         })

--- a/src/app/history_goals.rs
+++ b/src/app/history_goals.rs
@@ -1,8 +1,15 @@
+use std::collections::HashSet;
+
+use chrono::{Datelike, Duration, NaiveDate, Weekday};
+
 use crate::app::{
     App, AppMode, BreakGlassOverrideEvent, DailyGoalSnapshot, FocusInterruptionContext,
-    FocusSessionMetadata, Local, NaiveDate, SessionInterruptionEvent, SessionInterruptionReason,
-    carry_over_goal_target, current_day_key, previous_month_reference_day,
+    FocusSessionMetadata, Local, SessionInterruptionEvent, SessionInterruptionReason,
+    WeeklyDailyAllocationDay, WeeklyDailyGoalAllocation, carry_over_goal_target, current_day_key,
+    previous_month_reference_day,
 };
+use crate::config::RecurringScheduleConfig;
+use crate::stats::WeeklyStats;
 
 impl App {
     pub(super) fn build_focus_interruption_context(
@@ -172,6 +179,25 @@ impl App {
         carry_over_goal_target(base, self.goal_carry_over.monthly, previous)
     }
 
+    pub fn weekly_daily_goal_allocation(&self) -> WeeklyDailyGoalAllocation {
+        let today = Local::now().date_naive();
+        self.weekly_daily_goal_allocation_for_day(today)
+    }
+
+    pub(crate) fn weekly_daily_goal_allocation_for_day(
+        &self,
+        day: NaiveDate,
+    ) -> WeeklyDailyGoalAllocation {
+        let weekly_target = self.effective_weekly_goal_snapshot_for_day(day);
+        let weekly_stats = self.stats.weekly_for_day(day);
+        weekly_daily_goal_allocation_for_context(
+            day,
+            weekly_target,
+            weekly_stats,
+            &self.recurring_schedule,
+        )
+    }
+
     pub(super) fn sync_today_goal_snapshot(&mut self) {
         self.sync_goal_snapshot_for_day(Local::now().date_naive());
     }
@@ -205,4 +231,183 @@ impl App {
     pub fn latest_session_interruption(&self) -> Option<SessionInterruptionEvent> {
         self.stats.latest_session_interruption()
     }
+}
+
+pub(crate) fn weekly_daily_goal_allocation_for_context(
+    day: NaiveDate,
+    weekly_target: DailyGoalSnapshot,
+    weekly_stats: WeeklyStats,
+    schedule: &RecurringScheduleConfig,
+) -> WeeklyDailyGoalAllocation {
+    let remaining_days = remaining_days_in_current_iso_week(day);
+    let remaining_days_in_week = remaining_days.len();
+
+    let completed_minutes = weekly_stats.focused_minutes();
+    let completed_pomodoros = weekly_stats.pomodoros_completed;
+    let remaining_minutes = weekly_target.minutes.saturating_sub(completed_minutes);
+    let remaining_pomodoros = weekly_target.pomodoros.saturating_sub(completed_pomodoros);
+
+    let mut weights = schedule_weights_for_days(&remaining_days, schedule);
+    let mut allocatable_days = weights.iter().filter(|weight| **weight > 0).count();
+    let mut uses_schedule_weights = allocatable_days > 0;
+    if allocatable_days == 0 {
+        weights = vec![1; remaining_days.len()];
+        allocatable_days = remaining_days.len();
+        uses_schedule_weights = false;
+    }
+
+    let minute_targets = distribute_weighted_u64(remaining_minutes, &weights);
+    let pomodoro_targets = distribute_weighted_u64(u64::from(remaining_pomodoros), &weights);
+
+    let daily_targets = remaining_days
+        .iter()
+        .enumerate()
+        .map(|(index, target_day)| WeeklyDailyAllocationDay {
+            day: *target_day,
+            minutes_target: minute_targets.get(index).copied().unwrap_or(0),
+            pomodoros_target: pomodoro_targets
+                .get(index)
+                .copied()
+                .and_then(|value| u32::try_from(value).ok())
+                .unwrap_or(u32::MAX),
+            allocatable: weights.get(index).copied().unwrap_or(0) > 0,
+            weight_minutes: weights.get(index).copied().unwrap_or(0),
+        })
+        .collect();
+
+    WeeklyDailyGoalAllocation {
+        week_target: weekly_target,
+        completed_minutes,
+        completed_pomodoros,
+        remaining_minutes,
+        remaining_pomodoros,
+        remaining_days_in_week,
+        allocatable_days,
+        uses_schedule_weights,
+        daily_targets,
+    }
+}
+
+fn remaining_days_in_current_iso_week(day: NaiveDate) -> Vec<NaiveDate> {
+    let days_until_week_end = 6_u32.saturating_sub(day.weekday().num_days_from_monday());
+    (0..=days_until_week_end)
+        .map(|offset| day + Duration::days(i64::from(offset)))
+        .collect()
+}
+
+fn schedule_weights_for_days(days: &[NaiveDate], schedule: &RecurringScheduleConfig) -> Vec<u64> {
+    let exception_dates: HashSet<NaiveDate> = schedule
+        .exception_dates
+        .iter()
+        .filter_map(|value| parse_schedule_date(value))
+        .collect();
+    days.iter()
+        .map(|day| scheduled_weight_minutes_for_day(*day, schedule, &exception_dates))
+        .collect()
+}
+
+fn scheduled_weight_minutes_for_day(
+    day: NaiveDate,
+    schedule: &RecurringScheduleConfig,
+    exception_dates: &HashSet<NaiveDate>,
+) -> u64 {
+    let exception_applies = exception_dates.contains(&day);
+    let recurring_minutes = if exception_applies {
+        0
+    } else {
+        schedule
+            .windows
+            .iter()
+            .filter(|window| {
+                window
+                    .days
+                    .iter()
+                    .any(|token| weekday_token_matches(token, day.weekday()))
+            })
+            .map(|window| window_duration_minutes(&window.start, &window.end))
+            .sum()
+    };
+    let one_time_minutes: u64 = schedule
+        .one_time_windows
+        .iter()
+        .filter(|window| parse_schedule_date(&window.date) == Some(day))
+        .map(|window| window_duration_minutes(&window.start, &window.end))
+        .sum();
+    recurring_minutes.saturating_add(one_time_minutes)
+}
+
+fn weekday_token_matches(token: &str, weekday: Weekday) -> bool {
+    let expected = match weekday {
+        Weekday::Mon => "mon",
+        Weekday::Tue => "tue",
+        Weekday::Wed => "wed",
+        Weekday::Thu => "thu",
+        Weekday::Fri => "fri",
+        Weekday::Sat => "sat",
+        Weekday::Sun => "sun",
+    };
+    token.eq_ignore_ascii_case(expected)
+}
+
+fn parse_schedule_date(value: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").ok()
+}
+
+fn parse_schedule_time_minutes(value: &str) -> Option<u16> {
+    let (hour, minute) = value.trim().split_once(':')?;
+    let hour = hour.parse::<u16>().ok()?;
+    let minute = minute.parse::<u16>().ok()?;
+    if hour > 23 || minute > 59 {
+        return None;
+    }
+    Some(hour.saturating_mul(60).saturating_add(minute))
+}
+
+fn window_duration_minutes(start: &str, end: &str) -> u64 {
+    let Some(start_minutes) = parse_schedule_time_minutes(start) else {
+        return 0;
+    };
+    let Some(end_minutes) = parse_schedule_time_minutes(end) else {
+        return 0;
+    };
+    if end_minutes <= start_minutes {
+        return 0;
+    }
+    u64::from(end_minutes.saturating_sub(start_minutes))
+}
+
+fn distribute_weighted_u64(total: u64, weights: &[u64]) -> Vec<u64> {
+    if total == 0 || weights.is_empty() {
+        return vec![0; weights.len()];
+    }
+    let total_weight: u128 = weights.iter().map(|weight| u128::from(*weight)).sum();
+    if total_weight == 0 {
+        return vec![0; weights.len()];
+    }
+
+    let mut allocations = vec![0_u64; weights.len()];
+    let mut fractional_remainders = Vec::with_capacity(weights.len());
+    let mut allocated_sum = 0_u64;
+
+    for (index, weight) in weights.iter().enumerate() {
+        let scaled = u128::from(total).saturating_mul(u128::from(*weight));
+        let whole = (scaled / total_weight) as u64;
+        allocations[index] = whole;
+        allocated_sum = allocated_sum.saturating_add(whole);
+        fractional_remainders.push((index, scaled % total_weight));
+    }
+
+    let remaining_units = total.saturating_sub(allocated_sum);
+    if remaining_units == 0 {
+        return allocations;
+    }
+
+    fractional_remainders
+        .sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    let distribute_count = remaining_units.min(fractional_remainders.len() as u64) as usize;
+    for (index, _) in fractional_remainders.into_iter().take(distribute_count) {
+        allocations[index] = allocations[index].saturating_add(1);
+    }
+
+    allocations
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1521,6 +1521,95 @@ fn weekly_goal_progress_carries_full_previous_week_when_snapshot_exists_without_
 }
 
 #[test]
+fn weekly_daily_goal_allocation_uses_schedule_weights_for_remaining_days() {
+    let config = AppConfig {
+        weekly_goal: WeeklyGoalConfig {
+            minutes: 300,
+            pomodoros: 10,
+        },
+        recurring_schedule: RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec!["wed".to_string(), "thu".to_string(), "fri".to_string()],
+                start: "09:00".to_string(),
+                end: "12:00".to_string(),
+            }],
+            ..RecurringScheduleConfig::default()
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 4, 22).expect("test day should be valid");
+    assert_eq!(day.weekday(), chrono::Weekday::Wed);
+
+    app.insert_daily_stats_for_tests(
+        "2026-04-21",
+        crate::stats::DailyStats {
+            pomodoros_completed: 2,
+            focused_seconds: 60 * 60,
+            goal: None,
+        },
+    );
+
+    let allocation = app.weekly_daily_goal_allocation_for_day(day);
+    assert!(allocation.has_any_target());
+    assert_eq!(allocation.remaining_minutes, 240);
+    assert_eq!(allocation.remaining_pomodoros, 8);
+    assert_eq!(allocation.remaining_days_in_week, 5);
+    assert_eq!(allocation.allocatable_days, 3);
+    assert!(allocation.uses_schedule_weights);
+    assert_eq!(allocation.daily_targets.len(), 5);
+
+    assert_eq!(allocation.daily_targets[0].minutes_target, 80);
+    assert_eq!(allocation.daily_targets[0].pomodoros_target, 3);
+    assert_eq!(allocation.daily_targets[1].minutes_target, 80);
+    assert_eq!(allocation.daily_targets[1].pomodoros_target, 3);
+    assert_eq!(allocation.daily_targets[2].minutes_target, 80);
+    assert_eq!(allocation.daily_targets[2].pomodoros_target, 2);
+    assert_eq!(allocation.daily_targets[3].minutes_target, 0);
+    assert_eq!(allocation.daily_targets[3].pomodoros_target, 0);
+    assert_eq!(allocation.daily_targets[4].minutes_target, 0);
+    assert_eq!(allocation.daily_targets[4].pomodoros_target, 0);
+}
+
+#[test]
+fn weekly_daily_goal_allocation_falls_back_to_equal_split_without_schedule_windows() {
+    let config = AppConfig {
+        weekly_goal: WeeklyGoalConfig {
+            minutes: 100,
+            pomodoros: 5,
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 4, 24).expect("test day should be valid");
+    assert_eq!(day.weekday(), chrono::Weekday::Fri);
+
+    app.insert_daily_stats_for_tests(
+        "2026-04-23",
+        crate::stats::DailyStats {
+            pomodoros_completed: 2,
+            focused_seconds: 10 * 60,
+            goal: None,
+        },
+    );
+
+    let allocation = app.weekly_daily_goal_allocation_for_day(day);
+    assert!(allocation.has_any_target());
+    assert_eq!(allocation.remaining_minutes, 90);
+    assert_eq!(allocation.remaining_pomodoros, 3);
+    assert_eq!(allocation.remaining_days_in_week, 3);
+    assert_eq!(allocation.allocatable_days, 3);
+    assert!(!allocation.uses_schedule_weights);
+    assert_eq!(allocation.daily_targets.len(), 3);
+
+    for target in allocation.daily_targets {
+        assert_eq!(target.minutes_target, 30);
+        assert_eq!(target.pomodoros_target, 1);
+        assert!(target.allocatable);
+    }
+}
+
+#[test]
 fn sync_goal_snapshot_for_day_keeps_weekly_and_monthly_carry_across_idle_boundaries() {
     let config = AppConfig {
         weekly_goal: WeeklyGoalConfig {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -644,6 +644,29 @@ struct TemporaryAllowlistStatusOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct WeeklyAllocationDayOutput {
+    date: String,
+    minutes_target: u64,
+    pomodoros_target: u32,
+    allocatable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct WeeklyAllocationOutput {
+    available: bool,
+    uses_schedule_weights: bool,
+    remaining_days_in_week: usize,
+    allocatable_days: usize,
+    completed_minutes: u64,
+    completed_pomodoros: u32,
+    remaining_minutes: u64,
+    remaining_pomodoros: u32,
+    today_minutes_target: u64,
+    today_pomodoros_target: u32,
+    days: Vec<WeeklyAllocationDayOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct StatusOutput {
     day: String,
     selected_profile: ProfileView,
@@ -662,6 +685,7 @@ struct StatusOutput {
     strict_mode: bool,
     goal: GoalOutput,
     weekly_goal: GoalOutput,
+    weekly_allocation: WeeklyAllocationOutput,
     monthly_goal: GoalOutput,
     selected_task_goal: Option<TaskGoalOutput>,
     session: SessionOutput,

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -385,6 +385,7 @@ pub(super) fn print_status_output(payload: &StatusOutput) {
     );
     print_status_goal_line("Daily goal", &payload.goal);
     print_status_goal_line("Weekly goal", &payload.weekly_goal);
+    print_status_weekly_allocation_line(&payload.weekly_allocation);
     print_status_goal_line("Monthly goal", &payload.monthly_goal);
     print_status_task_goal_line(payload.selected_task_goal.as_ref());
     println!(
@@ -423,6 +424,42 @@ pub(super) fn print_status_output(payload: &StatusOutput) {
     if let Some(error) = payload.live.recovery_error.as_deref() {
         println!("Live timer warning: {error}");
     }
+}
+
+fn print_status_weekly_allocation_line(allocation: &crate::cli::WeeklyAllocationOutput) {
+    if !allocation.available {
+        println!("Weekly allocation: off (weekly goal off)");
+        return;
+    }
+
+    let strategy = if allocation.uses_schedule_weights {
+        "schedule-weighted"
+    } else {
+        "equal-split fallback"
+    };
+    println!(
+        "Weekly allocation: today {} min, {} pomodoros | remaining {} min, {} pomodoros across {}/{} days ({strategy})",
+        allocation.today_minutes_target,
+        allocation.today_pomodoros_target,
+        allocation.remaining_minutes,
+        allocation.remaining_pomodoros,
+        allocation.allocatable_days,
+        allocation.remaining_days_in_week,
+    );
+
+    let day_breakdown = allocation
+        .days
+        .iter()
+        .map(|day| {
+            let marker = if day.allocatable { "" } else { "*" };
+            format!(
+                "{}={}m/{}p{}",
+                day.date, day.minutes_target, day.pomodoros_target, marker
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("Weekly allocation days: {day_breakdown}");
 }
 
 fn print_status_goal_line(label: &str, goal: &GoalOutput) {

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,11 +1,12 @@
+use crate::app::weekly_daily_goal_allocation_for_context;
 use crate::cli::{
     AppConfig, BreakTemplateConfig, BreakTemplateView, CustomProfileConfig, DEFAULT_FOCUS_SECS,
     DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS, DEFAULT_SHORT_BREAK_SECS,
     DailyGoalSnapshot, Datelike, FocusScoreOutput, FocusStats, GoalOutput, LiveStatusOutput,
     NaiveDate, ProfileId, ProfileSpec, ProfileView, SessionOutput, StatsRetentionStatusOutput,
     StatusOutput, TaskGoalOutput, TemporaryAllowlistStatusOutput, ThemePreset, ThemePresetView,
-    TimerPhase, TimerStatus, TodayOutput, carry_over_goal_target, current_day_key,
-    effective_blocked_sites_for_profile, session_recovery,
+    TimerPhase, TimerStatus, TodayOutput, WeeklyAllocationDayOutput, WeeklyAllocationOutput,
+    carry_over_goal_target, current_day_key, effective_blocked_sites_for_profile, session_recovery,
 };
 use crate::timer::TimerState;
 
@@ -62,6 +63,12 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
     let focus_score_pct = completion_score_pct.map(|completion| {
         (u16::from(consistency_score_pct) + u16::from(completion)).div_ceil(2) as u8
     });
+    let weekly_allocation = build_weekly_allocation_output(
+        day_date,
+        weekly_goal_snapshot,
+        week,
+        &selected_automation.recurring_schedule,
+    );
     let stats_growth = stats.growth_summary();
     let retention_windows = config.stats_retention.windows();
     let pending_prune = stats.retention_preview(config.stats_retention, day_date);
@@ -97,6 +104,7 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
                 .is_met_by_totals(week.focused_minutes(), week.pomodoros_completed),
             carry_over: config.goal_carry_over.weekly,
         },
+        weekly_allocation,
         monthly_goal: GoalOutput {
             configured: monthly_goal_snapshot.has_any_target(),
             minutes_target: monthly_goal_snapshot.minutes,
@@ -222,6 +230,39 @@ fn weekly_goal_completion_score_pct(
         (None, None) => None,
         (Some(score), None) | (None, Some(score)) => Some(score),
         (Some(left), Some(right)) => Some((u16::from(left) + u16::from(right)).div_ceil(2) as u8),
+    }
+}
+
+fn build_weekly_allocation_output(
+    day: NaiveDate,
+    weekly_goal_snapshot: DailyGoalSnapshot,
+    week: crate::stats::WeeklyStats,
+    schedule: &crate::config::RecurringScheduleConfig,
+) -> WeeklyAllocationOutput {
+    let allocation =
+        weekly_daily_goal_allocation_for_context(day, weekly_goal_snapshot, week, schedule);
+    let today_target = allocation.today_target();
+    WeeklyAllocationOutput {
+        available: allocation.has_any_target(),
+        uses_schedule_weights: allocation.uses_schedule_weights,
+        remaining_days_in_week: allocation.remaining_days_in_week,
+        allocatable_days: allocation.allocatable_days,
+        completed_minutes: allocation.completed_minutes,
+        completed_pomodoros: allocation.completed_pomodoros,
+        remaining_minutes: allocation.remaining_minutes,
+        remaining_pomodoros: allocation.remaining_pomodoros,
+        today_minutes_target: today_target.minutes,
+        today_pomodoros_target: today_target.pomodoros,
+        days: allocation
+            .daily_targets
+            .into_iter()
+            .map(|target| WeeklyAllocationDayOutput {
+                date: target.day.format("%Y-%m-%d").to_string(),
+                minutes_target: target.minutes_target,
+                pomodoros_target: target.pomodoros_target,
+                allocatable: target.allocatable,
+            })
+            .collect(),
     }
 }
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2583,6 +2583,92 @@ fn build_status_output_weekly_carry_over_skips_when_previous_period_has_no_snaps
 }
 
 #[test]
+fn build_status_output_includes_weekly_allocation_breakdown() {
+    let mut stats = FocusStats::default();
+    let today = current_day_key();
+    let baseline_goal = DailyGoalSnapshot::default();
+    stats.record_focus_elapsed(&today, 30 * 60, baseline_goal);
+    stats.record_completed_pomodoro(&today, baseline_goal);
+
+    let config = AppConfig {
+        weekly_goal: WeeklyGoalConfig {
+            minutes: 210,
+            pomodoros: 7,
+        },
+        recurring_schedule: RecurringScheduleConfig {
+            windows: vec![RecurringFocusWindowConfig {
+                days: vec![
+                    "mon".to_string(),
+                    "tue".to_string(),
+                    "wed".to_string(),
+                    "thu".to_string(),
+                    "fri".to_string(),
+                    "sat".to_string(),
+                    "sun".to_string(),
+                ],
+                start: "09:00".to_string(),
+                end: "10:00".to_string(),
+            }],
+            ..RecurringScheduleConfig::default()
+        },
+        ..AppConfig::default()
+    };
+
+    let output = build_status_output(&config, &stats);
+    assert!(output.weekly_allocation.available);
+    assert_eq!(
+        output.weekly_allocation.allocatable_days,
+        output.weekly_allocation.remaining_days_in_week
+    );
+    assert!(!output.weekly_allocation.days.is_empty());
+    assert_eq!(
+        output.weekly_allocation.today_minutes_target,
+        output.weekly_allocation.days[0].minutes_target
+    );
+    assert_eq!(
+        output.weekly_allocation.today_pomodoros_target,
+        output.weekly_allocation.days[0].pomodoros_target
+    );
+    assert_eq!(
+        output
+            .weekly_allocation
+            .days
+            .iter()
+            .map(|day| day.minutes_target)
+            .sum::<u64>(),
+        output.weekly_allocation.remaining_minutes
+    );
+    assert_eq!(
+        output
+            .weekly_allocation
+            .days
+            .iter()
+            .map(|day| day.pomodoros_target)
+            .sum::<u32>(),
+        output.weekly_allocation.remaining_pomodoros
+    );
+}
+
+#[test]
+fn build_status_output_weekly_allocation_uses_equal_split_fallback_without_schedule() {
+    let config = AppConfig {
+        weekly_goal: WeeklyGoalConfig {
+            minutes: 90,
+            pomodoros: 3,
+        },
+        ..AppConfig::default()
+    };
+    let output = build_status_output(&config, &FocusStats::default());
+
+    assert!(output.weekly_allocation.available);
+    assert!(!output.weekly_allocation.uses_schedule_weights);
+    assert_eq!(
+        output.weekly_allocation.allocatable_days,
+        output.weekly_allocation.remaining_days_in_week
+    );
+}
+
+#[test]
 fn build_status_output_monthly_carry_over_uses_previous_snapshot_after_goal_change() {
     let mut stats = FocusStats::default();
     let today = current_day_key();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -21,13 +21,15 @@ use crate::wakatime::WakatimeRuntimeState;
 mod history;
 #[cfg(test)]
 use history::{
-    format_history_goal_streak_line, format_history_interruption_line, format_month_label,
-    format_task_goal_progress_summary,
+    format_history_goal_streak_line, format_history_interruption_line,
+    format_history_weekly_allocation_line, format_month_label, format_task_goal_progress_summary,
 };
 use history::{readable_goal_streak_text, render_stats_history};
 mod profile_manager;
 use profile_manager::render_profile_manager;
 mod session_planner;
+#[cfg(test)]
+use session_planner::planner_weekly_allocation_summary;
 use session_planner::render_session_planner;
 mod site_manager;
 use site_manager::render_site_manager;

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -20,7 +20,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(7), // overview
+            Constraint::Length(8), // overview
             Constraint::Min(6),    // history panels
             Constraint::Length(1), // status line
             Constraint::Length(2), // hints
@@ -36,6 +36,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .count();
     let focus_score_line = readable_focus_score_text(&format_history_focus_score_line(app));
     let goals_line = readable_goal_streak_text(&format_history_goal_streak_line(app));
+    let weekly_allocation_line = format_history_weekly_allocation_line(app);
     let interruption_line = format_history_interruption_line(app);
     let growth_summary = app.stats_growth_summary();
     let retention_preview = app.stats_retention_preview();
@@ -74,6 +75,10 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         ),
         Line::styled(
             goals_line,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
+        Line::styled(
+            weekly_allocation_line,
             Style::default().fg(app_color(app, Color::DarkGray)),
         ),
         Line::styled(
@@ -411,6 +416,30 @@ pub(super) fn format_history_focus_score_line(app: &App) -> String {
         },
         None => "Focus score: n/a".to_string(),
     }
+}
+
+pub(super) fn format_history_weekly_allocation_line(app: &App) -> String {
+    let allocation = app.weekly_daily_goal_allocation();
+    if !allocation.has_any_target() {
+        return "Weekly allocation: off".to_string();
+    }
+    if allocation.remaining_minutes == 0 && allocation.remaining_pomodoros == 0 {
+        return format!(
+            "Weekly allocation: met · 0m/0p remaining · {} day(s) left",
+            allocation.remaining_days_in_week
+        );
+    }
+
+    let today_target = allocation.today_target();
+    format!(
+        "Weekly allocation: today {}m/{}p · remaining {}m/{}p across {}/{} days",
+        today_target.minutes,
+        today_target.pomodoros,
+        allocation.remaining_minutes,
+        allocation.remaining_pomodoros,
+        allocation.allocatable_days,
+        allocation.remaining_days_in_week
+    )
 }
 
 pub(super) fn format_history_interruption_line(app: &App) -> String {

--- a/src/ui/session_planner.rs
+++ b/src/ui/session_planner.rs
@@ -21,7 +21,7 @@ pub(super) fn render_session_planner(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(1), // current task
+            Constraint::Length(2), // current task + weekly allocation
             Constraint::Min(4),    // task/template lists
             Constraint::Length(3), // task label input
             Constraint::Length(1), // feedback
@@ -50,11 +50,14 @@ fn render_session_planner_selected_task(frame: &mut Frame, app: &App, area: Rect
         .active_session_template_name()
         .map_or_else(|| "none".to_string(), str::to_string);
     let weekly_allocation = planner_weekly_allocation_summary(app);
-    let selected_text = format!(
-        "{selected_task}   |   Active template: {selected_template}   |   {weekly_allocation}"
-    );
+    let selected_text = vec![
+        Line::from(format!(
+            "{selected_task}   |   Active template: {selected_template}"
+        )),
+        Line::from(weekly_allocation),
+    ];
     frame.render_widget(
-        Paragraph::new(Line::from(selected_text))
+        Paragraph::new(selected_text)
             .style(Style::default().fg(app_color(app, Color::White)))
             .wrap(Wrap { trim: true }),
         area,

--- a/src/ui/session_planner.rs
+++ b/src/ui/session_planner.rs
@@ -49,13 +49,39 @@ fn render_session_planner_selected_task(frame: &mut Frame, app: &App, area: Rect
     let selected_template = app
         .active_session_template_name()
         .map_or_else(|| "none".to_string(), str::to_string);
-    let selected_text = format!("{selected_task}   |   Active template: {selected_template}");
+    let weekly_allocation = planner_weekly_allocation_summary(app);
+    let selected_text = format!(
+        "{selected_task}   |   Active template: {selected_template}   |   {weekly_allocation}"
+    );
     frame.render_widget(
         Paragraph::new(Line::from(selected_text))
             .style(Style::default().fg(app_color(app, Color::White)))
             .wrap(Wrap { trim: true }),
         area,
     );
+}
+
+pub(super) fn planner_weekly_allocation_summary(app: &App) -> String {
+    let allocation = app.weekly_daily_goal_allocation();
+    if !allocation.has_any_target() {
+        return "Weekly allocation: off".to_string();
+    }
+    if allocation.remaining_minutes == 0 && allocation.remaining_pomodoros == 0 {
+        return format!(
+            "Weekly allocation: met ({} day(s) left)",
+            allocation.remaining_days_in_week
+        );
+    }
+    let today_target = allocation.today_target();
+    format!(
+        "Weekly allocation: today {}m/{}p, left {}m/{}p ({}/{} day(s))",
+        today_target.minutes,
+        today_target.pomodoros,
+        allocation.remaining_minutes,
+        allocation.remaining_pomodoros,
+        allocation.allocatable_days,
+        allocation.remaining_days_in_week
+    )
 }
 
 fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -294,6 +294,35 @@ fn goal_streak_lines_render_daily_weekly_monthly_period_progress() {
 }
 
 #[test]
+fn weekly_allocation_lines_show_off_when_weekly_goal_is_disabled() {
+    let app = App::default();
+    assert_eq!(
+        format_history_weekly_allocation_line(&app),
+        "Weekly allocation: off"
+    );
+    assert_eq!(
+        planner_weekly_allocation_summary(&app),
+        "Weekly allocation: off"
+    );
+}
+
+#[test]
+fn weekly_allocation_lines_show_today_targets_when_weekly_goal_is_configured() {
+    let app = App::from_config_for_tests(AppConfig {
+        weekly_goal: crate::config::WeeklyGoalConfig {
+            minutes: 120,
+            pomodoros: 4,
+        },
+        ..AppConfig::default()
+    });
+    let history_line = format_history_weekly_allocation_line(&app);
+    let planner_line = planner_weekly_allocation_summary(&app);
+
+    assert!(history_line.contains("Weekly allocation: today"));
+    assert!(planner_line.contains("Weekly allocation: today"));
+}
+
+#[test]
 fn task_goal_progress_summary_formats_state_and_metrics() {
     let configured = crate::stats::TaskGoalProgress {
         task_label: "Docs".to_string(),


### PR DESCRIPTION
## What

- Add a deterministic weekly-to-daily allocation core that computes remaining weekly targets and distributes them into per-day targets.
- Use schedule-weighted allocation across remaining week days when schedule windows exist, with equal-split fallback when they do not.
- Surface the recommendation in TUI planning/history flows (Session Planner + Focus History).
- Extend CLI status output (text + JSON) with weekly allocation details.
- Add test coverage across app, UI, and CLI for allocation behavior and integration.

## Why

Weekly goals existed, but users did not get practical day-level guidance that adapts as progress changes during the week. This change turns weekly goals into actionable daily recommendations while keeping behavior deterministic and consistent across app surfaces.

Closes #323.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly-to-daily goal allocation added: weekly targets are split into per-day targets and remaining totals.
  * Status output now shows a "Weekly allocation" section with per-day targets and remaining amounts (marks non-allocatable days).
  * UI shows weekly allocation summaries in history overview and session planner, including today's targets and remaining totals.
  * Allocation uses schedule-based weights when available, otherwise falls back to equal split.

* **Tests**
  * Added unit and CLI/UI tests covering weighted and equal-split allocation behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->