### PR TITLE
Unify overlapping schedule and session flows

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -373,6 +373,19 @@ enum PendingTimerAction {
     BreakGlassOverride,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FocusStartTemplateMode {
+    ApplySelectedTemplate,
+    SkipSelectedTemplate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FocusStartOutcome {
+    Started,
+    MissingTaskLabel,
+    NotIdleFocusPhase,
+}
+
 #[derive(Debug, Clone)]
 struct ScheduleDisplayState {
     has_schedule_windows: bool,

--- a/src/app/automation_triggers.rs
+++ b/src/app/automation_triggers.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Datelike, Local, Timelike};
 
-use crate::app::{App, TimerPhase, TimerState, TimerStatus};
+use crate::app::{App, FocusStartTemplateMode, TimerStatus};
 use crate::config::{AutomationTriggerActionConfig, AutomationTriggerConditionConfig};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,12 +86,8 @@ impl App {
     ) -> Result<(), String> {
         match action {
             AutomationTriggerActionConfig::StartFocus => {
-                if self.timer.phase == TimerPhase::Focus
-                    && self.timer.status == TimerStatus::Idle
-                    && self.has_selectable_task_label_for_focus()
-                {
-                    self.update_timer_and_sync(TimerState::toggle_pause);
-                }
+                let _ =
+                    self.try_start_focus_session(FocusStartTemplateMode::SkipSelectedTemplate)?;
                 Ok(())
             }
             AutomationTriggerActionConfig::DelayScheduleStart { delay_secs } => {

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -1,6 +1,7 @@
 use crate::app::{
-    App, BlockingPreview, Local, ProfileId, SessionInterruptionReason, ShortcutAction, TimerPhase,
-    TimerState, TimerStatus, normalize_task_label, task_label_index,
+    App, BlockingPreview, FocusStartOutcome, FocusStartTemplateMode, Local, ProfileId,
+    SessionInterruptionReason, ShortcutAction, TimerPhase, TimerState, TimerStatus,
+    normalize_task_label, task_label_index,
 };
 
 impl App {
@@ -11,18 +12,16 @@ impl App {
     }
 
     pub fn start_focus_for_cli(&mut self) -> Result<(), String> {
-        if self.timer.phase != TimerPhase::Focus || self.timer.status != TimerStatus::Idle {
-            return Err("Cannot start focus: timer is not idle in focus phase.".to_string());
-        }
-        self.apply_selected_session_template_before_start()?;
-        if !self.has_selectable_task_label_for_focus() {
-            return Err(format!(
+        match self.try_start_focus_session(FocusStartTemplateMode::ApplySelectedTemplate)? {
+            FocusStartOutcome::Started => Ok(()),
+            FocusStartOutcome::MissingTaskLabel => Err(format!(
                 "Cannot start focus: select a task label first (run TUI and press {}).",
                 self.shortcut_hint(ShortcutAction::OpenSessionPlanner)
-            ));
+            )),
+            FocusStartOutcome::NotIdleFocusPhase => {
+                Err("Cannot start focus: timer is not idle in focus phase.".to_string())
+            }
         }
-        self.update_timer_and_sync(TimerState::toggle_pause);
-        Ok(())
     }
 
     pub fn pause_for_cli(&mut self) -> Result<(), String> {

--- a/src/app/mode_keys.rs
+++ b/src/app/mode_keys.rs
@@ -1,6 +1,6 @@
 use crate::app::{
-    App, AppMode, KeyCode, KeyEvent, KeyModifiers, NavigationAction, PendingTimerAction,
-    SessionInterruptionReason, ShortcutAction, TimerPhase, TimerState, TimerStatus,
+    App, AppMode, FocusStartOutcome, FocusStartTemplateMode, KeyCode, KeyEvent, KeyModifiers,
+    NavigationAction, PendingTimerAction, SessionInterruptionReason, ShortcutAction, TimerState,
     format_duration_label,
 };
 
@@ -91,20 +91,21 @@ impl App {
     }
 
     fn handle_timer_toggle_pause_key(&mut self) {
-        if self.timer.phase == TimerPhase::Focus && self.timer.status == TimerStatus::Idle {
-            if let Err(error) = self.apply_selected_session_template_before_start() {
-                self.phase_notification = Some(error);
-                return;
-            }
-            if !self.has_selectable_task_label_for_focus() {
+        match self.try_start_focus_session(FocusStartTemplateMode::ApplySelectedTemplate) {
+            Ok(FocusStartOutcome::Started) => {}
+            Ok(FocusStartOutcome::MissingTaskLabel) => {
                 self.phase_notification = Some(format!(
                     "Select a task label with {} before starting focus.",
                     self.shortcut_hint(ShortcutAction::OpenSessionPlanner)
                 ));
-                return;
+            }
+            Ok(FocusStartOutcome::NotIdleFocusPhase) => {
+                self.update_timer_and_sync(TimerState::toggle_pause);
+            }
+            Err(error) => {
+                self.phase_notification = Some(error);
             }
         }
-        self.update_timer_and_sync(TimerState::toggle_pause);
     }
 
     fn handle_timer_stop_reset_key(&mut self) {

--- a/src/app/schedule_runtime.rs
+++ b/src/app/schedule_runtime.rs
@@ -1,9 +1,9 @@
 use crate::app::automation_triggers::AutomationTriggerEvent;
 use crate::app::{
-    App, DateTime, Local, ScheduleDisplayState, ShortcutAction, TimerPhase, TimerState,
-    TimerStatus, WindowOccurrence, active_occurrence, active_one_time_occurrence,
-    format_duration_label, next_occurrence_after, next_one_time_occurrence_after, occurrence_key,
-    pick_active_occurrence, pick_next_occurrence,
+    App, DateTime, FocusStartOutcome, FocusStartTemplateMode, Local, ScheduleDisplayState,
+    ShortcutAction, TimerPhase, TimerState, TimerStatus, WindowOccurrence, active_occurrence,
+    active_one_time_occurrence, format_duration_label, next_occurrence_after,
+    next_one_time_occurrence_after, occurrence_key, pick_active_occurrence, pick_next_occurrence,
 };
 
 struct ScheduleShortcutLabels {
@@ -226,28 +226,21 @@ impl App {
             self.update_timer_and_sync(TimerState::next_phase);
         }
 
-        if let Err(error) = self.apply_selected_session_template_before_start() {
-            self.schedule_armed_occurrence_key = Some(active_occurrence_key.to_string());
-            self.phase_notification = Some(error);
-            return;
+        match self.try_start_focus_session(FocusStartTemplateMode::ApplySelectedTemplate) {
+            Ok(FocusStartOutcome::Started) => {
+                self.phase_notification =
+                    Some("Scheduled window started. Focus auto-started.".to_string());
+                self.schedule_armed_occurrence_key = None;
+            }
+            Ok(FocusStartOutcome::MissingTaskLabel) | Ok(FocusStartOutcome::NotIdleFocusPhase) => {
+                self.schedule_armed_occurrence_key = Some(active_occurrence_key.to_string());
+                self.phase_notification = Some(self.schedule_arm_notification());
+            }
+            Err(error) => {
+                self.schedule_armed_occurrence_key = Some(active_occurrence_key.to_string());
+                self.phase_notification = Some(error);
+            }
         }
-
-        if self.can_auto_start_focus_for_schedule() {
-            self.update_timer_and_sync(TimerState::toggle_pause);
-            self.phase_notification =
-                Some("Scheduled window started. Focus auto-started.".to_string());
-            self.schedule_armed_occurrence_key = None;
-            return;
-        }
-
-        self.schedule_armed_occurrence_key = Some(active_occurrence_key.to_string());
-        self.phase_notification = Some(self.schedule_arm_notification());
-    }
-
-    fn can_auto_start_focus_for_schedule(&self) -> bool {
-        self.timer.phase == TimerPhase::Focus
-            && self.timer.status == TimerStatus::Idle
-            && self.has_selectable_task_label_for_focus()
     }
 
     fn schedule_arm_notification(&self) -> String {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3650,6 +3650,31 @@ fn time_trigger_fires_once_per_minute() {
 }
 
 #[test]
+fn automation_start_focus_keeps_selected_task_without_template_reapply() {
+    let now = local_datetime_today(10, 15);
+    let mut app = App::default();
+    app.task_labels = vec!["Docs".to_string(), "Writing".to_string()];
+    app.selected_task_label = Some("Docs".to_string());
+    app.capture_session_template("Deep Flow")
+        .expect("template should be created");
+    app.selected_task_label = Some("Writing".to_string());
+    app.automation_triggers = vec![AutomationTriggerRuleConfig {
+        trigger: AutomationTriggerConditionConfig::Time {
+            days: vec![weekday_token(now.weekday()).to_string()],
+            at: now.format("%H:%M").to_string(),
+        },
+        action: AutomationTriggerActionConfig::StartFocus,
+    }];
+
+    app.sync_time_based_automation_triggers(now);
+
+    assert_eq!(app.timer.phase, TimerPhase::Focus);
+    assert_eq!(app.timer.status, TimerStatus::Running);
+    assert_eq!(app.active_focus_task_label.as_deref(), Some("Writing"));
+    assert_eq!(app.active_focus_intention.as_deref(), Some("Writing"));
+}
+
+#[test]
 fn profile_editor_adjusts_automation_trigger_fields() {
     let mut app = App::default();
 
@@ -5016,6 +5041,29 @@ fn cli_start_fails_when_selected_task_label_is_archived() {
 
     assert!(result.is_err());
     assert_eq!(app.timer.status, TimerStatus::Idle);
+}
+
+#[test]
+fn timer_and_cli_start_share_selected_template_validation_error() {
+    let mut app = App::default();
+    app.task_labels = vec!["Docs".to_string()];
+    app.selected_task_label = Some("Docs".to_string());
+    app.capture_session_template("Broken")
+        .expect("template should be created");
+    app.session_templates[0].blocklist_profile = "Missing".to_string();
+    app.select_session_template(Some("Broken"))
+        .expect("template should be selected");
+
+    app.handle_key(key(KeyCode::Char(' ')));
+    assert_eq!(app.timer.status, TimerStatus::Idle);
+    let tui_error = app
+        .phase_notification
+        .clone()
+        .expect("tui start should surface template error");
+    assert!(tui_error.contains("references missing blocklist profile"));
+
+    let cli_error = app.start_focus_for_cli().unwrap_err();
+    assert_eq!(cli_error, tui_error);
 }
 
 #[test]

--- a/src/app/timer_flow.rs
+++ b/src/app/timer_flow.rs
@@ -1,7 +1,7 @@
 use crate::app::automation_triggers::AutomationTriggerEvent;
 use crate::app::{
-    App, Local, SessionInterruptionReason, ShortcutAction, TimerPhase, TimerState, TimerStatus,
-    current_day_key,
+    App, FocusStartOutcome, FocusStartTemplateMode, Local, SessionInterruptionReason,
+    ShortcutAction, TimerPhase, TimerState, TimerStatus, current_day_key,
 };
 
 impl App {
@@ -118,6 +118,23 @@ impl App {
                 self.shortcut_hint(ShortcutAction::OpenSessionPlanner)
             ));
         }
+    }
+
+    pub(super) fn try_start_focus_session(
+        &mut self,
+        template_mode: FocusStartTemplateMode,
+    ) -> Result<FocusStartOutcome, String> {
+        if self.timer.phase != TimerPhase::Focus || self.timer.status != TimerStatus::Idle {
+            return Ok(FocusStartOutcome::NotIdleFocusPhase);
+        }
+        if matches!(template_mode, FocusStartTemplateMode::ApplySelectedTemplate) {
+            self.apply_selected_session_template_before_start()?;
+        }
+        if !self.has_selectable_task_label_for_focus() {
+            return Ok(FocusStartOutcome::MissingTaskLabel);
+        }
+        self.update_timer_and_sync(TimerState::toggle_pause);
+        Ok(FocusStartOutcome::Started)
     }
 
     pub(super) fn update_timer_and_sync(&mut self, action: fn(&mut TimerState)) {


### PR DESCRIPTION
## What

Unifies focus-start behavior across timer key, CLI start, schedule window start, and automation StartFocus by introducing a shared App helper for focus entry.

This removes duplicated start checks and keeps schedule-specific arming behavior at the caller boundary. The change is split into behavior and test commits.

## Why

The start path was implemented in multiple places, which risked drift between schedule/session flows and made behavior harder to reason about. A single canonical focus-entry flow makes behavior consistent while preserving intentional path-specific differences.

Closes #387.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when starting focus sessions with clearer error messages for missing task labels or invalid timer states.
  * Focus session startup behavior is now consistent across all methods (CLI, automation triggers, scheduled runs, manual timer).
  * Enhanced session template and blocklist profile validation.

* **Tests**
  * Added test coverage for session template handling and blocklist profile validation across different start flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->