### PR TITLE
Legacy stats migration/backfill for new analytics fields

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -17,11 +17,12 @@ mod helpers;
 #[cfg(test)]
 use helpers::create_unique_temp_path;
 use helpers::{
-    average_two_percentages, best_goal_streak, consistency_score_from_active_days,
-    current_goal_streak, daily_has_activity, days_in_month, format_week_label, month_key_for_day,
-    normalize_session_metadata_text, normalize_task_goal_targets, normalize_task_planner_state,
-    parse_week_label, percentage_round_nearest, planner_state_labels_for_keys, profile_bucket_for,
-    week_key_for_day, weekly_completion_score_pct, write_atomic_bytes,
+    average_two_percentages, backfilled_time_of_day_bucket, best_goal_streak,
+    consistency_score_from_active_days, current_goal_streak, daily_has_activity, days_in_month,
+    format_week_label, month_key_for_day, normalize_session_metadata_text,
+    normalize_task_goal_targets, normalize_task_planner_state, parse_week_label,
+    percentage_round_nearest, planner_state_labels_for_keys, profile_bucket_for, week_key_for_day,
+    weekly_completion_score_pct, write_atomic_bytes,
 };
 mod analytics;
 mod export;

--- a/src/stats/analytics.rs
+++ b/src/stats/analytics.rs
@@ -6,11 +6,11 @@ use crate::stats::{
     ProfileEffectiveness, ProfileEffectivenessAccumulator, ProfileTotals, StatsGrowthSection,
     StatsGrowthSummary, StatsRetentionConfig, StatsRetentionPruneResult, StreakRiskForecast,
     TimeOfDayBucket, WeeklyConsistency, WeeklyFocusScore, WeeklyStats, average_two_percentages,
-    canonical_task_label, consistency_score_from_active_days, daily_has_activity, days_in_month,
-    format_week_label, month_key_for_day, normalize_task_label, parse_week_label,
-    percentage_round_nearest, profile_bucket_for, week_key_for_day, weekly_completion_score_pct,
+    backfilled_time_of_day_bucket, canonical_task_label, consistency_score_from_active_days,
+    daily_has_activity, days_in_month, format_week_label, month_key_for_day, normalize_task_label,
+    parse_week_label, percentage_round_nearest, profile_bucket_for, week_key_for_day,
+    weekly_completion_score_pct,
 };
-use chrono::Timelike;
 
 impl FocusStats {
     pub fn weekly_for_day(&self, day: chrono::NaiveDate) -> WeeklyStats {
@@ -834,19 +834,10 @@ fn classify_calibration_signal(
 }
 
 fn focus_session_time_of_day(session: &FocusSessionRecord) -> TimeOfDayBucket {
-    if let Some(bucket) = session.completion_time_of_day_bucket {
-        return bucket;
-    }
-    let Some(epoch_secs) = session.completion_timestamp_epoch_secs else {
-        return TimeOfDayBucket::Unknown;
-    };
-    let Ok(epoch) = i64::try_from(epoch_secs) else {
-        return TimeOfDayBucket::Unknown;
-    };
-    let Some(timestamp) = chrono::DateTime::<chrono::Utc>::from_timestamp(epoch, 0) else {
-        return TimeOfDayBucket::Unknown;
-    };
-    TimeOfDayBucket::from_hour(timestamp.hour())
+    backfilled_time_of_day_bucket(
+        session.completion_time_of_day_bucket,
+        session.completion_timestamp_epoch_secs,
+    )
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/stats/helpers.rs
+++ b/src/stats/helpers.rs
@@ -1,8 +1,9 @@
 use crate::stats::{
     BTreeMap, BTreeSet, DailyGoalSnapshot, DailyStats, Datelike, OpenOptions, Ordering, Path,
-    PathBuf, ProfileBucket, ProfileId, SystemTime, TEMP_FILE_COUNTER, UNIX_EPOCH, WeeklyStats,
-    Write, canonical_task_label, fs, io, normalize_task_label,
+    PathBuf, ProfileBucket, ProfileId, SystemTime, TEMP_FILE_COUNTER, TimeOfDayBucket, UNIX_EPOCH,
+    WeeklyStats, Write, canonical_task_label, fs, io, normalize_task_label,
 };
+use chrono::Timelike;
 
 pub(super) fn normalize_task_planner_state(
     labels: Vec<String>,
@@ -174,6 +175,22 @@ pub(super) fn profile_bucket_for(profile: Option<ProfileId>) -> ProfileBucket {
         Some(ProfileId::Custom) => ProfileBucket::Custom,
         None => ProfileBucket::Unknown,
     }
+}
+
+pub(super) fn backfilled_time_of_day_bucket(
+    bucket: Option<TimeOfDayBucket>,
+    completion_timestamp_epoch_secs: Option<u64>,
+) -> TimeOfDayBucket {
+    bucket
+        .or_else(|| {
+            completion_timestamp_epoch_secs.and_then(|epoch_secs| {
+                let epoch = i64::try_from(epoch_secs).ok()?;
+                let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(epoch, 0)?;
+                let local_time = timestamp.with_timezone(&chrono::Local);
+                Some(TimeOfDayBucket::from_hour(local_time.hour()))
+            })
+        })
+        .unwrap_or(TimeOfDayBucket::Unknown)
 }
 
 pub(super) fn daily_has_activity(stats: DailyStats) -> bool {

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -4,9 +4,10 @@ use std::path::PathBuf;
 use crate::stats::fs;
 use crate::stats::{
     BreakGlassOverrideEvent, FocusSessionRecord, FocusStats, PersistedStats, STATS_FILE_NAME,
-    SessionInterruptionEvent, SessionStats, StatsLoadOptions, StatsSaveOptions, io,
-    normalize_session_metadata_text, normalize_task_goal_targets, normalize_task_label,
-    normalize_task_planner_state, planner_state_labels_for_keys, write_atomic_bytes,
+    SessionInterruptionEvent, SessionStats, StatsLoadOptions, StatsSaveOptions,
+    backfilled_time_of_day_bucket, io, normalize_session_metadata_text,
+    normalize_task_goal_targets, normalize_task_label, normalize_task_planner_state,
+    planner_state_labels_for_keys, write_atomic_bytes,
 };
 
 impl FocusStats {
@@ -84,7 +85,10 @@ impl FocusStats {
                     focused_seconds: session.focused_seconds,
                     profile: session.profile,
                     completion_timestamp_epoch_secs: session.completion_timestamp_epoch_secs,
-                    completion_time_of_day_bucket: session.completion_time_of_day_bucket,
+                    completion_time_of_day_bucket: Some(backfilled_time_of_day_bucket(
+                        session.completion_time_of_day_bucket,
+                        session.completion_timestamp_epoch_secs,
+                    )),
                 });
             }
         }

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -1106,6 +1106,57 @@ fn legacy_focus_sessions_keep_empty_metadata() {
 }
 
 #[test]
+fn legacy_focus_sessions_backfill_unknown_time_of_day_bucket() {
+    let legacy_toml = r#"
+            [[focus_sessions]]
+            date = "2026-04-09"
+            task_label = "Project A"
+            focused_seconds = 1500
+        "#;
+    let restored = FocusStats::try_from_toml(legacy_toml).unwrap();
+    let persisted = restored.to_persisted();
+
+    assert_eq!(persisted.focus_sessions.len(), 1);
+    assert_eq!(
+        persisted.focus_sessions[0].completion_time_of_day_bucket,
+        Some(TimeOfDayBucket::Unknown)
+    );
+}
+
+#[test]
+fn legacy_focus_sessions_backfill_time_of_day_bucket_from_timestamp() {
+    let day = current_day_key();
+    let completion_timestamp_epoch_secs = local_timestamp_today(9, 0);
+    let persisted_toml = format!(
+        r#"
+            [[focus_sessions]]
+            date = "{day}"
+            task_label = "Project A"
+            focused_seconds = 1800
+            completion_timestamp_epoch_secs = {completion_timestamp_epoch_secs}
+        "#
+    );
+    let restored = FocusStats::try_from_toml(&persisted_toml).unwrap();
+    let persisted = restored.to_persisted();
+
+    assert_eq!(persisted.focus_sessions.len(), 1);
+    assert_eq!(
+        persisted.focus_sessions[0].completion_time_of_day_bucket,
+        Some(TimeOfDayBucket::Morning)
+    );
+
+    let rows = restored.productivity_comparison(
+        ComparisonDimension::TimeOfDay,
+        &ProductivityComparisonFilter::default(),
+        10,
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].label, "Morning");
+    assert_eq!(rows[0].sessions_completed, 1);
+    assert_eq!(rows[0].focused_minutes(), 30);
+}
+
+#[test]
 fn persisted_focus_session_uses_stored_time_of_day_bucket() {
     let persisted_toml = r#"
             [[focus_sessions]]


### PR DESCRIPTION
## What

Add legacy focus-session analytics backfill for time-of-day fields so older `stats.toml` data remains compatible with current analytics.

- Centralized time-of-day bucket backfill in a shared stats helper.
- Applied load-time normalization so persisted legacy sessions get a deterministic bucket (`Unknown` when no timestamp exists, otherwise derived from timestamp).
- Reused the same backfill path in analytics grouping logic to keep behavior consistent across comparison/export surfaces.
- Added regression tests for both legacy-without-timestamp and timestamp-only legacy records.

## Why

Recent analytics rely on completion timestamp/time-of-day fields that may be missing from historical records. This change ensures legacy and mixed datasets load safely and produce stable comparison/export results without overwriting explicitly stored values.

Closes #330.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of time-of-day data for legacy focus sessions, ensuring accurate analytics and productivity comparisons even when historical data was incomplete.

* **Tests**
  * Added regression tests to verify proper backfilling of missing time-of-day information in legacy session records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->