### PR TITLE
Merge overlapping timer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,11 +425,10 @@ Open profile manager from timer view with **`p`**.
 - `↑/↓` (default `navigate_up`/`navigate_down`): move between profiles
 - `Enter` (default `confirm`): apply selected profile
 - `e`: open profile/settings editor
-- `[` / `]`: cycle the active break template for fast short/long break switching
 - In editor: `↑/↓` selects field, `←/→` adjusts numeric/boolean values (including **Theme preset**), `Type/Backspace` edits WakaTime project/language, `Enter` saves (all defaults are configurable via navigation/edit shortcut fields)
 
-Profile selection, break template selection, theme preset selection, custom durations,
-and profile-scoped automation settings are persisted in `config.toml`.
+Profile selection, theme preset selection, custom durations, and profile-scoped
+automation settings are persisted in `config.toml`.
 
 ## Session planner
 
@@ -488,7 +487,6 @@ matches `docs.example.com` and `api.example.com`, but does **not** match
 ```toml
 schema_version = 1
 selected_profile = "custom"
-selected_break_template = "Classic"
 selected_session_template = "Deep Flow"
 selected_theme_preset = "classic"
 selected_blocklist_profile = "Work"
@@ -519,18 +517,6 @@ quit = "q"
 [history_dashboard]
 card_order = ["session_summary", "focus_score", "goal_streak", "focus_risk", "weekly_allocation", "last_interruption", "stats_growth", "retention", "comparison_filters"]
 pinned_cards = ["session_summary", "focus_score"]
-
-[[break_templates]]
-name = "Classic"
-short_break_secs = 300
-long_break_secs = 900
-long_break_interval = 4
-
-[[break_templates]]
-name = "Deep Work"
-short_break_secs = 600
-long_break_secs = 1800
-long_break_interval = 3
 
 [[blocklist_profiles]]
 name = "Work"

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,14 +16,13 @@ use crate::calendar::{CalendarBusyWindow, active_window_at as active_calendar_wi
 use crate::config::{
     AppConfig, AutoStartConfig, AutomationTriggerRuleConfig, BlockingBackendConfig,
     BlockingBackendPolicyConfig, BlocklistCategoryConfig, BlocklistProfileConfig,
-    BreakTemplateConfig, CalendarSyncConfig, CommandBlockingBackendConfig, CustomProfileConfig,
-    DailyGoalConfig, FeatureFlagsConfig, GoalCarryOverConfig, HistoryDashboardConfig,
-    HistoryKpiCardId, MonthlyGoalConfig, NotificationConfig, OneTimeFocusWindowConfig,
-    ProfileAutomationConfig, ProfileAutomationSettingsConfig, ProfileId,
-    RecurringFocusWindowConfig, RecurringScheduleConfig, ScheduleRuntimeConfig,
-    SessionTemplateConfig, StatsRetentionConfig, ThemePreset, WakatimeMetadataConfig,
-    WakatimeRuntimeConfig, WeekdayProfileRuleConfig, WeeklyGoalConfig,
-    validate_automation_trigger_rules,
+    CalendarSyncConfig, CommandBlockingBackendConfig, CustomProfileConfig, DailyGoalConfig,
+    FeatureFlagsConfig, GoalCarryOverConfig, HistoryDashboardConfig, HistoryKpiCardId,
+    MonthlyGoalConfig, NotificationConfig, OneTimeFocusWindowConfig, ProfileAutomationConfig,
+    ProfileAutomationSettingsConfig, ProfileId, RecurringFocusWindowConfig,
+    RecurringScheduleConfig, ScheduleRuntimeConfig, SessionTemplateConfig, StatsRetentionConfig,
+    ThemePreset, WakatimeMetadataConfig, WakatimeRuntimeConfig, WeekdayProfileRuleConfig,
+    WeeklyGoalConfig, validate_automation_trigger_rules,
 };
 use crate::integration::{IntegrationLifecycleEvent, IntegrationRuntime};
 use crate::notifications::PhaseNotifier;
@@ -183,7 +182,6 @@ const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
 const DEFAULT_BLOCKLIST_CATEGORY_NAME: &str = "General";
-const UNLINKED_BREAK_TEMPLATE_NAME: &str = "Custom";
 #[cfg(not(test))]
 const STATS_FILE_NAME: &str = "stats.toml";
 pub(crate) const PLANNER_RECENT_LABEL_LIMIT: usize = 5;
@@ -270,12 +268,6 @@ fn blocklist_category_index(categories: &[BlocklistCategoryConfig], selected_nam
         .unwrap_or(0)
 }
 
-fn break_template_index(templates: &[BreakTemplateConfig], selected_name: &str) -> Option<usize> {
-    templates
-        .iter()
-        .position(|template| template.name.eq_ignore_ascii_case(selected_name))
-}
-
 fn session_template_index(
     templates: &[SessionTemplateConfig],
     selected_name: &str,
@@ -283,44 +275,6 @@ fn session_template_index(
     templates
         .iter()
         .position(|template| template.name.eq_ignore_ascii_case(selected_name))
-}
-
-fn break_template_matches_custom_profile(
-    template: &BreakTemplateConfig,
-    custom_profile: &CustomProfileConfig,
-) -> bool {
-    let template = template.normalized();
-    let custom_profile = custom_profile.normalized();
-    template.short_break_secs == custom_profile.short_break_secs
-        && template.long_break_secs == custom_profile.long_break_secs
-        && template.long_break_interval == custom_profile.long_break_interval
-}
-
-fn break_template_index_for_custom_profile(
-    templates: &[BreakTemplateConfig],
-    custom_profile: &CustomProfileConfig,
-) -> Option<usize> {
-    templates
-        .iter()
-        .position(|template| break_template_matches_custom_profile(template, custom_profile))
-}
-
-fn resolve_active_break_template(
-    templates: &[BreakTemplateConfig],
-    selected_name: &str,
-    custom_profile: &CustomProfileConfig,
-) -> Option<usize> {
-    let selected = break_template_index(templates, selected_name);
-    if let Some(selected_index) = selected {
-        if templates
-            .get(selected_index)
-            .is_some_and(|template| break_template_matches_custom_profile(template, custom_profile))
-        {
-            return Some(selected_index);
-        }
-    }
-
-    break_template_index_for_custom_profile(templates, custom_profile)
 }
 
 fn blocking_backend_policy_for_config(
@@ -835,8 +789,6 @@ pub struct App {
     site_edit_index: Option<usize>,
     pub blocklist_profiles: Vec<BlocklistProfileConfig>,
     active_blocklist_profile: usize,
-    pub break_templates: Vec<BreakTemplateConfig>,
-    active_break_template: Option<usize>,
     pub session_templates: Vec<SessionTemplateConfig>,
     active_session_template: Option<usize>,
     pub blocklist_profile_input: String,
@@ -1006,7 +958,6 @@ impl App {
         let blocklist_profiles = config.blocklist_profiles.clone();
         let active_blocklist_profile =
             blocklist_profile_index(&blocklist_profiles, &config.selected_blocklist_profile);
-        let break_templates = config.break_templates.clone();
         let (shortcuts, shortcut_diagnostics) =
             ShortcutBindings::from_config_with_diagnostics(&config.shortcuts);
         let shortcut_config_error = (!shortcut_diagnostics.is_empty()).then(|| {
@@ -1043,11 +994,6 @@ impl App {
         .join(" ");
         let initial_config_error =
             (!initial_config_error.trim().is_empty()).then_some(initial_config_error);
-        let active_break_template = resolve_active_break_template(
-            &break_templates,
-            &config.selected_break_template,
-            &custom_profile,
-        );
         let session_templates = config.session_templates.clone();
         let active_session_template =
             session_template_index(&session_templates, &config.selected_session_template);
@@ -1093,8 +1039,6 @@ impl App {
             site_edit_index: None,
             blocklist_profiles,
             active_blocklist_profile,
-            break_templates,
-            active_break_template,
             session_templates,
             active_session_template,
             blocklist_profile_input: String::new(),
@@ -1191,7 +1135,6 @@ impl App {
             stats_has_unsaved_elapsed: false,
             shortcuts,
         };
-        app.clamp_break_template_selection();
         app.recompute_blocker_sites_from_active_profile();
         app.restore_in_progress_session();
         app.restore_cli_workflow_state();
@@ -1742,13 +1685,6 @@ impl App {
             .unwrap_or(1)
     }
 
-    pub fn active_break_template_name(&self) -> &str {
-        self.active_break_template
-            .and_then(|index| self.break_templates.get(index))
-            .map(|template| template.name.as_str())
-            .unwrap_or(UNLINKED_BREAK_TEMPLATE_NAME)
-    }
-
     pub fn active_session_template_name(&self) -> Option<&str> {
         self.active_session_template
             .and_then(|index| self.session_templates.get(index))
@@ -1759,53 +1695,11 @@ impl App {
         self.session_templates.len()
     }
 
-    pub fn active_break_template_summary(&self) -> String {
-        if let Some(template) = self
-            .active_break_template
-            .and_then(|index| self.break_templates.get(index))
-        {
-            format!(
-                "{}/{}, every {} focus",
-                format_duration_label(template.short_break_secs),
-                format_duration_label(template.long_break_secs),
-                template.long_break_interval
-            )
-        } else {
-            let custom_profile = self.custom_profile.normalized();
-            format!(
-                "{}/{}, every {} focus",
-                format_duration_label(custom_profile.short_break_secs),
-                format_duration_label(custom_profile.long_break_secs),
-                custom_profile.long_break_interval
-            )
-        }
-    }
-
-    fn selected_break_template_for_persistence(&self) -> String {
-        self.active_break_template
-            .and_then(|index| self.break_templates.get(index))
-            .map(|template| template.name.clone())
-            .unwrap_or_default()
-    }
-
     fn selected_session_template_for_persistence(&self) -> String {
         self.active_session_template
             .and_then(|index| self.session_templates.get(index))
             .map(|template| template.name.clone())
             .unwrap_or_default()
-    }
-
-    fn sync_active_break_template_to_custom_profile(&mut self) {
-        let selected_name = self
-            .active_break_template
-            .and_then(|index| self.break_templates.get(index))
-            .map(|template| template.name.clone())
-            .unwrap_or_default();
-        self.active_break_template = resolve_active_break_template(
-            &self.break_templates,
-            &selected_name,
-            &self.custom_profile,
-        );
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) {

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -538,8 +538,6 @@ impl App {
             blocking_backend,
             selected_profile: self.selected_profile,
             custom_profile: Some(custom_profile),
-            break_templates: self.break_templates.clone(),
-            selected_break_template: self.selected_break_template_for_persistence(),
             weekday_profile_rules: self.weekday_profile_rules.clone(),
             session_templates: self.session_templates.clone(),
             selected_session_template: self.selected_session_template_for_persistence(),

--- a/src/app/profile_management.rs
+++ b/src/app/profile_management.rs
@@ -1,6 +1,6 @@
 use crate::app::{
-    App, AppMode, BreakTemplateConfig, KeyEvent, Local, NavigationAction,
-    PROFILE_EDIT_AUTOMATION_TRIGGER_ACTION_INDEX, PROFILE_EDIT_AUTOMATION_TRIGGER_ADD_REMOVE_INDEX,
+    App, AppMode, KeyEvent, Local, NavigationAction, PROFILE_EDIT_AUTOMATION_TRIGGER_ACTION_INDEX,
+    PROFILE_EDIT_AUTOMATION_TRIGGER_ADD_REMOVE_INDEX,
     PROFILE_EDIT_AUTOMATION_TRIGGER_BLOCKLIST_INDEX,
     PROFILE_EDIT_AUTOMATION_TRIGGER_CONDITION_INDEX, PROFILE_EDIT_AUTOMATION_TRIGGER_DELAY_INDEX,
     PROFILE_EDIT_AUTOMATION_TRIGGER_INDEX, PROFILE_EDIT_AUTOMATION_TRIGGER_PROFILE_INDEX,
@@ -29,11 +29,9 @@ use crate::app::{
 };
 use crate::config::validate_automation_trigger_rules;
 
-const PROFILE_MANAGER_SHORTCUT_ACTIONS: [ShortcutAction; 4] = [
+const PROFILE_MANAGER_SHORTCUT_ACTIONS: [ShortcutAction; 2] = [
     ShortcutAction::BackProfileManager,
     ShortcutAction::ProfileEdit,
-    ShortcutAction::SelectPreviousBreakTemplate,
-    ShortcutAction::SelectNextBreakTemplate,
 ];
 
 impl App {
@@ -135,7 +133,6 @@ impl App {
         self.profile_selection_index = profile_index(self.selected_profile);
         self.clamp_profile_selection();
         self.clamp_profile_edit_schedule_selection();
-        self.clamp_break_template_selection();
     }
 
     pub(super) fn exit_profile_manager(&mut self) {
@@ -226,8 +223,6 @@ impl App {
         match action {
             ShortcutAction::BackProfileManager => self.exit_profile_manager(),
             ShortcutAction::ProfileEdit => self.begin_profile_edit(),
-            ShortcutAction::SelectPreviousBreakTemplate => self.select_previous_break_template(),
-            ShortcutAction::SelectNextBreakTemplate => self.select_next_break_template(),
             _ => {}
         }
     }
@@ -325,7 +320,6 @@ impl App {
             .as_ref()
             .is_some_and(|snapshot| snapshot.goal_carry_over != self.goal_carry_over);
         self.custom_profile = self.custom_profile.normalized();
-        self.sync_active_break_template_to_custom_profile();
         self.recurring_schedule = normalized_schedule;
         self.wakatime_metadata = self.wakatime_metadata.normalized();
         if automation_triggers_changed
@@ -567,81 +561,5 @@ impl App {
             .resolved_project_language_for_task_label(self.current_task_label());
         self.integrations
             .set_wakatime_metadata(WakatimeHeartbeatMetadata { project, language });
-    }
-
-    pub(super) fn clamp_break_template_selection(&mut self) {
-        if self.break_templates.is_empty() {
-            self.break_templates.push(BreakTemplateConfig::default());
-            return;
-        }
-        if let Some(active_break_template) = self.active_break_template {
-            self.active_break_template =
-                Some(active_break_template.min(self.break_templates.len().saturating_sub(1)));
-        }
-    }
-
-    pub(super) fn select_previous_break_template(&mut self) {
-        self.clamp_break_template_selection();
-        if self.break_templates.is_empty() {
-            return;
-        }
-        let last = self.break_templates.len().saturating_sub(1);
-        let next = match self.active_break_template {
-            None | Some(0) => last,
-            Some(current) => current.min(last).saturating_sub(1),
-        };
-        self.switch_break_template(next);
-    }
-
-    pub(super) fn select_next_break_template(&mut self) {
-        self.clamp_break_template_selection();
-        if self.break_templates.is_empty() {
-            return;
-        }
-        let last = self.break_templates.len().saturating_sub(1);
-        let next = match self.active_break_template {
-            None => 0,
-            Some(current) => (current.min(last) + 1) % self.break_templates.len(),
-        };
-        self.switch_break_template(next);
-    }
-
-    fn switch_break_template(&mut self, next_index: usize) {
-        if next_index >= self.break_templates.len()
-            || self.active_break_template == Some(next_index)
-        {
-            return;
-        }
-
-        let previous_index = self.active_break_template;
-        let previous_custom_profile = self.custom_profile.clone();
-        let Some(template) = self.break_templates.get(next_index).cloned() else {
-            return;
-        };
-        self.active_break_template = Some(next_index);
-        let template = template.normalized();
-        self.custom_profile.short_break_secs = template.short_break_secs;
-        self.custom_profile.long_break_secs = template.long_break_secs;
-        self.custom_profile.long_break_interval = template.long_break_interval;
-        self.custom_profile = self.custom_profile.normalized();
-        let custom_profile_changed = self.custom_profile != previous_custom_profile;
-
-        if self.selected_profile == ProfileId::Custom && custom_profile_changed {
-            let original_profile_automation = self.profile_automation.clone();
-            if !self.apply_profile(ProfileId::Custom) {
-                self.profile_automation = original_profile_automation;
-                self.active_break_template = previous_index;
-                self.custom_profile = previous_custom_profile;
-                return;
-            }
-        } else {
-            self.save_config();
-        }
-
-        self.phase_notification = Some(format!(
-            "Break template selected: {} ({})",
-            self.active_break_template_name(),
-            self.active_break_template_summary()
-        ));
     }
 }

--- a/src/app/shortcuts.rs
+++ b/src/app/shortcuts.rs
@@ -37,8 +37,6 @@ pub enum ShortcutAction {
     PlannerSelectRecent,
     BackProfileManager,
     ProfileEdit,
-    SelectPreviousBreakTemplate,
-    SelectNextBreakTemplate,
     BackStatsHistory,
     ExportStatsHistory,
     HistoryDashboardSelectPrevious,
@@ -112,11 +110,9 @@ const SESSION_PLANNER_SCOPE_ACTIONS: [ShortcutAction; 7] = [
     ShortcutAction::PlannerSelectRecent,
 ];
 
-const PROFILE_MANAGER_SCOPE_ACTIONS: [ShortcutAction; 4] = [
+const PROFILE_MANAGER_SCOPE_ACTIONS: [ShortcutAction; 2] = [
     ShortcutAction::BackProfileManager,
     ShortcutAction::ProfileEdit,
-    ShortcutAction::SelectPreviousBreakTemplate,
-    ShortcutAction::SelectNextBreakTemplate,
 ];
 
 const STATS_HISTORY_SCOPE_ACTIONS: [ShortcutAction; 7] = [
@@ -365,12 +361,6 @@ impl ShortcutBindings {
             planner_select_recent: key_token(self.key(ShortcutAction::PlannerSelectRecent)),
             back_profile_manager: key_token(self.key(ShortcutAction::BackProfileManager)),
             profile_edit: key_token(self.key(ShortcutAction::ProfileEdit)),
-            select_previous_break_template: key_token(
-                self.key(ShortcutAction::SelectPreviousBreakTemplate),
-            ),
-            select_next_break_template: key_token(
-                self.key(ShortcutAction::SelectNextBreakTemplate),
-            ),
             back_stats_history: key_token(self.key(ShortcutAction::BackStatsHistory)),
             export_stats_history: key_token(self.key(ShortcutAction::ExportStatsHistory)),
             history_dashboard_select_previous: key_token(
@@ -558,8 +548,6 @@ fn requested_shortcut_char(config: &ShortcutConfig, action: ShortcutAction) -> c
         ShortcutAction::PlannerSelectRecent => &config.planner_select_recent,
         ShortcutAction::BackProfileManager => &config.back_profile_manager,
         ShortcutAction::ProfileEdit => &config.profile_edit,
-        ShortcutAction::SelectPreviousBreakTemplate => &config.select_previous_break_template,
-        ShortcutAction::SelectNextBreakTemplate => &config.select_next_break_template,
         ShortcutAction::BackStatsHistory => &config.back_stats_history,
         ShortcutAction::ExportStatsHistory => &config.export_stats_history,
         ShortcutAction::HistoryDashboardSelectPrevious => &config.history_dashboard_select_previous,
@@ -620,8 +608,6 @@ fn default_shortcut_char(action: ShortcutAction) -> char {
         ShortcutAction::PlannerSelectRecent => 'r',
         ShortcutAction::BackProfileManager => 'p',
         ShortcutAction::ProfileEdit => 'e',
-        ShortcutAction::SelectPreviousBreakTemplate => '[',
-        ShortcutAction::SelectNextBreakTemplate => ']',
         ShortcutAction::BackStatsHistory => 'h',
         ShortcutAction::ExportStatsHistory => 'e',
         ShortcutAction::HistoryDashboardSelectPrevious => 'k',

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -111,8 +111,6 @@ fn app_default_uses_canonical_config_in_tests() {
     assert!(app.blocker.sites.is_empty());
     assert_eq!(app.blocklist_profile_count(), 1);
     assert_eq!(app.active_blocklist_profile_name(), "Default");
-    assert_eq!(app.break_templates.len(), 2);
-    assert_eq!(app.active_break_template_name(), "Classic");
     assert_eq!(app.timer.focus_secs, DEFAULT_FOCUS_SECS);
     assert_eq!(app.timer.short_break_secs, DEFAULT_SHORT_BREAK_SECS);
     assert_eq!(app.timer.long_break_secs, DEFAULT_LONG_BREAK_SECS);
@@ -156,21 +154,6 @@ fn selected_builtin_profile_is_applied_on_startup() {
             long_break_secs: 16 * 60,
             long_break_interval: 2,
         }),
-        break_templates: vec![
-            BreakTemplateConfig {
-                name: "Classic".to_string(),
-                short_break_secs: 5 * 60,
-                long_break_secs: 15 * 60,
-                long_break_interval: 4,
-            },
-            BreakTemplateConfig {
-                name: "Deep Work".to_string(),
-                short_break_secs: 10 * 60,
-                long_break_secs: 30 * 60,
-                long_break_interval: 3,
-            },
-        ],
-        selected_break_template: "Classic".to_string(),
         session_templates: Vec::new(),
         selected_session_template: String::new(),
         automation_triggers: Vec::new(),
@@ -419,119 +402,6 @@ fn profile_manager_enter_applies_selection() {
     assert_eq!(app.timer.short_break_secs, short_break);
     assert_eq!(app.timer.long_break_secs, long_break);
     assert_eq!(app.timer.long_break_interval, cadence);
-}
-
-#[test]
-fn profile_manager_cycles_break_template_for_custom_profile() {
-    let config = AppConfig {
-        selected_profile: ProfileId::Custom,
-        custom_profile: Some(CustomProfileConfig::default()),
-        ..AppConfig::default()
-    };
-    let mut app = App::from_config(config);
-
-    app.handle_key(key(KeyCode::Char('p')));
-    app.handle_key(key(KeyCode::Char(']')));
-
-    assert_eq!(app.active_break_template_name(), "Deep Work");
-    assert_eq!(app.custom_profile.short_break_secs, 10 * 60);
-    assert_eq!(app.custom_profile.long_break_secs, 30 * 60);
-    assert_eq!(app.custom_profile.long_break_interval, 3);
-    assert_eq!(app.timer.short_break_secs, 10 * 60);
-    assert_eq!(app.timer.long_break_secs, 30 * 60);
-    assert_eq!(app.timer.long_break_interval, 3);
-}
-
-#[test]
-fn profile_manager_cycles_break_template_without_replacing_builtin_timer() {
-    let config = AppConfig {
-        selected_profile: ProfileId::Classic,
-        custom_profile: Some(CustomProfileConfig::default()),
-        ..AppConfig::default()
-    };
-    let mut app = App::from_config(config);
-    let original_short = app.timer.short_break_secs;
-    let original_long = app.timer.long_break_secs;
-    let original_cadence = app.timer.long_break_interval;
-
-    app.handle_key(key(KeyCode::Char('p')));
-    app.handle_key(key(KeyCode::Char(']')));
-
-    assert_eq!(app.active_break_template_name(), "Deep Work");
-    assert_eq!(app.custom_profile.short_break_secs, 10 * 60);
-    assert_eq!(app.custom_profile.long_break_secs, 30 * 60);
-    assert_eq!(app.custom_profile.long_break_interval, 3);
-    assert_eq!(app.timer.short_break_secs, original_short);
-    assert_eq!(app.timer.long_break_secs, original_long);
-    assert_eq!(app.timer.long_break_interval, original_cadence);
-}
-
-#[test]
-fn startup_recomputes_selected_break_template_from_custom_values() {
-    let config = AppConfig {
-        selected_profile: ProfileId::Classic,
-        custom_profile: Some(CustomProfileConfig {
-            focus_secs: DEFAULT_FOCUS_SECS,
-            short_break_secs: 10 * 60,
-            long_break_secs: 30 * 60,
-            long_break_interval: 3,
-        }),
-        break_templates: vec![
-            BreakTemplateConfig {
-                name: "Classic".to_string(),
-                short_break_secs: 5 * 60,
-                long_break_secs: 15 * 60,
-                long_break_interval: 4,
-            },
-            BreakTemplateConfig {
-                name: "Deep Work".to_string(),
-                short_break_secs: 10 * 60,
-                long_break_secs: 30 * 60,
-                long_break_interval: 3,
-            },
-        ],
-        selected_break_template: "Classic".to_string(),
-        ..AppConfig::default()
-    };
-
-    let app = App::from_config(config);
-
-    assert_eq!(app.active_break_template_name(), "Deep Work");
-}
-
-#[test]
-fn committing_custom_profile_edit_clears_unmatched_template_selection() {
-    let config = AppConfig {
-        selected_profile: ProfileId::Custom,
-        custom_profile: Some(CustomProfileConfig::default()),
-        selected_break_template: "Classic".to_string(),
-        ..AppConfig::default()
-    };
-    let mut app = App::from_config(config);
-
-    app.handle_key(key(KeyCode::Char('p')));
-    app.handle_key(key(KeyCode::Char('e')));
-    app.handle_key(key(KeyCode::Down));
-    app.handle_key(key(KeyCode::Right));
-    app.handle_key(key(KeyCode::Enter));
-
-    assert_eq!(app.active_break_template_name(), "Custom");
-    assert_eq!(app.persisted_config().selected_break_template, "");
-}
-
-#[test]
-fn cycling_break_templates_from_unlinked_state_uses_first_and_last_entries() {
-    let mut app = App::default();
-    app.active_break_template = None;
-
-    app.select_next_break_template();
-    assert_eq!(app.active_break_template, Some(0));
-    assert_eq!(app.active_break_template_name(), "Classic");
-
-    app.active_break_template = None;
-    app.select_previous_break_template();
-    assert_eq!(app.active_break_template, Some(1));
-    assert_eq!(app.active_break_template_name(), "Deep Work");
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,10 +12,10 @@ use crate::app::App;
 use crate::app::{SetupCheck, SetupCheckLevel, SetupDiagnostics};
 use crate::blocker::{BlockingPreviewAction, EditSiteResult, InvalidSiteInput, SiteBlocker};
 use crate::config::{
-    AppConfig, AutomationTriggerRuleConfig, BlocklistProfileConfig, BreakTemplateConfig,
-    CustomProfileConfig, DailyGoalConfig, HistoryKpiCardId, MonthlyGoalConfig,
-    OneTimeFocusWindowConfig, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig,
-    ThemePreset, WeekdayProfileRuleConfig, WeeklyGoalConfig,
+    AppConfig, AutomationTriggerRuleConfig, BlocklistProfileConfig, CustomProfileConfig,
+    DailyGoalConfig, HistoryKpiCardId, MonthlyGoalConfig, OneTimeFocusWindowConfig, ProfileId,
+    RecurringFocusWindowConfig, RecurringScheduleConfig, ThemePreset, WeekdayProfileRuleConfig,
+    WeeklyGoalConfig,
 };
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
@@ -78,9 +78,8 @@ use parsing::{
 #[cfg(test)]
 use status::build_status_output;
 use status::{
-    available_break_template_views, available_theme_preset_views,
-    build_status_output_with_comparison, build_task_goal_output, profile_id, profile_view,
-    selected_break_template_view, theme_preset_view, timer_phase_id, timer_status_id,
+    available_theme_preset_views, build_status_output_with_comparison, build_task_goal_output,
+    profile_id, profile_view, theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 const USAGE_TEXT: &str = r#"Usage:
@@ -681,14 +680,6 @@ struct ProfileView {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct BreakTemplateView {
-    name: String,
-    short_break_secs: u64,
-    long_break_secs: u64,
-    long_break_interval: u32,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct ThemePresetView {
     id: &'static str,
     label: &'static str,
@@ -699,8 +690,6 @@ struct ProfileOutput {
     updated: bool,
     selected: ProfileView,
     available: Vec<ProfileView>,
-    selected_break_template: BreakTemplateView,
-    available_break_templates: Vec<BreakTemplateView>,
     selected_theme_preset: ThemePresetView,
     available_theme_presets: Vec<ThemePresetView>,
 }
@@ -805,8 +794,6 @@ struct StatusComparisonOutput {
 struct StatusOutput {
     day: String,
     selected_profile: ProfileView,
-    selected_break_template: BreakTemplateView,
-    available_break_templates: Vec<BreakTemplateView>,
     selected_theme_preset: ThemePresetView,
     selected_task_label: Option<String>,
     focus_intention: Option<String>,

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -33,17 +33,17 @@ use crate::cli::{
     SyncRestoreOutput, TaskCommandOutput, TaskGoalCommandOutput, TaskGoalOutput,
     TemporaryAllowlistStatusOutput, TemporarySiteAddCommandOutput, ThemeCommandOutput, ThemePreset,
     TimerCommandOutput, TimerStateOutput, UsageSignalsCommandOutput, WeekdayProfileRuleConfig,
-    WeekdayRulesCommandOutput, WeeklyGoalConfig, available_break_template_views,
-    available_theme_preset_views, build_blocking_preview_command_output,
-    build_diagnostics_command_output, build_schedule_inspection_output,
-    build_status_output_with_comparison, build_task_goal_output, display_input_value,
-    effective_blocked_sites_for_profile, flush_stdout, print_automation_triggers_command_output,
-    print_backup_output, print_blocking_preview_command_output,
-    print_blocklist_category_command_output, print_blocklist_profile_command_output,
-    print_break_glass_command_output, print_calendar_sync_command_output,
-    print_daemon_start_command_output, print_daemon_status_command_output,
-    print_daemon_stop_command_output, print_diagnostics_command_output, print_export_output,
-    print_feature_inventory_output, print_goal_carry_command_output, print_goal_command_output,
+    WeekdayRulesCommandOutput, WeeklyGoalConfig, available_theme_preset_views,
+    build_blocking_preview_command_output, build_diagnostics_command_output,
+    build_schedule_inspection_output, build_status_output_with_comparison, build_task_goal_output,
+    display_input_value, effective_blocked_sites_for_profile, flush_stdout,
+    print_automation_triggers_command_output, print_backup_output,
+    print_blocking_preview_command_output, print_blocklist_category_command_output,
+    print_blocklist_profile_command_output, print_break_glass_command_output,
+    print_calendar_sync_command_output, print_daemon_start_command_output,
+    print_daemon_status_command_output, print_daemon_stop_command_output,
+    print_diagnostics_command_output, print_export_output, print_feature_inventory_output,
+    print_goal_carry_command_output, print_goal_command_output,
     print_history_dashboard_command_output, print_json, print_json_compact, print_profile_output,
     print_restore_output, print_schedule_command_output, print_schedule_delay_command_output,
     print_session_metadata_command_output, print_session_template_command_output,
@@ -52,8 +52,8 @@ use crate::cli::{
     print_strict_command_output, print_sync_backup_output, print_sync_restore_output,
     print_task_goal_command_output, print_temporary_site_add_command_output,
     print_theme_command_output, print_timer_state_output, print_usage_signals_command_output,
-    print_weekday_rules_command_output, profile_id, profile_view, selected_break_template_view,
-    theme_preset_view, timer_phase_id, timer_status_id,
+    print_weekday_rules_command_output, profile_id, profile_view, theme_preset_view,
+    timer_phase_id, timer_status_id,
 };
 
 const CONFIG_FILE_NAME: &str = "config.toml";
@@ -1391,16 +1391,12 @@ fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Re
         .into_iter()
         .map(|candidate| profile_view(candidate, &custom))
         .collect();
-    let selected_break_template = selected_break_template_view(&config);
-    let available_break_templates = available_break_template_views(&config);
     let selected_theme_preset = theme_preset_view(config.selected_theme_preset);
     let available_theme_presets = available_theme_preset_views();
     let payload = ProfileOutput {
         updated,
         selected,
         available,
-        selected_break_template,
-        available_break_templates,
         selected_theme_preset,
         available_theme_presets,
     };

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -33,26 +33,9 @@ pub(super) fn print_profile_output(payload: &ProfileOutput) {
         payload.selected.long_break_interval
     );
     println!(
-        "Selected break template: {} ({}/{}, every {} focus)",
-        payload.selected_break_template.name,
-        format_duration(payload.selected_break_template.short_break_secs),
-        format_duration(payload.selected_break_template.long_break_secs),
-        payload.selected_break_template.long_break_interval
-    );
-    println!(
         "Selected theme preset: {} ({})",
         payload.selected_theme_preset.label, payload.selected_theme_preset.id
     );
-    println!("Available break templates:");
-    for template in &payload.available_break_templates {
-        println!(
-            "  - {}: {}/{}, every {} focus",
-            template.name,
-            format_duration(template.short_break_secs),
-            format_duration(template.long_break_secs),
-            template.long_break_interval
-        );
-    }
     println!("Available profiles:");
     for profile in &payload.available {
         println!(
@@ -409,13 +392,6 @@ pub(super) fn print_status_output(payload: &StatusOutput) {
     println!(
         "Selected profile: {} ({})",
         payload.selected_profile.label, payload.selected_profile.id
-    );
-    println!(
-        "Selected break template: {} ({}/{}, every {} focus)",
-        payload.selected_break_template.name,
-        format_duration(payload.selected_break_template.short_break_secs),
-        format_duration(payload.selected_break_template.long_break_secs),
-        payload.selected_break_template.long_break_interval
     );
     println!(
         "Selected theme preset: {} ({})",

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,13 +1,13 @@
 use crate::app::weekly_daily_goal_allocation_for_context;
 use crate::cli::{
-    AppConfig, BreakTemplateConfig, BreakTemplateView, CustomProfileConfig, DEFAULT_FOCUS_SECS,
-    DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS, DEFAULT_SHORT_BREAK_SECS,
-    DailyGoalSnapshot, Datelike, FocusScoreOutput, FocusStats, GoalOutput, LiveStatusOutput,
-    NaiveDate, ProfileId, ProfileSpec, ProfileView, SessionOutput, StatsRetentionStatusOutput,
-    StatusComparisonOptions, StatusComparisonOutput, StatusOutput, TaskGoalOutput,
-    TemporaryAllowlistStatusOutput, ThemePreset, ThemePresetView, TimerPhase, TimerStatus,
-    TodayOutput, WeeklyAllocationDayOutput, WeeklyAllocationOutput, carry_over_goal_target,
-    current_day_key, effective_blocked_sites_for_profile, session_recovery,
+    AppConfig, CustomProfileConfig, DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL,
+    DEFAULT_LONG_BREAK_SECS, DEFAULT_SHORT_BREAK_SECS, DailyGoalSnapshot, Datelike,
+    FocusScoreOutput, FocusStats, GoalOutput, LiveStatusOutput, NaiveDate, ProfileId, ProfileSpec,
+    ProfileView, SessionOutput, StatsRetentionStatusOutput, StatusComparisonOptions,
+    StatusComparisonOutput, StatusOutput, TaskGoalOutput, TemporaryAllowlistStatusOutput,
+    ThemePreset, ThemePresetView, TimerPhase, TimerStatus, TodayOutput, WeeklyAllocationDayOutput,
+    WeeklyAllocationOutput, carry_over_goal_target, current_day_key,
+    effective_blocked_sites_for_profile, session_recovery,
 };
 use crate::stats::ProductivityComparisonFilter;
 use crate::timer::TimerState;
@@ -100,8 +100,6 @@ pub(super) fn build_status_output_with_comparison(
     StatusOutput {
         day,
         selected_profile: profile_view(config.selected_profile, &config.effective_custom_profile()),
-        selected_break_template: selected_break_template_view(config),
-        available_break_templates: available_break_template_views(config),
         selected_theme_preset: theme_preset_view(config.selected_theme_preset),
         selected_task_label,
         focus_intention,
@@ -545,75 +543,6 @@ pub(super) fn profile_id(profile: ProfileId) -> &'static str {
         ProfileId::DeepWork => "deep-work",
         ProfileId::Custom => "custom",
     }
-}
-
-fn break_template_view(template: &BreakTemplateConfig) -> BreakTemplateView {
-    let template = template.normalized();
-    BreakTemplateView {
-        name: template.name,
-        short_break_secs: template.short_break_secs,
-        long_break_secs: template.long_break_secs,
-        long_break_interval: template.long_break_interval,
-    }
-}
-
-fn break_template_matches_custom_profile(
-    template: &BreakTemplateConfig,
-    custom_profile: &CustomProfileConfig,
-) -> bool {
-    let template = template.normalized();
-    let custom_profile = custom_profile.normalized();
-    template.short_break_secs == custom_profile.short_break_secs
-        && template.long_break_secs == custom_profile.long_break_secs
-        && template.long_break_interval == custom_profile.long_break_interval
-}
-
-fn selected_break_template_index(config: &AppConfig) -> Option<usize> {
-    let custom_profile = config.effective_custom_profile();
-    let selected_name = config.selected_break_template.trim();
-    let selected_index = config
-        .break_templates
-        .iter()
-        .position(|template| template.name.eq_ignore_ascii_case(selected_name));
-
-    if let Some(index) = selected_index
-        && config.break_templates.get(index).is_some_and(|template| {
-            break_template_matches_custom_profile(template, &custom_profile)
-        })
-    {
-        return Some(index);
-    }
-
-    config
-        .break_templates
-        .iter()
-        .position(|template| break_template_matches_custom_profile(template, &custom_profile))
-}
-
-pub(super) fn selected_break_template_view(config: &AppConfig) -> BreakTemplateView {
-    if let Some(index) = selected_break_template_index(config) {
-        return config
-            .break_templates
-            .get(index)
-            .map(break_template_view)
-            .unwrap_or_else(|| break_template_view(&BreakTemplateConfig::default()));
-    }
-
-    let custom = config.effective_custom_profile();
-    BreakTemplateView {
-        name: "Custom".to_string(),
-        short_break_secs: custom.short_break_secs,
-        long_break_secs: custom.long_break_secs,
-        long_break_interval: custom.long_break_interval,
-    }
-}
-
-pub(super) fn available_break_template_views(config: &AppConfig) -> Vec<BreakTemplateView> {
-    config
-        .break_templates
-        .iter()
-        .map(break_template_view)
-        .collect()
 }
 
 pub(super) fn theme_preset_view(preset: ThemePreset) -> ThemePresetView {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2597,25 +2597,6 @@ fn build_status_output_matches_blocklist_profile_case_insensitively() {
 }
 
 #[test]
-fn build_status_output_trims_selected_break_template_name() {
-    let config = AppConfig {
-        selected_break_template: "  deep work  ".to_string(),
-        custom_profile: Some(CustomProfileConfig {
-            focus_secs: DEFAULT_FOCUS_SECS,
-            short_break_secs: 10 * 60,
-            long_break_secs: 30 * 60,
-            long_break_interval: 3,
-        }),
-        ..AppConfig::default()
-    };
-    let stats = FocusStats::default();
-
-    let output = build_status_output(&config, &stats);
-
-    assert_eq!(output.selected_break_template.name, "Deep Work");
-}
-
-#[test]
 fn build_status_output_includes_selected_theme_preset() {
     let config = AppConfig {
         selected_theme_preset: ThemePreset::DeuteranopiaFriendly,
@@ -2627,28 +2608,6 @@ fn build_status_output_includes_selected_theme_preset() {
 
     assert_eq!(output.selected_theme_preset.id, "deuteranopia-friendly");
     assert_eq!(output.selected_theme_preset.label, "Deuteranopia Friendly");
-}
-
-#[test]
-fn build_status_output_uses_custom_template_sentinel_when_unmatched() {
-    let config = AppConfig {
-        selected_break_template: String::new(),
-        custom_profile: Some(CustomProfileConfig {
-            focus_secs: DEFAULT_FOCUS_SECS,
-            short_break_secs: 7 * 60,
-            long_break_secs: 21 * 60,
-            long_break_interval: 5,
-        }),
-        ..AppConfig::default()
-    };
-    let stats = FocusStats::default();
-
-    let output = build_status_output(&config, &stats);
-
-    assert_eq!(output.selected_break_template.name, "Custom");
-    assert_eq!(output.selected_break_template.short_break_secs, 7 * 60);
-    assert_eq!(output.selected_break_template.long_break_secs, 21 * 60);
-    assert_eq!(output.selected_break_template.long_break_interval, 5);
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,14 +74,9 @@ pub struct AppConfig {
     /// Editable custom profile persisted by the app.
     ///
     /// When this is absent, the app derives it from the legacy duration fields.
+    /// This is the canonical persisted timer-duration surface.
     #[serde(default)]
     pub custom_profile: Option<CustomProfileConfig>,
-    /// Globally reusable break templates for quick selection.
-    #[serde(default = "default_break_templates")]
-    pub break_templates: Vec<BreakTemplateConfig>,
-    /// Name of the active break template.
-    #[serde(default)]
-    pub selected_break_template: String,
     /// Weekday smart-switch rules for profile and planning defaults.
     #[serde(default)]
     pub weekday_profile_rules: Vec<WeekdayProfileRuleConfig>,
@@ -341,10 +336,6 @@ pub struct ShortcutConfig {
     pub back_profile_manager: String,
     #[serde(default = "default_shortcut_profile_edit")]
     pub profile_edit: String,
-    #[serde(default = "default_shortcut_select_previous_break_template")]
-    pub select_previous_break_template: String,
-    #[serde(default = "default_shortcut_select_next_break_template")]
-    pub select_next_break_template: String,
     #[serde(default = "default_shortcut_back_stats_history")]
     pub back_stats_history: String,
     #[serde(default = "default_shortcut_export_stats_history")]
@@ -499,14 +490,6 @@ impl ShortcutConfig {
                 &self.profile_edit,
                 &default_shortcut_profile_edit(),
             ),
-            select_previous_break_template: normalize_shortcut_token(
-                &self.select_previous_break_template,
-                &default_shortcut_select_previous_break_template(),
-            ),
-            select_next_break_template: normalize_shortcut_token(
-                &self.select_next_break_template,
-                &default_shortcut_select_next_break_template(),
-            ),
             back_stats_history: normalize_shortcut_token(
                 &self.back_stats_history,
                 &default_shortcut_back_stats_history(),
@@ -607,8 +590,6 @@ impl Default for ShortcutConfig {
             planner_select_recent: default_shortcut_planner_select_recent(),
             back_profile_manager: default_shortcut_back_profile_manager(),
             profile_edit: default_shortcut_profile_edit(),
-            select_previous_break_template: default_shortcut_select_previous_break_template(),
-            select_next_break_template: default_shortcut_select_next_break_template(),
             back_stats_history: default_shortcut_back_stats_history(),
             export_stats_history: default_shortcut_export_stats_history(),
             history_dashboard_select_previous: default_shortcut_history_dashboard_select_previous(),
@@ -1712,10 +1693,6 @@ fn default_break_glass_duration_secs() -> u64 {
     5 * 60
 }
 
-fn default_break_template_name() -> String {
-    "Classic".to_string()
-}
-
 fn default_session_template_name() -> String {
     "Template".to_string()
 }
@@ -1844,14 +1821,6 @@ fn default_shortcut_profile_edit() -> String {
     "e".to_string()
 }
 
-fn default_shortcut_select_previous_break_template() -> String {
-    "[".to_string()
-}
-
-fn default_shortcut_select_next_break_template() -> String {
-    "]".to_string()
-}
-
 fn default_shortcut_back_stats_history() -> String {
     "h".to_string()
 }
@@ -1926,23 +1895,6 @@ fn default_history_dashboard_pinned_cards() -> Vec<HistoryKpiCardId> {
 
 fn default_history_dashboard_card_order() -> Vec<HistoryKpiCardId> {
     HistoryKpiCardId::all().to_vec()
-}
-
-fn default_break_templates() -> Vec<BreakTemplateConfig> {
-    vec![
-        BreakTemplateConfig {
-            name: "Classic".to_string(),
-            short_break_secs: default_short_break_secs(),
-            long_break_secs: default_long_break_secs(),
-            long_break_interval: default_long_break_interval(),
-        },
-        BreakTemplateConfig {
-            name: "Deep Work".to_string(),
-            short_break_secs: 10 * 60,
-            long_break_secs: 30 * 60,
-            long_break_interval: 3,
-        },
-    ]
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
@@ -2094,38 +2046,6 @@ impl Default for CustomProfileConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct BreakTemplateConfig {
-    #[serde(default = "default_break_template_name")]
-    pub name: String,
-    #[serde(default = "default_short_break_secs")]
-    pub short_break_secs: u64,
-    #[serde(default = "default_long_break_secs")]
-    pub long_break_secs: u64,
-    #[serde(default = "default_long_break_interval")]
-    pub long_break_interval: u32,
-}
-
-impl BreakTemplateConfig {
-    pub fn normalized(&self) -> Self {
-        Self {
-            name: normalize_nonempty_or_default_string(&self.name, &default_break_template_name()),
-            short_break_secs: nonzero_or_default_u64(
-                self.short_break_secs,
-                default_short_break_secs(),
-            ),
-            long_break_secs: nonzero_or_default_u64(
-                self.long_break_secs,
-                default_long_break_secs(),
-            ),
-            long_break_interval: nonzero_or_default_u32(
-                self.long_break_interval,
-                default_long_break_interval(),
-            ),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SessionTemplateConfig {
     #[serde(default = "default_session_template_name")]
     pub name: String,
@@ -2156,17 +2076,6 @@ impl SessionTemplateConfig {
             blocklist_profile,
             schedule: self.schedule.normalized(),
         })
-    }
-}
-
-impl Default for BreakTemplateConfig {
-    fn default() -> Self {
-        Self {
-            name: default_break_template_name(),
-            short_break_secs: default_short_break_secs(),
-            long_break_secs: default_long_break_secs(),
-            long_break_interval: default_long_break_interval(),
-        }
     }
 }
 
@@ -2203,8 +2112,6 @@ impl Default for AppConfig {
             blocking_backend: BlockingBackendConfig::default(),
             selected_profile: ProfileId::default(),
             custom_profile: None,
-            break_templates: default_break_templates(),
-            selected_break_template: default_break_template_name(),
             weekday_profile_rules: Vec::new(),
             session_templates: Vec::new(),
             selected_session_template: String::new(),
@@ -2381,13 +2288,6 @@ impl AppConfig {
         );
         self.feature_flags = self.feature_flags.normalized();
         self.custom_profile = self.custom_profile.map(|profile| profile.normalized());
-        self.break_templates = normalize_break_templates(&self.break_templates);
-        let effective_custom_profile = self.effective_custom_profile();
-        self.selected_break_template = normalize_selected_break_template(
-            &self.selected_break_template,
-            &self.break_templates,
-            &effective_custom_profile,
-        );
         self.recurring_schedule = self.recurring_schedule.normalized();
         let legacy_automation = ProfileAutomationConfig::from_legacy(
             self.notifications,
@@ -2793,47 +2693,6 @@ fn parse_schedule_exception_date(value: &str) -> Option<NaiveDate> {
     NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").ok()
 }
 
-fn normalize_break_templates(templates: &[BreakTemplateConfig]) -> Vec<BreakTemplateConfig> {
-    let mut normalized = Vec::new();
-    let mut seen_names = HashSet::new();
-
-    for template in templates {
-        let template = template.normalized();
-        let name = make_unique_profile_name(&template.name, &mut seen_names);
-        normalized.push(BreakTemplateConfig { name, ..template });
-    }
-
-    if normalized.is_empty() {
-        return default_break_templates();
-    }
-
-    normalized
-}
-
-fn normalize_selected_break_template(
-    selected_name: &str,
-    templates: &[BreakTemplateConfig],
-    custom_profile: &CustomProfileConfig,
-) -> String {
-    let selected_name = selected_name.trim();
-    if selected_name.is_empty() {
-        return String::new();
-    }
-
-    if let Some(template) = templates.iter().find(|template| {
-        template.name.eq_ignore_ascii_case(selected_name)
-            && break_template_matches_custom_profile(template, custom_profile)
-    }) {
-        template.name.clone()
-    } else {
-        templates
-            .iter()
-            .find(|template| break_template_matches_custom_profile(template, custom_profile))
-            .map(|template| template.name.clone())
-            .unwrap_or_default()
-    }
-}
-
 fn normalize_session_templates(
     templates: &[SessionTemplateConfig],
     blocklist_profiles: &[BlocklistProfileConfig],
@@ -3182,17 +3041,6 @@ fn weekday_token_from_index(index: usize) -> &'static str {
         6 => "sun",
         _ => "mon",
     }
-}
-
-fn break_template_matches_custom_profile(
-    template: &BreakTemplateConfig,
-    custom_profile: &CustomProfileConfig,
-) -> bool {
-    let template = template.normalized();
-    let custom_profile = custom_profile.normalized();
-    template.short_break_secs == custom_profile.short_break_secs
-        && template.long_break_secs == custom_profile.long_break_secs
-        && template.long_break_interval == custom_profile.long_break_interval
 }
 
 fn normalize_blocklist_profiles(

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -27,12 +27,10 @@ fn default_values_are_canonical_pomodoro() {
     assert_eq!(cfg.long_break_interval, 4);
     assert_eq!(cfg.selected_profile, ProfileId::Custom);
     assert!(cfg.custom_profile.is_none());
-    assert_eq!(cfg.selected_break_template, "Classic");
     assert!(cfg.session_templates.is_empty());
     assert!(cfg.selected_session_template.is_empty());
     assert!(cfg.automation_triggers.is_empty());
     assert_eq!(cfg.selected_theme_preset, ThemePreset::Classic);
-    assert_eq!(cfg.break_templates.len(), 2);
     assert!(cfg.blocked_sites.is_empty());
     assert_eq!(cfg.selected_blocklist_profile, "Default");
     assert!(cfg.blocklist_profiles.is_empty());
@@ -128,21 +126,6 @@ fn round_trip_full_config() {
             long_break_secs: 12 * 60,
             long_break_interval: 5,
         }),
-        break_templates: vec![
-            BreakTemplateConfig {
-                name: "Quick".to_string(),
-                short_break_secs: 3 * 60,
-                long_break_secs: 10 * 60,
-                long_break_interval: 4,
-            },
-            BreakTemplateConfig {
-                name: "Recovery".to_string(),
-                short_break_secs: 8 * 60,
-                long_break_secs: 20 * 60,
-                long_break_interval: 3,
-            },
-        ],
-        selected_break_template: "Recovery".to_string(),
         session_templates: vec![SessionTemplateConfig {
             name: "Morning deep work".to_string(),
             task_label: "Docs".to_string(),
@@ -350,11 +333,6 @@ fn round_trip_full_config() {
     assert_eq!(parsed.blocking_backend, original.blocking_backend);
     assert_eq!(parsed.selected_profile, original.selected_profile);
     assert_eq!(parsed.custom_profile, original.custom_profile);
-    assert_eq!(parsed.break_templates, original.break_templates);
-    assert_eq!(
-        parsed.selected_break_template,
-        original.selected_break_template
-    );
     assert_eq!(parsed.session_templates, original.session_templates);
     assert_eq!(
         parsed.selected_session_template,
@@ -397,11 +375,9 @@ fn missing_fields_fall_back_to_defaults() {
     assert_eq!(cfg.long_break_interval, 4);
     assert_eq!(cfg.selected_profile, ProfileId::Custom);
     assert!(cfg.custom_profile.is_none());
-    assert_eq!(cfg.selected_break_template, "");
     assert!(cfg.session_templates.is_empty());
     assert_eq!(cfg.selected_session_template, "");
     assert_eq!(cfg.selected_theme_preset, ThemePreset::Classic);
-    assert_eq!(cfg.break_templates.len(), 2);
     assert!(cfg.blocked_sites.is_empty());
     assert!(cfg.blocklist_profiles.is_empty());
     assert_eq!(cfg.selected_blocklist_profile, "Default");
@@ -422,6 +398,43 @@ fn missing_fields_fall_back_to_defaults() {
     assert_eq!(cfg.wakatime, WakatimeMetadataConfig::default());
     assert_eq!(cfg.feature_flags, FeatureFlagsConfig::default());
     assert_eq!(cfg.shortcuts, ShortcutConfig::default());
+}
+
+#[test]
+fn legacy_break_template_fields_are_ignored_and_not_reserialized() {
+    let legacy = r#"
+selected_profile = "custom"
+selected_break_template = "Deep Work"
+
+[custom_profile]
+focus_secs = 1800
+short_break_secs = 420
+long_break_secs = 900
+long_break_interval = 3
+
+[[break_templates]]
+name = "Classic"
+short_break_secs = 300
+long_break_secs = 900
+long_break_interval = 4
+
+[[break_templates]]
+name = "Deep Work"
+short_break_secs = 600
+long_break_secs = 1800
+long_break_interval = 3
+"#;
+    let cfg: AppConfig = toml::from_str(legacy).unwrap();
+    let normalized = cfg.normalize();
+    let custom = normalized.effective_custom_profile();
+    assert_eq!(custom.focus_secs, 1800);
+    assert_eq!(custom.short_break_secs, 420);
+    assert_eq!(custom.long_break_secs, 900);
+    assert_eq!(custom.long_break_interval, 3);
+
+    let serialized = toml::to_string_pretty(&normalized).unwrap();
+    assert!(!serialized.contains("selected_break_template"));
+    assert!(!serialized.contains("[[break_templates]]"));
 }
 
 #[test]
@@ -493,58 +506,6 @@ fn normalize_clamps_zero_break_glass_duration_to_default() {
         cfg.break_glass_duration_secs,
         default_break_glass_duration_secs()
     );
-}
-
-#[test]
-fn normalize_break_templates_preserves_empty_selection() {
-    let cfg = AppConfig {
-        break_templates: Vec::new(),
-        selected_break_template: String::new(),
-        ..AppConfig::default()
-    }
-    .normalize();
-
-    assert_eq!(cfg.break_templates.len(), 2);
-    assert_eq!(cfg.selected_break_template, "");
-}
-
-#[test]
-fn normalize_break_templates_deduplicates_names_and_clamps_values() {
-    let cfg = AppConfig {
-        break_templates: vec![
-            BreakTemplateConfig {
-                name: "Recovery".to_string(),
-                short_break_secs: 0,
-                long_break_secs: 0,
-                long_break_interval: 0,
-            },
-            BreakTemplateConfig {
-                name: "recovery".to_string(),
-                short_break_secs: 2 * 60,
-                long_break_secs: 12 * 60,
-                long_break_interval: 2,
-            },
-        ],
-        selected_break_template: "missing".to_string(),
-        ..AppConfig::default()
-    }
-    .normalize();
-
-    assert_eq!(cfg.break_templates[0].name, "Recovery");
-    assert_eq!(
-        cfg.break_templates[0].short_break_secs,
-        default_short_break_secs()
-    );
-    assert_eq!(
-        cfg.break_templates[0].long_break_secs,
-        default_long_break_secs()
-    );
-    assert_eq!(
-        cfg.break_templates[0].long_break_interval,
-        default_long_break_interval()
-    );
-    assert_eq!(cfg.break_templates[1].name, "recovery (2)");
-    assert_eq!(cfg.selected_break_template, "Recovery");
 }
 
 #[test]
@@ -668,40 +629,6 @@ delete = "DEL"
     assert_eq!(normalized.shortcuts.confirm, "enter");
     assert_eq!(normalized.shortcuts.cancel, "esc");
     assert_eq!(normalized.shortcuts.delete, "delete");
-}
-
-#[test]
-fn normalize_selected_break_template_uses_template_matching_custom_values() {
-    let cfg = AppConfig {
-        selected_break_template: "Classic".to_string(),
-        custom_profile: Some(CustomProfileConfig {
-            focus_secs: default_focus_secs(),
-            short_break_secs: 10 * 60,
-            long_break_secs: 30 * 60,
-            long_break_interval: 3,
-        }),
-        ..AppConfig::default()
-    }
-    .normalize();
-
-    assert_eq!(cfg.selected_break_template, "Deep Work");
-}
-
-#[test]
-fn normalize_selected_break_template_clears_unknown_when_no_template_matches_custom_values() {
-    let cfg = AppConfig {
-        selected_break_template: "Classic".to_string(),
-        custom_profile: Some(CustomProfileConfig {
-            focus_secs: default_focus_secs(),
-            short_break_secs: 7 * 60,
-            long_break_secs: 21 * 60,
-            long_break_interval: 5,
-        }),
-        ..AppConfig::default()
-    }
-    .normalize();
-
-    assert_eq!(cfg.selected_break_template, "");
 }
 
 #[test]
@@ -1269,8 +1196,6 @@ fn effective_custom_profile_uses_explicit_profile_when_present() {
             long_break_secs: 16 * 60,
             long_break_interval: 2,
         }),
-        break_templates: default_break_templates(),
-        selected_break_template: default_break_template_name(),
         session_templates: Vec::new(),
         selected_session_template: String::new(),
         automation_triggers: Vec::new(),
@@ -1327,8 +1252,6 @@ fn load_returns_default_when_config_file_is_corrupt() {
     );
     assert_eq!(cfg.selected_profile, ProfileId::Custom);
     assert!(cfg.custom_profile.is_none());
-    assert_eq!(cfg.selected_break_template, "Classic");
-    assert_eq!(cfg.break_templates.len(), 2);
     assert!(cfg.blocked_sites.is_empty());
     assert_eq!(cfg.selected_blocklist_profile, "Default");
     assert!(cfg.blocklist_profiles.is_empty());

--- a/src/ui/profile_manager.rs
+++ b/src/ui/profile_manager.rs
@@ -21,7 +21,7 @@ pub(super) fn render_profile_manager(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(2), // current profile + break template
+            Constraint::Length(2), // current profile summary
             Constraint::Length(6), // profile list
             Constraint::Length(editor_height),
             Constraint::Min(0),    // spacer
@@ -31,10 +31,9 @@ pub(super) fn render_profile_manager(frame: &mut Frame, app: &App) {
         .split(outer);
 
     let current = Paragraph::new(format!(
-        "Current profile: {} · Break template: {} ({})",
+        "Current profile: {} ({})",
         app.selected_profile_name(),
-        app.active_break_template_name(),
-        app.active_break_template_summary()
+        app.profile_summary(app.selected_profile)
     ))
     .style(
         Style::default()
@@ -227,11 +226,7 @@ fn profile_manager_hints(app: &App) -> Vec<Line<'static>> {
                     app.shortcut_hint(ShortcutAction::ProfileEdit)
                 )
             }),
-            Line::from(format!(
-                "Templates: '{}' previous  '{}' next break template",
-                app.shortcut_label(ShortcutAction::SelectPreviousBreakTemplate),
-                app.shortcut_label(ShortcutAction::SelectNextBreakTemplate),
-            )),
+            Line::from("Tip: edit the Custom profile timer fields for personalized break cadence."),
             Line::from(if app.strict_mode_enforced_for_focus() {
                 format!(
                     "View: [{}/{}] Back  [{}] Quit (Locked)",

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -292,8 +292,6 @@ fn status_json_success_emits_payload_on_stdout() {
 
     let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
     assert!(payload.get("day").is_some());
-    assert!(payload.get("selected_break_template").is_some());
-    assert!(payload.get("available_break_templates").is_some());
     assert!(payload.get("focus_intention").is_some());
     assert!(payload.get("task_note").is_some());
     assert!(payload.get("goal").is_some());


### PR DESCRIPTION
## What

Consolidates timer configuration around profile durations and removes the overlapping break-template pathway across config, runtime state, profile manager controls, and CLI status/profile payloads.

Also updates tests and README to reflect the simplified timer model, and adds compatibility coverage to confirm legacy configs containing `selected_break_template` / `[[break_templates]]` still load without changing effective timer behavior.

## Why

Timer options were previously split across `custom_profile` durations and break-template selection, creating duplicated pathways and extra reconciliation logic. This makes timer behavior easier to reason about and reduces product/config complexity while preserving core Pomodoro flows.

Closes #383.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Features**
  * Break template selection feature removed; configure break durations directly through profile settings instead.

* **Documentation**
  * Updated configuration examples and profile manager instructions to reflect profile-based break duration configuration.
  * Removed references to break template navigation from keyboard shortcuts documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->