### PR TITLE
Usage signal collection for command and screen frequency

### DIFF
--- a/FEATURE_INVENTORY.json
+++ b/FEATURE_INVENTORY.json
@@ -33,9 +33,9 @@
     ]
   },
   "summary": {
-    "total_features": 27,
+    "total_features": 28,
     "keep_count": 13,
-    "merge_count": 13,
+    "merge_count": 14,
     "remove_count": 1,
     "by_surface": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "surface": "stats",
-        "feature_count": 6
+        "feature_count": 7
       },
       {
         "surface": "integration",
@@ -131,6 +131,7 @@
       "--task-goal",
       "--task-note",
       "--theme",
+      "--usage-signals",
       "--watch",
       "--weekday-rules",
       "--weekday-rules-set"
@@ -531,6 +532,22 @@
       "maintenance_cost": 3.65,
       "value_to_maintenance_ratio": 1.37,
       "recommendation": "keep"
+    },
+    {
+      "feature_id": "usage-signal-inspection",
+      "name": "Usage signal inspection",
+      "surface": "stats",
+      "description": "Review command and screen frequency summaries to guide feature cleanup decisions.",
+      "cli_flags": [
+        "--usage-signals"
+      ],
+      "value": 3,
+      "complexity": 2,
+      "support_burden": 2,
+      "failure_impact": 2,
+      "maintenance_cost": 2.0,
+      "value_to_maintenance_ratio": 1.5,
+      "recommendation": "merge"
     },
     {
       "feature_id": "calendar-busy-window-sync",

--- a/FEATURE_INVENTORY.md
+++ b/FEATURE_INVENTORY.md
@@ -14,15 +14,15 @@
 
 ## Summary
 
-- Total features: 27
+- Total features: 28
 - Keep: 13
-- Merge: 13
+- Merge: 14
 - Remove: 1
 - Surface coverage:
   - Timer: 6
   - Schedule: 5
   - Blocker: 5
-  - Stats: 6
+  - Stats: 7
   - Integration: 5
 
 ## Release phase mapping (v0.14.x)
@@ -57,6 +57,7 @@
 | `stats-export-artifacts` | Stats | 4 | 2.65 | 1.51 | keep | --export |
 | `status-comparison-slicing` | Stats | 3 | 3.35 | 0.90 | merge | --compare-by, --compare-task, --compare-profile, --compare-time, --compare-limit |
 | `status-snapshot-and-streaming` | Stats | 5 | 3.65 | 1.37 | keep | --status, --watch |
+| `usage-signal-inspection` | Stats | 3 | 2.00 | 1.50 | merge | --usage-signals |
 | `calendar-busy-window-sync` | Integration | 3 | 3.75 | 0.80 | merge | --calendar-sync |
 | `daemon-api-lifecycle` | Integration | 3 | 4.25 | 0.71 | merge | --daemon-start, --daemon-status, --daemon-stop, --daemon-port |
 | `encrypted-sync-bundles` | Integration | 2 | 5.00 | 0.40 | remove | --sync-backup, --sync-restore, --sync-passphrase |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1890,7 +1890,25 @@ impl App {
     fn open_setup_diagnostics(&mut self) {
         self.pending_timer_action = None;
         self.refresh_setup_diagnostics();
-        self.mode = AppMode::SetupDiagnostics;
+        self.set_mode(AppMode::SetupDiagnostics);
+    }
+
+    pub(crate) fn record_current_screen_usage(&mut self) {
+        self.record_screen_usage_for_mode(self.mode);
+    }
+
+    pub(super) fn set_mode(&mut self, mode: AppMode) {
+        self.mode = mode;
+        self.record_screen_usage_for_mode(mode);
+    }
+
+    fn record_screen_usage_for_mode(&mut self, mode: AppMode) {
+        if self
+            .stats
+            .record_screen_usage(mode.screen_usage_surface_id())
+        {
+            self.mark_stats_dirty();
+        }
     }
 
     fn should_block_for_current_state(&self) -> bool {
@@ -1918,6 +1936,19 @@ impl App {
                 self.auto_start.break_to_focus
             }
             _ => false,
+        }
+    }
+}
+
+impl AppMode {
+    fn screen_usage_surface_id(self) -> &'static str {
+        match self {
+            Self::Timer => "timer",
+            Self::SiteManager => "site-manager",
+            Self::ProfileManager => "profile-manager",
+            Self::SessionPlanner => "session-planner",
+            Self::StatsHistory => "stats-history",
+            Self::SetupDiagnostics => "setup-diagnostics",
         }
     }
 }

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -4,6 +4,12 @@ use crate::app::{
 };
 
 impl App {
+    pub fn record_command_usage_for_cli(&mut self, surface_id: &str) {
+        if self.stats.record_command_usage(surface_id) {
+            self.mark_stats_dirty();
+        }
+    }
+
     pub fn start_focus_for_cli(&mut self) -> Result<(), String> {
         if self.timer.phase != TimerPhase::Focus || self.timer.status != TimerStatus::Idle {
             return Err("Cannot start focus: timer is not idle in focus phase.".to_string());

--- a/src/app/history_goals.rs
+++ b/src/app/history_goals.rs
@@ -57,7 +57,7 @@ impl App {
     pub(super) fn open_stats_history(&mut self) {
         self.pending_timer_action = None;
         self.history_feedback = None;
-        self.mode = AppMode::StatsHistory;
+        self.set_mode(AppMode::StatsHistory);
     }
 
     pub(super) fn record_completed_focus_session(&mut self, focused_seconds: u64) {

--- a/src/app/mode_keys.rs
+++ b/src/app/mode_keys.rs
@@ -226,7 +226,7 @@ impl App {
         if self.navigation_matches(NavigationAction::Cancel, &key)
             || self.shortcut_matches(ShortcutAction::BackStatsHistory, &key)
         {
-            self.mode = AppMode::Timer;
+            self.set_mode(AppMode::Timer);
             return;
         }
 
@@ -310,7 +310,7 @@ impl App {
         if self.navigation_matches(NavigationAction::Cancel, &key)
             || self.shortcut_matches(ShortcutAction::BackSetupDiagnostics, &key)
         {
-            self.mode = AppMode::Timer;
+            self.set_mode(AppMode::Timer);
         } else if self.shortcut_matches(ShortcutAction::RefreshSetupDiagnostics, &key) {
             self.refresh_setup_diagnostics();
         }

--- a/src/app/profile_management.rs
+++ b/src/app/profile_management.rs
@@ -121,7 +121,7 @@ impl App {
     }
 
     pub(super) fn open_profile_manager(&mut self) {
-        self.mode = AppMode::ProfileManager;
+        self.set_mode(AppMode::ProfileManager);
         self.profile_edit_active = false;
         self.profile_edit_field = 0;
         self.profile_edit_schedule_window = 0;
@@ -139,7 +139,7 @@ impl App {
     }
 
     pub(super) fn exit_profile_manager(&mut self) {
-        self.mode = AppMode::Timer;
+        self.set_mode(AppMode::Timer);
         self.profile_edit_automation_triggers.clear();
         self.profile_edit_snapshot = None;
     }

--- a/src/app/session_planner.rs
+++ b/src/app/session_planner.rs
@@ -47,7 +47,7 @@ impl App {
 
     fn handle_session_planner_navigation_key(&mut self, key: &KeyEvent) -> bool {
         if self.navigation_matches(NavigationAction::Cancel, key) {
-            self.mode = AppMode::Timer;
+            self.set_mode(AppMode::Timer);
             return true;
         }
         if self.handle_session_planner_move_up(key) {
@@ -155,7 +155,7 @@ impl App {
         if !self.shortcut_matches(ShortcutAction::BackSessionPlanner, key) {
             return false;
         }
-        self.mode = AppMode::Timer;
+        self.set_mode(AppMode::Timer);
         true
     }
 
@@ -835,7 +835,7 @@ impl App {
     }
 
     pub(super) fn open_session_planner(&mut self) {
-        self.mode = AppMode::SessionPlanner;
+        self.set_mode(AppMode::SessionPlanner);
         self.planner_feedback = None;
         self.planner_input.clear();
         self.planner_input_active = false;

--- a/src/app/site_manager.rs
+++ b/src/app/site_manager.rs
@@ -125,7 +125,7 @@ impl App {
                 true
             }
             _ if self.navigation_matches(NavigationAction::Cancel, key) => {
-                self.mode = AppMode::Timer;
+                self.set_mode(AppMode::Timer);
                 true
             }
             _ => false,
@@ -165,7 +165,7 @@ impl App {
         };
 
         match action {
-            ShortcutAction::BackSiteManager => self.mode = AppMode::Timer,
+            ShortcutAction::BackSiteManager => self.set_mode(AppMode::Timer),
             ShortcutAction::ToggleSiteListMode => self.toggle_site_list_mode(),
             ShortcutAction::SiteAdd => self.start_site_input(SiteInputMode::Add),
             ShortcutAction::SiteEdit => self.start_site_input(SiteInputMode::Edit),
@@ -883,7 +883,7 @@ impl App {
 
     pub(super) fn open_site_manager(&mut self) {
         self.pending_timer_action = None;
-        self.mode = AppMode::SiteManager;
+        self.set_mode(AppMode::SiteManager);
         self.site_list_mode = SiteListMode::Blocklist;
         self.cancel_site_input();
         self.cancel_blocklist_profile_input();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4802,6 +4802,69 @@ fn diagnostics_view_toggles_from_timer_mode() {
 }
 
 #[test]
+fn record_current_screen_usage_tracks_initial_timer_surface() {
+    let mut app = App::default();
+    app.record_current_screen_usage();
+    let summary = app.stats.usage_signal_summary(6);
+    assert_eq!(summary.screens.total_events, 1);
+    assert_eq!(summary.screens.unique_surfaces, 1);
+    assert_eq!(summary.screens.top[0].surface, "timer");
+    assert_eq!(summary.screens.top[0].count, 1);
+}
+
+#[test]
+fn screen_mode_transitions_record_usage_counts() {
+    let mut app = App::default();
+    app.record_current_screen_usage();
+    app.open_site_manager();
+    app.open_stats_history();
+    app.open_profile_manager();
+    app.open_session_planner();
+    app.open_setup_diagnostics();
+    app.handle_key(key(KeyCode::Esc));
+    let summary = app.stats.usage_signal_summary(6);
+    assert_eq!(summary.screens.total_events, 7);
+    assert_eq!(summary.screens.unique_surfaces, 6);
+    assert_eq!(summary.screens.top[0].surface, "timer");
+    assert_eq!(summary.screens.top[0].count, 2);
+    assert!(
+        summary
+            .screens
+            .top
+            .iter()
+            .any(|entry| entry.surface == "site-manager")
+    );
+    assert!(
+        summary
+            .screens
+            .top
+            .iter()
+            .any(|entry| entry.surface == "stats-history")
+    );
+    assert!(
+        summary
+            .screens
+            .top
+            .iter()
+            .any(|entry| entry.surface == "profile-manager")
+    );
+    assert!(
+        summary
+            .screens
+            .top
+            .iter()
+            .any(|entry| entry.surface == "session-planner")
+    );
+    assert!(
+        summary
+            .screens
+            .top
+            .iter()
+            .any(|entry| entry.surface == "setup-diagnostics")
+    );
+}
+
+#[test]
 fn pending_strict_reset_confirmation_clears_when_opening_setup_diagnostics() {
     let config = AppConfig {
         strict_mode: true,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,8 @@ use crate::session_recovery;
 use crate::stats::{
     ComparisonDimension, DailyGoalSnapshot, FocusRiskForecast, FocusStats,
     ProductivityComparisonRow, ProfileBucket, SessionInterruptionEvent, StatsGrowthSummary,
-    StatsRetentionPruneResult, TimeOfDayBucket, carry_over_goal_target, current_day_key,
+    StatsRetentionPruneResult, TimeOfDayBucket, UsageSignalsSummary, carry_over_goal_target,
+    current_day_key,
 };
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
@@ -60,7 +61,8 @@ use output::{
     print_site_edit_command_output, print_site_list_command_output, print_status_output,
     print_strict_command_output, print_sync_backup_output, print_sync_restore_output,
     print_task_goal_command_output, print_temporary_site_add_command_output,
-    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
+    print_theme_command_output, print_timer_state_output, print_usage_signals_command_output,
+    print_weekday_rules_command_output,
 };
 use parsing::{
     finalize_cli_action, invalid_usage, parse_automation_triggers_value, parse_compare_by_value,
@@ -151,6 +153,7 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --daemon-stop [--json]
   focustime --diagnostics [--json]
   focustime --blocking-preview [--json]
+  focustime --usage-signals [--json]
   focustime --status [--watch[=SECONDS]] [--compare-by=task|profile|time-of-day] [--compare-task=LABEL|all] [--compare-profile=classic|deep-work|custom|unknown|all] [--compare-time=morning|afternoon|evening|night|unknown|all] [--compare-limit=N] [--json]
   focustime --backup[=DIR] [--json]
   focustime --restore[=DIR] [--json]
@@ -220,6 +223,7 @@ Options:
   --daemon-port   Override daemon API listen port (daemon start only; default random loopback port)
   --diagnostics   Show setup diagnostics checks
   --blocking-preview  Preview backend-selected blocking changes without writing
+  --usage-signals  Show local command/screen usage summary (top + rare surfaces)
   --status        Print status summary (includes live timer/session fields and latest interruption)
   --watch         Stream periodic status updates (status command only; default 1s)
   --compare-by    Status comparison dimension: task | profile | time-of-day
@@ -367,6 +371,7 @@ pub enum CommandKind {
     BreakGlassCancel,
     Diagnostics,
     BlockingPreview,
+    UsageSignals,
     Status {
         watch_interval_secs: Option<u64>,
         comparison: StatusComparisonOptions,
@@ -468,6 +473,7 @@ enum PrimaryCommand {
     BreakGlassCancel,
     Diagnostics,
     BlockingPreview,
+    UsageSignals,
     Status,
     Backup(Option<PathBuf>),
     Restore(Option<PathBuf>),
@@ -551,6 +557,7 @@ enum ParsedToken {
     BreakGlassCancel,
     Diagnostics,
     BlockingPreview,
+    UsageSignals,
     Backup(Option<PathBuf>),
     Restore(Option<PathBuf>),
     SyncBackup(Option<PathBuf>),
@@ -1154,6 +1161,12 @@ struct HistoryDashboardCommandOutput {
     card_order: Vec<&'static str>,
     pinned_cards: Vec<&'static str>,
     cards: Vec<HistoryDashboardCardOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct UsageSignalsCommandOutput {
+    action: &'static str,
+    summary: UsageSignalsSummary,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -184,6 +184,7 @@ fn classify_simple_flag(arg: &str) -> Option<ParsedToken> {
         "--diagnostics" => Some(ParsedToken::Diagnostics),
         "--calendar-sync" => Some(ParsedToken::CalendarSync),
         "--blocking-preview" => Some(ParsedToken::BlockingPreview),
+        "--usage-signals" => Some(ParsedToken::UsageSignals),
         "--blocklist-profile-delete" => Some(ParsedToken::BlocklistProfileDelete),
         "--blocklist-category-delete" => Some(ParsedToken::BlocklistCategoryDelete),
         "--session-template-delete" => Some(ParsedToken::SessionTemplateDelete),

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -32,18 +32,18 @@ use crate::cli::{
     SiteListTarget, StatusComparisonOptions, StatusOutput, StrictCommandOutput, SyncBackupOutput,
     SyncRestoreOutput, TaskCommandOutput, TaskGoalCommandOutput, TaskGoalOutput,
     TemporaryAllowlistStatusOutput, TemporarySiteAddCommandOutput, ThemeCommandOutput, ThemePreset,
-    TimerCommandOutput, TimerStateOutput, WeekdayProfileRuleConfig, WeekdayRulesCommandOutput,
-    WeeklyGoalConfig, available_break_template_views, available_theme_preset_views,
-    build_blocking_preview_command_output, build_diagnostics_command_output,
-    build_schedule_inspection_output, build_status_output_with_comparison, build_task_goal_output,
-    display_input_value, effective_blocked_sites_for_profile, flush_stdout,
-    print_automation_triggers_command_output, print_backup_output,
-    print_blocking_preview_command_output, print_blocklist_category_command_output,
-    print_blocklist_profile_command_output, print_break_glass_command_output,
-    print_calendar_sync_command_output, print_daemon_start_command_output,
-    print_daemon_status_command_output, print_daemon_stop_command_output,
-    print_diagnostics_command_output, print_export_output, print_feature_inventory_output,
-    print_goal_carry_command_output, print_goal_command_output,
+    TimerCommandOutput, TimerStateOutput, UsageSignalsCommandOutput, WeekdayProfileRuleConfig,
+    WeekdayRulesCommandOutput, WeeklyGoalConfig, available_break_template_views,
+    available_theme_preset_views, build_blocking_preview_command_output,
+    build_diagnostics_command_output, build_schedule_inspection_output,
+    build_status_output_with_comparison, build_task_goal_output, display_input_value,
+    effective_blocked_sites_for_profile, flush_stdout, print_automation_triggers_command_output,
+    print_backup_output, print_blocking_preview_command_output,
+    print_blocklist_category_command_output, print_blocklist_profile_command_output,
+    print_break_glass_command_output, print_calendar_sync_command_output,
+    print_daemon_start_command_output, print_daemon_status_command_output,
+    print_daemon_stop_command_output, print_diagnostics_command_output, print_export_output,
+    print_feature_inventory_output, print_goal_carry_command_output, print_goal_command_output,
     print_history_dashboard_command_output, print_json, print_json_compact, print_profile_output,
     print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
     print_session_metadata_command_output, print_session_template_command_output,
@@ -51,20 +51,27 @@ use crate::cli::{
     print_site_edit_command_output, print_site_list_command_output, print_status_output,
     print_strict_command_output, print_sync_backup_output, print_sync_restore_output,
     print_task_goal_command_output, print_temporary_site_add_command_output,
-    print_theme_command_output, print_timer_state_output, print_weekday_rules_command_output,
-    profile_id, profile_view, selected_break_template_view, theme_preset_view, timer_phase_id,
-    timer_status_id,
+    print_theme_command_output, print_timer_state_output, print_usage_signals_command_output,
+    print_weekday_rules_command_output, profile_id, profile_view, selected_break_template_view,
+    theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
 const STATS_FILE_NAME: &str = "stats.toml";
 const WATCH_INTERRUPT_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const SYNC_PASSPHRASE_ENV: &str = "FOCUSTIME_SYNC_PASSPHRASE";
+const USAGE_SIGNAL_SUMMARY_LIMIT: usize = 5;
 
 static WATCH_INTERRUPTED: AtomicBool = AtomicBool::new(false);
 static WATCH_INTERRUPT_HANDLER: OnceLock<Result<(), String>> = OnceLock::new();
 
 pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
+    if let Some(surface_id) = command_usage_surface_id(&cli_command.kind)
+        && !command_usage_records_via_app(&cli_command.kind)
+    {
+        record_command_usage_direct(surface_id)?;
+    }
+
     match cli_command.kind {
         CommandKind::Start => execute_start_command(cli_command.output),
         CommandKind::Pause => execute_pause_command(cli_command.output),
@@ -111,6 +118,7 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         CommandKind::BreakGlassCancel => execute_break_glass_cancel_command(cli_command.output),
         CommandKind::Diagnostics => execute_diagnostics_command(cli_command.output),
         CommandKind::BlockingPreview => execute_blocking_preview_command(cli_command.output),
+        CommandKind::UsageSignals => execute_usage_signals_command(cli_command.output),
         CommandKind::Status {
             watch_interval_secs,
             comparison,
@@ -149,32 +157,119 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
     }
 }
 
+fn command_usage_surface_id(command: &CommandKind) -> Option<&'static str> {
+    match command {
+        CommandKind::Start => Some("start"),
+        CommandKind::Pause => Some("pause"),
+        CommandKind::Resume => Some("resume"),
+        CommandKind::Stop => Some("stop"),
+        CommandKind::Next => Some("next"),
+        CommandKind::Task { .. } => Some("task"),
+        CommandKind::TaskGoal { .. } => Some("task-goal"),
+        CommandKind::FocusIntention { .. } => Some("focus-intention"),
+        CommandKind::TaskNote { .. } => Some("task-note"),
+        CommandKind::Profile { .. } => Some("profile"),
+        CommandKind::Theme { .. } => Some("theme"),
+        CommandKind::Goal { .. } => Some("goal"),
+        CommandKind::GoalWeekly { .. } => Some("goal-weekly"),
+        CommandKind::GoalMonthly { .. } => Some("goal-monthly"),
+        CommandKind::GoalCarry { .. } => Some("goal-carry"),
+        CommandKind::GoalCarryWeekly { .. } => Some("goal-carry-weekly"),
+        CommandKind::GoalCarryMonthly { .. } => Some("goal-carry-monthly"),
+        CommandKind::Strict { .. } => Some("strict"),
+        CommandKind::Schedule { .. } => Some("schedule"),
+        CommandKind::WeekdayRules { .. } => Some("weekday-rules"),
+        CommandKind::AutomationTriggers { .. } => Some("automation-triggers"),
+        CommandKind::ScheduleDelay => Some("schedule-delay"),
+        CommandKind::BreakGlassTrigger => Some("break-glass-trigger"),
+        CommandKind::BreakGlassCancel => Some("break-glass-cancel"),
+        CommandKind::Diagnostics => Some("diagnostics"),
+        CommandKind::BlockingPreview => Some("blocking-preview"),
+        CommandKind::Status { .. } => Some("status"),
+        CommandKind::Backup { .. } => Some("backup"),
+        CommandKind::Restore { .. } => Some("restore"),
+        CommandKind::SyncBackup { .. } => Some("sync-backup"),
+        CommandKind::SyncRestore { .. } => Some("sync-restore"),
+        CommandKind::CalendarSync => Some("calendar-sync"),
+        CommandKind::Export { .. } => Some("export"),
+        CommandKind::FeatureInventory { .. } => Some("feature-inventory"),
+        CommandKind::BlocklistProfile { .. } => Some("blocklist-profile"),
+        CommandKind::BlocklistCategory { .. } => Some("blocklist-category"),
+        CommandKind::BlocklistSites { .. } => Some("blocklist-sites"),
+        CommandKind::AllowlistSiteAddTemporary { .. } => Some("allowlist-site-add-temporary"),
+        CommandKind::DaemonStart { .. } => Some("daemon-start"),
+        CommandKind::DaemonStatus => Some("daemon-status"),
+        CommandKind::DaemonStop => Some("daemon-stop"),
+        CommandKind::SessionTemplate { .. } => Some("session-template"),
+        CommandKind::HistoryDashboard { .. } => Some("history-dashboard"),
+        CommandKind::UsageSignals => None,
+    }
+}
+
+fn command_usage_records_via_app(command: &CommandKind) -> bool {
+    matches!(
+        command,
+        CommandKind::Start
+            | CommandKind::Pause
+            | CommandKind::Resume
+            | CommandKind::Stop
+            | CommandKind::Next
+            | CommandKind::Task { .. }
+            | CommandKind::FocusIntention { .. }
+            | CommandKind::TaskNote { .. }
+            | CommandKind::AllowlistSiteAddTemporary { .. }
+            | CommandKind::SessionTemplate { .. }
+            | CommandKind::ScheduleDelay
+            | CommandKind::BreakGlassTrigger
+            | CommandKind::BreakGlassCancel
+            | CommandKind::Diagnostics
+            | CommandKind::BlockingPreview
+    )
+}
+
+fn record_command_usage_direct(surface_id: &str) -> Result<(), String> {
+    let config = AppConfig::load().normalized();
+    let mut stats = FocusStats::load_with_options(stats_load_options(&config))
+        .map_err(|error| format!("Failed to load stats: {error}"))?;
+    if !stats.record_command_usage(surface_id) {
+        return Ok(());
+    }
+    stats
+        .save_with_options(stats_save_options(&config))
+        .map_err(|error| format!("Failed to save usage signals: {error}"))
+}
+
 fn execute_start_command(output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("start");
     app.start_focus_for_cli()?;
     emit_timer_command_output("start", &app, output)
 }
 
 fn execute_pause_command(output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("pause");
     app.pause_for_cli()?;
     emit_timer_command_output("pause", &app, output)
 }
 
 fn execute_resume_command(output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("resume");
     app.resume_for_cli()?;
     emit_timer_command_output("resume", &app, output)
 }
 
 fn execute_stop_command(output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("stop");
     app.stop_for_cli()?;
     emit_timer_command_output("stop", &app, output)
 }
 
 fn execute_next_command(output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("next");
     app.next_phase_for_cli()?;
     emit_timer_command_output("next", &app, output)
 }
@@ -237,6 +332,7 @@ fn daemon_connection_output(connection: &daemon::DaemonConnectionInfo) -> Daemon
 
 fn execute_task_command(label: String, output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("task");
     let created = app.select_task_label_for_cli(&label)?;
     let selected_task_label = app
         .selected_task_label_for_cli()
@@ -325,6 +421,7 @@ fn execute_focus_intention_command(
     output: OutputMode,
 ) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("focus-intention");
     let mut updated = false;
     if let Some(value) = value {
         app.set_focus_intention_for_cli(&value)?;
@@ -335,6 +432,7 @@ fn execute_focus_intention_command(
 
 fn execute_task_note_command(value: Option<String>, output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("task-note");
     let mut updated = false;
     if let Some(value) = value {
         app.set_task_note_for_cli(&value)?;
@@ -439,6 +537,7 @@ fn execute_allowlist_site_add_temporary_command(
     output: OutputMode,
 ) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("allowlist-site-add-temporary");
     let (added, refreshed) = app.add_temporary_allowlist_for_cli(&input)?;
     let payload = TemporarySiteAddCommandOutput {
         action: "allowlist-site-add-temporary",
@@ -468,6 +567,7 @@ fn execute_session_template_command(
     output: OutputMode,
 ) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("session-template");
     let (action, updated) = match command {
         SessionTemplateCommandKind::Select { name } => (
             "session-template",
@@ -1615,24 +1715,28 @@ fn validate_and_normalize_automation_triggers(
 
 fn execute_schedule_delay_command(output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("schedule-delay");
     let delayed_until = app.schedule_delay_for_cli()?;
     emit_schedule_delay_command_output("schedule-delay", delayed_until, &app, output)
 }
 
 fn execute_break_glass_trigger_command(output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("break-glass-trigger");
     app.trigger_break_glass_for_cli()?;
     emit_break_glass_command_output("break-glass-trigger", &app, output)
 }
 
 fn execute_break_glass_cancel_command(output: OutputMode) -> Result<(), String> {
     let mut app = App::new();
+    app.record_command_usage_for_cli("break-glass-cancel");
     app.cancel_break_glass_for_cli()?;
     emit_break_glass_command_output("break-glass-cancel", &app, output)
 }
 
 fn execute_diagnostics_command(output: OutputMode) -> Result<(), String> {
-    let app = App::new();
+    let mut app = App::new();
+    app.record_command_usage_for_cli("diagnostics");
     let payload = build_diagnostics_command_output(&app.setup_diagnostics);
 
     match output {
@@ -1643,12 +1747,28 @@ fn execute_diagnostics_command(output: OutputMode) -> Result<(), String> {
 }
 
 fn execute_blocking_preview_command(output: OutputMode) -> Result<(), String> {
-    let app = App::new();
+    let mut app = App::new();
+    app.record_command_usage_for_cli("blocking-preview");
     let preview = app.blocking_preview_for_cli()?;
     let payload = build_blocking_preview_command_output(&preview);
 
     match output {
         OutputMode::Text => print_blocking_preview_command_output(&payload),
+        OutputMode::Json => print_json(&payload)?,
+    }
+    Ok(())
+}
+
+fn execute_usage_signals_command(output: OutputMode) -> Result<(), String> {
+    let config = AppConfig::load().normalized();
+    let stats = FocusStats::load_with_options(stats_load_options(&config))
+        .map_err(|error| format!("Failed to load stats: {error}"))?;
+    let payload = UsageSignalsCommandOutput {
+        action: "usage-signals",
+        summary: stats.usage_signal_summary(USAGE_SIGNAL_SUMMARY_LIMIT),
+    };
+    match output {
+        OutputMode::Text => print_usage_signals_command_output(&payload),
         OutputMode::Json => print_json(&payload)?,
     }
     Ok(())
@@ -2475,6 +2595,38 @@ mod tests {
             .get_or_init(|| Mutex::new(()))
             .lock()
             .expect("watch test guard should lock")
+    }
+
+    #[test]
+    fn command_usage_surface_id_maps_expected_surfaces() {
+        assert_eq!(command_usage_surface_id(&CommandKind::Start), Some("start"));
+        assert_eq!(
+            command_usage_surface_id(&CommandKind::Task {
+                label: "docs".to_string()
+            }),
+            Some("task")
+        );
+        assert_eq!(
+            command_usage_surface_id(&CommandKind::Status {
+                watch_interval_secs: None,
+                comparison: StatusComparisonOptions::default(),
+            }),
+            Some("status")
+        );
+        assert_eq!(command_usage_surface_id(&CommandKind::UsageSignals), None);
+    }
+
+    #[test]
+    fn command_usage_records_via_app_matches_expected_commands() {
+        assert!(command_usage_records_via_app(&CommandKind::Start));
+        assert!(command_usage_records_via_app(&CommandKind::Diagnostics));
+        assert!(!command_usage_records_via_app(&CommandKind::Backup {
+            dir: None
+        }));
+        assert!(!command_usage_records_via_app(&CommandKind::Status {
+            watch_interval_secs: None,
+            comparison: StatusComparisonOptions::default(),
+        }));
     }
 
     #[test]

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -69,7 +69,9 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
     if let Some(surface_id) = command_usage_surface_id(&cli_command.kind)
         && !command_usage_records_via_app(&cli_command.kind)
     {
-        record_command_usage_direct(surface_id)?;
+        if let Err(error) = record_command_usage_direct(surface_id) {
+            eprintln!("Warning: failed to record command usage signal for `{surface_id}`: {error}");
+        }
     }
 
     match cli_command.kind {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -12,7 +12,7 @@ use crate::cli::{
     StatsGrowthSummary, StatsRetentionStatusOutput, StatusComparisonOutput, StatusOutput,
     StrictCommandOutput, SyncBackupOutput, SyncRestoreOutput, TaskGoalCommandOutput,
     TaskGoalOutput, TemporarySiteAddCommandOutput, ThemeCommandOutput, TimerStateOutput,
-    WeekdayRulesCommandOutput, Write, format_schedule_conflict,
+    UsageSignalsCommandOutput, WeekdayRulesCommandOutput, Write, format_schedule_conflict,
     inspect_schedule_conflicts_from_config, io,
 };
 use chrono::{Local, TimeZone};
@@ -175,6 +175,41 @@ pub(super) fn print_history_dashboard_command_output(payload: &HistoryDashboardC
     for card in &payload.cards {
         let marker = if card.pinned { "*" } else { " " };
         println!("  {marker} {} ({})", card.label, card.id);
+    }
+}
+
+pub(super) fn print_usage_signals_command_output(payload: &UsageSignalsCommandOutput) {
+    println!("Usage signals summary:");
+    print_usage_signal_summary("Commands", &payload.summary.commands);
+    print_usage_signal_summary("Screens", &payload.summary.screens);
+}
+
+fn print_usage_signal_summary(label: &str, summary: &crate::stats::UsageSignalSummary) {
+    println!(
+        "{label}: {} events across {} surface(s)",
+        summary.total_events, summary.unique_surfaces
+    );
+    if summary.top.is_empty() {
+        println!("  Top: none");
+    } else {
+        println!("  Top:");
+        for entry in &summary.top {
+            println!(
+                "    - {}: {} ({}%)",
+                entry.surface, entry.count, entry.share_pct
+            );
+        }
+    }
+    if summary.rare.is_empty() {
+        println!("  Rare: none");
+    } else {
+        println!("  Rare:");
+        for entry in &summary.rare {
+            println!(
+                "    - {}: {} ({}%)",
+                entry.surface, entry.count, entry.share_pct
+            );
+        }
     }
 }
 

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -71,6 +71,7 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::Diagnostics
             | ParsedToken::CalendarSync
             | ParsedToken::BlockingPreview
+            | ParsedToken::UsageSignals
             | ParsedToken::Backup(_)
             | ParsedToken::Restore(_)
             | ParsedToken::SyncBackup(_)
@@ -214,6 +215,9 @@ pub(super) fn parse_primary_command(
             }
             ParsedToken::BlockingPreview => {
                 set_primary_command(&mut primary, PrimaryCommand::BlockingPreview)?
+            }
+            ParsedToken::UsageSignals => {
+                set_primary_command(&mut primary, PrimaryCommand::UsageSignals)?
             }
             ParsedToken::Backup(dir) => {
                 set_primary_command(&mut primary, PrimaryCommand::Backup(dir.clone()))?
@@ -484,6 +488,10 @@ pub(super) fn finalize_cli_action(
         })),
         Some(PrimaryCommand::BlockingPreview) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::BlockingPreview,
+            output,
+        })),
+        Some(PrimaryCommand::UsageSignals) => Ok(CliAction::RunCommand(CliCommand {
+            kind: CommandKind::UsageSignals,
             output,
         })),
         Some(PrimaryCommand::Pause) => Ok(CliAction::RunCommand(CliCommand {
@@ -1146,6 +1154,7 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Diagnostics => "--diagnostics",
         PrimaryCommand::CalendarSync => "--calendar-sync",
         PrimaryCommand::BlockingPreview => "--blocking-preview",
+        PrimaryCommand::UsageSignals => "--usage-signals",
         PrimaryCommand::Status => "--status",
         PrimaryCommand::Backup(_) => "--backup",
         PrimaryCommand::Restore(_) => "--restore",

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -50,6 +50,30 @@ fn parse_status_supports_json_mode() {
 }
 
 #[test]
+fn parse_usage_signals_supports_text_mode() {
+    let parsed = parse(&["--usage-signals"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::UsageSignals,
+            output: OutputMode::Text
+        })
+    );
+}
+
+#[test]
+fn parse_usage_signals_supports_json_mode() {
+    let parsed = parse(&["--usage-signals", "--json"]).unwrap();
+    assert_eq!(
+        parsed,
+        CliAction::RunCommand(CliCommand {
+            kind: CommandKind::UsageSignals,
+            output: OutputMode::Json
+        })
+    );
+}
+
+#[test]
 fn parse_status_watch_without_interval_uses_default_cadence() {
     let parsed = parse(&["--status", "--watch"]).unwrap();
     assert_eq!(

--- a/src/feature_inventory.rs
+++ b/src/feature_inventory.rs
@@ -420,6 +420,17 @@ const FEATURE_SEEDS: &[FeatureSeed] = &[
         failure_impact: 2,
     },
     FeatureSeed {
+        feature_id: "usage-signal-inspection",
+        name: "Usage signal inspection",
+        surface: FeatureSurface::Stats,
+        description: "Review command and screen frequency summaries to guide feature cleanup decisions.",
+        cli_flags: &["--usage-signals"],
+        value: 3,
+        complexity: 2,
+        support_burden: 2,
+        failure_impact: 2,
+    },
+    FeatureSeed {
         feature_id: "stats-export-artifacts",
         name: "Stats export artifacts",
         surface: FeatureSurface::Stats,

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,9 @@ fn main() -> io::Result<()> {
     }
 
     let mut guard = TerminalGuard::new()?;
-    run_app(&mut guard.terminal, App::new())
+    let mut app = App::new();
+    app.record_current_screen_usage();
+    run_app(&mut guard.terminal, app)
 }
 
 fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) -> io::Result<()> {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -20,9 +20,9 @@ use helpers::{
     average_two_percentages, backfilled_time_of_day_bucket, best_goal_streak,
     consistency_score_from_active_days, current_goal_streak, daily_has_activity, days_in_month,
     format_week_label, month_key_for_day, normalize_session_metadata_text,
-    normalize_task_goal_targets, normalize_task_planner_state, parse_week_label,
-    percentage_round_nearest, planner_state_labels_for_keys, profile_bucket_for, week_key_for_day,
-    weekly_completion_score_pct, write_atomic_bytes,
+    normalize_task_goal_targets, normalize_task_planner_state, normalize_usage_counts,
+    parse_week_label, percentage_round_nearest, planner_state_labels_for_keys, profile_bucket_for,
+    week_key_for_day, weekly_completion_score_pct, write_atomic_bytes,
 };
 mod analytics;
 mod export;
@@ -435,6 +435,27 @@ impl StatsRetentionPruneResult {
     pub fn any_removed(self) -> bool {
         self.total_removed() > 0
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UsageSignalEntry {
+    pub surface: String,
+    pub count: u64,
+    pub share_pct: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UsageSignalSummary {
+    pub total_events: u64,
+    pub unique_surfaces: usize,
+    pub top: Vec<UsageSignalEntry>,
+    pub rare: Vec<UsageSignalEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UsageSignalsSummary {
+    pub commands: UsageSignalSummary,
+    pub screens: UsageSignalSummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1083,6 +1104,10 @@ struct PersistedStats {
     break_glass_overrides: Vec<BreakGlassOverrideEvent>,
     #[serde(default)]
     task_goal_targets: BTreeMap<String, DailyGoalSnapshot>,
+    #[serde(default)]
+    command_usage_counts: BTreeMap<String, u64>,
+    #[serde(default)]
+    screen_usage_counts: BTreeMap<String, u64>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1099,6 +1124,8 @@ pub struct FocusStats {
     session_interruptions: Vec<SessionInterruptionEvent>,
     break_glass_overrides: Vec<BreakGlassOverrideEvent>,
     task_goal_targets: BTreeMap<String, DailyGoalSnapshot>,
+    command_usage_counts: BTreeMap<String, u64>,
+    screen_usage_counts: BTreeMap<String, u64>,
 }
 
 pub fn current_day_key() -> String {

--- a/src/stats/analytics.rs
+++ b/src/stats/analytics.rs
@@ -5,11 +5,11 @@ use crate::stats::{
     MonthlyStats, ProductivityComparisonFilter, ProductivityComparisonRow, ProfileBucket,
     ProfileEffectiveness, ProfileEffectivenessAccumulator, ProfileTotals, StatsGrowthSection,
     StatsGrowthSummary, StatsRetentionConfig, StatsRetentionPruneResult, StreakRiskForecast,
-    TimeOfDayBucket, WeeklyConsistency, WeeklyFocusScore, WeeklyStats, average_two_percentages,
-    backfilled_time_of_day_bucket, canonical_task_label, consistency_score_from_active_days,
-    daily_has_activity, days_in_month, format_week_label, month_key_for_day, normalize_task_label,
-    parse_week_label, percentage_round_nearest, profile_bucket_for, week_key_for_day,
-    weekly_completion_score_pct,
+    TimeOfDayBucket, UsageSignalEntry, UsageSignalSummary, UsageSignalsSummary, WeeklyConsistency,
+    WeeklyFocusScore, WeeklyStats, average_two_percentages, backfilled_time_of_day_bucket,
+    canonical_task_label, consistency_score_from_active_days, daily_has_activity, days_in_month,
+    format_week_label, month_key_for_day, normalize_task_label, parse_week_label,
+    percentage_round_nearest, profile_bucket_for, week_key_for_day, weekly_completion_score_pct,
 };
 
 impl FocusStats {
@@ -674,6 +674,16 @@ impl FocusStats {
                 self.task_goal_targets.len(),
                 &self.task_goal_targets,
             ),
+            stats_growth_section(
+                "command_usage_counts",
+                self.command_usage_counts.len(),
+                &self.command_usage_counts,
+            ),
+            stats_growth_section(
+                "screen_usage_counts",
+                self.screen_usage_counts.len(),
+                &self.screen_usage_counts,
+            ),
         ];
         sections.sort_by(|left, right| left.name.cmp(&right.name));
         let total_record_count = sections.iter().fold(0_usize, |total, section| {
@@ -771,6 +781,14 @@ impl FocusStats {
     ) -> StatsRetentionPruneResult {
         let mut cloned = self.clone();
         cloned.apply_retention_policy(retention, reference_day)
+    }
+
+    pub fn usage_signal_summary(&self, limit: usize) -> UsageSignalsSummary {
+        let limit = limit.max(1);
+        UsageSignalsSummary {
+            commands: usage_signal_summary_for_counts(&self.command_usage_counts, limit),
+            screens: usage_signal_summary_for_counts(&self.screen_usage_counts, limit),
+        }
     }
 }
 
@@ -1193,6 +1211,43 @@ fn div_ceil_u64(value: u64, divisor: u64) -> u64 {
         return value;
     }
     value.div_ceil(divisor)
+}
+
+fn usage_signal_summary_for_counts(
+    counts: &BTreeMap<String, u64>,
+    limit: usize,
+) -> UsageSignalSummary {
+    let total_events = counts
+        .values()
+        .copied()
+        .fold(0_u64, |total, value| total.saturating_add(value));
+    let unique_surfaces = counts.len();
+    let mut entries: Vec<(String, u64)> = counts.iter().map(|(k, v)| (k.clone(), *v)).collect();
+
+    let mut top_entries = entries.clone();
+    top_entries.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    top_entries.truncate(limit);
+
+    entries.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+    entries.truncate(limit);
+
+    UsageSignalSummary {
+        total_events,
+        unique_surfaces,
+        top: usage_signal_rows(top_entries, total_events),
+        rare: usage_signal_rows(entries, total_events),
+    }
+}
+
+fn usage_signal_rows(entries: Vec<(String, u64)>, total_events: u64) -> Vec<UsageSignalEntry> {
+    entries
+        .into_iter()
+        .map(|(surface, count)| UsageSignalEntry {
+            surface,
+            count,
+            share_pct: percentage_round_nearest(count, total_events),
+        })
+        .collect()
 }
 
 fn stats_growth_section(

--- a/src/stats/helpers.rs
+++ b/src/stats/helpers.rs
@@ -116,6 +116,22 @@ pub(super) fn normalize_task_goal_targets(
     normalized
 }
 
+pub(super) fn normalize_usage_counts(input: BTreeMap<String, u64>) -> BTreeMap<String, u64> {
+    let mut normalized = BTreeMap::new();
+    for (surface, count) in input {
+        if count == 0 {
+            continue;
+        }
+        let key = surface.trim().to_ascii_lowercase();
+        if key.is_empty() {
+            continue;
+        }
+        let entry = normalized.entry(key).or_insert(0_u64);
+        *entry = entry.saturating_add(count);
+    }
+    normalized
+}
+
 pub(super) fn normalize_session_metadata_text(input: &str) -> Option<String> {
     let trimmed = input.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -7,7 +7,7 @@ use crate::stats::{
     SessionInterruptionEvent, SessionStats, StatsLoadOptions, StatsSaveOptions,
     backfilled_time_of_day_bucket, io, normalize_session_metadata_text,
     normalize_task_goal_targets, normalize_task_label, normalize_task_planner_state,
-    planner_state_labels_for_keys, write_atomic_bytes,
+    normalize_usage_counts, planner_state_labels_for_keys, write_atomic_bytes,
 };
 
 impl FocusStats {
@@ -70,6 +70,8 @@ impl FocusStats {
                 persisted.task_label_archived,
             );
         let task_goal_targets = normalize_task_goal_targets(persisted.task_goal_targets);
+        let command_usage_counts = normalize_usage_counts(persisted.command_usage_counts);
+        let screen_usage_counts = normalize_usage_counts(persisted.screen_usage_counts);
         let mut focus_sessions = Vec::new();
         for session in persisted.focus_sessions {
             if let Some(task_label) = normalize_task_label(&session.task_label) {
@@ -138,6 +140,8 @@ impl FocusStats {
             session_interruptions,
             break_glass_overrides,
             task_goal_targets,
+            command_usage_counts,
+            screen_usage_counts,
         }
     }
 
@@ -160,6 +164,8 @@ impl FocusStats {
             session_interruptions: self.session_interruptions.clone(),
             break_glass_overrides: self.break_glass_overrides.clone(),
             task_goal_targets: self.task_goal_targets.clone(),
+            command_usage_counts: self.command_usage_counts.clone(),
+            screen_usage_counts: self.screen_usage_counts.clone(),
         }
     }
 

--- a/src/stats/recording.rs
+++ b/src/stats/recording.rs
@@ -1,5 +1,5 @@
 use crate::stats::{
-    BreakGlassOverrideEvent, DailyGoalSnapshot, FocusSessionMetadata, FocusSessionRecord,
+    BTreeMap, BreakGlassOverrideEvent, DailyGoalSnapshot, FocusSessionMetadata, FocusSessionRecord,
     FocusStats, ProfileId, SessionInterruptionEvent, SessionInterruptionReason, TimeOfDayBucket,
     month_key_for_day, normalize_session_metadata_text, normalize_task_label, task_label_index,
     week_key_for_day,
@@ -200,6 +200,14 @@ impl FocusStats {
         self.monthly_goal_snapshots.insert(key, goal);
         true
     }
+
+    pub fn record_command_usage(&mut self, surface_id: &str) -> bool {
+        record_usage_count(&mut self.command_usage_counts, surface_id)
+    }
+
+    pub fn record_screen_usage(&mut self, surface_id: &str) -> bool {
+        record_usage_count(&mut self.screen_usage_counts, surface_id)
+    }
 }
 
 fn current_timestamp_epoch_secs() -> u64 {
@@ -211,4 +219,14 @@ fn completion_time_of_day_bucket(epoch_secs: Option<u64>) -> Option<TimeOfDayBuc
     let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(epoch, 0)?;
     let local_time = timestamp.with_timezone(&chrono::Local);
     Some(TimeOfDayBucket::from_hour(local_time.hour()))
+}
+
+fn record_usage_count(counts: &mut BTreeMap<String, u64>, surface_id: &str) -> bool {
+    let key = surface_id.trim().to_ascii_lowercase();
+    if key.is_empty() {
+        return false;
+    }
+    let entry = counts.entry(key).or_insert(0);
+    *entry = entry.saturating_add(1);
+    true
 }

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -109,6 +109,45 @@ fn recording_updates_session_and_daily_totals() {
 }
 
 #[test]
+fn usage_signal_recording_normalizes_and_accumulates_counts() {
+    let mut stats = FocusStats::default();
+    assert!(stats.record_command_usage("  STATUS  "));
+    assert!(stats.record_command_usage("status"));
+    assert!(stats.record_screen_usage(" Site-Manager "));
+
+    assert_eq!(stats.command_usage_counts.get("status"), Some(&2));
+    assert_eq!(stats.screen_usage_counts.get("site-manager"), Some(&1));
+}
+
+#[test]
+fn usage_signal_summary_reports_top_and_rare_entries() {
+    let mut stats = FocusStats::default();
+    stats.record_command_usage("status");
+    stats.record_command_usage("status");
+    stats.record_command_usage("status");
+    stats.record_command_usage("backup");
+    stats.record_command_usage("backup");
+    stats.record_command_usage("profile");
+    stats.record_screen_usage("timer");
+    stats.record_screen_usage("timer");
+    stats.record_screen_usage("site-manager");
+
+    let summary = stats.usage_signal_summary(2);
+    assert_eq!(summary.commands.total_events, 6);
+    assert_eq!(summary.commands.unique_surfaces, 3);
+    assert_eq!(summary.commands.top[0].surface, "status");
+    assert_eq!(summary.commands.top[0].count, 3);
+    assert_eq!(summary.commands.top[0].share_pct, 50);
+    assert_eq!(summary.commands.rare[0].surface, "profile");
+    assert_eq!(summary.commands.rare[0].count, 1);
+    assert_eq!(summary.commands.rare[0].share_pct, 17);
+    assert_eq!(summary.screens.total_events, 3);
+    assert_eq!(summary.screens.unique_surfaces, 2);
+    assert_eq!(summary.screens.top[0].surface, "timer");
+    assert_eq!(summary.screens.rare[0].surface, "site-manager");
+}
+
+#[test]
 fn task_planner_state_normalizes_and_deduplicates_labels() {
     let mut stats = FocusStats::default();
     let changed = stats.update_task_planner_state(


### PR DESCRIPTION
## What

Add local usage signal collection and reporting for CLI command surfaces and TUI screens, including a new `--usage-signals` command for text/JSON summaries.

## Why

We need concrete, local usage frequency data to prioritize feature cleanup and roadmap decisions with real command/screen usage patterns instead of assumptions.

Closes #382.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new --usage-signals command that prints a summary of command and screen usage (top and rare entries).
  * App now records screen-usage events when switching modes to improve usage tracking.

* **Documentation**
  * Feature inventory/report updated with a new "usage-signal-inspection" entry and adjusted totals.

* **Tests**
  * Added unit and CLI tests covering usage-signal recording and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->