### PR TITLE
Local API and daemon mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,6 +11,7 @@ stable while splitting implementation details by responsibility.
 flowchart LR
     M["main.rs<br/>entrypoint + terminal lifecycle"]
     CLI["cli.rs + cli/*<br/>CLI contract/parsing/execution/output"]
+    DAE["daemon.rs<br/>loopback local API + daemon lifecycle"]
     APP["app.rs + app/*<br/>runtime orchestration + state transitions"]
     UI["ui.rs + ui/*<br/>screen rendering"]
     ST["stats.rs + stats/*<br/>persistence/analytics/export"]
@@ -26,6 +27,8 @@ flowchart LR
     API["WakaTime API"]
 
     M --> CLI
+    CLI --> DAE
+    DAE --> APP
     M --> APP
     M --> UI
     APP --> CFG
@@ -52,7 +55,8 @@ flowchart LR
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | `main.rs`                       | Composition root, CLI vs TUI dispatch, terminal setup/teardown, frame/tick loop                                                                                                                                                                        | `cli`, `app`, `ui`, `crossterm`, `ratatui`                                     |
 | `app.rs` + `app/*`              | Core runtime state and orchestration split into focused domains (`timer_flow`, `session_planner`, `site_manager`, `profile_management`, `schedule_*`, `persistence`, `history_goals`, `feedback_diagnostics`, `break_glass`, `cli_api`, `mode_keys`)   | `timer`, `blocker`, `wakatime`, `notifications`, `schedule`, `stats`, `config` |
-| `cli.rs` + `cli/*`              | CLI contract and execution pipeline split into `args`, `parsing`, `execute`, `status`, and `output`, including headless `--start`, schedule delay/break-glass workflow controls, and backup/restore data-file workflows for canonical-path persistence | `app`, `config`, `stats`, `blocker`                                            |
+| `cli.rs` + `cli/*`              | CLI contract and execution pipeline split into `args`, `parsing`, `execute`, `status`, and `output`, including headless timer controls, daemon lifecycle commands, schedule delay/break-glass workflow controls, and backup/restore workflows          | `app`, `daemon`, `config`, `stats`, `blocker`                                  |
+| `daemon.rs`                     | Headless daemon runtime with loopback-only versioned local API, bearer-token auth, daemon metadata persistence, and graceful lifecycle/status/stop orchestration                                                                                       | `app`, `cli`, filesystem, `ureq`, `tiny_http`                                  |
 | `stats.rs` + `stats/*`          | Stats data model plus split persistence/analytics/export/recording/planner/trends helpers, including canonical-path persistence and legacy read-time compatibility handling during deprecation windows                                                 | `app`, `task_labels`, filesystem                                               |
 | `ui.rs` + `ui/*`                | Screen-oriented Ratatui rendering split into `timer`, `session_planner`, `site_manager`, `profile_manager`, `history`, and `setup`                                                                                                                     | `app`, `timer`, `wakatime`                                                     |
 | `config.rs` + `config/paths.rs` | Config schema/normalization and environment-aware config path resolution, including feature-flag compatibility defaults, runtime knob settings, and task-label-aware WakaTime metadata mapping rules                                                   | `app`, `cli`, filesystem/env                                                   |
@@ -103,6 +107,8 @@ sequenceDiagram
    `App::on_tick()` and applies phase-driven side effects.
 4. `App` keeps blocking, notifications, scheduling, and WakaTime in sync with
    timer state; side effects are isolated in dedicated modules.
+5. Daemon mode reuses the same `App` tick/update behavior in a headless loop,
+   then serves loopback-authenticated `/v1/*` API endpoints for automation.
 
 ## Visibility rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +160,12 @@ dependencies = [
  "num-traits",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "compact_str"
@@ -494,9 +506,11 @@ dependencies = [
  "chrono",
  "crossterm",
  "csv",
+ "getrandom 0.3.4",
  "ratatui",
  "serde",
  "serde_json",
+ "tiny_http",
  "toml",
  "ureq",
  "winrt-toast-reborn",
@@ -616,6 +630,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "iana-time-zone"
@@ -1780,6 +1800,18 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ csv = "1"
 toml = "1.1"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+getrandom = "0.3"
+tiny_http = "0.12"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winrt-toast-reborn = "0.3.8"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ cargo run -- --resume
 cargo run -- --stop
 cargo run -- --next --json
 
+# Run a headless daemon with local API access
+cargo run -- --daemon-start
+cargo run -- --daemon-start --daemon-port=43123 --json
+cargo run -- --daemon-status --json
+cargo run -- --daemon-stop --json
+
 # Select task label (creates label if it does not exist yet)
 cargo run -- --task "Write docs"
 cargo run -- --task=Write-docs --json
@@ -230,6 +236,12 @@ cargo run -- --restore=./reports --json
 cargo run -- --export
 cargo run -- --export=./reports --json
 ```
+
+### Local daemon API
+
+- Daemon mode binds to loopback (`127.0.0.1`) and stores daemon connection metadata in `daemon-state.toml` under the same app-data directory used by `config.toml`.
+- Control endpoints require `Authorization: Bearer <token>`, where `<token>` is the per-start random token persisted in daemon metadata.
+- API routes are versioned under `/v1/*`, including health (`/v1/health`), timer status (`/v1/status`), timer controls (`/v1/timer/*`), session metadata (`/v1/session/*`), workflow controls (`/v1/workflow/*`), and daemon shutdown (`/v1/daemon/stop`).
 
 Backup/restore behavior:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,25 +49,28 @@ use output::{
     flush_stdout, print_automation_triggers_command_output, print_backup_output,
     print_blocking_preview_command_output, print_blocklist_category_command_output,
     print_blocklist_profile_command_output, print_break_glass_command_output,
-    print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
-    print_goal_command_output, print_history_dashboard_command_output, print_json,
-    print_json_compact, print_profile_output, print_restore_output, print_schedule_command_output,
-    print_schedule_delay_command_output, print_session_metadata_command_output,
-    print_session_template_command_output, print_site_add_command_output,
-    print_site_delete_command_output, print_site_edit_command_output,
-    print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_temporary_site_add_command_output,
-    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
+    print_daemon_start_command_output, print_daemon_status_command_output,
+    print_daemon_stop_command_output, print_diagnostics_command_output, print_export_output,
+    print_goal_carry_command_output, print_goal_command_output,
+    print_history_dashboard_command_output, print_json, print_json_compact, print_profile_output,
+    print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
+    print_session_metadata_command_output, print_session_template_command_output,
+    print_site_add_command_output, print_site_delete_command_output,
+    print_site_edit_command_output, print_site_list_command_output, print_status_output,
+    print_strict_command_output, print_task_goal_command_output,
+    print_temporary_site_add_command_output, print_theme_command_output, print_timer_state_output,
+    print_weekday_rules_command_output,
 };
 use parsing::{
     finalize_cli_action, invalid_usage, parse_automation_triggers_value, parse_compare_by_value,
     parse_compare_limit_value, parse_compare_profile_value, parse_compare_time_of_day_value,
-    parse_global_tokens, parse_goal_carry_value, parse_goal_value,
-    parse_history_dashboard_order_value, parse_history_kpi_card_id, parse_monthly_goal_value,
-    parse_primary_command, parse_profile_id, parse_schedule_value, parse_site_edit_value,
-    parse_status_comparison_options, parse_strict_value, parse_task_goal_value, parse_theme_preset,
-    parse_watch_interval_option, parse_watch_interval_secs, parse_weekday_rules_value,
-    parse_weekly_goal_value, require_nonempty_key_value,
+    parse_daemon_port, parse_daemon_port_option, parse_global_tokens, parse_goal_carry_value,
+    parse_goal_value, parse_history_dashboard_order_value, parse_history_kpi_card_id,
+    parse_monthly_goal_value, parse_primary_command, parse_profile_id, parse_schedule_value,
+    parse_site_edit_value, parse_status_comparison_options, parse_strict_value,
+    parse_task_goal_value, parse_theme_preset, parse_watch_interval_option,
+    parse_watch_interval_secs, parse_weekday_rules_value, parse_weekly_goal_value,
+    require_nonempty_key_value,
 };
 #[cfg(test)]
 use status::build_status_output;
@@ -142,6 +145,9 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --allowlist-site-edit=OLD=NEW [--json]
   focustime --blocklist-site-delete=HOSTNAME [--json]
   focustime --allowlist-site-delete=HOSTNAME [--json]
+  focustime --daemon-start [--daemon-port=PORT] [--json]
+  focustime --daemon-status [--json]
+  focustime --daemon-stop [--json]
   focustime --diagnostics [--json]
   focustime --blocking-preview [--json]
   focustime --status [--watch[=SECONDS]] [--compare-by=task|profile|time-of-day] [--compare-task=LABEL|all] [--compare-profile=classic|deep-work|custom|unknown|all] [--compare-time=morning|afternoon|evening|night|unknown|all] [--compare-limit=N] [--json]
@@ -203,6 +209,10 @@ Options:
   --allowlist-site-edit       Replace allowlist hostname in active category using OLD=NEW
   --blocklist-site-delete     Delete blocklist hostname in active category within active profile
   --allowlist-site-delete     Delete allowlist hostname in active category within active profile
+  --daemon-start  Start local daemon mode in the background (loopback API + token auth)
+  --daemon-status Show local daemon mode status
+  --daemon-stop   Stop a running local daemon
+  --daemon-port   Override daemon API listen port (daemon start only; default random loopback port)
   --diagnostics   Show setup diagnostics checks
   --blocking-preview  Preview backend-selected blocking changes without writing
   --status        Print status summary (includes live timer/session fields and latest interruption)
@@ -373,6 +383,11 @@ pub enum CommandKind {
     AllowlistSiteAddTemporary {
         input: String,
     },
+    DaemonStart {
+        port: Option<u16>,
+    },
+    DaemonStatus,
+    DaemonStop,
     SessionTemplate {
         command: SessionTemplateCommandKind,
     },
@@ -408,6 +423,9 @@ enum PrimaryCommand {
     },
     FocusIntention(Option<String>),
     TaskNote(Option<String>),
+    DaemonStart,
+    DaemonStatus,
+    DaemonStop,
     Profile(Option<ProfileId>),
     Theme(Option<ThemePreset>),
     Goal(Option<DailyGoalConfig>),
@@ -477,6 +495,10 @@ enum ParsedToken {
     FocusIntention(Option<String>),
     TaskNote(Option<String>),
     Status,
+    DaemonStart,
+    DaemonStatus,
+    DaemonStop,
+    DaemonPort(u16),
     Watch(Option<u64>),
     CompareBy(ComparisonDimension),
     CompareTask(Option<String>),
@@ -806,6 +828,36 @@ struct RestoreOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct DaemonConnectionOutput {
+    pid: u32,
+    host: String,
+    port: u16,
+    started_at_epoch_secs: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct DaemonStartCommandOutput {
+    action: &'static str,
+    already_running: bool,
+    daemon: DaemonConnectionOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct DaemonStatusCommandOutput {
+    action: &'static str,
+    running: bool,
+    daemon: Option<DaemonConnectionOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct DaemonStopCommandOutput {
+    action: &'static str,
+    was_running: bool,
+    stopped: bool,
+    daemon: Option<DaemonConnectionOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct TimerStateOutput {
     phase: &'static str,
     status: &'static str,
@@ -1116,6 +1168,8 @@ where
     let (show_help, output) =
         parse_global_tokens(&tokens).map_err(|message| usage_error(output_hint, message))?;
     let primary = parse_primary_command(&tokens).map_err(|message| usage_error(output, message))?;
+    let daemon_port =
+        parse_daemon_port_option(&tokens).map_err(|message| usage_error(output, message))?;
     let watch_interval_secs =
         parse_watch_interval_option(&tokens).map_err(|message| usage_error(output, message))?;
     let (comparison, has_comparison_options) =
@@ -1124,6 +1178,7 @@ where
         show_help,
         output,
         primary,
+        daemon_port,
         watch_interval_secs,
         comparison,
         has_comparison_options,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,11 +1,12 @@
 use crate::cli::{
     KeyValueParser, OsString, OutputMode, ParsedToken, PathBuf, ValueArgParser, invalid_usage,
     parse_automation_triggers_value, parse_compare_by_value, parse_compare_limit_value,
-    parse_compare_profile_value, parse_compare_time_of_day_value, parse_goal_carry_value,
-    parse_goal_value, parse_history_dashboard_order_value, parse_history_kpi_card_id,
-    parse_monthly_goal_value, parse_profile_id, parse_schedule_value, parse_site_edit_value,
-    parse_strict_value, parse_task_goal_value, parse_theme_preset, parse_watch_interval_secs,
-    parse_weekday_rules_value, parse_weekly_goal_value, require_nonempty_key_value,
+    parse_compare_profile_value, parse_compare_time_of_day_value, parse_daemon_port,
+    parse_goal_carry_value, parse_goal_value, parse_history_dashboard_order_value,
+    parse_history_kpi_card_id, parse_monthly_goal_value, parse_profile_id, parse_schedule_value,
+    parse_site_edit_value, parse_strict_value, parse_task_goal_value, parse_theme_preset,
+    parse_watch_interval_secs, parse_weekday_rules_value, parse_weekly_goal_value,
+    require_nonempty_key_value,
 };
 
 pub(super) fn infer_output_mode_from_os_args(args: &[OsString]) -> OutputMode {
@@ -57,7 +58,7 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 45] = [
+    let parsers: [(&str, ValueArgParser); 46] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
         ("--focus-intention", classify_focus_intention_arg),
@@ -78,6 +79,7 @@ fn classify_value_arg(
             classify_automation_triggers_set_arg,
         ),
         ("--watch", classify_watch_arg),
+        ("--daemon-port", classify_daemon_port_arg),
         ("--compare-by", classify_compare_by_arg),
         ("--compare-task", classify_compare_task_arg),
         ("--compare-profile", classify_compare_profile_arg),
@@ -166,6 +168,9 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "--stop" => Some(ParsedToken::Stop),
         "--next" => Some(ParsedToken::Next),
         "--status" => Some(ParsedToken::Status),
+        "--daemon-start" => Some(ParsedToken::DaemonStart),
+        "--daemon-status" => Some(ParsedToken::DaemonStatus),
+        "--daemon-stop" => Some(ParsedToken::DaemonStop),
         "--schedule" => Some(ParsedToken::Schedule),
         "--weekday-rules" => Some(ParsedToken::WeekdayRules),
         "--automation-triggers" => Some(ParsedToken::AutomationTriggers),
@@ -310,6 +315,21 @@ fn classify_watch_arg(args: &[String], index: usize) -> Result<(ParsedToken, usi
         ));
     }
     Ok((ParsedToken::Watch(None), 1))
+}
+
+fn classify_daemon_port_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    if let Some(next) = args.get(index + 1)
+        && !next.starts_with('-')
+    {
+        let value = require_nonempty_key_value(
+            next,
+            "`--daemon-port` requires a port between 1 and 65535.",
+        )?;
+        return Ok((ParsedToken::DaemonPort(parse_daemon_port(value)?), 2));
+    }
+    Err(invalid_usage(
+        "`--daemon-port` requires a value. Use `--daemon-port=PORT`.",
+    ))
 }
 
 fn classify_compare_by_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
@@ -893,7 +913,7 @@ fn classify_automation_triggers_set_arg(
 }
 
 pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 45] = [
+    let parsers: [KeyValueParser; 46] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
         parse_focus_intention_key_value_arg,
@@ -911,6 +931,7 @@ pub(super) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, S
         parse_weekday_rules_set_key_value_arg,
         parse_automation_triggers_set_key_value_arg,
         parse_watch_key_value_arg,
+        parse_daemon_port_key_value_arg,
         parse_compare_by_key_value_arg,
         parse_compare_task_key_value_arg,
         parse_compare_profile_key_value_arg,
@@ -1150,6 +1171,17 @@ fn parse_watch_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
         return Ok(Some(ParsedToken::Watch(Some(parse_watch_interval_secs(
             value,
         )?))));
+    }
+    Ok(None)
+}
+
+fn parse_daemon_port_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix("--daemon-port=") {
+        let value = require_nonempty_key_value(
+            value,
+            "`--daemon-port=` requires a port between 1 and 65535.",
+        )?;
+        return Ok(Some(ParsedToken::DaemonPort(parse_daemon_port(value)?)));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -11,14 +11,16 @@ use std::{
 
 use crate::app::App;
 use crate::config::validate_automation_trigger_rules;
+use crate::daemon;
 
 use crate::cli::{
     AppConfig, AutomationTriggerRuleConfig, AutomationTriggersCommandOutput, BackupOutput,
     BlocklistCategoryCommandKind, BlocklistCategoryCommandOutput, BlocklistCategorySummaryOutput,
     BlocklistProfileCommandKind, BlocklistProfileCommandOutput, BlocklistProfileConfig,
     BlocklistProfileSummaryOutput, BlocklistSiteCommandKind, BreakGlassCommandOutput, CliCommand,
-    CommandKind, DailyGoalConfig, DailyGoalSnapshot, EditSiteResult, ExportOutput, FocusStats,
-    GoalCarryCommandOutput, GoalCommandOutput, HistoryDashboardCardOutput,
+    CommandKind, DaemonConnectionOutput, DaemonStartCommandOutput, DaemonStatusCommandOutput,
+    DaemonStopCommandOutput, DailyGoalConfig, DailyGoalSnapshot, EditSiteResult, ExportOutput,
+    FocusStats, GoalCarryCommandOutput, GoalCommandOutput, HistoryDashboardCardOutput,
     HistoryDashboardCommandKind, HistoryDashboardCommandOutput, HistoryKpiCardId,
     InvalidSiteEntryOutput, InvalidSiteInput, MonthlyGoalConfig, OutputMode, PathBuf, ProfileId,
     ProfileOutput, ProfileView, RecurringScheduleConfig, RestoreOutput, ScheduleCommandOutput,
@@ -36,17 +38,18 @@ use crate::cli::{
     print_automation_triggers_command_output, print_backup_output,
     print_blocking_preview_command_output, print_blocklist_category_command_output,
     print_blocklist_profile_command_output, print_break_glass_command_output,
-    print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
-    print_goal_command_output, print_history_dashboard_command_output, print_json,
-    print_json_compact, print_profile_output, print_restore_output, print_schedule_command_output,
-    print_schedule_delay_command_output, print_session_metadata_command_output,
-    print_session_template_command_output, print_site_add_command_output,
-    print_site_delete_command_output, print_site_edit_command_output,
-    print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_temporary_site_add_command_output,
-    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
-    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
-    timer_status_id,
+    print_daemon_start_command_output, print_daemon_status_command_output,
+    print_daemon_stop_command_output, print_diagnostics_command_output, print_export_output,
+    print_goal_carry_command_output, print_goal_command_output,
+    print_history_dashboard_command_output, print_json, print_json_compact, print_profile_output,
+    print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
+    print_session_metadata_command_output, print_session_template_command_output,
+    print_site_add_command_output, print_site_delete_command_output,
+    print_site_edit_command_output, print_site_list_command_output, print_status_output,
+    print_strict_command_output, print_task_goal_command_output,
+    print_temporary_site_add_command_output, print_theme_command_output, print_timer_state_output,
+    print_weekday_rules_command_output, profile_id, profile_view, selected_break_template_view,
+    theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
@@ -63,6 +66,9 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         CommandKind::Resume => execute_resume_command(cli_command.output),
         CommandKind::Stop => execute_stop_command(cli_command.output),
         CommandKind::Next => execute_next_command(cli_command.output),
+        CommandKind::DaemonStart { port } => execute_daemon_start_command(port, cli_command.output),
+        CommandKind::DaemonStatus => execute_daemon_status_command(cli_command.output),
+        CommandKind::DaemonStop => execute_daemon_stop_command(cli_command.output),
         CommandKind::Task { label } => execute_task_command(label, cli_command.output),
         CommandKind::TaskGoal { label, goal } => {
             execute_task_goal_command(label, goal, cli_command.output)
@@ -156,6 +162,62 @@ fn execute_next_command(output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
     app.next_phase_for_cli()?;
     emit_timer_command_output("next", &app, output)
+}
+
+fn execute_daemon_start_command(port: Option<u16>, output: OutputMode) -> Result<(), String> {
+    if daemon::is_daemon_child_process() {
+        return daemon::run_foreground(port);
+    }
+
+    let started = daemon::start_background(port)?;
+    let payload = DaemonStartCommandOutput {
+        action: "daemon-start",
+        already_running: started.already_running,
+        daemon: daemon_connection_output(&started.info),
+    };
+    match output {
+        OutputMode::Text => print_daemon_start_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_daemon_status_command(output: OutputMode) -> Result<(), String> {
+    let status = daemon::status()?;
+    let payload = DaemonStatusCommandOutput {
+        action: "daemon-status",
+        running: status.running,
+        daemon: status.info.as_ref().map(daemon_connection_output),
+    };
+    match output {
+        OutputMode::Text => print_daemon_status_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_daemon_stop_command(output: OutputMode) -> Result<(), String> {
+    let stopped = daemon::stop()?;
+    let payload = DaemonStopCommandOutput {
+        action: "daemon-stop",
+        was_running: stopped.was_running,
+        stopped: stopped.stopped,
+        daemon: stopped.info.as_ref().map(daemon_connection_output),
+    };
+    match output {
+        OutputMode::Text => print_daemon_stop_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn daemon_connection_output(connection: &daemon::DaemonConnectionInfo) -> DaemonConnectionOutput {
+    DaemonConnectionOutput {
+        pid: connection.pid,
+        host: connection.host.clone(),
+        port: connection.port,
+        started_at_epoch_secs: connection.started_at_epoch_secs,
+    }
 }
 
 fn execute_task_command(label: String, output: OutputMode) -> Result<(), String> {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,7 +1,8 @@
 use crate::cli::{
     AutomationTriggersCommandOutput, BackupOutput, BlockingPreviewAction,
     BlockingPreviewCommandOutput, BlocklistCategoryCommandOutput, BlocklistProfileCommandOutput,
-    BlocklistProfileConfig, BreakGlassCommandOutput, DiagnosticsCommandOutput, ExportOutput,
+    BlocklistProfileConfig, BreakGlassCommandOutput, DaemonStartCommandOutput,
+    DaemonStatusCommandOutput, DaemonStopCommandOutput, DiagnosticsCommandOutput, ExportOutput,
     FocusScoreOutput, GoalCarryCommandOutput, GoalCommandOutput, GoalOutput,
     HistoryDashboardCommandOutput, ProfileOutput, RecurringScheduleConfig, RestoreOutput,
     ScheduleCommandOutput, ScheduleDelayCommandOutput, ScheduleInspectionOutput, Serialize,
@@ -324,6 +325,47 @@ pub(super) fn print_session_metadata_command_output(payload: &SessionMetadataCom
         payload.task_note.as_deref().unwrap_or("none")
     );
     print_timer_state_output(&payload.timer);
+}
+
+pub(super) fn print_daemon_start_command_output(payload: &DaemonStartCommandOutput) {
+    if payload.already_running {
+        println!("Daemon already running.");
+    } else {
+        println!("Daemon started.");
+    }
+    println!("PID: {}", payload.daemon.pid);
+    println!("Address: {}:{}", payload.daemon.host, payload.daemon.port);
+    println!(
+        "Started at epoch seconds: {}",
+        payload.daemon.started_at_epoch_secs
+    );
+}
+
+pub(super) fn print_daemon_status_command_output(payload: &DaemonStatusCommandOutput) {
+    println!("Daemon running: {}", payload.running);
+    if let Some(daemon) = &payload.daemon {
+        println!("PID: {}", daemon.pid);
+        println!("Address: {}:{}", daemon.host, daemon.port);
+        println!("Started at epoch seconds: {}", daemon.started_at_epoch_secs);
+    } else {
+        println!("Daemon metadata: unavailable");
+    }
+}
+
+pub(super) fn print_daemon_stop_command_output(payload: &DaemonStopCommandOutput) {
+    if !payload.was_running {
+        println!("No running daemon found.");
+        return;
+    }
+    if payload.stopped {
+        println!("Daemon stopped.");
+    } else {
+        println!("Stop signal sent, but daemon shutdown was not confirmed.");
+    }
+    if let Some(daemon) = &payload.daemon {
+        println!("PID: {}", daemon.pid);
+        println!("Address: {}:{}", daemon.host, daemon.port);
+    }
 }
 
 pub(super) fn print_status_output(payload: &StatusOutput) {

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -40,6 +40,10 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::FocusIntention(_)
             | ParsedToken::TaskNote(_)
             | ParsedToken::Status
+            | ParsedToken::DaemonStart
+            | ParsedToken::DaemonStatus
+            | ParsedToken::DaemonStop
+            | ParsedToken::DaemonPort(_)
             | ParsedToken::Watch(_)
             | ParsedToken::CompareBy(_)
             | ParsedToken::CompareTask(_)
@@ -128,6 +132,16 @@ pub(super) fn parse_primary_command(
                 set_primary_command(&mut primary, PrimaryCommand::TaskNote(value.clone()))?
             }
             ParsedToken::Status => set_primary_command(&mut primary, PrimaryCommand::Status)?,
+            ParsedToken::DaemonStart => {
+                set_primary_command(&mut primary, PrimaryCommand::DaemonStart)?
+            }
+            ParsedToken::DaemonStatus => {
+                set_primary_command(&mut primary, PrimaryCommand::DaemonStatus)?
+            }
+            ParsedToken::DaemonStop => {
+                set_primary_command(&mut primary, PrimaryCommand::DaemonStop)?
+            }
+            ParsedToken::DaemonPort(_) => {}
             ParsedToken::Watch(_) => {}
             ParsedToken::CompareBy(_)
             | ParsedToken::CompareTask(_)
@@ -310,6 +324,7 @@ pub(super) fn finalize_cli_action(
     show_help: bool,
     output: OutputMode,
     primary: Option<PrimaryCommand>,
+    daemon_port: Option<u16>,
     watch_interval_secs: Option<u64>,
     comparison: StatusComparisonOptions,
     has_comparison_options: bool,
@@ -326,6 +341,11 @@ pub(super) fn finalize_cli_action(
             "`--compare-*` options are only valid with `--status`.",
         ));
     }
+    if daemon_port.is_some() && !matches!(primary, Some(PrimaryCommand::DaemonStart)) {
+        return Err(invalid_usage(
+            "`--daemon-port` is only valid with `--daemon-start`.",
+        ));
+    }
 
     match primary {
         None => {
@@ -338,6 +358,18 @@ pub(super) fn finalize_cli_action(
         }
         Some(PrimaryCommand::Start) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Start,
+            output,
+        })),
+        Some(PrimaryCommand::DaemonStart) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::DaemonStart { port: daemon_port },
+            output,
+        })),
+        Some(PrimaryCommand::DaemonStatus) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::DaemonStatus,
+            output,
+        })),
+        Some(PrimaryCommand::DaemonStop) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::DaemonStop,
             output,
         })),
         Some(PrimaryCommand::Profile(profile)) => Ok(CliAction::RunCommand(CliCommand {
@@ -1038,6 +1070,9 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::TaskGoal { .. } => "--task-goal",
         PrimaryCommand::FocusIntention(_) => "--focus-intention",
         PrimaryCommand::TaskNote(_) => "--task-note",
+        PrimaryCommand::DaemonStart => "--daemon-start",
+        PrimaryCommand::DaemonStatus => "--daemon-status",
+        PrimaryCommand::DaemonStop => "--daemon-stop",
         PrimaryCommand::Profile(_) => "--profile",
         PrimaryCommand::Theme(_) => "--theme",
         PrimaryCommand::Goal(_) => "--goal",
@@ -1106,6 +1141,19 @@ pub(super) fn parse_watch_interval_option(tokens: &[ParsedToken]) -> Result<Opti
         }
     }
     Ok(interval)
+}
+
+pub(super) fn parse_daemon_port_option(tokens: &[ParsedToken]) -> Result<Option<u16>, String> {
+    let mut port: Option<u16> = None;
+    for token in tokens {
+        if let ParsedToken::DaemonPort(value) = token {
+            if port.is_some() {
+                return Err(invalid_usage("`--daemon-port` can only be specified once."));
+            }
+            port = Some(*value);
+        }
+    }
+    Ok(port)
 }
 
 #[derive(Default)]
@@ -1262,6 +1310,19 @@ pub(super) fn parse_watch_interval_secs(value: &str) -> Result<u64, String> {
         ));
     }
     Ok(secs)
+}
+
+pub(super) fn parse_daemon_port(value: &str) -> Result<u16, String> {
+    let trimmed = value.trim();
+    let port = trimmed
+        .parse::<u16>()
+        .map_err(|_| invalid_usage("`--daemon-port` requires a port between 1 and 65535."))?;
+    if port == 0 {
+        return Err(invalid_usage(
+            "`--daemon-port` requires a port between 1 and 65535.",
+        ));
+    }
+    Ok(port)
 }
 
 pub(super) fn require_nonempty_key_value<'a>(

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -95,6 +95,54 @@ fn parse_status_watch_with_space_interval() {
 }
 
 #[test]
+fn parse_daemon_start_defaults_to_ephemeral_port() {
+    let parsed = parse(&["--daemon-start"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::DaemonStart { port: None },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_daemon_start_accepts_daemon_port_with_space_syntax() {
+    let parsed = parse(&["--daemon-start", "--daemon-port", "43123"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::DaemonStart { port: Some(43123) },
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_daemon_status_supports_json_mode() {
+    let parsed = parse(&["--daemon-status", "--json"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::DaemonStatus,
+            output: OutputMode::Json
+        })
+    );
+}
+
+#[test]
+fn parse_daemon_stop_defaults_to_text_mode() {
+    let parsed = parse(&["--daemon-stop"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::DaemonStop,
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
 fn parse_status_accepts_comparison_options() {
     let parsed = parse(&[
         "--status",
@@ -1829,6 +1877,23 @@ fn parse_rejects_watch_without_status() {
 fn parse_rejects_watch_with_non_status_command() {
     let error = parse(&["--export", "--watch"]).unwrap_err();
     assert!(error.contains("`--watch` is only valid with `--status`"));
+}
+
+#[test]
+fn parse_rejects_daemon_port_without_daemon_start() {
+    let error = parse(&["--daemon-port=41000"]).unwrap_err();
+    assert!(error.contains("`--daemon-port` is only valid with `--daemon-start`"));
+}
+
+#[test]
+fn parse_rejects_duplicate_daemon_port_flags() {
+    let error = parse(&[
+        "--daemon-start",
+        "--daemon-port=41000",
+        "--daemon-port=42000",
+    ])
+    .unwrap_err();
+    assert!(error.contains("`--daemon-port` can only be specified once"));
 }
 
 #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -24,6 +24,7 @@ const STARTUP_TIMEOUT: Duration = Duration::from_secs(6);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LOOP_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(2);
+const HEALTH_RETRY_ATTEMPTS: usize = 3;
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 #[cfg(target_os = "windows")]
@@ -116,18 +117,15 @@ pub fn status() -> Result<DaemonStatusResult, String> {
         });
     };
 
-    match ping_health(&state) {
+    match ping_health_with_retry(&state) {
         Ok(()) => Ok(DaemonStatusResult {
             running: true,
             info: Some(state.as_connection_info()),
         }),
-        Err(_) => {
-            clear_state_file()?;
-            Ok(DaemonStatusResult {
-                running: false,
-                info: Some(state.as_connection_info()),
-            })
-        }
+        Err(_) => Ok(DaemonStatusResult {
+            running: false,
+            info: Some(state.as_connection_info()),
+        }),
     }
 }
 
@@ -141,10 +139,9 @@ pub fn stop() -> Result<DaemonStopResult, String> {
     };
     let info = state.as_connection_info();
 
-    if ping_health(&state).is_err() {
-        clear_state_file()?;
+    if ping_health_with_retry(&state).is_err() {
         return Ok(DaemonStopResult {
-            was_running: false,
+            was_running: true,
             stopped: false,
             info: Some(info),
         });
@@ -176,7 +173,7 @@ pub fn stop() -> Result<DaemonStopResult, String> {
 
 pub fn run_foreground(port: Option<u16>) -> Result<(), String> {
     if let Some(existing_state) = load_state_file()? {
-        if ping_health(&existing_state).is_ok() {
+        if ping_health_with_retry(&existing_state).is_ok() {
             return Err(format!(
                 "Daemon is already running on {}:{}.",
                 existing_state.host, existing_state.port
@@ -283,6 +280,22 @@ fn ping_health(state: &DaemonStateDisk) -> Result<(), String> {
         .call()
         .map(|_| ())
         .map_err(|error| format!("Daemon health request failed: {error}"))
+}
+
+fn ping_health_with_retry(state: &DaemonStateDisk) -> Result<(), String> {
+    let mut last_error: Option<String> = None;
+    for attempt in 0..HEALTH_RETRY_ATTEMPTS {
+        match ping_health(state) {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                last_error = Some(error);
+                if attempt + 1 < HEALTH_RETRY_ATTEMPTS {
+                    thread::sleep(READY_POLL_INTERVAL);
+                }
+            }
+        }
+    }
+    Err(last_error.unwrap_or_else(|| "Daemon health request failed.".to_string()))
 }
 
 fn request_stop(state: &DaemonStateDisk) -> Result<(), String> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,697 @@
+use std::fs;
+use std::io;
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use getrandom::fill as random_fill;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
+
+use crate::app::App;
+use crate::config::app_data_path;
+use crate::timer::{TimerPhase, TimerStatus};
+
+const DAEMON_STATE_FILE_NAME: &str = "daemon-state.toml";
+const DAEMON_CHILD_ENV: &str = "FOCUSTIME_DAEMON_CHILD";
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(6);
+const READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const LOOP_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(2);
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+const DETACHED_PROCESS: u32 = 0x0000_0008;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonConnectionInfo {
+    pub pid: u32,
+    pub host: String,
+    pub port: u16,
+    pub started_at_epoch_secs: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonStartResult {
+    pub already_running: bool,
+    pub info: DaemonConnectionInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonStatusResult {
+    pub running: bool,
+    pub info: Option<DaemonConnectionInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonStopResult {
+    pub was_running: bool,
+    pub stopped: bool,
+    pub info: Option<DaemonConnectionInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DaemonStateDisk {
+    pid: u32,
+    host: String,
+    port: u16,
+    token: String,
+    started_at_epoch_secs: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct TaskSelectRequest {
+    label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct MetadataRequest {
+    value: String,
+}
+
+struct DaemonStateGuard {
+    pid: u32,
+}
+
+impl Drop for DaemonStateGuard {
+    fn drop(&mut self) {
+        let _ = clear_state_file_if_matches_pid(self.pid);
+    }
+}
+
+pub fn is_daemon_child_process() -> bool {
+    std::env::var_os(DAEMON_CHILD_ENV).is_some()
+}
+
+pub fn start_background(port: Option<u16>) -> Result<DaemonStartResult, String> {
+    let status = status()?;
+    if status.running {
+        return Ok(DaemonStartResult {
+            already_running: true,
+            info: status
+                .info
+                .ok_or_else(|| "Daemon status is running but metadata is missing.".to_string())?,
+        });
+    }
+
+    let mut child = spawn_daemon_child_process(port)?;
+    let state = wait_for_daemon_ready(child.id(), &mut child)?;
+    Ok(DaemonStartResult {
+        already_running: false,
+        info: state.as_connection_info(),
+    })
+}
+
+pub fn status() -> Result<DaemonStatusResult, String> {
+    let Some(state) = load_state_file()? else {
+        return Ok(DaemonStatusResult {
+            running: false,
+            info: None,
+        });
+    };
+
+    match ping_health(&state) {
+        Ok(()) => Ok(DaemonStatusResult {
+            running: true,
+            info: Some(state.as_connection_info()),
+        }),
+        Err(_) => {
+            clear_state_file()?;
+            Ok(DaemonStatusResult {
+                running: false,
+                info: Some(state.as_connection_info()),
+            })
+        }
+    }
+}
+
+pub fn stop() -> Result<DaemonStopResult, String> {
+    let Some(state) = load_state_file()? else {
+        return Ok(DaemonStopResult {
+            was_running: false,
+            stopped: false,
+            info: None,
+        });
+    };
+    let info = state.as_connection_info();
+
+    if ping_health(&state).is_err() {
+        clear_state_file()?;
+        return Ok(DaemonStopResult {
+            was_running: false,
+            stopped: false,
+            info: Some(info),
+        });
+    }
+
+    request_stop(&state)?;
+    let mut stopped = false;
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    while Instant::now() < deadline {
+        thread::sleep(READY_POLL_INTERVAL);
+        let current = load_state_file()?;
+        if current.is_none() {
+            stopped = true;
+            break;
+        }
+        if ping_health(&state).is_err() {
+            let _ = clear_state_file();
+            stopped = true;
+            break;
+        }
+    }
+
+    Ok(DaemonStopResult {
+        was_running: true,
+        stopped,
+        info: Some(info),
+    })
+}
+
+pub fn run_foreground(port: Option<u16>) -> Result<(), String> {
+    if let Some(existing_state) = load_state_file()? {
+        if ping_health(&existing_state).is_ok() {
+            return Err(format!(
+                "Daemon is already running on {}:{}.",
+                existing_state.host, existing_state.port
+            ));
+        }
+        clear_state_file()?;
+    }
+
+    let bind_port = port.unwrap_or(0);
+    let server = Server::http(format!("127.0.0.1:{bind_port}"))
+        .map_err(|error| format!("Failed to bind daemon API server: {error}"))?;
+    let server_port = parse_bound_port(&server.server_addr().to_string())?;
+    let token = generate_token()?;
+    let started_at_epoch_secs = current_epoch_secs();
+    let pid = std::process::id();
+    let state = DaemonStateDisk {
+        pid,
+        host: "127.0.0.1".to_string(),
+        port: server_port,
+        token,
+        started_at_epoch_secs,
+    };
+    save_state_file(&state)?;
+    let _state_guard = DaemonStateGuard { pid };
+
+    let mut app = App::new();
+    let tick_rate = Duration::from_millis(100);
+    let mut last_tick = Instant::now();
+    let mut tick_accumulator_ms: u64 = 0;
+    let mut should_stop = false;
+    while !should_stop {
+        app.poll_wakatime_status();
+        tick_if_due(
+            &mut app,
+            tick_rate,
+            &mut last_tick,
+            &mut tick_accumulator_ms,
+        );
+        match server.recv_timeout(LOOP_POLL_INTERVAL) {
+            Ok(Some(request)) => {
+                should_stop = handle_api_request(request, &mut app, &state.token)?;
+            }
+            Ok(None) => {}
+            Err(error) => return Err(format!("Daemon receive loop failed: {error}")),
+        }
+    }
+
+    Ok(())
+}
+
+fn spawn_daemon_child_process(port: Option<u16>) -> Result<Child, String> {
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("Failed to resolve executable path: {error}"))?;
+    let mut command = Command::new(executable);
+    command.arg("--daemon-start");
+    if let Some(port) = port {
+        command.arg(format!("--daemon-port={port}"));
+    }
+    command.env(DAEMON_CHILD_ENV, "1");
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::null());
+    command.stderr(Stdio::null());
+    #[cfg(target_os = "windows")]
+    {
+        command.creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS);
+    }
+    command
+        .spawn()
+        .map_err(|error| format!("Failed to start daemon process: {error}"))
+}
+
+fn wait_for_daemon_ready(expected_pid: u32, child: &mut Child) -> Result<DaemonStateDisk, String> {
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    while Instant::now() < deadline {
+        if let Some(exit_status) = child
+            .try_wait()
+            .map_err(|error| format!("Failed to inspect daemon process state: {error}"))?
+        {
+            return Err(format!(
+                "Daemon process exited early with status {exit_status}."
+            ));
+        }
+
+        if let Some(state) = load_state_file()? {
+            if state.pid == expected_pid && ping_health(&state).is_ok() {
+                return Ok(state);
+            }
+        }
+        thread::sleep(READY_POLL_INTERVAL);
+    }
+    Err("Daemon did not become ready before timeout.".to_string())
+}
+
+fn ping_health(state: &DaemonStateDisk) -> Result<(), String> {
+    let url = daemon_endpoint_url(state, "/v1/health");
+    let auth_header = format!("Bearer {}", state.token);
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(HTTP_TIMEOUT))
+        .build()
+        .into();
+    agent
+        .get(&url)
+        .header("Authorization", &auth_header)
+        .call()
+        .map(|_| ())
+        .map_err(|error| format!("Daemon health request failed: {error}"))
+}
+
+fn request_stop(state: &DaemonStateDisk) -> Result<(), String> {
+    let url = daemon_endpoint_url(state, "/v1/daemon/stop");
+    let auth_header = format!("Bearer {}", state.token);
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(HTTP_TIMEOUT))
+        .build()
+        .into();
+    agent
+        .post(&url)
+        .header("Authorization", &auth_header)
+        .send_json(json!({}))
+        .map(|_| ())
+        .map_err(|error| format!("Daemon stop request failed: {error}"))
+}
+
+fn daemon_endpoint_url(state: &DaemonStateDisk, path: &str) -> String {
+    format!("http://{}:{}{path}", state.host, state.port)
+}
+
+fn parse_bound_port(address: &str) -> Result<u16, String> {
+    address
+        .rsplit(':')
+        .next()
+        .ok_or_else(|| format!("Failed to parse daemon server address `{address}`."))?
+        .parse::<u16>()
+        .map_err(|error| format!("Failed to parse daemon server port from `{address}`: {error}"))
+}
+
+fn generate_token() -> Result<String, String> {
+    let mut bytes = [0u8; 32];
+    random_fill(&mut bytes)
+        .map_err(|error| format!("Failed to generate daemon auth token: {error}"))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn current_epoch_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
+        .unwrap_or(0)
+}
+
+fn tick_if_due(
+    app: &mut App,
+    tick_rate: Duration,
+    last_tick: &mut Instant,
+    tick_accumulator_ms: &mut u64,
+) {
+    if last_tick.elapsed() < tick_rate {
+        return;
+    }
+
+    let elapsed_ms = last_tick.elapsed().as_millis() as u64;
+    *last_tick = Instant::now();
+    if app.is_running() {
+        *tick_accumulator_ms += elapsed_ms;
+        let mut elapsed_secs = 0u64;
+        while *tick_accumulator_ms >= 1000 {
+            *tick_accumulator_ms -= 1000;
+            elapsed_secs += 1;
+        }
+        let is_catchup = elapsed_secs > 1;
+        for _ in 0..elapsed_secs {
+            app.on_tick(is_catchup);
+        }
+        if elapsed_secs > 0 {
+            app.on_wakatime_elapsed(elapsed_secs);
+        }
+    } else {
+        *tick_accumulator_ms = 0;
+    }
+}
+
+fn handle_api_request(mut request: Request, app: &mut App, token: &str) -> Result<bool, String> {
+    if !request_is_loopback(&request) {
+        respond_error(
+            request,
+            403,
+            "forbidden",
+            "Only loopback clients can access the local API.".to_string(),
+        )?;
+        return Ok(false);
+    }
+    if !request_has_valid_token(&request, token) {
+        respond_error(
+            request,
+            401,
+            "unauthorized",
+            "Missing or invalid bearer token.".to_string(),
+        )?;
+        return Ok(false);
+    }
+
+    let path = request.url().split('?').next().unwrap_or("/").to_string();
+    match (request.method(), path.as_str()) {
+        (&Method::Get, "/v1/health") => {
+            respond_ok(
+                request,
+                json!({
+                    "status": "ok",
+                    "timestamp_epoch_secs": current_epoch_secs()
+                }),
+            )?;
+            Ok(false)
+        }
+        (&Method::Get, "/v1/status") => {
+            respond_ok(request, api_timer_state(app))?;
+            Ok(false)
+        }
+        (&Method::Post, "/v1/timer/start") => {
+            run_timer_action(request, app, App::start_focus_for_cli)?;
+            Ok(false)
+        }
+        (&Method::Post, "/v1/timer/pause") => {
+            run_timer_action(request, app, App::pause_for_cli)?;
+            Ok(false)
+        }
+        (&Method::Post, "/v1/timer/resume") => {
+            run_timer_action(request, app, App::resume_for_cli)?;
+            Ok(false)
+        }
+        (&Method::Post, "/v1/timer/stop") => {
+            run_timer_action(request, app, App::stop_for_cli)?;
+            Ok(false)
+        }
+        (&Method::Post, "/v1/timer/next") => {
+            run_timer_action(request, app, App::next_phase_for_cli)?;
+            Ok(false)
+        }
+        (&Method::Post, "/v1/task/select") => {
+            let body: TaskSelectRequest = parse_json_body(&mut request)?;
+            match app.select_task_label_for_cli(&body.label) {
+                Ok(created) => respond_ok(
+                    request,
+                    json!({
+                        "created": created,
+                        "state": api_timer_state(app)
+                    }),
+                )?,
+                Err(error) => {
+                    respond_error(request, 400, "invalid_request", error)?;
+                }
+            }
+            Ok(false)
+        }
+        (&Method::Post, "/v1/session/focus-intention") => {
+            let body: MetadataRequest = parse_json_body(&mut request)?;
+            match app.set_focus_intention_for_cli(&body.value) {
+                Ok(()) => respond_ok(
+                    request,
+                    json!({
+                        "focus_intention": app.focus_intention_for_cli(),
+                        "state": api_timer_state(app)
+                    }),
+                )?,
+                Err(error) => respond_error(request, 400, "invalid_request", error)?,
+            }
+            Ok(false)
+        }
+        (&Method::Post, "/v1/session/task-note") => {
+            let body: MetadataRequest = parse_json_body(&mut request)?;
+            match app.set_task_note_for_cli(&body.value) {
+                Ok(()) => respond_ok(
+                    request,
+                    json!({
+                        "task_note": app.task_note_for_cli(),
+                        "state": api_timer_state(app)
+                    }),
+                )?,
+                Err(error) => respond_error(request, 400, "invalid_request", error)?,
+            }
+            Ok(false)
+        }
+        (&Method::Post, "/v1/workflow/schedule-delay") => {
+            match app.schedule_delay_for_cli() {
+                Ok(delayed_until) => respond_ok(
+                    request,
+                    json!({
+                        "delayed_until": delayed_until,
+                        "state": api_timer_state(app)
+                    }),
+                )?,
+                Err(error) => respond_error(request, 400, "invalid_request", error)?,
+            }
+            Ok(false)
+        }
+        (&Method::Post, "/v1/workflow/break-glass/trigger") => {
+            run_workflow_action(request, app, App::trigger_break_glass_for_cli)?;
+            Ok(false)
+        }
+        (&Method::Post, "/v1/workflow/break-glass/cancel") => {
+            run_workflow_action(request, app, App::cancel_break_glass_for_cli)?;
+            Ok(false)
+        }
+        (&Method::Post, "/v1/daemon/stop") => {
+            respond_ok(
+                request,
+                json!({
+                    "stopping": true
+                }),
+            )?;
+            Ok(true)
+        }
+        _ => {
+            respond_error(
+                request,
+                404,
+                "not_found",
+                format!("Unknown endpoint `{path}`."),
+            )?;
+            Ok(false)
+        }
+    }
+}
+
+fn run_timer_action(
+    request: Request,
+    app: &mut App,
+    action: fn(&mut App) -> Result<(), String>,
+) -> Result<(), String> {
+    match action(app) {
+        Ok(()) => respond_ok(request, api_timer_state(app)),
+        Err(error) => respond_error(request, 400, "invalid_request", error),
+    }
+}
+
+fn run_workflow_action(
+    request: Request,
+    app: &mut App,
+    action: fn(&mut App) -> Result<(), String>,
+) -> Result<(), String> {
+    match action(app) {
+        Ok(()) => respond_ok(request, json!({ "state": api_timer_state(app) })),
+        Err(error) => respond_error(request, 400, "invalid_request", error),
+    }
+}
+
+fn api_timer_state(app: &App) -> serde_json::Value {
+    let (phase, status, remaining_secs, pomodoros_completed) = app.timer_state_for_cli();
+    json!({
+        "phase": timer_phase_id(phase),
+        "status": timer_status_id(status),
+        "remaining_secs": remaining_secs,
+        "pomodoros_completed": pomodoros_completed,
+        "selected_profile": app.selected_profile_name(),
+        "selected_task_label": app.selected_task_label_for_cli(),
+        "focus_intention": app.focus_intention_for_cli(),
+        "task_note": app.task_note_for_cli(),
+        "selected_blocklist_profile": app.selected_blocklist_profile_name_for_cli()
+    })
+}
+
+fn timer_phase_id(phase: TimerPhase) -> &'static str {
+    match phase {
+        TimerPhase::Focus => "focus",
+        TimerPhase::ShortBreak => "short-break",
+        TimerPhase::LongBreak => "long-break",
+    }
+}
+
+fn timer_status_id(status: TimerStatus) -> &'static str {
+    match status {
+        TimerStatus::Idle => "idle",
+        TimerStatus::Running => "running",
+        TimerStatus::Paused => "paused",
+    }
+}
+
+fn parse_json_body<T: for<'de> Deserialize<'de>>(request: &mut Request) -> Result<T, String> {
+    let mut body = String::new();
+    request
+        .as_reader()
+        .read_to_string(&mut body)
+        .map_err(|error| format!("Failed to read request body: {error}"))?;
+    serde_json::from_str::<T>(&body).map_err(|error| format!("Invalid JSON body: {error}"))
+}
+
+fn request_is_loopback(request: &Request) -> bool {
+    request
+        .remote_addr()
+        .map(|address| address.ip().is_loopback())
+        .unwrap_or(true)
+}
+
+fn request_has_valid_token(request: &Request, token: &str) -> bool {
+    let expected = format!("Bearer {token}");
+    request
+        .headers()
+        .iter()
+        .find(|header| header.field.equiv("Authorization"))
+        .map(|header| header.value.as_str() == expected)
+        .unwrap_or(false)
+}
+
+fn respond_ok(request: Request, data: serde_json::Value) -> Result<(), String> {
+    respond_json(request, 200, json!({ "ok": true, "data": data }))
+}
+
+fn respond_error(request: Request, status: u16, code: &str, message: String) -> Result<(), String> {
+    respond_json(
+        request,
+        status,
+        json!({
+            "ok": false,
+            "error": {
+                "code": code,
+                "message": message
+            }
+        }),
+    )
+}
+
+fn respond_json(request: Request, status: u16, payload: serde_json::Value) -> Result<(), String> {
+    let body = serde_json::to_string(&payload)
+        .map_err(|error| format!("Failed to encode API response JSON: {error}"))?;
+    let content_type = Header::from_bytes("Content-Type", "application/json")
+        .map_err(|_| "Failed to build JSON response header.".to_string())?;
+    let response = Response::from_string(body)
+        .with_status_code(StatusCode(status))
+        .with_header(content_type);
+    request
+        .respond(response)
+        .map_err(|error| format!("Failed to send API response: {error}"))
+}
+
+fn daemon_state_path() -> Result<PathBuf, String> {
+    app_data_path(DAEMON_STATE_FILE_NAME)
+        .ok_or_else(|| "Could not determine application data path for daemon state.".to_string())
+}
+
+fn load_state_file() -> Result<Option<DaemonStateDisk>, String> {
+    let path = daemon_state_path()?;
+    match fs::read_to_string(path) {
+        Ok(content) => toml::from_str::<DaemonStateDisk>(&content)
+            .map(Some)
+            .map_err(|error| format!("Failed to parse daemon state: {error}")),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!("Failed to read daemon state: {error}")),
+    }
+}
+
+fn save_state_file(state: &DaemonStateDisk) -> Result<(), String> {
+    let path = daemon_state_path()?;
+    write_atomic_toml(&path, state).map_err(|error| format!("Failed to save daemon state: {error}"))
+}
+
+fn clear_state_file() -> Result<(), String> {
+    let path = daemon_state_path()?;
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("Failed to remove daemon state: {error}")),
+    }
+}
+
+fn clear_state_file_if_matches_pid(expected_pid: u32) -> Result<(), String> {
+    let Some(state) = load_state_file()? else {
+        return Ok(());
+    };
+    if state.pid == expected_pid {
+        clear_state_file()?;
+    }
+    Ok(())
+}
+
+fn write_atomic_toml(path: &Path, value: &DaemonStateDisk) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let content = toml::to_string_pretty(value)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let tmp_path = path.with_extension("toml.tmp");
+    fs::write(&tmp_path, content)?;
+
+    #[cfg(target_os = "windows")]
+    {
+        match fs::rename(&tmp_path, path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                fs::remove_file(path)?;
+                fs::rename(&tmp_path, path)
+            }
+            Err(error) => {
+                let _ = fs::remove_file(&tmp_path);
+                Err(error)
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        match fs::rename(&tmp_path, path) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                let _ = fs::remove_file(&tmp_path);
+                Err(error)
+            }
+        }
+    }
+}
+
+impl DaemonStateDisk {
+    fn as_connection_info(&self) -> DaemonConnectionInfo {
+        DaemonConnectionInfo {
+            pid: self.pid,
+            host: self.host.clone(),
+            port: self.port,
+            started_at_epoch_secs: self.started_at_epoch_secs,
+        }
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -24,7 +24,9 @@ const STARTUP_TIMEOUT: Duration = Duration::from_secs(6);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LOOP_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+#[cfg(target_os = "windows")]
 const DETACHED_PROCESS: u32 = 0x0000_0008;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod blocker;
 mod cli;
 mod config;
+mod daemon;
 mod notifications;
 mod schedule;
 mod session_recovery;

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -4,12 +4,106 @@ use std::{
     process::{Child, Command, Output, Stdio},
     sync::atomic::{AtomicU64, Ordering},
     thread,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use serde_json::Value;
+use serde::Deserialize;
+use serde_json::{Value, json};
 
 static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Deserialize)]
+struct DaemonStateFile {
+    pid: u32,
+    host: String,
+    port: u16,
+    token: String,
+    started_at_epoch_secs: i64,
+}
+
+struct DaemonGuard<'a> {
+    env: &'a TestEnv,
+}
+
+impl Drop for DaemonGuard<'_> {
+    fn drop(&mut self) {
+        let _ = self.env.run(&["--daemon-stop", "--json"]);
+    }
+}
+
+fn start_daemon(env: &TestEnv) -> DaemonGuard<'_> {
+    let output = env.run(&["--daemon-start", "--json"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stderr_text(&output).trim().is_empty());
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["action"], "daemon-start");
+    assert!(payload["daemon"]["pid"].as_u64().is_some_and(|pid| pid > 0));
+    assert_eq!(payload["daemon"]["host"], "127.0.0.1");
+    assert!(
+        payload["daemon"]["port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    DaemonGuard { env }
+}
+
+fn load_daemon_state(env: &TestEnv) -> DaemonStateFile {
+    let state_path = env.app_data_dir().join("daemon-state.toml");
+    let content = fs::read_to_string(state_path).expect("failed to read daemon state file");
+    toml::from_str::<DaemonStateFile>(&content).expect("failed to parse daemon state file")
+}
+
+fn daemon_get_json(state: &DaemonStateFile, path: &str) -> Value {
+    let url = format!("http://{}:{}{path}", state.host, state.port);
+    let auth_header = format!("Bearer {}", state.token);
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(2)))
+        .build()
+        .into();
+    let response = agent
+        .get(&url)
+        .header("Authorization", &auth_header)
+        .call()
+        .expect("daemon GET request failed");
+    response
+        .into_body()
+        .read_json::<Value>()
+        .expect("daemon GET response body should be valid JSON")
+}
+
+fn daemon_post_json(state: &DaemonStateFile, path: &str, payload: Value) -> Value {
+    let url = format!("http://{}:{}{path}", state.host, state.port);
+    let auth_header = format!("Bearer {}", state.token);
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(2)))
+        .build()
+        .into();
+    let response = agent
+        .post(&url)
+        .header("Authorization", &auth_header)
+        .send_json(payload)
+        .expect("daemon POST request failed");
+    response
+        .into_body()
+        .read_json::<Value>()
+        .expect("daemon POST response body should be valid JSON")
+}
+
+fn wait_until_daemon_stopped(env: &TestEnv) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        let output = env.run(&["--daemon-status", "--json"]);
+        assert_eq!(output.status.code(), Some(0));
+        assert!(stderr_text(&output).trim().is_empty());
+        let payload: Value =
+            serde_json::from_slice(&output.stdout).expect("daemon status should be JSON");
+        if payload["running"] == Value::Bool(false) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("daemon did not stop before timeout");
+}
 
 struct TestEnv {
     root: PathBuf,
@@ -54,6 +148,11 @@ impl TestEnv {
     }
 
     fn run(&self, args: &[&str]) -> Output {
+        let capture_id = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let stdout_path = self.root.join(format!("command-stdout-{capture_id}.log"));
+        let stderr_path = self.root.join(format!("command-stderr-{capture_id}.log"));
+        let stdout_file = fs::File::create(&stdout_path).expect("failed to create stdout capture");
+        let stderr_file = fs::File::create(&stderr_path).expect("failed to create stderr capture");
         let mut command = Command::new(focustime_bin_path());
         command.args(args);
         command.current_dir(&self.root);
@@ -63,9 +162,20 @@ impl TestEnv {
         command.env("XDG_STATE_HOME", self.root.join(".state"));
         command.env("XDG_DATA_HOME", self.root.join(".data"));
         command.env("HOME", &self.root);
-        command
-            .output()
-            .expect("failed to run focustime integration command")
+        command.stdout(Stdio::from(stdout_file));
+        command.stderr(Stdio::from(stderr_file));
+        let status = command
+            .status()
+            .expect("failed to run focustime integration command");
+        let stdout = fs::read(&stdout_path).expect("failed to read stdout capture");
+        let stderr = fs::read(&stderr_path).expect("failed to read stderr capture");
+        let _ = fs::remove_file(stdout_path);
+        let _ = fs::remove_file(stderr_path);
+        Output {
+            status,
+            stdout,
+            stderr,
+        }
     }
 
     fn spawn_watch(&self, args: &[&str]) -> Child {
@@ -936,4 +1046,110 @@ fn recurring_schedule_is_profile_scoped_via_cli_commands() {
             .len(),
         1
     );
+}
+
+#[test]
+fn daemon_lifecycle_json_contract_round_trip() {
+    let env = TestEnv::new("daemon-lifecycle-json");
+
+    let start_output = env.run(&["--daemon-start", "--json"]);
+    assert_eq!(start_output.status.code(), Some(0));
+    assert!(stderr_text(&start_output).trim().is_empty());
+    let start_payload: Value =
+        serde_json::from_slice(&start_output.stdout).expect("stdout should be JSON");
+    assert_eq!(start_payload["action"], "daemon-start");
+    assert_eq!(start_payload["already_running"], false);
+    assert!(
+        start_payload["daemon"]["pid"]
+            .as_u64()
+            .is_some_and(|pid| pid > 0)
+    );
+    assert_eq!(start_payload["daemon"]["host"], "127.0.0.1");
+    assert!(
+        start_payload["daemon"]["port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    assert!(
+        start_payload["daemon"]["started_at_epoch_secs"]
+            .as_i64()
+            .is_some_and(|timestamp| timestamp > 0)
+    );
+
+    let status_output = env.run(&["--daemon-status", "--json"]);
+    assert_eq!(status_output.status.code(), Some(0));
+    assert!(stderr_text(&status_output).trim().is_empty());
+    let status_payload: Value =
+        serde_json::from_slice(&status_output.stdout).expect("stdout should be JSON");
+    assert_eq!(status_payload["action"], "daemon-status");
+    assert_eq!(status_payload["running"], true);
+    assert_eq!(
+        status_payload["daemon"]["pid"],
+        start_payload["daemon"]["pid"]
+    );
+    assert_eq!(status_payload["daemon"]["host"], "127.0.0.1");
+    assert_eq!(
+        status_payload["daemon"]["port"],
+        start_payload["daemon"]["port"]
+    );
+
+    let stop_output = env.run(&["--daemon-stop", "--json"]);
+    assert_eq!(stop_output.status.code(), Some(0));
+    assert!(stderr_text(&stop_output).trim().is_empty());
+    let stop_payload: Value = serde_json::from_slice(&stop_output.stdout).expect("stdout JSON");
+    assert_eq!(stop_payload["action"], "daemon-stop");
+    assert_eq!(stop_payload["was_running"], true);
+    assert_eq!(stop_payload["stopped"], true);
+    assert_eq!(
+        stop_payload["daemon"]["pid"],
+        start_payload["daemon"]["pid"]
+    );
+
+    let status_after_stop = env.run(&["--daemon-status", "--json"]);
+    assert_eq!(status_after_stop.status.code(), Some(0));
+    assert!(stderr_text(&status_after_stop).trim().is_empty());
+    let status_after_stop_payload: Value =
+        serde_json::from_slice(&status_after_stop.stdout).expect("stdout JSON");
+    assert_eq!(status_after_stop_payload["action"], "daemon-status");
+    assert_eq!(status_after_stop_payload["running"], false);
+}
+
+#[test]
+fn daemon_local_api_supports_timer_and_metadata_controls() {
+    let env = TestEnv::new("daemon-local-api-controls");
+    let _daemon_guard = start_daemon(&env);
+    let state = load_daemon_state(&env);
+    assert!(state.pid > 0);
+    assert_eq!(state.host, "127.0.0.1");
+    assert!(state.port > 0);
+    assert!(!state.token.trim().is_empty());
+    assert!(state.started_at_epoch_secs > 0);
+
+    let health = daemon_get_json(&state, "/v1/health");
+    assert_eq!(health["ok"], true);
+    assert_eq!(health["data"]["status"], "ok");
+
+    let task_select = daemon_post_json(&state, "/v1/task/select", json!({ "label": "Docs" }));
+    assert_eq!(task_select["ok"], true);
+    assert!(task_select["data"]["state"].is_object());
+
+    let timer_start = daemon_post_json(&state, "/v1/timer/start", json!({}));
+    assert_eq!(timer_start["ok"], true);
+    assert_eq!(timer_start["data"]["phase"], "focus");
+    assert_eq!(timer_start["data"]["status"], "running");
+    assert_eq!(timer_start["data"]["selected_task_label"], "Docs");
+
+    let focus_intention = daemon_post_json(
+        &state,
+        "/v1/session/focus-intention",
+        json!({ "value": "Write docs" }),
+    );
+    assert_eq!(focus_intention["ok"], true);
+    assert_eq!(focus_intention["data"]["focus_intention"], "Write docs");
+    assert_eq!(focus_intention["data"]["state"]["status"], "running");
+
+    let stop = daemon_post_json(&state, "/v1/daemon/stop", json!({}));
+    assert_eq!(stop["ok"], true);
+    assert_eq!(stop["data"]["stopping"], true);
+    wait_until_daemon_stopped(&env);
 }


### PR DESCRIPTION
## What

- Add a new `src/daemon.rs` runtime that runs a headless `App` loop and exposes a versioned local API on loopback-only HTTP (`/v1/*`).
- Add daemon lifecycle CLI commands and wiring: `--daemon-start`, `--daemon-status`, `--daemon-stop`, and `--daemon-port`.
- Persist daemon connection metadata (host/port/pid/start time/token) to app data, enforce bearer-token auth for control endpoints, and support graceful daemon stop.
- Add parser and contract coverage for daemon CLI/API behavior, including lifecycle and timer/metadata API controls.
- Update README and ARCHITECTURE docs for daemon mode, local API contract, and auth model.

## Why

Issue #331 requests automation support without requiring interactive TUI startup. This adds a stable local control plane that reuses existing runtime behavior while keeping local-access safety constraints explicit.

Closes #331.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon mode: run headless with --daemon-start, check with --daemon-status, stop with --daemon-stop
  * Local HTTP API on localhost with Bearer-token auth and configurable port via --daemon-port
  * Persistent on-disk daemon metadata and lifecycle control

* **Documentation**
  * README and architecture docs updated with daemon usage, API layout, and examples

* **Tests**
  * Integration and CLI tests added for daemon lifecycle, JSON outputs, and local API endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/focustime/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->