### PR TITLE
Prepare v0.13.1 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.13.0 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.13.1 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -116,7 +116,7 @@ When preparing a release update, keep these files aligned:
 - `README.md` release automation and latest-release references
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
-- Release tag examples in docs use the current target release version (for example, `v0.13.0`)
+- Release tag examples in docs use the current target release version (for example, `v0.13.1`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-05-25
+
 ### Added
 
-- **KPI export parity across JSON and CSV (#329):** added machine-readable `history_kpis` export coverage for all History dashboard KPI cards, plus matching CSV `history_kpi` rows (`kpi_card_id`, `kpi_payload_json`) and schema version bump to `7`.
+- **KPI export parity across JSON and CSV (#365):** added machine-readable `history_kpis` export coverage for all History dashboard KPI cards, plus matching CSV `history_kpi` rows (`kpi_card_id`, `kpi_payload_json`) and schema version bump to `7`.
+
+### Changed
+
+- **Dashboard performance improvements on large histories (#364):** added revision-based history dashboard snapshots and snapshot-driven rendering to reduce repeated analytics recomputation during History interactions.
+- **Dependency update for JSON handling (#361):** bumped `serde_json` from `1.0.149` to `1.0.150`.
+
+### Fixed
+
+- **Focus-risk forecasting false-positive calibration (#363):** retuned risk weighting and alert gating to reduce noisy borderline warnings while preserving meaningful high-risk signals.
+- **Legacy analytics time-of-day backfill compatibility (#366):** normalized legacy session time-of-day fields during load/grouping so mixed historical datasets remain stable across comparison and export workflows.
 
 ## [0.13.0] - 2026-05-22
 
@@ -323,7 +335,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/utilForever/focustime/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/utilForever/focustime/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/utilForever/focustime/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/utilForever/focustime/compare/v0.11.1...v0.12.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ The project uses Conventional Commit-style release commits:
 
 Before preparing a release commit, make sure all CI jobs pass for the release changes.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.13.0`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.13.1`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -890,12 +890,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.13.0`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.13.1`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.13.0](https://github.com/utilForever/focustime/releases/tag/v0.13.0).
+The latest stable release is [v0.13.1](https://github.com/utilForever/focustime/releases/tag/v0.13.1).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

- Aligns v0.13.1 release metadata and release-facing documentation references.
- Expands the v0.13.1 changelog entry to cover merged PRs #361, #363, #364, #365, and #366 across Added, Changed, and Fixed sections.
- Updates package version surfaces to `0.13.1` in `Cargo.toml` and `Cargo.lock`.

## Why

The v0.13.1 release notes and metadata were incomplete and inconsistent, which made release tracking harder. This syncs package versioning, release references, and changelog coverage so the documented release state matches what landed on `main`.

Closes #367.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.13.1 across project configuration and documentation
  * Release notes documented with improvements to KPI export parity, dashboard rendering, and forecasting functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->