### PR TITLE
Custom dashboard with pinable KPI cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ cargo run -- --session-template-apply
 cargo run -- --session-template-apply "Deep Flow"
 cargo run -- --session-template-delete --json
 
+# Manage Focus History KPI dashboard cards
+cargo run -- --history-dashboard
+cargo run -- --history-dashboard-pin focus_score
+cargo run -- --history-dashboard-unpin goal_streak
+cargo run -- --history-dashboard-order=focus_score,goal_streak,session_summary,focus_risk,weekly_allocation,last_interruption,stats_growth,retention,comparison_filters
+cargo run -- --history-dashboard --json
+
 # Manage blocklist/allowlist sites for the active blocklist profile
 cargo run -- --blocklist-sites
 cargo run -- --allowlist-sites --json
@@ -388,6 +395,20 @@ Open the session planner from timer view with **`t`**.
 Starting a focus session from idle now requires a selected task label. The timer
 view always shows the current task label (or a reminder to select one).
 
+## Focus history dashboard
+
+Open Focus History from timer view with **`h`**.
+
+- `k` / `j`: select previous/next KPI card
+- `p`: pin/unpin selected KPI card
+- `<` / `>`: move selected pinned card left/right
+- `←/→`: cycle comparison dimension
+- `↑/↓`: cycle task slice, `[`/`]`: cycle profile slice, `,`/`.`: cycle time-of-day slice
+
+Pinned cards always render first in the dashboard list. Dashboard card order and
+pin state persist to `config.toml` and can be scripted with
+`--history-dashboard*` CLI commands.
+
 ### Mid-session notes
 
 While a focus session is running or paused, press **`m`** in timer view to edit a
@@ -401,8 +422,9 @@ Saved notes are reflected in live status metadata (`task_note`), recovery state,
 and interruption/completed-session history export fields.
 
 CLI parity is available via `--focus-intention`, `--task-note`, `--schedule-delay`,
-`--weekday-rules*`, `--session-template*`, `--break-glass-trigger`, and `--break-glass-cancel` for
-non-interactive inspection and in-session workflow control.
+`--weekday-rules*`, `--session-template*`, `--history-dashboard*`,
+`--break-glass-trigger`, and `--break-glass-cancel` for non-interactive
+inspection and in-session workflow control.
 
 Blocklist rules support exact hosts and wildcard subdomain rules. `*.example.com`
 matches `docs.example.com` and `api.example.com`, but does **not** match
@@ -434,7 +456,16 @@ timer_toggle_pause = "space"
 timer_stop_reset = "s"
 open_session_planner = "t"
 open_stats_history = "h"
+history_dashboard_select_previous = "k"
+history_dashboard_select_next = "j"
+history_dashboard_toggle_pin = "p"
+history_dashboard_move_left = "<"
+history_dashboard_move_right = ">"
 quit = "q"
+
+[history_dashboard]
+card_order = ["session_summary", "focus_score", "goal_streak", "focus_risk", "weekly_allocation", "last_interruption", "stats_growth", "retention", "comparison_filters"]
+pinned_cards = ["session_summary", "focus_score"]
 
 [[break_templates]]
 name = "Classic"

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,12 +15,12 @@ use crate::config::{
     AppConfig, AutoStartConfig, AutomationTriggerRuleConfig, BlockingBackendConfig,
     BlockingBackendPolicyConfig, BlocklistCategoryConfig, BlocklistProfileConfig,
     BreakTemplateConfig, CommandBlockingBackendConfig, CustomProfileConfig, DailyGoalConfig,
-    FeatureFlagsConfig, GoalCarryOverConfig, MonthlyGoalConfig, NotificationConfig,
-    OneTimeFocusWindowConfig, ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, ScheduleRuntimeConfig,
-    SessionTemplateConfig, StatsRetentionConfig, ThemePreset, WakatimeMetadataConfig,
-    WakatimeRuntimeConfig, WeekdayProfileRuleConfig, WeeklyGoalConfig,
-    validate_automation_trigger_rules,
+    FeatureFlagsConfig, GoalCarryOverConfig, HistoryDashboardConfig, HistoryKpiCardId,
+    MonthlyGoalConfig, NotificationConfig, OneTimeFocusWindowConfig, ProfileAutomationConfig,
+    ProfileAutomationSettingsConfig, ProfileId, RecurringFocusWindowConfig,
+    RecurringScheduleConfig, ScheduleRuntimeConfig, SessionTemplateConfig, StatsRetentionConfig,
+    ThemePreset, WakatimeMetadataConfig, WakatimeRuntimeConfig, WeekdayProfileRuleConfig,
+    WeeklyGoalConfig, validate_automation_trigger_rules,
 };
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
@@ -728,6 +728,9 @@ pub struct App {
     history_task_filter: Option<String>,
     history_profile_filter: Option<ProfileBucket>,
     history_time_of_day_filter: Option<TimeOfDayBucket>,
+    history_dashboard_card_order: Vec<HistoryKpiCardId>,
+    history_dashboard_pinned_cards: Vec<HistoryKpiCardId>,
+    history_dashboard_selected_card: HistoryKpiCardId,
     pub phase_notification: Option<String>,
     pub wakatime: WakatimeTracker,
     pub selected_profile: ProfileId,
@@ -830,6 +833,7 @@ impl App {
         let monthly_goal = config.monthly_goal;
         let goal_carry_over = config.goal_carry_over;
         let stats_retention = config.stats_retention;
+        let history_dashboard = config.history_dashboard;
         let wakatime_metadata = config.wakatime;
         let wakatime_runtime = config.wakatime_runtime;
         let blocklist_profiles = config.blocklist_profiles.clone();
@@ -892,6 +896,11 @@ impl App {
         );
         let setup_diagnostics =
             SetupDiagnostics::collect(&blocker, setup_deprecation_warnings.clone());
+        let history_dashboard_selected_card = history_dashboard
+            .card_order
+            .first()
+            .copied()
+            .unwrap_or(HistoryKpiCardId::SessionSummary);
         let mut app = Self {
             timer,
             should_quit: false,
@@ -939,6 +948,9 @@ impl App {
             history_task_filter: None,
             history_profile_filter: None,
             history_time_of_day_filter: None,
+            history_dashboard_card_order: history_dashboard.card_order,
+            history_dashboard_pinned_cards: history_dashboard.pinned_cards,
+            history_dashboard_selected_card,
             phase_notification: None,
             wakatime: WakatimeTracker::new_with_settings(
                 WakatimeHeartbeatMetadata {

--- a/src/app/history_comparison.rs
+++ b/src/app/history_comparison.rs
@@ -1,4 +1,5 @@
-use crate::app::App;
+use crate::app::{App, HistoryFeedbackLevel};
+use crate::config::HistoryKpiCardId;
 use crate::stats::{
     ComparisonDimension, ProductivityComparisonFilter, ProductivityComparisonRow, ProfileBucket,
     TimeOfDayBucket,
@@ -54,6 +55,137 @@ impl App {
             .map(|value| value.label().to_string())
             .unwrap_or_else(|| "All".to_string());
         format!("Slices: task {task} · profile {profile} · time {time_of_day}")
+    }
+
+    pub fn history_dashboard_card_order(&self) -> &[HistoryKpiCardId] {
+        &self.history_dashboard_card_order
+    }
+
+    pub fn history_dashboard_pinned_cards(&self) -> &[HistoryKpiCardId] {
+        &self.history_dashboard_pinned_cards
+    }
+
+    pub fn history_dashboard_cards(&self) -> Vec<HistoryKpiCardId> {
+        let mut cards = self.history_dashboard_pinned_cards.clone();
+        for card in &self.history_dashboard_card_order {
+            if !cards.contains(card) {
+                cards.push(*card);
+            }
+        }
+        cards
+    }
+
+    pub fn history_dashboard_selected_card(&self) -> HistoryKpiCardId {
+        self.history_dashboard_selected_card
+    }
+
+    pub fn history_dashboard_card_is_pinned(&self, card: HistoryKpiCardId) -> bool {
+        self.history_dashboard_pinned_cards.contains(&card)
+    }
+
+    pub(super) fn cycle_history_dashboard_selected_card(&mut self, forward: bool) {
+        let cards = self.history_dashboard_cards();
+        if cards.is_empty() {
+            return;
+        }
+        let current_index = cards
+            .iter()
+            .position(|card| *card == self.history_dashboard_selected_card)
+            .unwrap_or(0);
+        let next_index = if forward {
+            (current_index + 1) % cards.len()
+        } else {
+            (current_index + cards.len() - 1) % cards.len()
+        };
+        self.history_dashboard_selected_card = cards[next_index];
+    }
+
+    pub(super) fn toggle_history_dashboard_pin_for_selected_card(&mut self) {
+        let selected = self.history_dashboard_selected_card;
+        if let Some(index) = self
+            .history_dashboard_pinned_cards
+            .iter()
+            .position(|card| *card == selected)
+        {
+            if self.history_dashboard_pinned_cards.len() <= 1 {
+                self.set_history_feedback(
+                    HistoryFeedbackLevel::Warning,
+                    "At least one KPI card must remain pinned.",
+                );
+                return;
+            }
+            self.history_dashboard_pinned_cards.remove(index);
+            self.set_history_feedback(
+                HistoryFeedbackLevel::Success,
+                format!("Unpinned KPI card `{}`.", selected.id()),
+            );
+            return;
+        }
+
+        let order_index = self
+            .history_dashboard_card_order
+            .iter()
+            .position(|card| *card == selected)
+            .unwrap_or(usize::MAX);
+        let insert_at = self
+            .history_dashboard_pinned_cards
+            .iter()
+            .position(|card| {
+                self.history_dashboard_card_order
+                    .iter()
+                    .position(|candidate| candidate == card)
+                    .unwrap_or(usize::MAX)
+                    > order_index
+            })
+            .unwrap_or(self.history_dashboard_pinned_cards.len());
+        self.history_dashboard_pinned_cards
+            .insert(insert_at, selected);
+        self.set_history_feedback(
+            HistoryFeedbackLevel::Success,
+            format!("Pinned KPI card `{}`.", selected.id()),
+        );
+    }
+
+    pub(super) fn move_history_dashboard_selected_card(&mut self, right: bool) {
+        let selected = self.history_dashboard_selected_card;
+        let Some(index) = self
+            .history_dashboard_pinned_cards
+            .iter()
+            .position(|card| *card == selected)
+        else {
+            self.set_history_feedback(
+                HistoryFeedbackLevel::Warning,
+                "Pin the selected KPI card before reordering it.",
+            );
+            return;
+        };
+
+        let target_index = if right {
+            if index + 1 >= self.history_dashboard_pinned_cards.len() {
+                self.set_history_feedback(
+                    HistoryFeedbackLevel::Warning,
+                    "Selected KPI card is already at the right edge.",
+                );
+                return;
+            }
+            index + 1
+        } else {
+            if index == 0 {
+                self.set_history_feedback(
+                    HistoryFeedbackLevel::Warning,
+                    "Selected KPI card is already at the left edge.",
+                );
+                return;
+            }
+            index - 1
+        };
+
+        self.history_dashboard_pinned_cards
+            .swap(index, target_index);
+        self.set_history_feedback(
+            HistoryFeedbackLevel::Success,
+            format!("Moved KPI card `{}`.", selected.id()),
+        );
     }
 
     pub(super) fn cycle_history_comparison_dimension(&mut self, forward: bool) {

--- a/src/app/mode_keys.rs
+++ b/src/app/mode_keys.rs
@@ -227,27 +227,71 @@ impl App {
             || self.shortcut_matches(ShortcutAction::BackStatsHistory, &key)
         {
             self.mode = AppMode::Timer;
-        } else if self.shortcut_matches(ShortcutAction::ExportStatsHistory, &key) {
+            return;
+        }
+
+        if self.shortcut_matches(ShortcutAction::ExportStatsHistory, &key) {
             self.export_stats_history();
-        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardSelectPrevious, &key) {
+            return;
+        }
+
+        if self.handle_key_stats_history_dashboard_shortcuts(&key) {
+            return;
+        }
+
+        if self.handle_key_stats_history_navigation_shortcuts(&key) {
+            return;
+        }
+
+        self.handle_key_stats_history_filter_shortcuts(&key);
+    }
+
+    fn handle_key_stats_history_dashboard_shortcuts(&mut self, key: &KeyEvent) -> bool {
+        if self.shortcut_matches(ShortcutAction::HistoryDashboardSelectPrevious, key) {
             self.cycle_history_dashboard_selected_card(false);
-        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardSelectNext, &key) {
+            return true;
+        }
+        if self.shortcut_matches(ShortcutAction::HistoryDashboardSelectNext, key) {
             self.cycle_history_dashboard_selected_card(true);
-        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardTogglePin, &key) {
+            return true;
+        }
+        if self.shortcut_matches(ShortcutAction::HistoryDashboardTogglePin, key) {
             self.toggle_history_dashboard_pin_for_selected_card();
-        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardMoveLeft, &key) {
+            return true;
+        }
+        if self.shortcut_matches(ShortcutAction::HistoryDashboardMoveLeft, key) {
             self.move_history_dashboard_selected_card(false);
-        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardMoveRight, &key) {
+            return true;
+        }
+        if self.shortcut_matches(ShortcutAction::HistoryDashboardMoveRight, key) {
             self.move_history_dashboard_selected_card(true);
-        } else if self.navigation_matches(NavigationAction::MoveLeft, &key) {
+            return true;
+        }
+        false
+    }
+
+    fn handle_key_stats_history_navigation_shortcuts(&mut self, key: &KeyEvent) -> bool {
+        if self.navigation_matches(NavigationAction::MoveLeft, key) {
             self.cycle_history_comparison_dimension(false);
-        } else if self.navigation_matches(NavigationAction::MoveRight, &key) {
+            return true;
+        }
+        if self.navigation_matches(NavigationAction::MoveRight, key) {
             self.cycle_history_comparison_dimension(true);
-        } else if self.navigation_matches(NavigationAction::MoveUp, &key) {
+            return true;
+        }
+        if self.navigation_matches(NavigationAction::MoveUp, key) {
             self.cycle_history_task_filter(false);
-        } else if self.navigation_matches(NavigationAction::MoveDown, &key) {
+            return true;
+        }
+        if self.navigation_matches(NavigationAction::MoveDown, key) {
             self.cycle_history_task_filter(true);
-        } else if key.code == KeyCode::Char('[') {
+            return true;
+        }
+        false
+    }
+
+    fn handle_key_stats_history_filter_shortcuts(&mut self, key: &KeyEvent) {
+        if key.code == KeyCode::Char('[') {
             self.cycle_history_profile_filter(false);
         } else if key.code == KeyCode::Char(']') {
             self.cycle_history_profile_filter(true);

--- a/src/app/mode_keys.rs
+++ b/src/app/mode_keys.rs
@@ -229,6 +229,16 @@ impl App {
             self.mode = AppMode::Timer;
         } else if self.shortcut_matches(ShortcutAction::ExportStatsHistory, &key) {
             self.export_stats_history();
+        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardSelectPrevious, &key) {
+            self.cycle_history_dashboard_selected_card(false);
+        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardSelectNext, &key) {
+            self.cycle_history_dashboard_selected_card(true);
+        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardTogglePin, &key) {
+            self.toggle_history_dashboard_pin_for_selected_card();
+        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardMoveLeft, &key) {
+            self.move_history_dashboard_selected_card(false);
+        } else if self.shortcut_matches(ShortcutAction::HistoryDashboardMoveRight, &key) {
+            self.move_history_dashboard_selected_card(true);
         } else if self.navigation_matches(NavigationAction::MoveLeft, &key) {
             self.cycle_history_comparison_dimension(false);
         } else if self.navigation_matches(NavigationAction::MoveRight, &key) {

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -1,8 +1,8 @@
 use crate::app::{
     App, AppConfig, BlocklistCategoryConfig, BlocklistProfileConfig,
-    DEFAULT_BLOCKLIST_PROFILE_NAME, Local, PendingTimerAction, TimerPhase, TimerState, TimerStatus,
-    blocking_backend_config_for_persistence, format_duration_label, occurrence_key, profile_index,
-    profile_spec_for, task_label_index,
+    DEFAULT_BLOCKLIST_PROFILE_NAME, HistoryDashboardConfig, Local, PendingTimerAction, TimerPhase,
+    TimerState, TimerStatus, blocking_backend_config_for_persistence, format_duration_label,
+    occurrence_key, profile_index, profile_spec_for, task_label_index,
 };
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, WorkflowStateSnapshot, WorkflowTemporaryAllowlistEntrySnapshot,
@@ -557,6 +557,10 @@ impl App {
             monthly_goal: self.monthly_goal,
             goal_carry_over: self.goal_carry_over,
             stats_retention: self.stats_retention,
+            history_dashboard: HistoryDashboardConfig {
+                card_order: self.history_dashboard_card_order().to_vec(),
+                pinned_cards: self.history_dashboard_pinned_cards().to_vec(),
+            },
             wakatime: self.wakatime_metadata.clone(),
             wakatime_runtime: self.wakatime_runtime.clone(),
             feature_flags: self.feature_flags,

--- a/src/app/shortcuts.rs
+++ b/src/app/shortcuts.rs
@@ -41,6 +41,11 @@ pub enum ShortcutAction {
     SelectNextBreakTemplate,
     BackStatsHistory,
     ExportStatsHistory,
+    HistoryDashboardSelectPrevious,
+    HistoryDashboardSelectNext,
+    HistoryDashboardTogglePin,
+    HistoryDashboardMoveLeft,
+    HistoryDashboardMoveRight,
     BackSetupDiagnostics,
     RefreshSetupDiagnostics,
 }
@@ -114,9 +119,14 @@ const PROFILE_MANAGER_SCOPE_ACTIONS: [ShortcutAction; 4] = [
     ShortcutAction::SelectNextBreakTemplate,
 ];
 
-const STATS_HISTORY_SCOPE_ACTIONS: [ShortcutAction; 2] = [
+const STATS_HISTORY_SCOPE_ACTIONS: [ShortcutAction; 7] = [
     ShortcutAction::BackStatsHistory,
     ShortcutAction::ExportStatsHistory,
+    ShortcutAction::HistoryDashboardSelectPrevious,
+    ShortcutAction::HistoryDashboardSelectNext,
+    ShortcutAction::HistoryDashboardTogglePin,
+    ShortcutAction::HistoryDashboardMoveLeft,
+    ShortcutAction::HistoryDashboardMoveRight,
 ];
 
 const SETUP_SCOPE_ACTIONS: [ShortcutAction; 2] = [
@@ -363,6 +373,21 @@ impl ShortcutBindings {
             ),
             back_stats_history: key_token(self.key(ShortcutAction::BackStatsHistory)),
             export_stats_history: key_token(self.key(ShortcutAction::ExportStatsHistory)),
+            history_dashboard_select_previous: key_token(
+                self.key(ShortcutAction::HistoryDashboardSelectPrevious),
+            ),
+            history_dashboard_select_next: key_token(
+                self.key(ShortcutAction::HistoryDashboardSelectNext),
+            ),
+            history_dashboard_toggle_pin: key_token(
+                self.key(ShortcutAction::HistoryDashboardTogglePin),
+            ),
+            history_dashboard_move_left: key_token(
+                self.key(ShortcutAction::HistoryDashboardMoveLeft),
+            ),
+            history_dashboard_move_right: key_token(
+                self.key(ShortcutAction::HistoryDashboardMoveRight),
+            ),
             back_setup_diagnostics: key_token(self.key(ShortcutAction::BackSetupDiagnostics)),
             refresh_setup_diagnostics: key_token(self.key(ShortcutAction::RefreshSetupDiagnostics)),
             navigate_up: navigation_key_token(self.navigation_key(NavigationAction::MoveUp)),
@@ -537,6 +562,11 @@ fn requested_shortcut_char(config: &ShortcutConfig, action: ShortcutAction) -> c
         ShortcutAction::SelectNextBreakTemplate => &config.select_next_break_template,
         ShortcutAction::BackStatsHistory => &config.back_stats_history,
         ShortcutAction::ExportStatsHistory => &config.export_stats_history,
+        ShortcutAction::HistoryDashboardSelectPrevious => &config.history_dashboard_select_previous,
+        ShortcutAction::HistoryDashboardSelectNext => &config.history_dashboard_select_next,
+        ShortcutAction::HistoryDashboardTogglePin => &config.history_dashboard_toggle_pin,
+        ShortcutAction::HistoryDashboardMoveLeft => &config.history_dashboard_move_left,
+        ShortcutAction::HistoryDashboardMoveRight => &config.history_dashboard_move_right,
         ShortcutAction::BackSetupDiagnostics => &config.back_setup_diagnostics,
         ShortcutAction::RefreshSetupDiagnostics => &config.refresh_setup_diagnostics,
     };
@@ -594,6 +624,11 @@ fn default_shortcut_char(action: ShortcutAction) -> char {
         ShortcutAction::SelectNextBreakTemplate => ']',
         ShortcutAction::BackStatsHistory => 'h',
         ShortcutAction::ExportStatsHistory => 'e',
+        ShortcutAction::HistoryDashboardSelectPrevious => 'k',
+        ShortcutAction::HistoryDashboardSelectNext => 'j',
+        ShortcutAction::HistoryDashboardTogglePin => 'p',
+        ShortcutAction::HistoryDashboardMoveLeft => '<',
+        ShortcutAction::HistoryDashboardMoveRight => '>',
         ShortcutAction::BackSetupDiagnostics => 'd',
         ShortcutAction::RefreshSetupDiagnostics => 'r',
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2,7 +2,8 @@ use crate::app::*;
 use crate::blocker;
 use crate::config::{
     AutomationTriggerActionConfig, AutomationTriggerConditionConfig, AutomationTriggerRuleConfig,
-    FeatureFlagsConfig, ShortcutConfig, StatsRetentionConfig, WeekdayProfileRuleConfig,
+    FeatureFlagsConfig, HistoryDashboardConfig, HistoryKpiCardId, ShortcutConfig,
+    StatsRetentionConfig, WeekdayProfileRuleConfig,
 };
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
@@ -147,6 +148,7 @@ fn selected_builtin_profile_is_applied_on_startup() {
         monthly_goal: MonthlyGoalConfig::default(),
         goal_carry_over: GoalCarryOverConfig::default(),
         stats_retention: StatsRetentionConfig::default(),
+        history_dashboard: HistoryDashboardConfig::default(),
         selected_theme_preset: ThemePreset::Classic,
         wakatime: WakatimeMetadataConfig::default(),
         wakatime_runtime: WakatimeRuntimeConfig::default(),
@@ -4459,6 +4461,104 @@ fn history_view_comparison_filters_cycle_with_wrap_and_stale_task_selection() {
         app.history_time_of_day_filter,
         Some(crate::stats::TimeOfDayBucket::Unknown)
     );
+}
+
+#[test]
+fn history_dashboard_shortcuts_toggle_reorder_and_persist() {
+    let mut app = App::from_config(AppConfig {
+        history_dashboard: HistoryDashboardConfig {
+            card_order: vec![
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::FocusScore,
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::FocusRisk,
+                HistoryKpiCardId::WeeklyAllocation,
+                HistoryKpiCardId::LastInterruption,
+                HistoryKpiCardId::StatsGrowth,
+                HistoryKpiCardId::Retention,
+                HistoryKpiCardId::ComparisonFilters,
+            ],
+            pinned_cards: vec![
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::FocusScore,
+            ],
+        },
+        ..AppConfig::default()
+    });
+    app.handle_key(key(KeyCode::Char('h')));
+
+    assert_eq!(
+        app.history_dashboard_selected_card(),
+        HistoryKpiCardId::SessionSummary
+    );
+    app.handle_key(key(KeyCode::Char('j')));
+    assert_eq!(
+        app.history_dashboard_selected_card(),
+        HistoryKpiCardId::FocusScore
+    );
+
+    app.handle_key(key(KeyCode::Char('p')));
+    assert_eq!(
+        app.history_dashboard_pinned_cards(),
+        &[HistoryKpiCardId::SessionSummary]
+    );
+    app.handle_key(key(KeyCode::Char('p')));
+    assert_eq!(
+        app.history_dashboard_pinned_cards(),
+        &[
+            HistoryKpiCardId::SessionSummary,
+            HistoryKpiCardId::FocusScore
+        ]
+    );
+
+    app.handle_key(key(KeyCode::Char('<')));
+    assert_eq!(
+        app.history_dashboard_pinned_cards(),
+        &[
+            HistoryKpiCardId::FocusScore,
+            HistoryKpiCardId::SessionSummary
+        ]
+    );
+
+    let persisted = app.persisted_config();
+    assert_eq!(
+        persisted.history_dashboard.pinned_cards,
+        vec![
+            HistoryKpiCardId::FocusScore,
+            HistoryKpiCardId::SessionSummary
+        ]
+    );
+}
+
+#[test]
+fn history_dashboard_prevents_unpinning_last_card() {
+    let mut app = App::from_config(AppConfig {
+        history_dashboard: HistoryDashboardConfig {
+            card_order: vec![
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::FocusScore,
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::FocusRisk,
+                HistoryKpiCardId::WeeklyAllocation,
+                HistoryKpiCardId::LastInterruption,
+                HistoryKpiCardId::StatsGrowth,
+                HistoryKpiCardId::Retention,
+                HistoryKpiCardId::ComparisonFilters,
+            ],
+            pinned_cards: vec![HistoryKpiCardId::SessionSummary],
+        },
+        ..AppConfig::default()
+    });
+    app.handle_key(key(KeyCode::Char('h')));
+    app.handle_key(key(KeyCode::Char('p')));
+
+    assert_eq!(
+        app.history_dashboard_pinned_cards(),
+        &[HistoryKpiCardId::SessionSummary]
+    );
+    let feedback = app.history_feedback.as_ref().expect("warning expected");
+    assert_eq!(feedback.level, HistoryFeedbackLevel::Warning);
+    assert!(feedback.message.contains("must remain pinned"));
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,9 +13,9 @@ use crate::app::{SetupCheck, SetupCheckLevel, SetupDiagnostics};
 use crate::blocker::{BlockingPreviewAction, EditSiteResult, InvalidSiteInput, SiteBlocker};
 use crate::config::{
     AppConfig, AutomationTriggerRuleConfig, BlocklistProfileConfig, BreakTemplateConfig,
-    CustomProfileConfig, DailyGoalConfig, MonthlyGoalConfig, OneTimeFocusWindowConfig, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, ThemePreset, WeekdayProfileRuleConfig,
-    WeeklyGoalConfig,
+    CustomProfileConfig, DailyGoalConfig, HistoryKpiCardId, MonthlyGoalConfig,
+    OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig,
+    ThemePreset, WeekdayProfileRuleConfig, WeeklyGoalConfig,
 };
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
@@ -40,8 +40,8 @@ use args::{classify_args, infer_output_mode_from_os_args};
 use execute::execute_cli_command;
 #[cfg(test)]
 use execute::{
-    apply_blocklist_profile_command, apply_site_add_command, apply_site_delete_command,
-    apply_site_edit_command,
+    apply_blocklist_profile_command, apply_history_dashboard_command, apply_site_add_command,
+    apply_site_delete_command, apply_site_edit_command,
 };
 use output::{
     build_blocking_preview_command_output, build_diagnostics_command_output,
@@ -50,19 +50,20 @@ use output::{
     print_blocking_preview_command_output, print_blocklist_category_command_output,
     print_blocklist_profile_command_output, print_break_glass_command_output,
     print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
-    print_goal_command_output, print_json, print_json_compact, print_profile_output,
-    print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
-    print_session_metadata_command_output, print_session_template_command_output,
-    print_site_add_command_output, print_site_delete_command_output,
-    print_site_edit_command_output, print_site_list_command_output, print_status_output,
-    print_strict_command_output, print_task_goal_command_output,
-    print_temporary_site_add_command_output, print_theme_command_output, print_timer_state_output,
-    print_weekday_rules_command_output,
+    print_goal_command_output, print_history_dashboard_command_output, print_json,
+    print_json_compact, print_profile_output, print_restore_output, print_schedule_command_output,
+    print_schedule_delay_command_output, print_session_metadata_command_output,
+    print_session_template_command_output, print_site_add_command_output,
+    print_site_delete_command_output, print_site_edit_command_output,
+    print_site_list_command_output, print_status_output, print_strict_command_output,
+    print_task_goal_command_output, print_temporary_site_add_command_output,
+    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
 };
 use parsing::{
     finalize_cli_action, invalid_usage, parse_automation_triggers_value, parse_compare_by_value,
     parse_compare_limit_value, parse_compare_profile_value, parse_compare_time_of_day_value,
-    parse_global_tokens, parse_goal_carry_value, parse_goal_value, parse_monthly_goal_value,
+    parse_global_tokens, parse_goal_carry_value, parse_goal_value,
+    parse_history_dashboard_order_value, parse_history_kpi_card_id, parse_monthly_goal_value,
     parse_primary_command, parse_profile_id, parse_schedule_value, parse_site_edit_value,
     parse_status_comparison_options, parse_strict_value, parse_task_goal_value, parse_theme_preset,
     parse_watch_interval_option, parse_watch_interval_secs, parse_weekday_rules_value,
@@ -128,6 +129,10 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --session-template-create=TEMPLATE_NAME [--json]
   focustime --session-template-rename=TEMPLATE_NAME [--json]
   focustime --session-template-delete [--json]
+  focustime --history-dashboard [--json]
+  focustime --history-dashboard-pin=CARD_ID [--json]
+  focustime --history-dashboard-unpin=CARD_ID [--json]
+  focustime --history-dashboard-order=CARD_IDS [--json]
   focustime --blocklist-sites [--json]
   focustime --allowlist-sites [--json]
   focustime --blocklist-site-add=HOSTNAMES [--json]
@@ -185,6 +190,10 @@ Options:
   --session-template-create  Capture current task/profile/blocklist/schedule as a template
   --session-template-rename  Rename the active session template
   --session-template-delete  Delete the active session template
+  --history-dashboard       Show KPI dashboard card order + pinned cards
+  --history-dashboard-pin   Pin a KPI card by ID
+  --history-dashboard-unpin Unpin a KPI card by ID
+  --history-dashboard-order Replace full KPI card order with a complete comma-separated list
   --blocklist-sites           List blocklist sites in active category within active profile
   --allowlist-sites           List allowlist sites in active category within active profile
   --blocklist-site-add        Add/import blocklist hostnames in active category within active profile
@@ -367,6 +376,9 @@ pub enum CommandKind {
     SessionTemplate {
         command: SessionTemplateCommandKind,
     },
+    HistoryDashboard {
+        command: HistoryDashboardCommandKind,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -433,6 +445,10 @@ enum PrimaryCommand {
     SessionTemplateCreate(String),
     SessionTemplateRename(String),
     SessionTemplateDelete,
+    HistoryDashboard,
+    HistoryDashboardPin(HistoryKpiCardId),
+    HistoryDashboardUnpin(HistoryKpiCardId),
+    HistoryDashboardOrder(Vec<HistoryKpiCardId>),
     BlocklistSites,
     AllowlistSites,
     BlocklistSiteAdd(String),
@@ -503,6 +519,10 @@ enum ParsedToken {
     SessionTemplateCreate(String),
     SessionTemplateRename(String),
     SessionTemplateDelete,
+    HistoryDashboard,
+    HistoryDashboardPin(HistoryKpiCardId),
+    HistoryDashboardUnpin(HistoryKpiCardId),
+    HistoryDashboardOrder(Vec<HistoryKpiCardId>),
     BlocklistSites,
     AllowlistSites,
     BlocklistSiteAdd(String),
@@ -572,6 +592,14 @@ pub enum SessionTemplateCommandKind {
     Create { name: String },
     Rename { name: String },
     Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HistoryDashboardCommandKind {
+    Show,
+    Pin { card: HistoryKpiCardId },
+    Unpin { card: HistoryKpiCardId },
+    SetOrder { order: Vec<HistoryKpiCardId> },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -975,6 +1003,22 @@ struct SessionTemplateCommandOutput {
     updated: bool,
     selected_session_template: Option<String>,
     templates: Vec<SessionTemplateSummaryOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct HistoryDashboardCardOutput {
+    id: &'static str,
+    label: &'static str,
+    pinned: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct HistoryDashboardCommandOutput {
+    action: &'static str,
+    updated: bool,
+    card_order: Vec<&'static str>,
+    pinned_cards: Vec<&'static str>,
+    cards: Vec<HistoryDashboardCardOutput>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,10 +2,10 @@ use crate::cli::{
     KeyValueParser, OsString, OutputMode, ParsedToken, PathBuf, ValueArgParser, invalid_usage,
     parse_automation_triggers_value, parse_compare_by_value, parse_compare_limit_value,
     parse_compare_profile_value, parse_compare_time_of_day_value, parse_goal_carry_value,
-    parse_goal_value, parse_monthly_goal_value, parse_profile_id, parse_schedule_value,
-    parse_site_edit_value, parse_strict_value, parse_task_goal_value, parse_theme_preset,
-    parse_watch_interval_secs, parse_weekday_rules_value, parse_weekly_goal_value,
-    require_nonempty_key_value,
+    parse_goal_value, parse_history_dashboard_order_value, parse_history_kpi_card_id,
+    parse_monthly_goal_value, parse_profile_id, parse_schedule_value, parse_site_edit_value,
+    parse_strict_value, parse_task_goal_value, parse_theme_preset, parse_watch_interval_secs,
+    parse_weekday_rules_value, parse_weekly_goal_value, require_nonempty_key_value,
 };
 
 pub(super) fn infer_output_mode_from_os_args(args: &[OsString]) -> OutputMode {
@@ -57,7 +57,7 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 42] = [
+    let parsers: [(&str, ValueArgParser); 45] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
         ("--focus-intention", classify_focus_intention_arg),
@@ -117,6 +117,18 @@ fn classify_value_arg(
             "--session-template-rename",
             classify_session_template_rename_arg,
         ),
+        (
+            "--history-dashboard-pin",
+            classify_history_dashboard_pin_arg,
+        ),
+        (
+            "--history-dashboard-unpin",
+            classify_history_dashboard_unpin_arg,
+        ),
+        (
+            "--history-dashboard-order",
+            classify_history_dashboard_order_arg,
+        ),
         ("--blocklist-site-add", classify_blocklist_site_add_arg),
         ("--allowlist-site-add", classify_allowlist_site_add_arg),
         (
@@ -165,6 +177,7 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "--blocklist-profile-delete" => Some(ParsedToken::BlocklistProfileDelete),
         "--blocklist-category-delete" => Some(ParsedToken::BlocklistCategoryDelete),
         "--session-template-delete" => Some(ParsedToken::SessionTemplateDelete),
+        "--history-dashboard" => Some(ParsedToken::HistoryDashboard),
         "--blocklist-sites" => Some(ParsedToken::BlocklistSites),
         "--allowlist-sites" => Some(ParsedToken::AllowlistSites),
         _ => None,
@@ -569,6 +582,65 @@ fn classify_session_template_rename_arg(
     ))
 }
 
+fn classify_history_dashboard_pin_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value =
+            require_nonempty_key_value(next, "`--history-dashboard-pin` requires a card ID.")?;
+        return Ok((
+            ParsedToken::HistoryDashboardPin(parse_history_kpi_card_id(value)?),
+            2,
+        ));
+    }
+    Err(invalid_usage(
+        "`--history-dashboard-pin` requires a card ID. Use `--history-dashboard-pin=CARD_ID` or `--history-dashboard-pin CARD_ID`.",
+    ))
+}
+
+fn classify_history_dashboard_unpin_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value =
+            require_nonempty_key_value(next, "`--history-dashboard-unpin` requires a card ID.")?;
+        return Ok((
+            ParsedToken::HistoryDashboardUnpin(parse_history_kpi_card_id(value)?),
+            2,
+        ));
+    }
+    Err(invalid_usage(
+        "`--history-dashboard-unpin` requires a card ID. Use `--history-dashboard-unpin=CARD_ID` or `--history-dashboard-unpin CARD_ID`.",
+    ))
+}
+
+fn classify_history_dashboard_order_arg(
+    args: &[String],
+    index: usize,
+) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value = require_nonempty_key_value(
+            next,
+            "`--history-dashboard-order` requires a comma-separated card ID list.",
+        )?;
+        return Ok((
+            ParsedToken::HistoryDashboardOrder(parse_history_dashboard_order_value(value)?),
+            2,
+        ));
+    }
+    Err(invalid_usage(
+        "`--history-dashboard-order` requires a comma-separated card ID list. Use `--history-dashboard-order=id1,id2,...`.",
+    ))
+}
+
 fn classify_blocklist_site_add_arg(
     args: &[String],
     index: usize,
@@ -821,7 +893,7 @@ fn classify_automation_triggers_set_arg(
 }
 
 pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 42] = [
+    let parsers: [KeyValueParser; 45] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
         parse_focus_intention_key_value_arg,
@@ -857,6 +929,9 @@ pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, S
         parse_session_template_apply_key_value_arg,
         parse_session_template_create_key_value_arg,
         parse_session_template_rename_key_value_arg,
+        parse_history_dashboard_pin_key_value_arg,
+        parse_history_dashboard_unpin_key_value_arg,
+        parse_history_dashboard_order_key_value_arg,
         parse_blocklist_site_add_key_value_arg,
         parse_allowlist_site_add_key_value_arg,
         parse_allowlist_site_add_temporary_key_value_arg,
@@ -1247,6 +1322,41 @@ fn parse_session_template_rename_key_value_arg(arg: &str) -> Result<Option<Parse
         let value =
             require_nonempty_key_value(value, "`--session-template-rename=` requires a name.")?;
         return Ok(Some(ParsedToken::SessionTemplateRename(value.to_string())));
+    }
+    Ok(None)
+}
+
+fn parse_history_dashboard_pin_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--history-dashboard-pin=") {
+        let value =
+            require_nonempty_key_value(value, "`--history-dashboard-pin=` requires a card ID.")?;
+        return Ok(Some(ParsedToken::HistoryDashboardPin(
+            parse_history_kpi_card_id(value)?,
+        )));
+    }
+    Ok(None)
+}
+
+fn parse_history_dashboard_unpin_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--history-dashboard-unpin=") {
+        let value =
+            require_nonempty_key_value(value, "`--history-dashboard-unpin=` requires a card ID.")?;
+        return Ok(Some(ParsedToken::HistoryDashboardUnpin(
+            parse_history_kpi_card_id(value)?,
+        )));
+    }
+    Ok(None)
+}
+
+fn parse_history_dashboard_order_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--history-dashboard-order=") {
+        let value = require_nonempty_key_value(
+            value,
+            "`--history-dashboard-order=` requires a comma-separated card ID list.",
+        )?;
+        return Ok(Some(ParsedToken::HistoryDashboardOrder(
+            parse_history_dashboard_order_value(value)?,
+        )));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -18,13 +18,14 @@ use crate::cli::{
     BlocklistProfileCommandKind, BlocklistProfileCommandOutput, BlocklistProfileConfig,
     BlocklistProfileSummaryOutput, BlocklistSiteCommandKind, BreakGlassCommandOutput, CliCommand,
     CommandKind, DailyGoalConfig, DailyGoalSnapshot, EditSiteResult, ExportOutput, FocusStats,
-    GoalCarryCommandOutput, GoalCommandOutput, InvalidSiteEntryOutput, InvalidSiteInput,
-    MonthlyGoalConfig, OutputMode, PathBuf, ProfileId, ProfileOutput, ProfileView,
-    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, ScheduleDelayCommandOutput,
-    SessionMetadataCommandOutput, SessionTemplateCommandKind, SessionTemplateCommandOutput,
-    SessionTemplateSummaryOutput, SiteAddCommandOutput, SiteBlocker, SiteDeleteCommandOutput,
-    SiteEditCommandOutput, SiteEditValue, SiteListCommandOutput, SiteListTarget,
-    StatusComparisonOptions, StatusOutput, StrictCommandOutput, TaskCommandOutput,
+    GoalCarryCommandOutput, GoalCommandOutput, HistoryDashboardCardOutput,
+    HistoryDashboardCommandKind, HistoryDashboardCommandOutput, HistoryKpiCardId,
+    InvalidSiteEntryOutput, InvalidSiteInput, MonthlyGoalConfig, OutputMode, PathBuf, ProfileId,
+    ProfileOutput, ProfileView, RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput,
+    ScheduleDelayCommandOutput, SessionMetadataCommandOutput, SessionTemplateCommandKind,
+    SessionTemplateCommandOutput, SessionTemplateSummaryOutput, SiteAddCommandOutput, SiteBlocker,
+    SiteDeleteCommandOutput, SiteEditCommandOutput, SiteEditValue, SiteListCommandOutput,
+    SiteListTarget, StatusComparisonOptions, StatusOutput, StrictCommandOutput, TaskCommandOutput,
     TaskGoalCommandOutput, TaskGoalOutput, TemporaryAllowlistStatusOutput,
     TemporarySiteAddCommandOutput, ThemeCommandOutput, ThemePreset, TimerCommandOutput,
     TimerStateOutput, WeekdayProfileRuleConfig, WeekdayRulesCommandOutput, WeeklyGoalConfig,
@@ -36,15 +37,16 @@ use crate::cli::{
     print_blocking_preview_command_output, print_blocklist_category_command_output,
     print_blocklist_profile_command_output, print_break_glass_command_output,
     print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
-    print_goal_command_output, print_json, print_json_compact, print_profile_output,
-    print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
-    print_session_metadata_command_output, print_session_template_command_output,
-    print_site_add_command_output, print_site_delete_command_output,
-    print_site_edit_command_output, print_site_list_command_output, print_status_output,
-    print_strict_command_output, print_task_goal_command_output,
-    print_temporary_site_add_command_output, print_theme_command_output, print_timer_state_output,
-    print_weekday_rules_command_output, profile_id, profile_view, selected_break_template_view,
-    theme_preset_view, timer_phase_id, timer_status_id,
+    print_goal_command_output, print_history_dashboard_command_output, print_json,
+    print_json_compact, print_profile_output, print_restore_output, print_schedule_command_output,
+    print_schedule_delay_command_output, print_session_metadata_command_output,
+    print_session_template_command_output, print_site_add_command_output,
+    print_site_delete_command_output, print_site_edit_command_output,
+    print_site_list_command_output, print_status_output, print_strict_command_output,
+    print_task_goal_command_output, print_temporary_site_add_command_output,
+    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
+    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
+    timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
@@ -119,6 +121,9 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         }
         CommandKind::SessionTemplate { command } => {
             execute_session_template_command(command, cli_command.output)
+        }
+        CommandKind::HistoryDashboard { command } => {
+            execute_history_dashboard_command(command, cli_command.output)
         }
     }
 }
@@ -414,6 +419,131 @@ fn execute_session_template_command(
         OutputMode::Json => print_json(&payload)?,
     }
     Ok(())
+}
+
+fn execute_history_dashboard_command(
+    command: HistoryDashboardCommandKind,
+    output: OutputMode,
+) -> Result<(), String> {
+    let mut config = AppConfig::load().normalized();
+    let payload = apply_history_dashboard_command(&mut config, command)?;
+    if payload.updated {
+        config
+            .save()
+            .map_err(|error| format!("Failed to save history dashboard settings: {error}"))?;
+    }
+    match output {
+        OutputMode::Text => print_history_dashboard_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+pub(super) fn apply_history_dashboard_command(
+    config: &mut AppConfig,
+    command: HistoryDashboardCommandKind,
+) -> Result<HistoryDashboardCommandOutput, String> {
+    let (action, updated) = match command {
+        HistoryDashboardCommandKind::Show => ("history-dashboard", false),
+        HistoryDashboardCommandKind::Pin { card } => {
+            if config.history_dashboard.pinned_cards.contains(&card) {
+                ("history-dashboard-pin", false)
+            } else {
+                let insert_at = config
+                    .history_dashboard
+                    .pinned_cards
+                    .iter()
+                    .position(|candidate| {
+                        card_order_index(&config.history_dashboard.card_order, *candidate)
+                            > card_order_index(&config.history_dashboard.card_order, card)
+                    })
+                    .unwrap_or(config.history_dashboard.pinned_cards.len());
+                config
+                    .history_dashboard
+                    .pinned_cards
+                    .insert(insert_at, card);
+                ("history-dashboard-pin", true)
+            }
+        }
+        HistoryDashboardCommandKind::Unpin { card } => {
+            if let Some(index) = config
+                .history_dashboard
+                .pinned_cards
+                .iter()
+                .position(|candidate| *candidate == card)
+            {
+                if config.history_dashboard.pinned_cards.len() <= 1 {
+                    return Err(
+                        "At least one history dashboard card must remain pinned.".to_string()
+                    );
+                }
+                config.history_dashboard.pinned_cards.remove(index);
+                ("history-dashboard-unpin", true)
+            } else {
+                ("history-dashboard-unpin", false)
+            }
+        }
+        HistoryDashboardCommandKind::SetOrder { order } => {
+            if config.history_dashboard.card_order == order {
+                ("history-dashboard-order", false)
+            } else {
+                config.history_dashboard.card_order = order;
+                ("history-dashboard-order", true)
+            }
+        }
+    };
+
+    config
+        .history_dashboard
+        .pinned_cards
+        .sort_by_key(|card| card_order_index(&config.history_dashboard.card_order, *card));
+    Ok(build_history_dashboard_command_output(
+        config, action, updated,
+    ))
+}
+
+fn build_history_dashboard_command_output(
+    config: &AppConfig,
+    action: &'static str,
+    updated: bool,
+) -> HistoryDashboardCommandOutput {
+    let mut cards = config.history_dashboard.pinned_cards.clone();
+    for card in &config.history_dashboard.card_order {
+        if !cards.contains(card) {
+            cards.push(*card);
+        }
+    }
+    HistoryDashboardCommandOutput {
+        action,
+        updated,
+        card_order: config
+            .history_dashboard
+            .card_order
+            .iter()
+            .map(|card| card.id())
+            .collect(),
+        pinned_cards: config
+            .history_dashboard
+            .pinned_cards
+            .iter()
+            .map(|card| card.id())
+            .collect(),
+        cards: cards
+            .into_iter()
+            .map(|card| HistoryDashboardCardOutput {
+                id: card.id(),
+                label: card.label(),
+                pinned: config.history_dashboard.pinned_cards.contains(&card),
+            })
+            .collect(),
+    }
+}
+
+fn card_order_index(order: &[HistoryKpiCardId], card: HistoryKpiCardId) -> usize {
+    order
+        .iter()
+        .position(|candidate| *candidate == card)
+        .unwrap_or(usize::MAX)
 }
 
 pub(super) fn apply_blocklist_profile_command(

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -2,15 +2,16 @@ use crate::cli::{
     AutomationTriggersCommandOutput, BackupOutput, BlockingPreviewAction,
     BlockingPreviewCommandOutput, BlocklistCategoryCommandOutput, BlocklistProfileCommandOutput,
     BlocklistProfileConfig, BreakGlassCommandOutput, DiagnosticsCommandOutput, ExportOutput,
-    FocusScoreOutput, GoalCarryCommandOutput, GoalCommandOutput, GoalOutput, ProfileOutput,
-    RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput, ScheduleDelayCommandOutput,
-    ScheduleInspectionOutput, Serialize, SessionMetadataCommandOutput,
-    SessionTemplateCommandOutput, SetupCheck, SetupCheckLevel, SetupCheckOutput, SetupDiagnostics,
-    SiteAddCommandOutput, SiteDeleteCommandOutput, SiteEditCommandOutput, SiteListCommandOutput,
-    StatsGrowthSummary, StatsRetentionStatusOutput, StatusComparisonOutput, StatusOutput,
-    StrictCommandOutput, TaskGoalCommandOutput, TaskGoalOutput, TemporarySiteAddCommandOutput,
-    ThemeCommandOutput, TimerStateOutput, WeekdayRulesCommandOutput, Write,
-    format_schedule_conflict, inspect_schedule_conflicts_from_config, io,
+    FocusScoreOutput, GoalCarryCommandOutput, GoalCommandOutput, GoalOutput,
+    HistoryDashboardCommandOutput, ProfileOutput, RecurringScheduleConfig, RestoreOutput,
+    ScheduleCommandOutput, ScheduleDelayCommandOutput, ScheduleInspectionOutput, Serialize,
+    SessionMetadataCommandOutput, SessionTemplateCommandOutput, SetupCheck, SetupCheckLevel,
+    SetupCheckOutput, SetupDiagnostics, SiteAddCommandOutput, SiteDeleteCommandOutput,
+    SiteEditCommandOutput, SiteListCommandOutput, StatsGrowthSummary, StatsRetentionStatusOutput,
+    StatusComparisonOutput, StatusOutput, StrictCommandOutput, TaskGoalCommandOutput,
+    TaskGoalOutput, TemporarySiteAddCommandOutput, ThemeCommandOutput, TimerStateOutput,
+    WeekdayRulesCommandOutput, Write, format_schedule_conflict,
+    inspect_schedule_conflicts_from_config, io,
 };
 use chrono::{Local, TimeZone};
 
@@ -155,6 +156,23 @@ pub(super) fn print_session_template_command_output(payload: &SessionTemplateCom
             template.blocklist_profile,
             template.schedule_windows_count
         );
+    }
+}
+
+pub(super) fn print_history_dashboard_command_output(payload: &HistoryDashboardCommandOutput) {
+    if payload.updated {
+        println!("History dashboard updated.");
+    }
+    println!("Card order: {}", payload.card_order.join(", "));
+    println!("Pinned cards: {}", payload.pinned_cards.join(", "));
+    if payload.cards.is_empty() {
+        println!("Cards: none");
+        return;
+    }
+    println!("Cards:");
+    for card in &payload.cards {
+        let marker = if card.pinned { "*" } else { " " };
+        println!("  {marker} {} ({})", card.label, card.id);
     }
 }
 

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -2,10 +2,11 @@ use crate::cli::{
     AutomationTriggerRuleConfig, BlocklistCategoryCommandKind, BlocklistProfileCommandKind,
     BlocklistSiteCommandKind, CliAction, CliCommand, CommandKind, ComparisonDimension,
     DEFAULT_STATUS_COMPARISON_LIMIT, DEFAULT_WATCH_INTERVAL_SECS, DailyGoalConfig,
-    MonthlyGoalConfig, NaiveDate, OneTimeFocusWindowConfig, OutputMode, ParsedToken,
-    PrimaryCommand, ProfileBucket, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig,
-    SessionTemplateCommandKind, SiteEditValue, SiteListTarget, StatusComparisonOptions,
-    ThemePreset, TimeOfDayBucket, USAGE_TEXT, WeekdayProfileRuleConfig, WeeklyGoalConfig,
+    HistoryDashboardCommandKind, HistoryKpiCardId, MonthlyGoalConfig, NaiveDate,
+    OneTimeFocusWindowConfig, OutputMode, ParsedToken, PrimaryCommand, ProfileBucket, ProfileId,
+    RecurringFocusWindowConfig, RecurringScheduleConfig, SessionTemplateCommandKind, SiteEditValue,
+    SiteListTarget, StatusComparisonOptions, ThemePreset, TimeOfDayBucket, USAGE_TEXT,
+    WeekdayProfileRuleConfig, WeeklyGoalConfig,
 };
 
 pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, OutputMode), String> {
@@ -81,6 +82,10 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::SessionTemplateCreate(_)
             | ParsedToken::SessionTemplateRename(_)
             | ParsedToken::SessionTemplateDelete
+            | ParsedToken::HistoryDashboard
+            | ParsedToken::HistoryDashboardPin(_)
+            | ParsedToken::HistoryDashboardUnpin(_)
+            | ParsedToken::HistoryDashboardOrder(_)
             | ParsedToken::BlocklistSites
             | ParsedToken::AllowlistSites
             | ParsedToken::BlocklistSiteAdd(_)
@@ -245,6 +250,19 @@ pub(super) fn parse_primary_command(
             ParsedToken::SessionTemplateDelete => {
                 set_primary_command(&mut primary, PrimaryCommand::SessionTemplateDelete)?
             }
+            ParsedToken::HistoryDashboard => {
+                set_primary_command(&mut primary, PrimaryCommand::HistoryDashboard)?
+            }
+            ParsedToken::HistoryDashboardPin(card) => {
+                set_primary_command(&mut primary, PrimaryCommand::HistoryDashboardPin(*card))?
+            }
+            ParsedToken::HistoryDashboardUnpin(card) => {
+                set_primary_command(&mut primary, PrimaryCommand::HistoryDashboardUnpin(*card))?
+            }
+            ParsedToken::HistoryDashboardOrder(order) => set_primary_command(
+                &mut primary,
+                PrimaryCommand::HistoryDashboardOrder(order.clone()),
+            )?,
             ParsedToken::BlocklistSites => {
                 set_primary_command(&mut primary, PrimaryCommand::BlocklistSites)?
             }
@@ -549,6 +567,34 @@ pub(super) fn finalize_cli_action(
             },
             output,
         })),
+        Some(PrimaryCommand::HistoryDashboard) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::HistoryDashboard {
+                command: HistoryDashboardCommandKind::Show,
+            },
+            output,
+        })),
+        Some(PrimaryCommand::HistoryDashboardPin(card)) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::HistoryDashboard {
+                command: HistoryDashboardCommandKind::Pin { card },
+            },
+            output,
+        })),
+        Some(PrimaryCommand::HistoryDashboardUnpin(card)) => {
+            Ok(CliAction::RunCommand(CliCommand {
+                kind: CommandKind::HistoryDashboard {
+                    command: HistoryDashboardCommandKind::Unpin { card },
+                },
+                output,
+            }))
+        }
+        Some(PrimaryCommand::HistoryDashboardOrder(order)) => {
+            Ok(CliAction::RunCommand(CliCommand {
+                kind: CommandKind::HistoryDashboard {
+                    command: HistoryDashboardCommandKind::SetOrder { order },
+                },
+                output,
+            }))
+        }
         Some(PrimaryCommand::BlocklistSites) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::BlocklistSites {
                 target: SiteListTarget::Blocklist,
@@ -639,6 +685,48 @@ pub(super) fn parse_theme_preset(value: &str) -> Result<ThemePreset, String> {
             "Invalid theme preset `{value}`. Use `classic`, `high-contrast`, or `deuteranopia-friendly`."
         ))),
     }
+}
+
+pub(super) fn parse_history_kpi_card_id(value: &str) -> Result<HistoryKpiCardId, String> {
+    HistoryKpiCardId::from_id(value).ok_or_else(|| {
+        invalid_usage(&format!(
+            "Invalid history dashboard card `{value}`. Use one of: session_summary, focus_score, goal_streak, focus_risk, weekly_allocation, last_interruption, stats_growth, retention, comparison_filters."
+        ))
+    })
+}
+
+pub(super) fn parse_history_dashboard_order_value(
+    value: &str,
+) -> Result<Vec<HistoryKpiCardId>, String> {
+    let entries: Vec<&str> = value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .collect();
+    if entries.is_empty() {
+        return Err(invalid_usage(
+            "`--history-dashboard-order` requires a comma-separated list of KPI card IDs.",
+        ));
+    }
+    let mut order = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let card = parse_history_kpi_card_id(entry)?;
+        if order.contains(&card) {
+            return Err(invalid_usage(&format!(
+                "Duplicate history dashboard card `{}` in `--history-dashboard-order`.",
+                card.id()
+            )));
+        }
+        order.push(card);
+    }
+
+    let required = HistoryKpiCardId::all();
+    if order.len() != required.len() || required.iter().any(|card| !order.contains(card)) {
+        return Err(invalid_usage(
+            "`--history-dashboard-order` must include every KPI card exactly once.",
+        ));
+    }
+    Ok(order)
 }
 
 pub(super) fn parse_task_goal_value(
@@ -986,6 +1074,10 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::SessionTemplateCreate(_) => "--session-template-create",
         PrimaryCommand::SessionTemplateRename(_) => "--session-template-rename",
         PrimaryCommand::SessionTemplateDelete => "--session-template-delete",
+        PrimaryCommand::HistoryDashboard => "--history-dashboard",
+        PrimaryCommand::HistoryDashboardPin(_) => "--history-dashboard-pin",
+        PrimaryCommand::HistoryDashboardUnpin(_) => "--history-dashboard-unpin",
+        PrimaryCommand::HistoryDashboardOrder(_) => "--history-dashboard-order",
         PrimaryCommand::BlocklistSites => "--blocklist-sites",
         PrimaryCommand::AllowlistSites => "--allowlist-sites",
         PrimaryCommand::BlocklistSiteAdd(_) => "--blocklist-site-add",

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -688,9 +688,10 @@ pub(super) fn parse_theme_preset(value: &str) -> Result<ThemePreset, String> {
 }
 
 pub(super) fn parse_history_kpi_card_id(value: &str) -> Result<HistoryKpiCardId, String> {
-    HistoryKpiCardId::from_id(value).ok_or_else(|| {
+    let normalized = value.trim();
+    HistoryKpiCardId::from_id(normalized).ok_or_else(|| {
         invalid_usage(&format!(
-            "Invalid history dashboard card `{value}`. Use one of: session_summary, focus_score, goal_streak, focus_risk, weekly_allocation, last_interruption, stats_growth, retention, comparison_filters."
+            "Invalid history dashboard card `{normalized}`. Use one of: session_summary, focus_score, goal_streak, focus_risk, weekly_allocation, last_interruption, stats_growth, retention, comparison_filters."
         ))
     })
 }

--- a/src/cli/parsing/tests.rs
+++ b/src/cli/parsing/tests.rs
@@ -62,3 +62,49 @@ fn parse_status_comparison_options_rejects_zero_limit() {
 
     assert!(error.contains("`--compare-limit` requires a positive whole number."));
 }
+
+#[test]
+fn parse_history_kpi_card_id_accepts_known_card() {
+    let parsed = parse_history_kpi_card_id("focus_score").unwrap();
+
+    assert_eq!(parsed, HistoryKpiCardId::FocusScore);
+}
+
+#[test]
+fn parse_history_kpi_card_id_rejects_unknown_card() {
+    let error = parse_history_kpi_card_id("legacy-card").unwrap_err();
+
+    assert!(error.contains("Invalid history dashboard card"));
+}
+
+#[test]
+fn parse_history_dashboard_order_value_accepts_complete_catalog() {
+    let parsed = parse_history_dashboard_order_value(
+        "focus_score,goal_streak,session_summary,focus_risk,weekly_allocation,last_interruption,stats_growth,retention,comparison_filters",
+    )
+    .unwrap();
+
+    assert_eq!(parsed.len(), HistoryKpiCardId::all().len());
+    assert_eq!(parsed[0], HistoryKpiCardId::FocusScore);
+    assert_eq!(parsed[2], HistoryKpiCardId::SessionSummary);
+}
+
+#[test]
+fn parse_history_dashboard_order_value_rejects_duplicates() {
+    let error = parse_history_dashboard_order_value(
+        "focus_score,focus_score,session_summary,goal_streak,focus_risk,weekly_allocation,last_interruption,stats_growth,retention,comparison_filters",
+    )
+    .unwrap_err();
+
+    assert!(error.contains("Duplicate history dashboard card"));
+}
+
+#[test]
+fn parse_history_dashboard_order_value_rejects_missing_cards() {
+    let error = parse_history_dashboard_order_value(
+        "focus_score,goal_streak,session_summary,focus_risk,weekly_allocation,last_interruption,stats_growth,retention",
+    )
+    .unwrap_err();
+
+    assert!(error.contains("must include every KPI card exactly once"));
+}

--- a/src/cli/parsing/tests.rs
+++ b/src/cli/parsing/tests.rs
@@ -71,6 +71,13 @@ fn parse_history_kpi_card_id_accepts_known_card() {
 }
 
 #[test]
+fn parse_history_kpi_card_id_accepts_trimmed_known_card() {
+    let parsed = parse_history_kpi_card_id("  focus_score  ").unwrap();
+
+    assert_eq!(parsed, HistoryKpiCardId::FocusScore);
+}
+
+#[test]
 fn parse_history_kpi_card_id_rejects_unknown_card() {
     let error = parse_history_kpi_card_id("legacy-card").unwrap_err();
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1065,6 +1065,81 @@ fn parse_session_template_delete_runs_command() {
 }
 
 #[test]
+fn parse_history_dashboard_without_value_reads_dashboard_state() {
+    let parsed = parse(&["--history-dashboard"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::HistoryDashboard {
+                command: HistoryDashboardCommandKind::Show
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_history_dashboard_pin_with_value_sets_card() {
+    let parsed = parse(&["--history-dashboard-pin", "focus_score"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::HistoryDashboard {
+                command: HistoryDashboardCommandKind::Pin {
+                    card: HistoryKpiCardId::FocusScore
+                }
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_history_dashboard_unpin_with_equals_sets_card() {
+    let parsed = parse(&["--history-dashboard-unpin=goal_streak"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::HistoryDashboard {
+                command: HistoryDashboardCommandKind::Unpin {
+                    card: HistoryKpiCardId::GoalStreak
+                }
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_history_dashboard_order_sets_complete_order() {
+    let parsed = parse(&[
+        "--history-dashboard-order=focus_score,goal_streak,session_summary,focus_risk,weekly_allocation,last_interruption,stats_growth,retention,comparison_filters",
+    ])
+    .unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::HistoryDashboard {
+                command: HistoryDashboardCommandKind::SetOrder {
+                    order: vec![
+                        HistoryKpiCardId::FocusScore,
+                        HistoryKpiCardId::GoalStreak,
+                        HistoryKpiCardId::SessionSummary,
+                        HistoryKpiCardId::FocusRisk,
+                        HistoryKpiCardId::WeeklyAllocation,
+                        HistoryKpiCardId::LastInterruption,
+                        HistoryKpiCardId::StatsGrowth,
+                        HistoryKpiCardId::Retention,
+                        HistoryKpiCardId::ComparisonFilters
+                    ]
+                }
+            },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
 fn parse_blocklist_site_add_with_equals() {
     let parsed = parse(&["--blocklist-site-add=github.com,news.ycombinator.com"]).unwrap();
     assert_eq!(
@@ -1377,6 +1452,39 @@ fn classify_key_value_arg_accepts_session_template_rename_equals_value() {
 }
 
 #[test]
+fn classify_key_value_arg_accepts_history_dashboard_pin_equals_value() {
+    let parsed = classify_key_value_arg("--history-dashboard-pin=focus_score").unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::HistoryDashboardPin(
+            HistoryKpiCardId::FocusScore
+        ))
+    );
+}
+
+#[test]
+fn classify_key_value_arg_accepts_history_dashboard_order_equals_value() {
+    let parsed = classify_key_value_arg(
+        "--history-dashboard-order=focus_score,goal_streak,session_summary,focus_risk,weekly_allocation,last_interruption,stats_growth,retention,comparison_filters",
+    )
+    .unwrap();
+    assert_eq!(
+        parsed,
+        Some(ParsedToken::HistoryDashboardOrder(vec![
+            HistoryKpiCardId::FocusScore,
+            HistoryKpiCardId::GoalStreak,
+            HistoryKpiCardId::SessionSummary,
+            HistoryKpiCardId::FocusRisk,
+            HistoryKpiCardId::WeeklyAllocation,
+            HistoryKpiCardId::LastInterruption,
+            HistoryKpiCardId::StatsGrowth,
+            HistoryKpiCardId::Retention,
+            HistoryKpiCardId::ComparisonFilters
+        ]))
+    );
+}
+
+#[test]
 fn classify_key_value_arg_rejects_empty_export_equals_value() {
     let error = classify_key_value_arg("--export=").unwrap_err();
     assert!(error.contains("`--export=` requires a target directory."));
@@ -1602,6 +1710,18 @@ fn parse_rejects_session_template_create_without_value() {
 fn parse_rejects_session_template_rename_without_value() {
     let error = parse(&["--session-template-rename"]).unwrap_err();
     assert!(error.contains("`--session-template-rename` requires a template name"));
+}
+
+#[test]
+fn parse_rejects_history_dashboard_pin_without_value() {
+    let error = parse(&["--history-dashboard-pin"]).unwrap_err();
+    assert!(error.contains("`--history-dashboard-pin` requires a card ID"));
+}
+
+#[test]
+fn parse_rejects_history_dashboard_order_without_full_catalog() {
+    let error = parse(&["--history-dashboard-order=focus_score,goal_streak"]).unwrap_err();
+    assert!(error.contains("must include every KPI card exactly once"));
 }
 
 #[test]
@@ -1908,6 +2028,124 @@ fn apply_blocklist_profile_delete_switches_selection() {
     assert_eq!(config.selected_blocklist_profile, "Study");
     assert_eq!(config.blocklist_profiles.len(), 1);
     assert!(config.blocked_sites.is_empty());
+}
+
+#[test]
+fn apply_history_dashboard_pin_inserts_card_using_order() {
+    let mut config = AppConfig {
+        history_dashboard: crate::config::HistoryDashboardConfig {
+            card_order: vec![
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::FocusScore,
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::FocusRisk,
+                HistoryKpiCardId::WeeklyAllocation,
+                HistoryKpiCardId::LastInterruption,
+                HistoryKpiCardId::StatsGrowth,
+                HistoryKpiCardId::Retention,
+                HistoryKpiCardId::ComparisonFilters,
+            ],
+            pinned_cards: vec![
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::GoalStreak,
+            ],
+        },
+        ..AppConfig::default()
+    }
+    .normalized();
+
+    let payload = apply_history_dashboard_command(
+        &mut config,
+        HistoryDashboardCommandKind::Pin {
+            card: HistoryKpiCardId::FocusScore,
+        },
+    )
+    .unwrap();
+
+    assert!(payload.updated);
+    assert_eq!(
+        config.history_dashboard.pinned_cards,
+        vec![
+            HistoryKpiCardId::SessionSummary,
+            HistoryKpiCardId::FocusScore,
+            HistoryKpiCardId::GoalStreak
+        ]
+    );
+}
+
+#[test]
+fn apply_history_dashboard_unpin_rejects_last_pinned_card() {
+    let mut config = AppConfig {
+        history_dashboard: crate::config::HistoryDashboardConfig {
+            card_order: HistoryKpiCardId::all().to_vec(),
+            pinned_cards: vec![HistoryKpiCardId::SessionSummary],
+        },
+        ..AppConfig::default()
+    }
+    .normalized();
+
+    let error = apply_history_dashboard_command(
+        &mut config,
+        HistoryDashboardCommandKind::Unpin {
+            card: HistoryKpiCardId::SessionSummary,
+        },
+    )
+    .unwrap_err();
+
+    assert!(error.contains("must remain pinned"));
+}
+
+#[test]
+fn apply_history_dashboard_order_resorts_pinned_cards() {
+    let mut config = AppConfig {
+        history_dashboard: crate::config::HistoryDashboardConfig {
+            card_order: vec![
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::FocusScore,
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::FocusRisk,
+                HistoryKpiCardId::WeeklyAllocation,
+                HistoryKpiCardId::LastInterruption,
+                HistoryKpiCardId::StatsGrowth,
+                HistoryKpiCardId::Retention,
+                HistoryKpiCardId::ComparisonFilters,
+            ],
+            pinned_cards: vec![
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::SessionSummary,
+            ],
+        },
+        ..AppConfig::default()
+    }
+    .normalized();
+
+    let payload = apply_history_dashboard_command(
+        &mut config,
+        HistoryDashboardCommandKind::SetOrder {
+            order: vec![
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::FocusScore,
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::FocusRisk,
+                HistoryKpiCardId::WeeklyAllocation,
+                HistoryKpiCardId::LastInterruption,
+                HistoryKpiCardId::StatsGrowth,
+                HistoryKpiCardId::Retention,
+                HistoryKpiCardId::ComparisonFilters,
+            ],
+        },
+    )
+    .unwrap();
+
+    assert!(payload.updated);
+    assert_eq!(
+        config.history_dashboard.pinned_cards,
+        vec![
+            HistoryKpiCardId::GoalStreak,
+            HistoryKpiCardId::SessionSummary
+        ]
+    );
+    assert_eq!(payload.pinned_cards, vec!["goal_streak", "session_summary"]);
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,6 +140,9 @@ pub struct AppConfig {
     /// Retention policy for persisted stats history.
     #[serde(default)]
     pub stats_retention: StatsRetentionConfig,
+    /// History dashboard KPI card layout (pinning + display order).
+    #[serde(default)]
+    pub history_dashboard: HistoryDashboardConfig,
     /// WakaTime heartbeat metadata labels.
     #[serde(default)]
     pub wakatime: WakatimeMetadataConfig,
@@ -299,6 +302,16 @@ pub struct ShortcutConfig {
     pub back_stats_history: String,
     #[serde(default = "default_shortcut_export_stats_history")]
     pub export_stats_history: String,
+    #[serde(default = "default_shortcut_history_dashboard_select_previous")]
+    pub history_dashboard_select_previous: String,
+    #[serde(default = "default_shortcut_history_dashboard_select_next")]
+    pub history_dashboard_select_next: String,
+    #[serde(default = "default_shortcut_history_dashboard_toggle_pin")]
+    pub history_dashboard_toggle_pin: String,
+    #[serde(default = "default_shortcut_history_dashboard_move_left")]
+    pub history_dashboard_move_left: String,
+    #[serde(default = "default_shortcut_history_dashboard_move_right")]
+    pub history_dashboard_move_right: String,
     #[serde(default = "default_shortcut_back_setup_diagnostics")]
     pub back_setup_diagnostics: String,
     #[serde(default = "default_shortcut_refresh_setup_diagnostics")]
@@ -455,6 +468,26 @@ impl ShortcutConfig {
                 &self.export_stats_history,
                 &default_shortcut_export_stats_history(),
             ),
+            history_dashboard_select_previous: normalize_shortcut_token(
+                &self.history_dashboard_select_previous,
+                &default_shortcut_history_dashboard_select_previous(),
+            ),
+            history_dashboard_select_next: normalize_shortcut_token(
+                &self.history_dashboard_select_next,
+                &default_shortcut_history_dashboard_select_next(),
+            ),
+            history_dashboard_toggle_pin: normalize_shortcut_token(
+                &self.history_dashboard_toggle_pin,
+                &default_shortcut_history_dashboard_toggle_pin(),
+            ),
+            history_dashboard_move_left: normalize_shortcut_token(
+                &self.history_dashboard_move_left,
+                &default_shortcut_history_dashboard_move_left(),
+            ),
+            history_dashboard_move_right: normalize_shortcut_token(
+                &self.history_dashboard_move_right,
+                &default_shortcut_history_dashboard_move_right(),
+            ),
             back_setup_diagnostics: normalize_shortcut_token(
                 &self.back_setup_diagnostics,
                 &default_shortcut_back_setup_diagnostics(),
@@ -531,6 +564,11 @@ impl Default for ShortcutConfig {
             select_next_break_template: default_shortcut_select_next_break_template(),
             back_stats_history: default_shortcut_back_stats_history(),
             export_stats_history: default_shortcut_export_stats_history(),
+            history_dashboard_select_previous: default_shortcut_history_dashboard_select_previous(),
+            history_dashboard_select_next: default_shortcut_history_dashboard_select_next(),
+            history_dashboard_toggle_pin: default_shortcut_history_dashboard_toggle_pin(),
+            history_dashboard_move_left: default_shortcut_history_dashboard_move_left(),
+            history_dashboard_move_right: default_shortcut_history_dashboard_move_right(),
             back_setup_diagnostics: default_shortcut_back_setup_diagnostics(),
             refresh_setup_diagnostics: default_shortcut_refresh_setup_diagnostics(),
             navigate_up: default_shortcut_navigate_up(),
@@ -1179,6 +1217,164 @@ pub struct StatsRetentionWindows {
     pub keep_monthly_goal_snapshots_days: Option<u16>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryKpiCardId {
+    SessionSummary,
+    FocusScore,
+    GoalStreak,
+    FocusRisk,
+    WeeklyAllocation,
+    LastInterruption,
+    StatsGrowth,
+    Retention,
+    ComparisonFilters,
+    Unknown,
+}
+
+impl HistoryKpiCardId {
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::SessionSummary => "session_summary",
+            Self::FocusScore => "focus_score",
+            Self::GoalStreak => "goal_streak",
+            Self::FocusRisk => "focus_risk",
+            Self::WeeklyAllocation => "weekly_allocation",
+            Self::LastInterruption => "last_interruption",
+            Self::StatsGrowth => "stats_growth",
+            Self::Retention => "retention",
+            Self::ComparisonFilters => "comparison_filters",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::SessionSummary => "Session Summary",
+            Self::FocusScore => "Focus Score",
+            Self::GoalStreak => "Goal Streak",
+            Self::FocusRisk => "Focus Risk",
+            Self::WeeklyAllocation => "Weekly Allocation",
+            Self::LastInterruption => "Last Interruption",
+            Self::StatsGrowth => "Stats Growth",
+            Self::Retention => "Retention",
+            Self::ComparisonFilters => "Comparison Filters",
+            Self::Unknown => "Unknown",
+        }
+    }
+
+    pub const fn all() -> [Self; 9] {
+        [
+            Self::SessionSummary,
+            Self::FocusScore,
+            Self::GoalStreak,
+            Self::FocusRisk,
+            Self::WeeklyAllocation,
+            Self::LastInterruption,
+            Self::StatsGrowth,
+            Self::Retention,
+            Self::ComparisonFilters,
+        ]
+    }
+
+    pub fn from_id(value: &str) -> Option<Self> {
+        let parsed = Self::from_config_value(value);
+        if parsed == Self::Unknown {
+            None
+        } else {
+            Some(parsed)
+        }
+    }
+
+    fn from_config_value(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "session_summary" | "session-summary" | "sessionsummary" => Self::SessionSummary,
+            "focus_score" | "focus-score" | "focusscore" => Self::FocusScore,
+            "goal_streak" | "goal-streak" | "goalstreak" => Self::GoalStreak,
+            "focus_risk" | "focus-risk" | "focusrisk" => Self::FocusRisk,
+            "weekly_allocation" | "weekly-allocation" | "weeklyallocation" => {
+                Self::WeeklyAllocation
+            }
+            "last_interruption" | "last-interruption" | "lastinterruption" => {
+                Self::LastInterruption
+            }
+            "stats_growth" | "stats-growth" | "statsgrowth" => Self::StatsGrowth,
+            "retention" => Self::Retention,
+            "comparison_filters" | "comparison-filters" | "comparisonfilters" => {
+                Self::ComparisonFilters
+            }
+            _ => Self::Unknown,
+        }
+    }
+
+    fn is_unknown(self) -> bool {
+        self == Self::Unknown
+    }
+}
+
+impl<'de> Deserialize<'de> for HistoryKpiCardId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::from_config_value(&value))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HistoryDashboardConfig {
+    #[serde(default = "default_history_dashboard_card_order")]
+    pub card_order: Vec<HistoryKpiCardId>,
+    #[serde(default = "default_history_dashboard_pinned_cards")]
+    pub pinned_cards: Vec<HistoryKpiCardId>,
+}
+
+impl HistoryDashboardConfig {
+    pub fn normalized(&self) -> Self {
+        let mut card_order = Vec::new();
+        for card in &self.card_order {
+            if card.is_unknown() || card_order.contains(card) {
+                continue;
+            }
+            card_order.push(*card);
+        }
+        if card_order.is_empty() {
+            card_order = default_history_dashboard_card_order();
+        } else {
+            for card in HistoryKpiCardId::all() {
+                if !card_order.contains(&card) {
+                    card_order.push(card);
+                }
+            }
+        }
+
+        let mut pinned_cards = Vec::new();
+        for card in &self.pinned_cards {
+            if card.is_unknown() || pinned_cards.contains(card) || !card_order.contains(card) {
+                continue;
+            }
+            pinned_cards.push(*card);
+        }
+        if pinned_cards.is_empty() {
+            pinned_cards = card_order.clone();
+        }
+        Self {
+            card_order,
+            pinned_cards,
+        }
+    }
+}
+
+impl Default for HistoryDashboardConfig {
+    fn default() -> Self {
+        Self {
+            card_order: default_history_dashboard_card_order(),
+            pinned_cards: default_history_dashboard_pinned_cards(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WakatimeTaskMappingConfig {
     #[serde(default)]
@@ -1518,6 +1714,26 @@ fn default_shortcut_export_stats_history() -> String {
     "e".to_string()
 }
 
+fn default_shortcut_history_dashboard_select_previous() -> String {
+    "k".to_string()
+}
+
+fn default_shortcut_history_dashboard_select_next() -> String {
+    "j".to_string()
+}
+
+fn default_shortcut_history_dashboard_toggle_pin() -> String {
+    "p".to_string()
+}
+
+fn default_shortcut_history_dashboard_move_left() -> String {
+    "<".to_string()
+}
+
+fn default_shortcut_history_dashboard_move_right() -> String {
+    ">".to_string()
+}
+
 fn default_shortcut_back_setup_diagnostics() -> String {
     "d".to_string()
 }
@@ -1556,6 +1772,14 @@ fn default_shortcut_delete() -> String {
 
 fn default_shortcut_backspace() -> String {
     "backspace".to_string()
+}
+
+fn default_history_dashboard_pinned_cards() -> Vec<HistoryKpiCardId> {
+    HistoryKpiCardId::all().to_vec()
+}
+
+fn default_history_dashboard_card_order() -> Vec<HistoryKpiCardId> {
+    HistoryKpiCardId::all().to_vec()
 }
 
 fn default_break_templates() -> Vec<BreakTemplateConfig> {
@@ -1848,6 +2072,7 @@ impl Default for AppConfig {
             monthly_goal: MonthlyGoalConfig::default(),
             goal_carry_over: GoalCarryOverConfig::default(),
             stats_retention: StatsRetentionConfig::default(),
+            history_dashboard: HistoryDashboardConfig::default(),
             wakatime: WakatimeMetadataConfig::default(),
             wakatime_runtime: WakatimeRuntimeConfig::default(),
             feature_flags: FeatureFlagsConfig::default(),
@@ -2052,6 +2277,7 @@ impl AppConfig {
         );
         self.blocking_backend = self.blocking_backend.normalized();
         self.schedule_runtime = self.schedule_runtime.normalized();
+        self.history_dashboard = self.history_dashboard.normalized();
         self.wakatime = self.wakatime.normalized();
         self.wakatime_runtime = self.wakatime_runtime.normalized();
         self.shortcuts = self.shortcuts.normalized();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1332,38 +1332,53 @@ pub struct HistoryDashboardConfig {
 
 impl HistoryDashboardConfig {
     pub fn normalized(&self) -> Self {
-        let mut card_order = Vec::new();
-        for card in &self.card_order {
-            if card.is_unknown() || card_order.contains(card) {
-                continue;
-            }
-            card_order.push(*card);
-        }
-        if card_order.is_empty() {
-            card_order = default_history_dashboard_card_order();
-        } else {
-            for card in HistoryKpiCardId::all() {
-                if !card_order.contains(&card) {
-                    card_order.push(card);
-                }
-            }
-        }
-
-        let mut pinned_cards = Vec::new();
-        for card in &self.pinned_cards {
-            if card.is_unknown() || pinned_cards.contains(card) || !card_order.contains(card) {
-                continue;
-            }
-            pinned_cards.push(*card);
-        }
-        if pinned_cards.is_empty() {
-            pinned_cards = card_order.clone();
-        }
+        let card_order = normalize_history_dashboard_card_order(&self.card_order);
+        let pinned_cards =
+            normalize_history_dashboard_pinned_cards(&self.pinned_cards, &card_order);
         Self {
             card_order,
             pinned_cards,
         }
     }
+}
+
+fn normalize_history_dashboard_card_order(input: &[HistoryKpiCardId]) -> Vec<HistoryKpiCardId> {
+    let mut card_order = Vec::new();
+    for card in input {
+        if card.is_unknown() || card_order.contains(card) {
+            continue;
+        }
+        card_order.push(*card);
+    }
+
+    if card_order.is_empty() {
+        return default_history_dashboard_card_order();
+    }
+
+    for card in HistoryKpiCardId::all() {
+        if !card_order.contains(&card) {
+            card_order.push(card);
+        }
+    }
+    card_order
+}
+
+fn normalize_history_dashboard_pinned_cards(
+    input: &[HistoryKpiCardId],
+    card_order: &[HistoryKpiCardId],
+) -> Vec<HistoryKpiCardId> {
+    let mut pinned_cards = Vec::new();
+    for card in input {
+        if card.is_unknown() || pinned_cards.contains(card) || !card_order.contains(card) {
+            continue;
+        }
+        pinned_cards.push(*card);
+    }
+
+    if pinned_cards.is_empty() {
+        return card_order.to_vec();
+    }
+    pinned_cards
 }
 
 impl Default for HistoryDashboardConfig {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -52,6 +52,7 @@ fn default_values_are_canonical_pomodoro() {
     assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
     assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
     assert_eq!(cfg.stats_retention, StatsRetentionConfig::default());
+    assert_eq!(cfg.history_dashboard, HistoryDashboardConfig::default());
     assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     assert_eq!(cfg.wakatime_runtime, WakatimeRuntimeConfig::default());
     assert_eq!(cfg.feature_flags, FeatureFlagsConfig::default());
@@ -272,6 +273,24 @@ fn round_trip_full_config() {
         stats_retention: StatsRetentionConfig {
             preset: StatsRetentionPreset::Aggressive,
         },
+        history_dashboard: HistoryDashboardConfig {
+            card_order: vec![
+                HistoryKpiCardId::FocusScore,
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::FocusRisk,
+                HistoryKpiCardId::WeeklyAllocation,
+                HistoryKpiCardId::LastInterruption,
+                HistoryKpiCardId::StatsGrowth,
+                HistoryKpiCardId::Retention,
+                HistoryKpiCardId::ComparisonFilters,
+            ],
+            pinned_cards: vec![
+                HistoryKpiCardId::FocusScore,
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::Retention,
+            ],
+        },
         wakatime: WakatimeMetadataConfig {
             project: "Team Focus".to_string(),
             language: "Focus Session".to_string(),
@@ -360,6 +379,7 @@ fn round_trip_full_config() {
     assert_eq!(parsed.monthly_goal, original.monthly_goal);
     assert_eq!(parsed.goal_carry_over, original.goal_carry_over);
     assert_eq!(parsed.stats_retention, original.stats_retention);
+    assert_eq!(parsed.history_dashboard, original.history_dashboard);
     assert_eq!(parsed.wakatime, original.wakatime);
     assert_eq!(parsed.wakatime_runtime, original.wakatime_runtime);
     assert_eq!(parsed.feature_flags, original.feature_flags);
@@ -397,9 +417,68 @@ fn missing_fields_fall_back_to_defaults() {
     assert_eq!(cfg.weekly_goal, WeeklyGoalConfig::default());
     assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
     assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
+    assert_eq!(cfg.history_dashboard, HistoryDashboardConfig::default());
     assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     assert_eq!(cfg.feature_flags, FeatureFlagsConfig::default());
     assert_eq!(cfg.shortcuts, ShortcutConfig::default());
+}
+
+#[test]
+fn normalize_history_dashboard_filters_unknown_and_appends_missing_cards() {
+    let cfg = AppConfig {
+        history_dashboard: HistoryDashboardConfig {
+            card_order: vec![
+                HistoryKpiCardId::Unknown,
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::FocusScore,
+            ],
+            pinned_cards: vec![HistoryKpiCardId::GoalStreak],
+        },
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    assert_eq!(
+        cfg.history_dashboard.card_order[0],
+        HistoryKpiCardId::GoalStreak
+    );
+    assert_eq!(
+        cfg.history_dashboard.card_order[1],
+        HistoryKpiCardId::FocusScore
+    );
+    assert_eq!(
+        cfg.history_dashboard.card_order.len(),
+        HistoryKpiCardId::all().len()
+    );
+    for card in HistoryKpiCardId::all() {
+        assert!(cfg.history_dashboard.card_order.contains(&card));
+    }
+}
+
+#[test]
+fn normalize_history_dashboard_filters_unknown_and_duplicate_pins() {
+    let cfg = AppConfig {
+        history_dashboard: HistoryDashboardConfig {
+            card_order: vec![HistoryKpiCardId::FocusScore, HistoryKpiCardId::Retention],
+            pinned_cards: vec![
+                HistoryKpiCardId::Unknown,
+                HistoryKpiCardId::Retention,
+                HistoryKpiCardId::Retention,
+                HistoryKpiCardId::LastInterruption,
+            ],
+        },
+        ..AppConfig::default()
+    }
+    .normalize();
+
+    assert_eq!(
+        cfg.history_dashboard.pinned_cards,
+        vec![
+            HistoryKpiCardId::Retention,
+            HistoryKpiCardId::LastInterruption
+        ]
+    );
 }
 
 #[test]
@@ -1208,6 +1287,7 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
         monthly_goal: MonthlyGoalConfig::default(),
         goal_carry_over: GoalCarryOverConfig::default(),
         stats_retention: StatsRetentionConfig::default(),
+        history_dashboard: HistoryDashboardConfig::default(),
         wakatime: WakatimeMetadataConfig::default(),
         wakatime_runtime: WakatimeRuntimeConfig::default(),
         feature_flags: FeatureFlagsConfig::default(),
@@ -1262,6 +1342,7 @@ fn load_returns_default_when_config_file_is_corrupt() {
     assert_eq!(cfg.weekly_goal, WeeklyGoalConfig::default());
     assert_eq!(cfg.monthly_goal, MonthlyGoalConfig::default());
     assert_eq!(cfg.goal_carry_over, GoalCarryOverConfig::default());
+    assert_eq!(cfg.history_dashboard, HistoryDashboardConfig::default());
     assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
 }
 

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -17,19 +17,20 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .style(Style::default().fg(app_color(app, Color::Cyan)));
     frame.render_widget(block, outer);
 
+    let dashboard_cards = app.history_dashboard_cards();
+    let dashboard_height = (dashboard_cards.len() as u16).saturating_add(2);
     let inner = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(9), // overview
+            Constraint::Length(dashboard_height), // dashboard + borders
             Constraint::Min(6),    // history panels
             Constraint::Length(1), // status line
             Constraint::Length(3), // hints
         ])
         .split(outer);
 
-    let overview_lines: Vec<Line> = app
-        .history_dashboard_cards()
+    let overview_lines: Vec<Line> = dashboard_cards
         .into_iter()
         .map(|card| {
             let selected = card == app.history_dashboard_selected_card();

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -24,9 +24,9 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
         .margin(2)
         .constraints([
             Constraint::Length(dashboard_height), // dashboard + borders
-            Constraint::Min(6),    // history panels
-            Constraint::Length(1), // status line
-            Constraint::Length(3), // hints
+            Constraint::Min(6),                   // history panels
+            Constraint::Length(1),                // status line
+            Constraint::Length(3),                // hints
         ])
         .split(outer);
 

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -1,3 +1,4 @@
+use crate::config::HistoryKpiCardId;
 use crate::ui::{
     Alignment, App, Block, Borders, Color, Constraint, Direction, Frame, HistoryFeedbackLevel,
     Layout, Line, List, ListItem, Modifier, NavigationAction, Paragraph, Rect, ShortcutAction,
@@ -23,84 +24,37 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
             Constraint::Length(9), // overview
             Constraint::Min(6),    // history panels
             Constraint::Length(1), // status line
-            Constraint::Length(2), // hints
+            Constraint::Length(3), // hints
         ])
         .split(outer);
 
-    let session_stats = app.session_stats();
-    let today_stats = app.today_stats();
-    let focus_score_line = readable_focus_score_text(&format_history_focus_score_line(app));
-    let goals_line = readable_goal_streak_text(&format_history_goal_streak_line(app));
-    let risk_line = format_history_focus_risk_line(app);
-    let weekly_allocation_line = format_history_weekly_allocation_line(app);
-    let interruption_line = format_history_interruption_line(app);
-    let growth_summary = app.stats_growth_summary();
-    let retention_preview = app.stats_retention_preview();
-    let retention = app.stats_retention_config();
-    let comparison_filters = app.history_comparison_filter_summary();
-    let growth_line = format!(
-        "Stats growth: {} records · ~{} · {}",
-        growth_summary.total_record_count,
-        format_bytes(growth_summary.estimated_bytes),
-        format_top_sections(&growth_summary.high_volume_sections)
-    );
-    let retention_line = if retention_preview.any_removed() {
-        format!(
-            "Retention: {} · prunes {} old record(s) on next save",
-            retention.preset.id(),
-            retention_preview.total_removed()
-        )
-    } else {
-        format!("Retention: {} · no pending prune", retention.preset.id())
-    };
-    let overview = Paragraph::new(vec![
-        Line::styled(
-            format!(
-                "Session 🍅{} · {}m | Today 🍅{} · {}m",
-                session_stats.pomodoros_completed,
-                session_stats.focused_minutes(),
-                today_stats.pomodoros_completed,
-                today_stats.focused_minutes()
-            ),
-            Style::default()
-                .fg(app_color(app, Color::White))
-                .add_modifier(Modifier::BOLD),
-        ),
-        Line::styled(
-            focus_score_line,
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        ),
-        Line::styled(
-            goals_line,
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        ),
-        Line::styled(
-            risk_line,
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        ),
-        Line::styled(
-            weekly_allocation_line,
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        ),
-        Line::styled(
-            interruption_line,
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        ),
-        Line::styled(
-            growth_line,
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        ),
-        Line::styled(
-            retention_line,
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        ),
-        Line::styled(
-            comparison_filters,
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        ),
-    ])
-    .block(Block::default().borders(Borders::ALL).title(" Overview "))
-    .wrap(Wrap { trim: true });
+    let overview_lines: Vec<Line> = app
+        .history_dashboard_cards()
+        .into_iter()
+        .map(|card| {
+            let selected = card == app.history_dashboard_selected_card();
+            let pinned = app.history_dashboard_card_is_pinned(card);
+            let style = if selected {
+                Style::default()
+                    .fg(app_color(app, Color::White))
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(app_color(app, Color::DarkGray))
+            };
+            Line::styled(
+                format!(
+                    "{}{} {}",
+                    if selected { ">" } else { " " },
+                    if pinned { "*" } else { "-" },
+                    history_kpi_card_text(app, card)
+                ),
+                style,
+            )
+        })
+        .collect();
+    let overview = Paragraph::new(overview_lines)
+        .block(Block::default().borders(Borders::ALL).title(" Dashboard "))
+        .wrap(Wrap { trim: true });
     frame.render_widget(overview, inner[0]);
 
     let content_layout = Layout::default()
@@ -272,6 +226,14 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
                 app.navigation_label(NavigationAction::MoveUp),
                 app.navigation_label(NavigationAction::MoveDown),
             )),
+            Line::from(format!(
+                "Dashboard: Select {}/{} Toggle pin {} Move {}/{}",
+                app.shortcut_hint(ShortcutAction::HistoryDashboardSelectPrevious),
+                app.shortcut_hint(ShortcutAction::HistoryDashboardSelectNext),
+                app.shortcut_hint(ShortcutAction::HistoryDashboardTogglePin),
+                app.shortcut_hint(ShortcutAction::HistoryDashboardMoveLeft),
+                app.shortcut_hint(ShortcutAction::HistoryDashboardMoveRight),
+            )),
             Line::from(if app.strict_mode_enforced_for_focus() {
                 format!(
                     "View: [{}/{}] Back  [{}/Ctrl-C] Quit (Locked)",
@@ -289,6 +251,55 @@ pub(super) fn render_stats_history(frame: &mut Frame, app: &App) {
             }),
         ],
     );
+}
+
+fn history_kpi_card_text(app: &App, card: HistoryKpiCardId) -> String {
+    match card {
+        HistoryKpiCardId::SessionSummary => {
+            let session_stats = app.session_stats();
+            let today_stats = app.today_stats();
+            format!(
+                "Session {} pomodoros · {}m | Today {} pomodoros · {}m",
+                session_stats.pomodoros_completed,
+                session_stats.focused_minutes(),
+                today_stats.pomodoros_completed,
+                today_stats.focused_minutes()
+            )
+        }
+        HistoryKpiCardId::FocusScore => {
+            readable_focus_score_text(&format_history_focus_score_line(app))
+        }
+        HistoryKpiCardId::GoalStreak => {
+            readable_goal_streak_text(&format_history_goal_streak_line(app))
+        }
+        HistoryKpiCardId::FocusRisk => format_history_focus_risk_line(app),
+        HistoryKpiCardId::WeeklyAllocation => format_history_weekly_allocation_line(app),
+        HistoryKpiCardId::LastInterruption => format_history_interruption_line(app),
+        HistoryKpiCardId::StatsGrowth => {
+            let growth_summary = app.stats_growth_summary();
+            format!(
+                "Stats growth: {} records · ~{} · {}",
+                growth_summary.total_record_count,
+                format_bytes(growth_summary.estimated_bytes),
+                format_top_sections(&growth_summary.high_volume_sections)
+            )
+        }
+        HistoryKpiCardId::Retention => {
+            let retention_preview = app.stats_retention_preview();
+            let retention = app.stats_retention_config();
+            if retention_preview.any_removed() {
+                format!(
+                    "Retention: {} · prunes {} old record(s) on next save",
+                    retention.preset.id(),
+                    retention_preview.total_removed()
+                )
+            } else {
+                format!("Retention: {} · no pending prune", retention.preset.id())
+            }
+        }
+        HistoryKpiCardId::ComparisonFilters => app.history_comparison_filter_summary(),
+        HistoryKpiCardId::Unknown => "Unknown KPI card".to_string(),
+    }
 }
 
 pub(super) fn readable_goal_streak_text(text: &str) -> String {

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    AppConfig, ProfileId, RecurringScheduleConfig, SessionTemplateConfig, ShortcutConfig,
-    ThemePreset,
+    AppConfig, HistoryDashboardConfig, HistoryKpiCardId, ProfileId, RecurringScheduleConfig,
+    SessionTemplateConfig, ShortcutConfig, ThemePreset,
 };
 use crate::ui::*;
 use chrono::{Datelike, Duration, NaiveDate};
@@ -713,6 +713,62 @@ fn history_view_hints_include_export_shortcut() {
 
     let text = terminal_text(&terminal, width, height);
     assert!(text.contains("[e] Export CSV + JSON"));
+}
+
+#[test]
+fn history_view_hints_include_dashboard_controls() {
+    let width = 140;
+    let height = 40;
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    let mut app = App::default();
+    app.mode = AppMode::StatsHistory;
+
+    terminal
+        .draw(|frame| render(frame, &app))
+        .expect("render should succeed");
+
+    let text = terminal_text(&terminal, width, height);
+    assert!(text.contains("Dashboard: Select [k]/[j]"), "{text}");
+    assert!(text.contains("Toggle pin [p]"), "{text}");
+    assert!(text.contains("Move [<]/[>]"), "{text}");
+}
+
+#[test]
+fn history_view_dashboard_shows_selected_and_pinned_markers() {
+    let width = 120;
+    let height = 24;
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    let mut app = App::from_config_for_tests(AppConfig {
+        history_dashboard: HistoryDashboardConfig {
+            card_order: vec![
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::FocusScore,
+                HistoryKpiCardId::GoalStreak,
+                HistoryKpiCardId::FocusRisk,
+                HistoryKpiCardId::WeeklyAllocation,
+                HistoryKpiCardId::LastInterruption,
+                HistoryKpiCardId::StatsGrowth,
+                HistoryKpiCardId::Retention,
+                HistoryKpiCardId::ComparisonFilters,
+            ],
+            pinned_cards: vec![
+                HistoryKpiCardId::SessionSummary,
+                HistoryKpiCardId::FocusScore,
+            ],
+        },
+        ..AppConfig::default()
+    });
+    app.mode = AppMode::StatsHistory;
+
+    terminal
+        .draw(|frame| render(frame, &app))
+        .expect("render should succeed");
+
+    let text = terminal_text(&terminal, width, height);
+    assert!(text.contains(">* Session"));
+    assert!(text.contains("* Focus"));
 }
 
 #[test]


### PR DESCRIPTION
## What

Add a configurable, pinable KPI dashboard in Focus History with persistent card order and pins, keyboard controls in the TUI, and non-interactive CLI management commands.

- Added history dashboard config model and normalization for KPI IDs, card order, and pin state.
- Wired app/runtime state, persistence, and history key handling for select/pin/reorder behavior.
- Refactored History UI overview to render dashboard cards from configured state.
- Added CLI support for `--history-dashboard`, `--history-dashboard-pin`, `--history-dashboard-unpin`, and full-list `--history-dashboard-order`.
- Added/updated tests across config, app, ui, and cli modules.
- Updated README with history dashboard controls, config fields, and CLI usage.

## Why

Issue #326 asks for a custom KPI dashboard in the history view so users can prioritize which metrics stay visible and reorder/pin them consistently across sessions and automation workflows.

Closes #326.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Focus History KPI dashboard: customizable card order, pinning, selection, keyboard walkthrough, and persisted state.
  * Keyboard shortcuts to cycle/select cards, toggle pin, and move pinned cards; UI shows dashboard hints and selected/pinned markers.
  * CLI commands to show/manage dashboard: --history-dashboard, --history-dashboard-pin, --history-dashboard-unpin, --history-dashboard-order.

* **Documentation**
  * README updated with Focus History features, CLI parity, walkthrough, and example config/shortcuts.

* **Tests**
  * Added unit and UI tests covering dashboard parsing, CLI, persistence, shortcuts, and rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->