### PR TITLE
Export parity for all new KPIs in JSON and CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **KPI export parity across JSON and CSV (#329):** added machine-readable `history_kpis` export coverage for all History dashboard KPI cards, plus matching CSV `history_kpi` rows (`kpi_card_id`, `kpi_payload_json`) and schema version bump to `7`.
+
 ## [0.13.0] - 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -820,8 +820,13 @@ attached. Focus-session rows
 persist and export first-class `focus_intention` and `task_note` fields; when
 dedicated metadata input is not provided, both fields default to the selected
 `task_label`. Interruption records include structured `reason` values and
-remaining-time metadata. Export files expose `schema_version` (currently `6`)
-so downstream consumers can handle versioned contracts explicitly.
+remaining-time metadata. Export files now also include a `history_kpis` JSON
+object covering all History dashboard KPI cards (`session_summary`,
+`focus_score`, `goal_streak`, `focus_risk`, `weekly_allocation`,
+`last_interruption`, `stats_growth`, `retention`, `comparison_filters`), with
+matching CSV `history_kpi` rows (`kpi_card_id` + `kpi_payload_json`) for
+JSON/CSV parity. Export files expose `schema_version` (currently `7`) so
+downstream consumers can handle versioned contracts explicitly.
 
 ## The way the system works
 

--- a/src/app/feedback_diagnostics.rs
+++ b/src/app/feedback_diagnostics.rs
@@ -21,10 +21,39 @@ impl App {
 
     pub(super) fn export_stats_to_dir(&mut self, dir: &std::path::Path) {
         self.history_feedback = None;
-        match self.stats.export_to_dir(dir) {
+        let context = self.history_kpi_export_context();
+        match self.stats.export_to_dir_with_context(dir, &context) {
             Ok(paths) => self.set_history_feedback_for_export(paths),
             Err(e) => self
                 .set_history_feedback(HistoryFeedbackLevel::Warning, format!("Export failed: {e}")),
+        }
+    }
+
+    fn history_kpi_export_context(&self) -> crate::stats::HistoryKpiExportContext {
+        let reference_day = chrono::Local::now().date_naive();
+        crate::stats::HistoryKpiExportContext {
+            reference_day,
+            daily_goal: crate::stats::DailyGoalSnapshot {
+                minutes: self.daily_goal.minutes,
+                pomodoros: self.daily_goal.pomodoros,
+            },
+            weekly_goal: crate::stats::DailyGoalSnapshot {
+                minutes: self.weekly_goal.minutes,
+                pomodoros: self.weekly_goal.pomodoros,
+            },
+            monthly_goal: crate::stats::DailyGoalSnapshot {
+                minutes: self.monthly_goal.minutes,
+                pomodoros: self.monthly_goal.pomodoros,
+            },
+            carry_over_daily: self.goal_carry_over.daily,
+            carry_over_weekly: self.goal_carry_over.weekly,
+            carry_over_monthly: self.goal_carry_over.monthly,
+            recurring_schedule: self.recurring_schedule.clone(),
+            stats_retention: self.stats_retention,
+            comparison_dimension: self.history_comparison_dimension,
+            comparison_task_filter: self.history_task_filter.clone(),
+            comparison_profile_filter: self.history_profile_filter,
+            comparison_time_of_day_filter: self.history_time_of_day_filter,
         }
     }
 

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -1741,13 +1741,14 @@ fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
     let config = AppConfig::load().normalized();
     let stats = FocusStats::load_with_options(stats_load_options(&config))
         .map_err(|error| format!("Failed to load stats: {error}"))?;
+    let history_kpi_context = build_history_kpi_export_context(&config);
     let target_dir = match dir {
         Some(path) => path,
         None => env::current_dir()
             .map_err(|error| format!("Failed to determine current directory: {error}"))?,
     };
     let exported = stats
-        .export_to_dir(&target_dir)
+        .export_to_dir_with_context(&target_dir, &history_kpi_context)
         .map_err(|error| format!("Export failed: {error}"))?;
 
     let payload = ExportOutput {
@@ -1760,6 +1761,34 @@ fn execute_export_command(dir: Option<PathBuf>, output: OutputMode) -> Result<()
         OutputMode::Json => print_json(&payload)?,
     }
     Ok(())
+}
+
+fn build_history_kpi_export_context(config: &AppConfig) -> crate::stats::HistoryKpiExportContext {
+    let selected_automation = config.profile_automation_for(config.selected_profile);
+    crate::stats::HistoryKpiExportContext {
+        reference_day: chrono::Local::now().date_naive(),
+        daily_goal: DailyGoalSnapshot {
+            minutes: config.daily_goal.minutes,
+            pomodoros: config.daily_goal.pomodoros,
+        },
+        weekly_goal: DailyGoalSnapshot {
+            minutes: config.weekly_goal.minutes,
+            pomodoros: config.weekly_goal.pomodoros,
+        },
+        monthly_goal: DailyGoalSnapshot {
+            minutes: config.monthly_goal.minutes,
+            pomodoros: config.monthly_goal.pomodoros,
+        },
+        carry_over_daily: config.goal_carry_over.daily,
+        carry_over_weekly: config.goal_carry_over.weekly,
+        carry_over_monthly: config.goal_carry_over.monthly,
+        recurring_schedule: selected_automation.recurring_schedule,
+        stats_retention: config.stats_retention,
+        comparison_dimension: crate::stats::ComparisonDimension::TaskLabel,
+        comparison_task_filter: None,
+        comparison_profile_filter: None,
+        comparison_time_of_day_filter: None,
+    }
 }
 
 fn execute_backup_command(dir: Option<PathBuf>, output: OutputMode) -> Result<(), String> {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -7,11 +7,10 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use chrono::Datelike;
+use chrono::{Datelike, NaiveDate};
 use serde::{Deserialize, Serialize};
 
-use crate::config::ProfileId;
-use crate::config::StatsRetentionConfig;
+use crate::config::{ProfileId, RecurringScheduleConfig, StatsRetentionConfig};
 use crate::task_labels::{canonical_task_label, normalize_task_label, task_label_index};
 
 mod helpers;
@@ -35,7 +34,7 @@ mod trends;
 const STATS_FILE_NAME: &str = "stats.toml";
 const JSON_EXPORT_FILE_NAME: &str = "focustime-stats.json";
 const CSV_EXPORT_FILE_NAME: &str = "focustime-stats.csv";
-const EXPORT_SCHEMA_VERSION: u32 = 6;
+const EXPORT_SCHEMA_VERSION: u32 = 7;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -358,6 +357,43 @@ impl DailyStats {
 pub struct ExportedStatsFiles {
     pub json_path: PathBuf,
     pub csv_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryKpiExportContext {
+    pub reference_day: NaiveDate,
+    pub daily_goal: DailyGoalSnapshot,
+    pub weekly_goal: DailyGoalSnapshot,
+    pub monthly_goal: DailyGoalSnapshot,
+    pub carry_over_daily: bool,
+    pub carry_over_weekly: bool,
+    pub carry_over_monthly: bool,
+    pub recurring_schedule: RecurringScheduleConfig,
+    pub stats_retention: StatsRetentionConfig,
+    pub comparison_dimension: ComparisonDimension,
+    pub comparison_task_filter: Option<String>,
+    pub comparison_profile_filter: Option<ProfileBucket>,
+    pub comparison_time_of_day_filter: Option<TimeOfDayBucket>,
+}
+
+impl Default for HistoryKpiExportContext {
+    fn default() -> Self {
+        Self {
+            reference_day: chrono::Local::now().date_naive(),
+            daily_goal: DailyGoalSnapshot::default(),
+            weekly_goal: DailyGoalSnapshot::default(),
+            monthly_goal: DailyGoalSnapshot::default(),
+            carry_over_daily: false,
+            carry_over_weekly: false,
+            carry_over_monthly: false,
+            recurring_schedule: RecurringScheduleConfig::default(),
+            stats_retention: StatsRetentionConfig::default(),
+            comparison_dimension: ComparisonDimension::TaskLabel,
+            comparison_task_filter: None,
+            comparison_profile_filter: None,
+            comparison_time_of_day_filter: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -725,6 +761,7 @@ struct StatsExport {
     focus_scores: Vec<FocusScoreExportRow>,
     profile_effectiveness: Vec<ProfileEffectivenessExportRow>,
     productivity_comparisons: Vec<ProductivityComparisonExportRow>,
+    history_kpis: HistoryKpiExport,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -849,6 +886,132 @@ struct ProductivityComparisonExportRow {
     focus_share_pct: u8,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiExport {
+    session_summary: HistoryKpiSessionSummary,
+    focus_score: HistoryKpiFocusScore,
+    goal_streak: HistoryKpiGoalStreak,
+    focus_risk: HistoryKpiFocusRisk,
+    weekly_allocation: HistoryKpiWeeklyAllocation,
+    last_interruption: HistoryKpiLastInterruption,
+    stats_growth: HistoryKpiStatsGrowth,
+    retention: HistoryKpiRetention,
+    comparison_filters: HistoryKpiComparisonFilters,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiSessionSummary {
+    session_pomodoros_completed: u32,
+    session_focused_minutes: u64,
+    today_pomodoros_completed: u32,
+    today_focused_minutes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiFocusScore {
+    week_label: Option<String>,
+    active_days: Option<u8>,
+    consistency_score_pct: Option<u8>,
+    completion_score_pct: Option<u8>,
+    focus_score_pct: Option<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiGoalPeriodProgress {
+    focused_minutes_completed: u64,
+    focused_minutes_target: u64,
+    pomodoros_completed: u32,
+    pomodoros_target: u32,
+    target_configured: bool,
+    met: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiGoalStreak {
+    daily: HistoryKpiGoalPeriodProgress,
+    weekly: HistoryKpiGoalPeriodProgress,
+    monthly: HistoryKpiGoalPeriodProgress,
+    current_days: u32,
+    best_days: u32,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiFocusRisk {
+    alert_active: bool,
+    highest_risk_level: FocusRiskLevel,
+    highest_signal_scope: Option<String>,
+    highest_signal_label: Option<String>,
+    highest_signal_value: Option<String>,
+    daily_risk_level: FocusRiskLevel,
+    daily_risk_score_pct: u8,
+    weekly_risk_level: FocusRiskLevel,
+    weekly_risk_score_pct: u8,
+    monthly_risk_level: FocusRiskLevel,
+    monthly_risk_score_pct: u8,
+    streak_risk_level: FocusRiskLevel,
+    streak_risk_score_pct: u8,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiWeeklyAllocation {
+    week_target_minutes: u64,
+    week_target_pomodoros: u32,
+    completed_minutes: u64,
+    completed_pomodoros: u32,
+    remaining_minutes: u64,
+    remaining_pomodoros: u32,
+    remaining_days_in_week: usize,
+    allocatable_days: usize,
+    uses_schedule_weights: bool,
+    today_target_minutes: u64,
+    today_target_pomodoros: u32,
+    daily_targets: Vec<HistoryKpiWeeklyAllocationDay>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiWeeklyAllocationDay {
+    day: String,
+    minutes_target: u64,
+    pomodoros_target: u32,
+    allocatable: bool,
+    weight_minutes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiLastInterruption {
+    timestamp_epoch_secs: Option<u64>,
+    reason: Option<SessionInterruptionReason>,
+    task_label: Option<String>,
+    focus_intention: Option<String>,
+    task_note: Option<String>,
+    remaining_secs: Option<u64>,
+    profile_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiStatsGrowth {
+    total_record_count: usize,
+    estimated_bytes: u64,
+    sections: Vec<StatsGrowthSection>,
+    high_volume_sections: Vec<StatsGrowthSection>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiRetention {
+    preset_id: String,
+    preview: StatsRetentionPruneResult,
+    pending_prune: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct HistoryKpiComparisonFilters {
+    dimension: ComparisonDimension,
+    task_filter: Option<String>,
+    profile_filter: Option<ProfileBucket>,
+    time_of_day_filter: Option<TimeOfDayBucket>,
+    summary: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct CsvExportRow {
     schema_version: u32,
@@ -891,6 +1054,8 @@ struct CsvExportRow {
     comparison_dimension: Option<String>,
     comparison_label: Option<String>,
     time_of_day_bucket: Option<String>,
+    kpi_card_id: Option<String>,
+    kpi_payload_json: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/src/stats/export.rs
+++ b/src/stats/export.rs
@@ -1,16 +1,34 @@
+use chrono::{Datelike, Duration, NaiveDate};
+
+use crate::app::weekly_daily_goal_allocation_for_context;
+use crate::config::HistoryKpiCardId;
 use crate::stats::{
     BreakGlassOverrideExportRow, CSV_EXPORT_FILE_NAME, ComparisonDimension, CsvExportRow,
-    DailyExportRow, EXPORT_SCHEMA_VERSION, ExportedStatsFiles, FocusScoreExportRow, FocusStats,
-    JSON_EXPORT_FILE_NAME, Path, ProductivityComparisonExportRow, ProductivityComparisonFilter,
-    ProfileEffectivenessExportRow, SessionExportRow, SessionInterruptionExportRow, StatsExport,
-    TaskTotalsExportRow, TaskTrendExportRow, WeeklyConsistencyExportRow, WeeklyExportRow,
-    format_week_label, fs, io, write_atomic_bytes,
+    DailyExportRow, DailyGoalSnapshot, EXPORT_SCHEMA_VERSION, ExportedStatsFiles,
+    FocusRiskForecast, FocusScoreExportRow, FocusStats, HistoryKpiComparisonFilters,
+    HistoryKpiExport, HistoryKpiExportContext, HistoryKpiFocusRisk, HistoryKpiFocusScore,
+    HistoryKpiGoalPeriodProgress, HistoryKpiGoalStreak, HistoryKpiLastInterruption,
+    HistoryKpiRetention, HistoryKpiSessionSummary, HistoryKpiStatsGrowth,
+    HistoryKpiWeeklyAllocation, HistoryKpiWeeklyAllocationDay, JSON_EXPORT_FILE_NAME, Path,
+    ProductivityComparisonExportRow, ProductivityComparisonFilter, ProfileEffectivenessExportRow,
+    SessionExportRow, SessionInterruptionExportRow, StatsExport, TaskTotalsExportRow,
+    TaskTrendExportRow, WeeklyConsistencyExportRow, WeeklyExportRow, format_week_label, fs, io,
+    write_atomic_bytes,
 };
 
 impl FocusStats {
+    #[allow(dead_code)]
     pub fn export_to_dir(&self, dir: &Path) -> io::Result<ExportedStatsFiles> {
+        self.export_to_dir_with_context(dir, &HistoryKpiExportContext::default())
+    }
+
+    pub fn export_to_dir_with_context(
+        &self,
+        dir: &Path,
+        context: &HistoryKpiExportContext,
+    ) -> io::Result<ExportedStatsFiles> {
         fs::create_dir_all(dir)?;
-        let export = self.export_data();
+        let export = self.export_data_with_context(context);
         let json_path = dir.join(JSON_EXPORT_FILE_NAME);
         let csv_path = dir.join(CSV_EXPORT_FILE_NAME);
 
@@ -27,7 +45,15 @@ impl FocusStats {
         })
     }
 
+    #[allow(dead_code)]
     pub(super) fn export_data(&self) -> StatsExport {
+        self.export_data_with_context(&HistoryKpiExportContext::default())
+    }
+
+    pub(super) fn export_data_with_context(
+        &self,
+        context: &HistoryKpiExportContext,
+    ) -> StatsExport {
         StatsExport {
             schema_version: EXPORT_SCHEMA_VERSION,
             daily: self.export_daily_rows(),
@@ -41,6 +67,162 @@ impl FocusStats {
             focus_scores: self.export_focus_score_rows(),
             profile_effectiveness: self.export_profile_effectiveness_rows(),
             productivity_comparisons: self.export_productivity_comparison_rows(),
+            history_kpis: self.export_history_kpis(context),
+        }
+    }
+
+    fn export_history_kpis(&self, context: &HistoryKpiExportContext) -> HistoryKpiExport {
+        let day = context.reference_day;
+        let day_key = day.format("%Y-%m-%d").to_string();
+        let today_stats = self.daily_for(&day_key);
+        let session_stats = self.session();
+        let weekly_stats = self.weekly_for_day(day);
+        let monthly_stats = self.monthly_for_day(day);
+
+        let daily_goal = self.effective_daily_goal_snapshot_for_day(day, context);
+        let weekly_goal = self.effective_weekly_goal_snapshot_for_day(day, context);
+        let monthly_goal = self.effective_monthly_goal_snapshot_for_day(day, context);
+
+        let daily_progress = goal_period_progress(
+            today_stats.focused_minutes(),
+            today_stats.pomodoros_completed,
+            daily_goal,
+        );
+        let weekly_progress = goal_period_progress(
+            weekly_stats.focused_minutes(),
+            weekly_stats.pomodoros_completed,
+            weekly_goal,
+        );
+        let monthly_progress = goal_period_progress(
+            monthly_stats.focused_minutes(),
+            monthly_stats.pomodoros_completed,
+            monthly_goal,
+        );
+
+        let goal_streak =
+            self.goal_streak_with_day_goal(day, daily_goal, today_stats, |target_day| {
+                self.effective_daily_goal_snapshot_for_day(target_day, context)
+            });
+        let focus_score = self.latest_weekly_focus_score();
+        let focus_risk =
+            self.focus_risk_forecast_for_day(day, daily_goal, weekly_goal, monthly_goal);
+        let (highest_signal_scope, highest_signal_label, highest_signal_value) =
+            focus_risk_highest_signal(&focus_risk);
+
+        let weekly_allocation = weekly_daily_goal_allocation_for_context(
+            day,
+            weekly_goal,
+            weekly_stats,
+            &context.recurring_schedule,
+        );
+        let today_target = weekly_allocation.today_target();
+        let latest_interruption = self.latest_session_interruption();
+        let growth_summary = self.growth_summary();
+        let retention_preview = self.retention_preview(context.stats_retention, day);
+
+        HistoryKpiExport {
+            session_summary: HistoryKpiSessionSummary {
+                session_pomodoros_completed: session_stats.pomodoros_completed,
+                session_focused_minutes: session_stats.focused_minutes(),
+                today_pomodoros_completed: today_stats.pomodoros_completed,
+                today_focused_minutes: today_stats.focused_minutes(),
+            },
+            focus_score: HistoryKpiFocusScore {
+                week_label: focus_score.as_ref().map(|score| score.week_label.clone()),
+                active_days: focus_score.as_ref().map(|score| score.active_days),
+                consistency_score_pct: focus_score
+                    .as_ref()
+                    .map(|score| score.consistency_score_pct),
+                completion_score_pct: focus_score
+                    .as_ref()
+                    .and_then(|score| score.completion_score_pct),
+                focus_score_pct: focus_score.as_ref().and_then(|score| score.focus_score_pct),
+            },
+            goal_streak: HistoryKpiGoalStreak {
+                daily: daily_progress,
+                weekly: weekly_progress,
+                monthly: monthly_progress,
+                current_days: goal_streak.current,
+                best_days: goal_streak.best,
+            },
+            focus_risk: HistoryKpiFocusRisk {
+                alert_active: focus_risk.alert_active(),
+                highest_risk_level: focus_risk.highest_risk_level(),
+                highest_signal_scope,
+                highest_signal_label,
+                highest_signal_value,
+                daily_risk_level: focus_risk.daily_goal.risk_level,
+                daily_risk_score_pct: focus_risk.daily_goal.risk_score_pct,
+                weekly_risk_level: focus_risk.weekly_goal.risk_level,
+                weekly_risk_score_pct: focus_risk.weekly_goal.risk_score_pct,
+                monthly_risk_level: focus_risk.monthly_goal.risk_level,
+                monthly_risk_score_pct: focus_risk.monthly_goal.risk_score_pct,
+                streak_risk_level: focus_risk.streak.risk_level,
+                streak_risk_score_pct: focus_risk.streak.risk_score_pct,
+            },
+            weekly_allocation: HistoryKpiWeeklyAllocation {
+                week_target_minutes: weekly_allocation.week_target.minutes,
+                week_target_pomodoros: weekly_allocation.week_target.pomodoros,
+                completed_minutes: weekly_allocation.completed_minutes,
+                completed_pomodoros: weekly_allocation.completed_pomodoros,
+                remaining_minutes: weekly_allocation.remaining_minutes,
+                remaining_pomodoros: weekly_allocation.remaining_pomodoros,
+                remaining_days_in_week: weekly_allocation.remaining_days_in_week,
+                allocatable_days: weekly_allocation.allocatable_days,
+                uses_schedule_weights: weekly_allocation.uses_schedule_weights,
+                today_target_minutes: today_target.minutes,
+                today_target_pomodoros: today_target.pomodoros,
+                daily_targets: weekly_allocation
+                    .daily_targets
+                    .into_iter()
+                    .map(|entry| HistoryKpiWeeklyAllocationDay {
+                        day: entry.day.format("%Y-%m-%d").to_string(),
+                        minutes_target: entry.minutes_target,
+                        pomodoros_target: entry.pomodoros_target,
+                        allocatable: entry.allocatable,
+                        weight_minutes: entry.weight_minutes,
+                    })
+                    .collect(),
+            },
+            last_interruption: HistoryKpiLastInterruption {
+                timestamp_epoch_secs: latest_interruption
+                    .as_ref()
+                    .map(|event| event.timestamp_epoch_secs),
+                reason: latest_interruption.as_ref().map(|event| event.reason),
+                task_label: latest_interruption
+                    .as_ref()
+                    .and_then(|event| event.task_label.clone()),
+                focus_intention: latest_interruption
+                    .as_ref()
+                    .and_then(|event| event.focus_intention.clone()),
+                task_note: latest_interruption
+                    .as_ref()
+                    .and_then(|event| event.task_note.clone()),
+                remaining_secs: latest_interruption
+                    .as_ref()
+                    .map(|event| event.remaining_secs),
+                profile_name: latest_interruption
+                    .as_ref()
+                    .and_then(|event| event.profile.map(|profile| profile.label().to_string())),
+            },
+            stats_growth: HistoryKpiStatsGrowth {
+                total_record_count: growth_summary.total_record_count,
+                estimated_bytes: growth_summary.estimated_bytes,
+                sections: growth_summary.sections.clone(),
+                high_volume_sections: growth_summary.high_volume_sections.clone(),
+            },
+            retention: HistoryKpiRetention {
+                preset_id: context.stats_retention.preset.id().to_string(),
+                preview: retention_preview,
+                pending_prune: retention_preview.any_removed(),
+            },
+            comparison_filters: HistoryKpiComparisonFilters {
+                dimension: context.comparison_dimension,
+                task_filter: context.comparison_task_filter.clone(),
+                profile_filter: context.comparison_profile_filter,
+                time_of_day_filter: context.comparison_time_of_day_filter,
+                summary: comparison_filter_summary(context),
+            },
         }
     }
 
@@ -244,13 +426,80 @@ impl FocusStats {
         })
         .collect()
     }
+
+    fn effective_daily_goal_snapshot_for_day(
+        &self,
+        day: NaiveDate,
+        context: &HistoryKpiExportContext,
+    ) -> DailyGoalSnapshot {
+        let day_key = day.format("%Y-%m-%d").to_string();
+        let base = self
+            .daily_entry(&day_key)
+            .and_then(|stats| stats.goal)
+            .unwrap_or(context.daily_goal);
+        let previous = day.pred_opt().and_then(|previous_day| {
+            let previous_day_key = previous_day.format("%Y-%m-%d").to_string();
+            self.daily_entry(&previous_day_key).and_then(|stats| {
+                stats
+                    .goal
+                    .map(|goal| (goal, stats.focused_minutes(), stats.pomodoros_completed))
+            })
+        });
+        crate::stats::carry_over_goal_target(base, context.carry_over_daily, previous)
+    }
+
+    fn effective_weekly_goal_snapshot_for_day(
+        &self,
+        day: NaiveDate,
+        context: &HistoryKpiExportContext,
+    ) -> DailyGoalSnapshot {
+        let base = self
+            .weekly_goal_snapshot_for_day(day)
+            .unwrap_or(context.weekly_goal);
+        let previous = day
+            .checked_sub_signed(Duration::weeks(1))
+            .and_then(|previous_week_day| {
+                self.weekly_goal_snapshot_for_day(previous_week_day)
+                    .map(|previous_target| {
+                        let week = self.weekly_for_day(previous_week_day);
+                        (
+                            previous_target,
+                            week.focused_minutes(),
+                            week.pomodoros_completed,
+                        )
+                    })
+            });
+        crate::stats::carry_over_goal_target(base, context.carry_over_weekly, previous)
+    }
+
+    fn effective_monthly_goal_snapshot_for_day(
+        &self,
+        day: NaiveDate,
+        context: &HistoryKpiExportContext,
+    ) -> DailyGoalSnapshot {
+        let base = self
+            .monthly_goal_snapshot_for_day(day)
+            .unwrap_or(context.monthly_goal);
+        let previous = previous_month_reference_day(day).and_then(|previous_month_day| {
+            self.monthly_goal_snapshot_for_day(previous_month_day)
+                .map(|previous_target| {
+                    let month = self.monthly_for_day(previous_month_day);
+                    (
+                        previous_target,
+                        month.focused_minutes(),
+                        month.pomodoros_completed,
+                    )
+                })
+        });
+        crate::stats::carry_over_goal_target(base, context.carry_over_monthly, previous)
+    }
 }
 
 impl StatsExport {
     fn to_csv_bytes(&self) -> io::Result<Vec<u8>> {
         let mut writer = csv::Writer::from_writer(Vec::new());
 
-        for row in self.csv_rows() {
+        for row in self.csv_rows()? {
             writer
                 .serialize(row)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -304,10 +553,12 @@ impl StatsExport {
             comparison_dimension: None,
             comparison_label: None,
             time_of_day_bucket: None,
+            kpi_card_id: None,
+            kpi_payload_json: None,
         }
     }
 
-    fn csv_rows(&self) -> Vec<CsvExportRow> {
+    fn csv_rows(&self) -> io::Result<Vec<CsvExportRow>> {
         let mut rows = Vec::with_capacity(
             self.daily.len()
                 + self.weekly.len()
@@ -319,7 +570,8 @@ impl StatsExport {
                 + self.weekly_consistency.len()
                 + self.focus_scores.len()
                 + self.profile_effectiveness.len()
-                + self.productivity_comparisons.len(),
+                + self.productivity_comparisons.len()
+                + 9,
         );
 
         for daily in &self.daily {
@@ -475,6 +727,134 @@ impl StatsExport {
             });
         }
 
-        rows
+        rows.extend(self.history_kpi_csv_rows()?);
+        Ok(rows)
     }
+
+    fn history_kpi_csv_rows(&self) -> io::Result<Vec<CsvExportRow>> {
+        fn payload_json(value: &impl serde::Serialize) -> io::Result<String> {
+            serde_json::to_string(value)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+        }
+        Ok(vec![
+            CsvExportRow {
+                kpi_card_id: Some(HistoryKpiCardId::SessionSummary.id().to_string()),
+                kpi_payload_json: Some(payload_json(&self.history_kpis.session_summary)?),
+                ..Self::csv_row_defaults("history_kpi")
+            },
+            CsvExportRow {
+                kpi_card_id: Some(HistoryKpiCardId::FocusScore.id().to_string()),
+                kpi_payload_json: Some(payload_json(&self.history_kpis.focus_score)?),
+                ..Self::csv_row_defaults("history_kpi")
+            },
+            CsvExportRow {
+                kpi_card_id: Some(HistoryKpiCardId::GoalStreak.id().to_string()),
+                kpi_payload_json: Some(payload_json(&self.history_kpis.goal_streak)?),
+                ..Self::csv_row_defaults("history_kpi")
+            },
+            CsvExportRow {
+                kpi_card_id: Some(HistoryKpiCardId::FocusRisk.id().to_string()),
+                kpi_payload_json: Some(payload_json(&self.history_kpis.focus_risk)?),
+                ..Self::csv_row_defaults("history_kpi")
+            },
+            CsvExportRow {
+                kpi_card_id: Some(HistoryKpiCardId::WeeklyAllocation.id().to_string()),
+                kpi_payload_json: Some(payload_json(&self.history_kpis.weekly_allocation)?),
+                ..Self::csv_row_defaults("history_kpi")
+            },
+            CsvExportRow {
+                kpi_card_id: Some(HistoryKpiCardId::LastInterruption.id().to_string()),
+                kpi_payload_json: Some(payload_json(&self.history_kpis.last_interruption)?),
+                ..Self::csv_row_defaults("history_kpi")
+            },
+            CsvExportRow {
+                kpi_card_id: Some(HistoryKpiCardId::StatsGrowth.id().to_string()),
+                kpi_payload_json: Some(payload_json(&self.history_kpis.stats_growth)?),
+                ..Self::csv_row_defaults("history_kpi")
+            },
+            CsvExportRow {
+                kpi_card_id: Some(HistoryKpiCardId::Retention.id().to_string()),
+                kpi_payload_json: Some(payload_json(&self.history_kpis.retention)?),
+                ..Self::csv_row_defaults("history_kpi")
+            },
+            CsvExportRow {
+                kpi_card_id: Some(HistoryKpiCardId::ComparisonFilters.id().to_string()),
+                kpi_payload_json: Some(payload_json(&self.history_kpis.comparison_filters)?),
+                ..Self::csv_row_defaults("history_kpi")
+            },
+        ])
+    }
+}
+
+fn goal_period_progress(
+    focused_minutes_completed: u64,
+    pomodoros_completed: u32,
+    target: DailyGoalSnapshot,
+) -> HistoryKpiGoalPeriodProgress {
+    let target_configured = target.has_any_target();
+    let met = target.is_met_by_totals(focused_minutes_completed, pomodoros_completed);
+    HistoryKpiGoalPeriodProgress {
+        focused_minutes_completed,
+        focused_minutes_target: target.minutes,
+        pomodoros_completed,
+        pomodoros_target: target.pomodoros,
+        target_configured,
+        met,
+    }
+}
+
+fn previous_month_reference_day(day: NaiveDate) -> Option<NaiveDate> {
+    let first_of_month = day.with_day(1)?;
+    let previous_month_last_day = first_of_month.checked_sub_signed(Duration::days(1))?;
+    let reference_day = day.day().min(previous_month_last_day.day());
+    previous_month_last_day.with_day(reference_day)
+}
+
+fn comparison_filter_summary(context: &HistoryKpiExportContext) -> String {
+    let task = context
+        .comparison_task_filter
+        .as_deref()
+        .unwrap_or("all")
+        .to_string();
+    let profile = context
+        .comparison_profile_filter
+        .map(|value| value.label().to_string())
+        .unwrap_or_else(|| "All".to_string());
+    let time_of_day = context
+        .comparison_time_of_day_filter
+        .map(|value| value.label().to_string())
+        .unwrap_or_else(|| "All".to_string());
+    format!("Slices: task {task} · profile {profile} · time {time_of_day}")
+}
+
+fn focus_risk_highest_signal(
+    forecast: &FocusRiskForecast,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let mut highest_scope = "daily";
+    let mut highest_score = forecast.daily_goal.risk_score_pct;
+    let mut highest_signal = forecast.daily_goal.signals.first();
+    if forecast.weekly_goal.risk_score_pct > highest_score {
+        highest_scope = "weekly";
+        highest_score = forecast.weekly_goal.risk_score_pct;
+        highest_signal = forecast.weekly_goal.signals.first();
+    }
+    if forecast.monthly_goal.risk_score_pct > highest_score {
+        highest_scope = "monthly";
+        highest_score = forecast.monthly_goal.risk_score_pct;
+        highest_signal = forecast.monthly_goal.signals.first();
+    }
+    if forecast.streak.risk_score_pct > highest_score {
+        highest_scope = "streak";
+        highest_signal = forecast.streak.signals.first();
+    }
+
+    if !forecast.alert_active() {
+        return (None, None, None);
+    }
+
+    (
+        Some(highest_scope.to_string()),
+        highest_signal.map(|signal| signal.label.clone()),
+        highest_signal.map(|signal| signal.value.clone()),
+    )
 }

--- a/src/stats/export.rs
+++ b/src/stats/export.rs
@@ -12,8 +12,9 @@ use crate::stats::{
     HistoryKpiWeeklyAllocation, HistoryKpiWeeklyAllocationDay, JSON_EXPORT_FILE_NAME, Path,
     ProductivityComparisonExportRow, ProductivityComparisonFilter, ProfileEffectivenessExportRow,
     SessionExportRow, SessionInterruptionExportRow, StatsExport, TaskTotalsExportRow,
-    TaskTrendExportRow, WeeklyConsistencyExportRow, WeeklyExportRow, format_week_label, fs, io,
-    write_atomic_bytes,
+    TaskTrendExportRow, WeeklyConsistencyExportRow, WeeklyExportRow, WeeklyFocusScore,
+    average_two_percentages, consistency_score_from_active_days, format_week_label, fs, io,
+    weekly_completion_score_pct, write_atomic_bytes,
 };
 
 impl FocusStats {
@@ -103,7 +104,7 @@ impl FocusStats {
             self.goal_streak_with_day_goal(day, daily_goal, today_stats, |target_day| {
                 self.effective_daily_goal_snapshot_for_day(target_day, context)
             });
-        let focus_score = self.latest_weekly_focus_score();
+        let focus_score = self.focus_score_for_day(day, context);
         let focus_risk =
             self.focus_risk_forecast_for_day(day, daily_goal, weekly_goal, monthly_goal);
         let (highest_signal_scope, highest_signal_label, highest_signal_value) =
@@ -492,6 +493,51 @@ impl FocusStats {
                 })
         });
         crate::stats::carry_over_goal_target(base, context.carry_over_monthly, previous)
+    }
+
+    fn focus_score_for_day(
+        &self,
+        day: NaiveDate,
+        context: &HistoryKpiExportContext,
+    ) -> Option<WeeklyFocusScore> {
+        let iso_week = day.iso_week();
+        let year = iso_week.year();
+        let week = iso_week.week();
+        let week_label = format_week_label(year, week);
+        let consistency = self
+            .weekly_consistency_stats()
+            .into_iter()
+            .find(|entry| entry.year == year && entry.week == week);
+        let active_days = consistency
+            .as_ref()
+            .map(|entry| entry.active_days)
+            .unwrap_or(0);
+        let consistency_score_pct = consistency
+            .as_ref()
+            .map(|entry| entry.consistency_score_pct)
+            .unwrap_or_else(|| consistency_score_from_active_days(active_days));
+        let totals = self.weekly_for_day(day);
+        let weekly_goal = self.effective_weekly_goal_snapshot_for_day(day, context);
+        let completion_score_pct = weekly_completion_score_pct(weekly_goal, totals);
+        let focus_score_pct = completion_score_pct
+            .map(|completion| average_two_percentages(consistency_score_pct, completion));
+
+        let has_activity = active_days > 0;
+        let has_goal_context =
+            weekly_goal.has_any_target() || self.weekly_goal_snapshot_for_day(day).is_some();
+        if !has_activity && !has_goal_context {
+            return None;
+        }
+
+        Some(WeeklyFocusScore {
+            year,
+            week,
+            week_label,
+            active_days,
+            consistency_score_pct,
+            completion_score_pct,
+            focus_score_pct,
+        })
     }
 }
 

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -1887,6 +1887,50 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
 }
 
 #[test]
+fn history_kpi_focus_score_uses_reference_day_context_week() {
+    let mut stats = FocusStats::default();
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 4, 9).unwrap();
+    let later_week_day = day.checked_add_signed(chrono::Duration::days(14)).unwrap();
+    let goal = DailyGoalSnapshot {
+        minutes: 30,
+        pomodoros: 1,
+    };
+    let day_key = day.format("%Y-%m-%d").to_string();
+    let later_day_key = later_week_day.format("%Y-%m-%d").to_string();
+
+    stats.record_focus_elapsed(&day_key, 30 * 60, goal);
+    stats.record_completed_pomodoro(&day_key, goal);
+    stats.record_focus_elapsed(&later_day_key, 45 * 60, goal);
+    stats.record_completed_pomodoro(&later_day_key, goal);
+
+    let context = HistoryKpiExportContext {
+        reference_day: day,
+        weekly_goal: DailyGoalSnapshot {
+            minutes: 30,
+            pomodoros: 1,
+        },
+        ..HistoryKpiExportContext::default()
+    };
+
+    let export = stats.export_data_with_context(&context);
+    let json_value = serde_json::to_value(&export).unwrap();
+    let expected_week_label = format_week_label(day.iso_week().year(), day.iso_week().week());
+    let latest_week_label = format_week_label(
+        later_week_day.iso_week().year(),
+        later_week_day.iso_week().week(),
+    );
+
+    assert_eq!(
+        json_value["history_kpis"]["focus_score"]["week_label"],
+        expected_week_label
+    );
+    assert_ne!(
+        json_value["history_kpis"]["focus_score"]["week_label"],
+        latest_week_label
+    );
+}
+
+#[test]
 fn export_to_dir_returns_error_when_target_is_not_directory() {
     let stats = FocusStats::default();
     let export_root = unique_temp_dir("stats-export-error");

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -1702,6 +1702,7 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
     let focus_scores = json_value["focus_scores"].as_array().unwrap();
     let profile_effectiveness = json_value["profile_effectiveness"].as_array().unwrap();
     let productivity_comparisons = json_value["productivity_comparisons"].as_array().unwrap();
+    let history_kpis = json_value["history_kpis"].as_object().unwrap();
     assert_eq!(daily.len(), 2);
     assert!(!weekly.is_empty());
     assert_eq!(sessions.len(), 1);
@@ -1713,6 +1714,22 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
     assert!(!focus_scores.is_empty());
     assert_eq!(profile_effectiveness.len(), 1);
     assert!(!productivity_comparisons.is_empty());
+    for card_id in [
+        "session_summary",
+        "focus_score",
+        "goal_streak",
+        "focus_risk",
+        "weekly_allocation",
+        "last_interruption",
+        "stats_growth",
+        "retention",
+        "comparison_filters",
+    ] {
+        assert!(
+            history_kpis.contains_key(card_id),
+            "missing history_kpis entry for {card_id}"
+        );
+    }
     assert!(
         daily
             .iter()
@@ -1787,6 +1804,8 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
     assert!(csv_header.contains("comparison_dimension"));
     assert!(csv_header.contains("comparison_label"));
     assert!(csv_header.contains("time_of_day_bucket"));
+    assert!(csv_header.contains("kpi_card_id"));
+    assert!(csv_header.contains("kpi_payload_json"));
     assert!(csv.contains(&format!("{},daily,{labeled_day}", EXPORT_SCHEMA_VERSION)));
     assert!(csv.contains(&format!("{},weekly,,", EXPORT_SCHEMA_VERSION)));
     assert!(csv.contains(&format!(
@@ -1817,7 +1836,52 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
         "{},productivity_comparison",
         EXPORT_SCHEMA_VERSION
     )));
+    assert!(csv.contains(&format!("{},history_kpi", EXPORT_SCHEMA_VERSION)));
     assert!(csv.contains("Classic,1,1,"));
+
+    #[derive(serde::Deserialize)]
+    struct CsvKpiRow {
+        record_type: String,
+        kpi_card_id: Option<String>,
+        kpi_payload_json: Option<String>,
+    }
+
+    let mut csv_reader = csv::Reader::from_reader(csv.as_bytes());
+    let mut csv_kpi_payloads = std::collections::BTreeMap::new();
+    for row in csv_reader.deserialize::<CsvKpiRow>() {
+        let row = row.expect("history kpi row should deserialize");
+        if row.record_type != "history_kpi" {
+            continue;
+        }
+        let card_id = row
+            .kpi_card_id
+            .expect("history_kpi row should include kpi_card_id");
+        let payload = row
+            .kpi_payload_json
+            .expect("history_kpi row should include kpi_payload_json");
+        let parsed_payload: serde_json::Value =
+            serde_json::from_str(&payload).expect("kpi_payload_json should be valid JSON");
+        csv_kpi_payloads.insert(card_id, parsed_payload);
+    }
+
+    assert_eq!(csv_kpi_payloads.len(), 9);
+    for card_id in [
+        "session_summary",
+        "focus_score",
+        "goal_streak",
+        "focus_risk",
+        "weekly_allocation",
+        "last_interruption",
+        "stats_growth",
+        "retention",
+        "comparison_filters",
+    ] {
+        assert_eq!(
+            csv_kpi_payloads.get(card_id),
+            history_kpis.get(card_id),
+            "csv/json parity mismatch for {card_id}"
+        );
+    }
 
     fs::remove_dir_all(export_dir).unwrap();
 }


### PR DESCRIPTION
## What

- Add a typed `history_kpis` section to `focustime-stats.json` for all History dashboard KPI cards.
- Add matching CSV `history_kpi` rows with `kpi_card_id` and `kpi_payload_json` so every KPI payload has JSON/CSV parity.
- Wire context-aware export inputs through both TUI history export and CLI `--export` paths so KPI values use effective goals, carry-over settings, schedule, retention, and comparison filters.
- Bump export `schema_version` from `6` to `7` for the additive contract update.
- Expand export tests to assert KPI coverage and JSON/CSV payload parity, and update README plus changelog documentation.

## Why

History dashboard KPIs had grown, but export contracts did not provide full machine-readable parity for all cards across both formats. This change closes that gap so automation consumers can rely on consistent KPI data from either JSON or CSV export.

Closes #329.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a versioned history_kpis JSON export covering all History dashboard KPI cards and matching CSV KPI rows with card IDs and JSON payloads
  * Export schema version bumped to 7 to guarantee JSON/CSV parity

* **Documentation**
  * Updated export docs to describe the new versioned export contract and schema changes

* **Tests**
  * Added tests validating JSON/CSV parity for KPI exports and reference-day behavior for focus score calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->