### PR TITLE
Focus-risk forecasting for goal and streak misses

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,7 @@ use crate::schedule::{
     next_one_time_occurrence_after, occurrence_key, pick_active_occurrence, pick_next_occurrence,
 };
 use crate::stats::{
-    BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles,
+    BreakGlassOverrideEvent, DailyGoalSnapshot, DailyStats, ExportedStatsFiles, FocusRiskForecast,
     FocusSessionMetadata, FocusStats, GoalStreak, MonthlyHeatmap, MonthlyStats,
     ProfileEffectiveness, ProfileTotals, SessionInterruptionEvent, SessionInterruptionReason,
     SessionStats, StatsGrowthSummary, StatsRetentionPruneResult, TaskGoalProgress, TaskTotals,
@@ -1211,6 +1211,16 @@ impl App {
 
     pub fn latest_weekly_focus_score(&self) -> Option<WeeklyFocusScore> {
         self.stats.latest_weekly_focus_score()
+    }
+
+    pub fn focus_risk_forecast(&self) -> FocusRiskForecast {
+        let today = Local::now().date_naive();
+        self.stats.focus_risk_forecast_for_day(
+            today,
+            self.effective_daily_goal_snapshot_for_day(today),
+            self.effective_weekly_goal_snapshot_for_day(today),
+            self.effective_monthly_goal_snapshot_for_day(today),
+        )
     }
 
     pub fn recent_monthly_stats(&self, limit: usize) -> Vec<MonthlyStats> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ use crate::config::{
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
 use crate::stats::{
-    DailyGoalSnapshot, FocusStats, SessionInterruptionEvent, StatsGrowthSummary,
+    DailyGoalSnapshot, FocusRiskForecast, FocusStats, SessionInterruptionEvent, StatsGrowthSummary,
     StatsRetentionPruneResult, carry_over_goal_target, current_day_key,
 };
 use crate::timer::{
@@ -692,6 +692,7 @@ struct StatusOutput {
     today: TodayOutput,
     latest_interruption: Option<SessionInterruptionEvent>,
     focus_score: FocusScoreOutput,
+    focus_risk: FocusRiskForecast,
     stats_growth: StatsGrowthSummary,
     stats_retention: StatsRetentionStatusOutput,
     live: LiveStatusOutput,

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -404,6 +404,7 @@ pub(super) fn print_status_output(payload: &StatusOutput) {
         println!("Last interruption: none");
     }
     print_status_focus_score_line(&payload.focus_score);
+    print_status_focus_risk_line(&payload.focus_risk);
     print_status_growth_line(&payload.stats_growth);
     print_status_retention_line(&payload.stats_retention);
     println!(
@@ -514,6 +515,56 @@ fn print_status_focus_score_line(focus_score: &FocusScoreOutput) {
         println!(
             "Focus score: n/a (weekly goal off; consistency {}%)",
             focus_score.consistency_score_pct
+        );
+    }
+}
+
+fn print_status_focus_risk_line(forecast: &crate::stats::FocusRiskForecast) {
+    let daily_label = forecast.daily_goal.period.short_label();
+    let weekly_label = forecast.weekly_goal.period.short_label();
+    let monthly_label = forecast.monthly_goal.period.short_label();
+    let alert_suffix = if forecast.alert_active() {
+        " (alert)"
+    } else {
+        ""
+    };
+    println!(
+        "Focus risk: {} {} {}% | {} {} {}% | {} {} {}% | Streak {} {}%{}",
+        daily_label,
+        forecast.daily_goal.risk_level.label(),
+        forecast.daily_goal.risk_score_pct,
+        weekly_label,
+        forecast.weekly_goal.risk_level.label(),
+        forecast.weekly_goal.risk_score_pct,
+        monthly_label,
+        forecast.monthly_goal.risk_level.label(),
+        forecast.monthly_goal.risk_score_pct,
+        forecast.streak.risk_level.label(),
+        forecast.streak.risk_score_pct,
+        alert_suffix
+    );
+
+    let mut highest_label = daily_label;
+    let mut highest_score = forecast.daily_goal.risk_score_pct;
+    let mut highest_signal = forecast.daily_goal.signals.first();
+    if forecast.weekly_goal.risk_score_pct > highest_score {
+        highest_label = weekly_label;
+        highest_score = forecast.weekly_goal.risk_score_pct;
+        highest_signal = forecast.weekly_goal.signals.first();
+    }
+    if forecast.monthly_goal.risk_score_pct > highest_score {
+        highest_label = monthly_label;
+        highest_score = forecast.monthly_goal.risk_score_pct;
+        highest_signal = forecast.monthly_goal.signals.first();
+    }
+    if forecast.streak.risk_score_pct > highest_score {
+        highest_label = "Streak";
+        highest_signal = forecast.streak.signals.first();
+    }
+    if let Some(signal) = highest_signal {
+        println!(
+            "Focus risk signal: {highest_label} {} ({})",
+            signal.label, signal.value
         );
     }
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -63,6 +63,12 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
     let focus_score_pct = completion_score_pct.map(|completion| {
         (u16::from(consistency_score_pct) + u16::from(completion)).div_ceil(2) as u8
     });
+    let focus_risk = stats.focus_risk_forecast_for_day(
+        day_date,
+        goal_snapshot,
+        weekly_goal_snapshot,
+        monthly_goal_snapshot,
+    );
     let weekly_allocation = build_weekly_allocation_output(
         day_date,
         weekly_goal_snapshot,
@@ -129,6 +135,7 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
             consistency_score_pct,
             completion_score_pct,
         },
+        focus_risk,
         stats_growth,
         stats_retention: StatsRetentionStatusOutput {
             preset: config.stats_retention.preset.id(),

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2254,6 +2254,8 @@ fn build_status_output_reports_daily_weekly_monthly_goal_state() {
     assert!(in_period_output.focus_score.available);
     assert_eq!(in_period_output.focus_score.completion_score_pct, Some(100));
     assert!(in_period_output.focus_score.focus_score_pct.is_some());
+    assert_eq!(in_period_output.focus_risk.daily_goal.risk_score_pct, 0);
+    assert!(!in_period_output.focus_risk.daily_goal.signals.is_empty());
 
     let boundary_config = AppConfig {
         daily_goal: DailyGoalConfig {
@@ -2277,6 +2279,7 @@ fn build_status_output_reports_daily_weekly_monthly_goal_state() {
     assert!(!boundary_output.weekly_goal.met);
     assert!(!boundary_output.monthly_goal.met);
     assert!(boundary_output.focus_score.available);
+    assert!(boundary_output.focus_risk.alert_active());
 }
 
 #[test]
@@ -2327,6 +2330,8 @@ fn build_status_output_includes_unconfigured_selected_task_goal() {
     assert!(!selected_task_goal.met);
     assert!(!output.focus_score.available);
     assert!(output.focus_score.focus_score_pct.is_none());
+    assert!(!output.focus_risk.daily_goal.configured);
+    assert!(!output.focus_risk.streak.configured);
 }
 
 #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -147,6 +147,121 @@ pub struct WeeklyFocusScore {
     pub focus_score_pct: Option<u8>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FocusRiskLevel {
+    Low,
+    Medium,
+    High,
+}
+
+impl FocusRiskLevel {
+    pub fn from_score(score_pct: u8) -> Self {
+        if score_pct >= 70 {
+            Self::High
+        } else if score_pct >= 40 {
+            Self::Medium
+        } else {
+            Self::Low
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+
+    pub fn triggers_alert(self) -> bool {
+        matches!(self, Self::Medium | Self::High)
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            Self::Low => 0,
+            Self::Medium => 1,
+            Self::High => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalPeriod {
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+impl GoalPeriod {
+    pub fn short_label(self) -> &'static str {
+        match self {
+            Self::Daily => "D",
+            Self::Weekly => "W",
+            Self::Monthly => "M",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FocusRiskSignal {
+    pub label: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GoalRiskForecast {
+    pub period: GoalPeriod,
+    pub configured: bool,
+    pub met: bool,
+    pub completion_pct: Option<u8>,
+    pub risk_score_pct: u8,
+    pub risk_level: FocusRiskLevel,
+    pub signals: Vec<FocusRiskSignal>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StreakRiskForecast {
+    pub configured: bool,
+    pub current_streak: u32,
+    pub best_streak: u32,
+    pub today_goal_met: bool,
+    pub recent_goal_reliability_pct: u8,
+    pub risk_score_pct: u8,
+    pub risk_level: FocusRiskLevel,
+    pub signals: Vec<FocusRiskSignal>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FocusRiskForecast {
+    pub daily_goal: GoalRiskForecast,
+    pub weekly_goal: GoalRiskForecast,
+    pub monthly_goal: GoalRiskForecast,
+    pub streak: StreakRiskForecast,
+}
+
+impl FocusRiskForecast {
+    pub fn highest_risk_level(&self) -> FocusRiskLevel {
+        let mut level = self.daily_goal.risk_level;
+        for candidate in [
+            self.weekly_goal.risk_level,
+            self.monthly_goal.risk_level,
+            self.streak.risk_level,
+        ] {
+            if candidate.rank() > level.rank() {
+                level = candidate;
+            }
+        }
+        level
+    }
+
+    pub fn alert_active(&self) -> bool {
+        self.highest_risk_level().triggers_alert()
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct MonthlyStats {
     pub year: i32,

--- a/src/stats/analytics.rs
+++ b/src/stats/analytics.rs
@@ -1,11 +1,12 @@
 use crate::stats::{
-    BTreeMap, BTreeSet, DailyGoalSnapshot, Datelike, FocusStats, HeatmapDayStats, MonthlyHeatmap,
+    BTreeMap, BTreeSet, DailyGoalSnapshot, Datelike, FocusRiskForecast, FocusRiskLevel,
+    FocusRiskSignal, FocusStats, GoalPeriod, GoalRiskForecast, HeatmapDayStats, MonthlyHeatmap,
     MonthlyStats, ProfileBucket, ProfileEffectiveness, ProfileEffectivenessAccumulator,
     ProfileTotals, StatsGrowthSection, StatsGrowthSummary, StatsRetentionConfig,
-    StatsRetentionPruneResult, WeeklyConsistency, WeeklyFocusScore, WeeklyStats,
-    average_two_percentages, consistency_score_from_active_days, daily_has_activity, days_in_month,
-    format_week_label, month_key_for_day, parse_week_label, percentage_round_nearest,
-    profile_bucket_for, week_key_for_day, weekly_completion_score_pct,
+    StatsRetentionPruneResult, StreakRiskForecast, WeeklyConsistency, WeeklyFocusScore,
+    WeeklyStats, average_two_percentages, consistency_score_from_active_days, daily_has_activity,
+    days_in_month, format_week_label, month_key_for_day, parse_week_label,
+    percentage_round_nearest, profile_bucket_for, week_key_for_day, weekly_completion_score_pct,
 };
 
 impl FocusStats {
@@ -122,6 +123,55 @@ impl FocusStats {
 
     pub fn latest_weekly_focus_score(&self) -> Option<WeeklyFocusScore> {
         self.recent_weekly_focus_scores(1).into_iter().next()
+    }
+
+    pub fn focus_risk_forecast_for_day(
+        &self,
+        day: chrono::NaiveDate,
+        daily_goal: DailyGoalSnapshot,
+        weekly_goal: DailyGoalSnapshot,
+        monthly_goal: DailyGoalSnapshot,
+    ) -> FocusRiskForecast {
+        let day_key = day.format("%Y-%m-%d").to_string();
+        let daily_stats = self.daily_for(&day_key);
+        let weekly_stats = self.weekly_for_day(day);
+        let monthly_stats = self.monthly_for_day(day);
+        let cadence = rolling_cadence_window(self, day, 7);
+        let daily_goal_forecast = goal_risk_forecast(
+            GoalPeriod::Daily,
+            daily_goal,
+            daily_stats.focused_minutes(),
+            daily_stats.pomodoros_completed,
+            1,
+            cadence,
+        );
+        let weekly_goal_forecast = goal_risk_forecast(
+            GoalPeriod::Weekly,
+            weekly_goal,
+            weekly_stats.focused_minutes(),
+            weekly_stats.pomodoros_completed,
+            remaining_days_in_week(day),
+            cadence,
+        );
+        let monthly_goal_forecast = goal_risk_forecast(
+            GoalPeriod::Monthly,
+            monthly_goal,
+            monthly_stats.focused_minutes(),
+            monthly_stats.pomodoros_completed,
+            remaining_days_in_month(day),
+            cadence,
+        );
+
+        let streak = self.goal_streak_with_day_goal(day, daily_goal, daily_stats, |_| daily_goal);
+        let streak_forecast =
+            streak_risk_forecast(self, day, daily_goal, daily_stats, cadence, streak);
+
+        FocusRiskForecast {
+            daily_goal: daily_goal_forecast,
+            weekly_goal: weekly_goal_forecast,
+            monthly_goal: monthly_goal_forecast,
+            streak: streak_forecast,
+        }
     }
 
     pub fn recent_monthly(&self, limit: usize) -> Vec<MonthlyStats> {
@@ -532,6 +582,337 @@ impl FocusStats {
         let mut cloned = self.clone();
         cloned.apply_retention_policy(retention, reference_day)
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CadenceWindow {
+    window_days: u8,
+    active_days: u8,
+    focused_minutes: u64,
+    pomodoros_completed: u32,
+}
+
+impl CadenceWindow {
+    fn consistency_pct(self) -> u8 {
+        consistency_score_from_active_days(self.active_days)
+    }
+
+    fn average_daily_minutes(self) -> u64 {
+        self.focused_minutes / u64::from(self.window_days.max(1))
+    }
+
+    fn average_daily_pomodoros(self) -> u64 {
+        u64::from(self.pomodoros_completed) / u64::from(self.window_days.max(1))
+    }
+}
+
+fn rolling_cadence_window(
+    stats: &FocusStats,
+    day: chrono::NaiveDate,
+    window_days: u8,
+) -> CadenceWindow {
+    let mut cadence = CadenceWindow {
+        window_days: window_days.max(1),
+        active_days: 0,
+        focused_minutes: 0,
+        pomodoros_completed: 0,
+    };
+    for offset in 0..cadence.window_days {
+        let candidate = day
+            .checked_sub_signed(chrono::Duration::days(i64::from(offset)))
+            .unwrap_or(day);
+        let day_key = candidate.format("%Y-%m-%d").to_string();
+        let day_stats = stats.daily_for(&day_key);
+        if daily_has_activity(day_stats) {
+            cadence.active_days = cadence
+                .active_days
+                .saturating_add(1)
+                .min(cadence.window_days);
+        }
+        cadence.focused_minutes = cadence
+            .focused_minutes
+            .saturating_add(day_stats.focused_minutes());
+        cadence.pomodoros_completed = cadence
+            .pomodoros_completed
+            .saturating_add(day_stats.pomodoros_completed);
+    }
+    cadence
+}
+
+fn goal_risk_forecast(
+    period: GoalPeriod,
+    goal: DailyGoalSnapshot,
+    completed_minutes: u64,
+    completed_pomodoros: u32,
+    remaining_days: u32,
+    cadence: CadenceWindow,
+) -> GoalRiskForecast {
+    if !goal.has_any_target() {
+        return GoalRiskForecast {
+            period,
+            configured: false,
+            met: false,
+            completion_pct: None,
+            risk_score_pct: 0,
+            risk_level: FocusRiskLevel::Low,
+            signals: vec![risk_signal("status", "goal off")],
+        };
+    }
+
+    let met = goal.is_met_by_totals(completed_minutes, completed_pomodoros);
+    let completion_pct = completion_pct_for_totals(goal, completed_minutes, completed_pomodoros);
+    let completion_gap = completion_pct.map_or(0, |pct| 100_u8.saturating_sub(pct));
+    let consistency_pct = cadence.consistency_pct();
+    let consistency_gap = 100_u8.saturating_sub(consistency_pct);
+    let pace_gap = pace_gap_pct(
+        goal,
+        completed_minutes,
+        completed_pomodoros,
+        remaining_days,
+        cadence,
+    );
+    let risk_score_pct = if met {
+        0
+    } else {
+        weighted_pct(&[(completion_gap, 55), (consistency_gap, 20), (pace_gap, 25)])
+    };
+    let risk_level = FocusRiskLevel::from_score(risk_score_pct);
+
+    let mut signals = vec![
+        risk_signal("completion", &format!("{}%", completion_pct.unwrap_or(0))),
+        risk_signal(
+            "consistency",
+            &format!(
+                "{}% ({}/{} days)",
+                consistency_pct, cadence.active_days, cadence.window_days
+            ),
+        ),
+    ];
+    if met {
+        signals.push(risk_signal("pace", "goal already met"));
+    } else {
+        signals.push(risk_signal(
+            "pace",
+            &format!(
+                "{}% gap with {} day(s) left",
+                pace_gap,
+                remaining_days.max(1)
+            ),
+        ));
+    }
+
+    GoalRiskForecast {
+        period,
+        configured: true,
+        met,
+        completion_pct,
+        risk_score_pct,
+        risk_level,
+        signals,
+    }
+}
+
+fn streak_risk_forecast(
+    stats: &FocusStats,
+    day: chrono::NaiveDate,
+    daily_goal: DailyGoalSnapshot,
+    today_stats: crate::stats::DailyStats,
+    cadence: CadenceWindow,
+    streak: crate::stats::GoalStreak,
+) -> StreakRiskForecast {
+    if !daily_goal.has_any_target() {
+        return StreakRiskForecast {
+            configured: false,
+            current_streak: 0,
+            best_streak: 0,
+            today_goal_met: false,
+            recent_goal_reliability_pct: 0,
+            risk_score_pct: 0,
+            risk_level: FocusRiskLevel::Low,
+            signals: vec![risk_signal("status", "daily goal off")],
+        };
+    }
+
+    let today_goal_met = daily_goal.is_met_by(today_stats);
+    let reliability_pct = rolling_goal_reliability_pct(stats, day, daily_goal, 7);
+    let consistency_pct = cadence.consistency_pct();
+    let today_pressure = if today_goal_met { 20 } else { 90 };
+    let reliability_gap = 100_u8.saturating_sub(reliability_pct);
+    let consistency_gap = 100_u8.saturating_sub(consistency_pct);
+    let mut risk_score_pct = weighted_pct(&[
+        (today_pressure, 45),
+        (reliability_gap, 35),
+        (consistency_gap, 20),
+    ]);
+    risk_score_pct = if streak.current >= 7 {
+        risk_score_pct.saturating_add(10).min(100)
+    } else if streak.current >= 3 {
+        risk_score_pct.saturating_add(5).min(100)
+    } else {
+        risk_score_pct
+    };
+    let risk_level = FocusRiskLevel::from_score(risk_score_pct);
+
+    let signals = vec![
+        risk_signal(
+            "today",
+            if today_goal_met {
+                "met so far"
+            } else {
+                "not met yet"
+            },
+        ),
+        risk_signal("recent reliability", &format!("{reliability_pct}%")),
+        risk_signal(
+            "consistency",
+            &format!(
+                "{}% ({}/{} days)",
+                consistency_pct, cadence.active_days, cadence.window_days
+            ),
+        ),
+        risk_signal(
+            "streak",
+            &format!("{}d current / {}d best", streak.current, streak.best),
+        ),
+    ];
+
+    StreakRiskForecast {
+        configured: true,
+        current_streak: streak.current,
+        best_streak: streak.best,
+        today_goal_met,
+        recent_goal_reliability_pct: reliability_pct,
+        risk_score_pct,
+        risk_level,
+        signals,
+    }
+}
+
+fn rolling_goal_reliability_pct(
+    stats: &FocusStats,
+    day: chrono::NaiveDate,
+    fallback_goal: DailyGoalSnapshot,
+    window_days: u8,
+) -> u8 {
+    let mut eligible_days = 0_u32;
+    let mut met_days = 0_u32;
+    for offset in 0..window_days.max(1) {
+        let candidate = day
+            .checked_sub_signed(chrono::Duration::days(i64::from(offset)))
+            .unwrap_or(day);
+        let day_key = candidate.format("%Y-%m-%d").to_string();
+        let day_stats = stats.daily_for(&day_key);
+        let has_observed_day =
+            candidate == day || stats.daily.contains_key(&day_key) || daily_has_activity(day_stats);
+        if !has_observed_day {
+            continue;
+        }
+        let configured_goal = stats
+            .daily
+            .get(&day_key)
+            .and_then(|entry| entry.goal)
+            .unwrap_or(fallback_goal);
+        if !configured_goal.has_any_target() {
+            continue;
+        }
+        eligible_days = eligible_days.saturating_add(1);
+        if configured_goal.is_met_by(day_stats) {
+            met_days = met_days.saturating_add(1);
+        }
+    }
+
+    if eligible_days == 0 {
+        0
+    } else {
+        percentage_round_nearest(u64::from(met_days), u64::from(eligible_days))
+    }
+}
+
+fn completion_pct_for_totals(
+    goal: DailyGoalSnapshot,
+    focused_minutes: u64,
+    pomodoros_completed: u32,
+) -> Option<u8> {
+    weekly_completion_score_pct(
+        goal,
+        WeeklyStats {
+            pomodoros_completed,
+            focused_seconds: focused_minutes.saturating_mul(60),
+            ..WeeklyStats::default()
+        },
+    )
+}
+
+fn pace_gap_pct(
+    goal: DailyGoalSnapshot,
+    completed_minutes: u64,
+    completed_pomodoros: u32,
+    remaining_days: u32,
+    cadence: CadenceWindow,
+) -> u8 {
+    let days_remaining = u64::from(remaining_days.max(1));
+    let remaining_minutes = goal.minutes.saturating_sub(completed_minutes);
+    let remaining_pomodoros = u64::from(goal.pomodoros.saturating_sub(completed_pomodoros));
+    let required_minutes_per_day = if goal.minutes > 0 {
+        div_ceil_u64(remaining_minutes, days_remaining)
+    } else {
+        0
+    };
+    let required_pomodoros_per_day = if goal.pomodoros > 0 {
+        div_ceil_u64(remaining_pomodoros, days_remaining)
+    } else {
+        0
+    };
+
+    let minutes_gap = gap_pct(cadence.average_daily_minutes(), required_minutes_per_day);
+    let pomodoros_gap = gap_pct(
+        cadence.average_daily_pomodoros(),
+        required_pomodoros_per_day,
+    );
+    minutes_gap.max(pomodoros_gap)
+}
+
+fn gap_pct(recent_rate: u64, required_rate: u64) -> u8 {
+    if required_rate == 0 || recent_rate >= required_rate {
+        return 0;
+    }
+    percentage_round_nearest(required_rate.saturating_sub(recent_rate), required_rate)
+}
+
+fn weighted_pct(parts: &[(u8, u16)]) -> u8 {
+    let total_weight = parts.iter().fold(0_u64, |total, (_, weight)| {
+        total.saturating_add(u64::from(*weight))
+    });
+    if total_weight == 0 {
+        return 0;
+    }
+    let weighted_sum = parts.iter().fold(0_u64, |total, (value, weight)| {
+        total.saturating_add(u64::from(*value).saturating_mul(u64::from(*weight)))
+    });
+    ((weighted_sum.saturating_add(total_weight / 2)) / total_weight).min(u64::from(u8::MAX)) as u8
+}
+
+fn risk_signal(label: &str, value: &str) -> FocusRiskSignal {
+    FocusRiskSignal {
+        label: label.to_string(),
+        value: value.to_string(),
+    }
+}
+
+fn remaining_days_in_week(day: chrono::NaiveDate) -> u32 {
+    7_u32.saturating_sub(day.weekday().num_days_from_monday())
+}
+
+fn remaining_days_in_month(day: chrono::NaiveDate) -> u32 {
+    let total_days = days_in_month(day.year(), day.month());
+    total_days.saturating_sub(day.day()).saturating_add(1)
+}
+
+fn div_ceil_u64(value: u64, divisor: u64) -> u64 {
+    if divisor == 0 {
+        return value;
+    }
+    value.div_ceil(divisor)
 }
 
 fn stats_growth_section(

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -672,6 +672,97 @@ fn weekly_focus_score_includes_goal_enabled_idle_weeks() {
 }
 
 #[test]
+fn focus_risk_forecast_flags_high_risk_for_unmet_goals_and_streak() {
+    let mut stats = FocusStats::default();
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 4, 9).unwrap();
+    let day_key = day.format("%Y-%m-%d").to_string();
+    stats.insert_daily_for_tests(
+        &day_key,
+        DailyStats {
+            pomodoros_completed: 1,
+            focused_seconds: 20 * 60,
+            goal: None,
+        },
+    );
+
+    let forecast = stats.focus_risk_forecast_for_day(
+        day,
+        DailyGoalSnapshot {
+            minutes: 120,
+            pomodoros: 4,
+        },
+        DailyGoalSnapshot {
+            minutes: 600,
+            pomodoros: 24,
+        },
+        DailyGoalSnapshot {
+            minutes: 2400,
+            pomodoros: 96,
+        },
+    );
+
+    assert_eq!(forecast.daily_goal.risk_level, FocusRiskLevel::High);
+    assert_eq!(forecast.streak.risk_level, FocusRiskLevel::High);
+    assert!(forecast.alert_active());
+}
+
+#[test]
+fn focus_risk_forecast_stays_low_when_goals_are_met() {
+    let mut stats = FocusStats::default();
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 4, 9).unwrap();
+    let day_key = day.format("%Y-%m-%d").to_string();
+    stats.insert_daily_for_tests(
+        &day_key,
+        DailyStats {
+            pomodoros_completed: 1,
+            focused_seconds: 25 * 60,
+            goal: None,
+        },
+    );
+
+    let forecast = stats.focus_risk_forecast_for_day(
+        day,
+        DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        },
+        DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        },
+        DailyGoalSnapshot {
+            minutes: 25,
+            pomodoros: 1,
+        },
+    );
+
+    assert_eq!(forecast.daily_goal.risk_score_pct, 0);
+    assert_eq!(forecast.weekly_goal.risk_score_pct, 0);
+    assert_eq!(forecast.monthly_goal.risk_score_pct, 0);
+    assert_eq!(forecast.daily_goal.risk_level, FocusRiskLevel::Low);
+    assert!(!forecast.alert_active());
+}
+
+#[test]
+fn focus_risk_forecast_marks_goals_off_when_targets_are_disabled() {
+    let stats = FocusStats::default();
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 4, 9).unwrap();
+    let forecast = stats.focus_risk_forecast_for_day(
+        day,
+        DailyGoalSnapshot::default(),
+        DailyGoalSnapshot::default(),
+        DailyGoalSnapshot::default(),
+    );
+
+    assert!(!forecast.daily_goal.configured);
+    assert!(!forecast.weekly_goal.configured);
+    assert!(!forecast.monthly_goal.configured);
+    assert!(!forecast.streak.configured);
+    assert_eq!(forecast.daily_goal.signals[0].value, "goal off",);
+    assert!(!forecast.alert_active());
+}
+
+#[test]
 fn persisted_stats_round_trip_preserves_daily_history() {
     let mut original = FocusStats::default();
     let goal = DailyGoalSnapshot {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -21,8 +21,9 @@ use crate::wakatime::WakatimeRuntimeState;
 mod history;
 #[cfg(test)]
 use history::{
-    format_history_goal_streak_line, format_history_interruption_line,
-    format_history_weekly_allocation_line, format_month_label, format_task_goal_progress_summary,
+    format_history_focus_risk_line, format_history_goal_streak_line,
+    format_history_interruption_line, format_history_weekly_allocation_line, format_month_label,
+    format_task_goal_progress_summary,
 };
 use history::{readable_goal_streak_text, render_stats_history};
 mod profile_manager;

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -20,7 +20,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(8), // overview
+            Constraint::Length(9), // overview
             Constraint::Min(6),    // history panels
             Constraint::Length(1), // status line
             Constraint::Length(2), // hints
@@ -36,6 +36,7 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .count();
     let focus_score_line = readable_focus_score_text(&format_history_focus_score_line(app));
     let goals_line = readable_goal_streak_text(&format_history_goal_streak_line(app));
+    let risk_line = format_history_focus_risk_line(app);
     let weekly_allocation_line = format_history_weekly_allocation_line(app);
     let interruption_line = format_history_interruption_line(app);
     let growth_summary = app.stats_growth_summary();
@@ -75,6 +76,10 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         ),
         Line::styled(
             goals_line,
+            Style::default().fg(app_color(app, Color::DarkGray)),
+        ),
+        Line::styled(
+            risk_line,
             Style::default().fg(app_color(app, Color::DarkGray)),
         ),
         Line::styled(
@@ -416,6 +421,54 @@ pub(super) fn format_history_focus_score_line(app: &App) -> String {
         },
         None => "Focus score: n/a".to_string(),
     }
+}
+
+pub(super) fn format_history_focus_risk_line(app: &App) -> String {
+    let forecast = app.focus_risk_forecast();
+    let daily_label = forecast.daily_goal.period.short_label();
+    let weekly_label = forecast.weekly_goal.period.short_label();
+    let monthly_label = forecast.monthly_goal.period.short_label();
+    let mut highest_label = daily_label;
+    let mut highest_score = forecast.daily_goal.risk_score_pct;
+    let mut highest_signal = forecast.daily_goal.signals.first();
+    if forecast.weekly_goal.risk_score_pct > highest_score {
+        highest_label = weekly_label;
+        highest_score = forecast.weekly_goal.risk_score_pct;
+        highest_signal = forecast.weekly_goal.signals.first();
+    }
+    if forecast.monthly_goal.risk_score_pct > highest_score {
+        highest_label = monthly_label;
+        highest_score = forecast.monthly_goal.risk_score_pct;
+        highest_signal = forecast.monthly_goal.signals.first();
+    }
+    if forecast.streak.risk_score_pct > highest_score {
+        highest_label = "S";
+        highest_signal = forecast.streak.signals.first();
+    }
+    let reason_suffix = highest_signal
+        .map(|signal| format!(" · {highest_label} {} {}", signal.label, signal.value))
+        .unwrap_or_default();
+    let alert_suffix = if forecast.alert_active() {
+        " · ALERT"
+    } else {
+        ""
+    };
+    format!(
+        "Risk: {} {} {}% · {} {} {}% · {} {} {}% · S {} {}%{}{}",
+        daily_label,
+        forecast.daily_goal.risk_level.label(),
+        forecast.daily_goal.risk_score_pct,
+        weekly_label,
+        forecast.weekly_goal.risk_level.label(),
+        forecast.weekly_goal.risk_score_pct,
+        monthly_label,
+        forecast.monthly_goal.risk_level.label(),
+        forecast.monthly_goal.risk_score_pct,
+        forecast.streak.risk_level.label(),
+        forecast.streak.risk_score_pct,
+        alert_suffix,
+        reason_suffix
+    )
 }
 
 pub(super) fn format_history_weekly_allocation_line(app: &App) -> String {

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -201,6 +201,37 @@ fn readable_goal_streak_text_normalizes_off_state() {
 }
 
 #[test]
+fn history_focus_risk_line_shows_low_risk_when_goals_are_off() {
+    let app = App::default();
+    assert_eq!(
+        format_history_focus_risk_line(&app),
+        "Risk: D low 0% · W low 0% · M low 0% · S low 0% · D status goal off"
+    );
+}
+
+#[test]
+fn history_focus_risk_line_marks_alert_for_high_risk_forecast() {
+    let app = App::from_config_for_tests(AppConfig {
+        daily_goal: crate::config::DailyGoalConfig {
+            minutes: 120,
+            pomodoros: 4,
+        },
+        weekly_goal: crate::config::WeeklyGoalConfig {
+            minutes: 600,
+            pomodoros: 24,
+        },
+        monthly_goal: crate::config::MonthlyGoalConfig {
+            minutes: 2400,
+            pomodoros: 96,
+        },
+        ..AppConfig::default()
+    });
+    let line = format_history_focus_risk_line(&app);
+    assert!(line.contains("Risk: D high"));
+    assert!(line.contains("ALERT"));
+}
+
+#[test]
 fn goal_streak_lines_render_daily_weekly_monthly_period_progress() {
     let mut app = App::default();
     app.handle_key(crossterm::event::KeyEvent::new(


### PR DESCRIPTION
## What

- Adds focus-risk forecasting for daily, weekly, and monthly goal misses plus streak-break risk.
- Introduces deterministic risk scoring with explainable signals derived from completion gaps, cadence consistency, and pace pressure.
- Surfaces risk output in both `--status` CLI output and the TUI History overview.
- Adds focused stats, CLI, and UI tests for the new behavior.

## Why

This adds proactive visibility into likely goal misses and streak breaks so users can adjust earlier instead of only seeing outcomes after a miss.

Closes #324.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added focus risk forecasting to assess risk across daily, weekly, and monthly goal periods plus streaks
  * Automated risk alerts trigger when focus risk levels are elevated
  * Risk signals provide contextual reasons for high risk levels
  * Focus risk metrics now displayed in status output and task history view

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->