### PR TITLE
Prepare v0.14.1 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.14.0 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.14.1 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -116,7 +116,7 @@ When preparing a release update, keep these files aligned:
 - `README.md` release automation and latest-release references
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
-- Release tag examples in docs use the current target release version (for example, `v0.14.0`)
+- Release tag examples in docs use the current target release version (for example, `v0.14.1`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,4 +148,5 @@ sequenceDiagram
 - Keep platform-specific behavior explicit with `#[cfg(...)]` in the module that
   owns it.
 - For release docs updates, keep architecture-facing terminology aligned with the
-  module names and responsibility language used in `README.md` and release notes.
+  module names and responsibility language used in `README.md`, `CHANGELOG.md`,
+  and release tag examples in contributor-facing docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-05-31
+
+### Added
+
+- **Feature inventory with value and maintenance scoring (#401):** added the feature-inventory command/report workflow with value/maintenance scoring, JSON output support, and CLI contract coverage.
+- **Keep/Merge/Remove decision rubric (#402):** added deterministic rubric scoring and generated rubric inventory artifacts for decision recommendations.
+- **Usage signal collection for command and screen frequency (#403):** added usage-signal capture in app/CLI flows and usage-signal summary support in stats surfaces.
+
+### Changed
+
+- **CI toolchain maintenance (#379):** bumped `crate-ci/typos` from `1.46.3` to `1.47.0`.
+
+### Fixed
+
+- **Feature-inventory markdown stability (#401, #402):** hardened feature-inventory/rubric markdown rendering parity by normalizing line endings and escaping markdown formula content.
+
 ## [0.14.0] - 2026-05-28
 
 ### Added
@@ -355,7 +371,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/utilForever/focustime/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/utilForever/focustime/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/utilForever/focustime/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/utilForever/focustime/compare/v0.12.1...v0.13.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ The project uses Conventional Commit-style release commits:
 
 Before preparing a release commit, make sure all CI jobs pass for the release changes.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.14.0`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.14.1`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -970,12 +970,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.14.0`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.14.1`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.14.0](https://github.com/utilForever/focustime/releases/tag/v0.14.0).
+The latest stable release is [v0.14.1](https://github.com/utilForever/focustime/releases/tag/v0.14.1).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

- Bump crate version metadata from `0.14.0` to `0.14.1` in `Cargo.toml` and `Cargo.lock`.
- Align `v0.14.1` release references across `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `ARCHITECTURE.md` release guidance.
- Expand `CHANGELOG.md` for `0.14.1` to include merged PR scope (`#401`, `#402`, `#403`, `#379`) and roll compare links to `v0.14.1`.

## Why

This release update ensures version metadata, release docs, and changelog notes are synchronized before tagging `v0.14.1`.

Closes #404.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature-inventory workflow for organized feature management and tracking
  * Keep/Merge/Remove decision rubric to guide feature evaluation decisions
  * Usage-signal collection capabilities for tracking feature usage patterns

* **Bug Fixes**
  * Enhanced feature-inventory markdown stability with improved formatting handling

* **Chores**
  * Version bumped to 0.14.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->