### PR TITLE
Simplify configuration into three presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cargo run -- --task-note="Capture blockers for retro" --json
 
 # Show or set the active profile
 cargo run -- --profile
-cargo run -- --profile deep-work
+cargo run -- --profile standard
 cargo run -- --profile --json
 
 # Show or set the active theme preset
@@ -194,7 +194,7 @@ cargo run -- --allowlist-site-delete reddit.com
 cargo run -- --schedule
 cargo run -- --schedule-set='{"windows":[{"days":["mon","tue"],"start":"09:00","end":"11:00"}],"exception_dates":["2026-12-25"],"one_time_windows":[{"date":"2026-05-02","start":"14:00","end":"16:00"}]}'
 cargo run -- --weekday-rules
-cargo run -- --weekday-rules-set='[{"day":"mon","profile":"deep-work","blocklist_profile":"Work","session_template":"Deep Flow"}]'
+cargo run -- --weekday-rules-set='[{"day":"mon","profile":"standard","blocklist_profile":"Work","session_template":"Deep Flow"}]'
 cargo run -- --schedule-delay
 cargo run -- --schedule --json
 cargo run -- --weekday-rules --json
@@ -298,7 +298,7 @@ deprecation warnings when legacy compatibility fields are detected.
 | Legacy field/path                                                                    | Canonical replacement                                                                                                                             | Removal milestone |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | Top-level `focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval` | `[custom_profile]`                                                                                                                                | v0.12.0           |
-| Top-level `notifications`, `auto_start`, `strict_mode`, `recurring_schedule`         | `[profile_automation.<profile>.notifications]`, `[profile_automation.<profile>.auto_start]`, and per-profile `strict_mode` / `recurring_schedule` | v0.12.0           |
+| Top-level `notifications`, `auto_start`, `strict_mode`, `recurring_schedule`         | `[profile_automation.<preset>.notifications]`, `[profile_automation.<preset>.auto_start]`, and per-preset `strict_mode` / `recurring_schedule` | v0.12.0           |
 | Top-level `blocked_sites` (without canonical profiles)                               | `[[blocklist_profiles]]` + `selected_blocklist_profile`                                                                                           | v0.12.0           |
 
 Milestone policy:
@@ -412,22 +412,22 @@ backspace = "backspace"
 Navigation/edit tokens accept either a single character or a named key:
 `enter`, `esc`, `up`, `down`, `left`, `right`, `delete`, `backspace`, `space`.
 
-## Pomodoro profiles
+## Pomodoro presets
 
-`focustime` now supports selectable Pomodoro profiles:
+`focustime` now supports selectable Pomodoro presets:
 
-- **Classic** (25/5/15, long break every 4 focus sessions)
-- **Deep Work** (50/10/30, long break every 3 focus sessions)
-- **Custom** (editable in-app)
+- **Basic** (25/5/15, long break every 4 focus sessions)
+- **Standard** (50/10/30, long break every 3 focus sessions)
+- **Advanced** (editable in-app)
 
 Open profile manager from timer view with **`p`**.
 
-- `↑/↓` (default `navigate_up`/`navigate_down`): move between profiles
-- `Enter` (default `confirm`): apply selected profile
+- `↑/↓` (default `navigate_up`/`navigate_down`): move between presets
+- `Enter` (default `confirm`): apply selected preset
 - `e`: open profile/settings editor
 - In editor: `↑/↓` selects field, `←/→` adjusts numeric/boolean values (including **Theme preset**), `Type/Backspace` edits WakaTime project/language, `Enter` saves (all defaults are configurable via navigation/edit shortcut fields)
 
-Profile selection, theme preset selection, custom durations, and profile-scoped
+Preset selection, theme preset selection, custom durations, and preset-scoped
 automation settings are persisted in `config.toml`.
 
 ## Session planner
@@ -485,8 +485,8 @@ matches `docs.example.com` and `api.example.com`, but does **not** match
 ### Example config
 
 ```toml
-schema_version = 1
-selected_profile = "custom"
+schema_version = 2
+selected_profile = "advanced"
 selected_session_template = "Deep Flow"
 selected_theme_preset = "classic"
 selected_blocklist_profile = "Work"
@@ -544,7 +544,7 @@ allowlist_sites = []
 [[session_templates]]
 name = "Deep Flow"
 task_label = "Docs"
-profile = "deep-work"
+profile = "standard"
 blocklist_profile = "Work"
 
 [[session_templates.schedule.windows]]
@@ -558,25 +558,25 @@ short_break_secs = 360
 long_break_secs = 900
 long_break_interval = 3
 
-[profile_automation.custom]
+[profile_automation.advanced]
 # Strict mode for the selected profile.
 strict_mode = false
 
-[profile_automation.custom.notifications]
+[profile_automation.advanced.notifications]
 enabled = true
 sound = false
 
-[profile_automation.custom.auto_start]
+[profile_automation.advanced.auto_start]
 focus_to_break = false
 break_to_focus = false
 
-[profile_automation.custom.recurring_schedule]
+[profile_automation.advanced.recurring_schedule]
 exception_dates = ["2026-12-25", "2027-01-01"]
-[[profile_automation.custom.recurring_schedule.windows]]
+[[profile_automation.advanced.recurring_schedule.windows]]
 days = ["mon", "tue", "wed", "thu", "fri"]
 start = "09:00"
 end = "11:00"
-[[profile_automation.custom.recurring_schedule.one_time_windows]]
+[[profile_automation.advanced.recurring_schedule.one_time_windows]]
 date = "2026-05-02"
 start = "14:00"
 end = "16:00"
@@ -747,19 +747,19 @@ Notifications are delivered best-effort:
 
 - terminal notice in the timer view
 - desktop notification via platform-specific delivery (`winrt-toast-reborn` toast on Windows with a `msg` fallback, `osascript` on macOS, `notify-send` on Linux)
-- optional sound alert using platform audio capabilities when `profile_automation.<profile>.notifications.sound = true`
+- optional sound alert using platform audio capabilities when `profile_automation.<preset>.notifications.sound = true`
 
 Natural, non-catchup phase transitions can also auto-start the next timer with safe defaults (`Off`):
 
-- `profile_automation.<profile>.auto_start.focus_to_break` starts break timers automatically after focus completion on non-catchup ticks
-- `profile_automation.<profile>.auto_start.break_to_focus` starts focus timers automatically after break completion on non-catchup ticks
+- `profile_automation.<preset>.auto_start.focus_to_break` starts break timers automatically after focus completion on non-catchup ticks
+- `profile_automation.<preset>.auto_start.break_to_focus` starts focus timers automatically after break completion on non-catchup ticks
 
 Recurring schedule windows can also trigger focus behavior at wall-clock times:
 
-- `profile_automation.<profile>.recurring_schedule.windows[].days` accepts day tokens (`mon`..`sun`, case-insensitive)
-- `profile_automation.<profile>.recurring_schedule.windows[].start` / `end` use 24-hour `HH:MM` local time (`start < end`)
-- `profile_automation.<profile>.recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
-- `profile_automation.<profile>.recurring_schedule.one_time_windows[]` accepts one-time date windows with `date` (`YYYY-MM-DD`) plus `start`/`end` (`HH:MM`)
+- `profile_automation.<preset>.recurring_schedule.windows[].days` accepts day tokens (`mon`..`sun`, case-insensitive)
+- `profile_automation.<preset>.recurring_schedule.windows[].start` / `end` use 24-hour `HH:MM` local time (`start < end`)
+- `profile_automation.<preset>.recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
+- `profile_automation.<preset>.recurring_schedule.one_time_windows[]` accepts one-time date windows with `date` (`YYYY-MM-DD`) plus `start`/`end` (`HH:MM`)
 - when a window begins, focus auto-starts if possible; otherwise schedule mode arms and shows a reminder until you manually start focus
 - while a schedule window is active and focus is not already running, press `z` to delay the scheduled start (configurable via `[schedule_runtime].delay_secs`, default `10m`, clamped `60..43200` seconds)
 - recurring exception dates only skip recurring windows; one-time windows still apply on their configured date

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -222,7 +222,7 @@ fn applying_profile_loads_profile_scoped_automation_rules() {
     let config = AppConfig {
         selected_profile: ProfileId::Classic,
         profile_automation: Some(ProfileAutomationSettingsConfig {
-            classic: Some(ProfileAutomationConfig {
+            basic: Some(ProfileAutomationConfig {
                 notifications: NotificationConfig {
                     enabled: true,
                     sound: false,
@@ -234,7 +234,7 @@ fn applying_profile_loads_profile_scoped_automation_rules() {
                 strict_mode: false,
                 recurring_schedule: classic_schedule.clone(),
             }),
-            deep_work: Some(ProfileAutomationConfig {
+            standard: Some(ProfileAutomationConfig {
                 notifications: NotificationConfig {
                     enabled: false,
                     sound: false,
@@ -246,7 +246,7 @@ fn applying_profile_loads_profile_scoped_automation_rules() {
                 strict_mode: true,
                 recurring_schedule: deep_work_schedule.clone(),
             }),
-            custom: None,
+            advanced: None,
         }),
         ..AppConfig::default()
     };
@@ -285,7 +285,7 @@ fn applying_profile_with_missing_automation_uses_neutral_defaults() {
         exception_dates: vec!["2026-12-25".to_string()],
         one_time_windows: Vec::new(),
     };
-    app.profile_automation.deep_work = None;
+    app.profile_automation.standard = None;
 
     assert!(app.apply_profile(ProfileId::DeepWork));
     assert_eq!(app.selected_profile, ProfileId::DeepWork);
@@ -6343,8 +6343,8 @@ fn startup_recovery_rehydrates_profile_automation_runtime_for_snapshot_profile()
         selected_profile: ProfileId::Custom,
         strict_mode: false,
         profile_automation: Some(ProfileAutomationSettingsConfig {
-            classic: Some(ProfileAutomationConfig::default()),
-            deep_work: Some(ProfileAutomationConfig {
+            basic: Some(ProfileAutomationConfig::default()),
+            standard: Some(ProfileAutomationConfig {
                 notifications: NotificationConfig {
                     enabled: false,
                     sound: true,
@@ -6356,7 +6356,7 @@ fn startup_recovery_rehydrates_profile_automation_runtime_for_snapshot_profile()
                 strict_mode: true,
                 recurring_schedule: deep_work_schedule.clone(),
             }),
-            custom: Some(ProfileAutomationConfig::default()),
+            advanced: Some(ProfileAutomationConfig::default()),
         }),
         ..AppConfig::default()
     };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,7 +96,7 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --focus-intention=TEXT [--json]
   focustime --task-note [TEXT] [--json]
   focustime --task-note=TEXT [--json]
-  focustime --profile [classic|deep-work|custom] [--json]
+  focustime --profile [basic|standard|advanced] [--json]
   focustime --theme [classic|high-contrast|deuteranopia-friendly] [--json]
   focustime --goal [--json]
   focustime --goal=MINUTES,POMODOROS [--json]
@@ -153,7 +153,7 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --diagnostics [--json]
   focustime --blocking-preview [--json]
   focustime --usage-signals [--json]
-  focustime --status [--watch[=SECONDS]] [--compare-by=task|profile|time-of-day] [--compare-task=LABEL|all] [--compare-profile=classic|deep-work|custom|unknown|all] [--compare-time=morning|afternoon|evening|night|unknown|all] [--compare-limit=N] [--json]
+  focustime --status [--watch[=SECONDS]] [--compare-by=task|profile|time-of-day] [--compare-task=LABEL|all] [--compare-profile=basic|standard|advanced|unknown|all] [--compare-time=morning|afternoon|evening|night|unknown|all] [--compare-limit=N] [--json]
   focustime --backup[=DIR] [--json]
   focustime --restore[=DIR] [--json]
   focustime --sync-backup[=DIR] [--sync-passphrase=PASSPHRASE] [--json]
@@ -227,7 +227,7 @@ Options:
   --watch         Stream periodic status updates (status command only; default 1s)
   --compare-by    Status comparison dimension: task | profile | time-of-day
   --compare-task  Status comparison task slice label, or `all` to clear
-  --compare-profile  Status comparison profile slice: classic | deep-work | custom | unknown | all
+  --compare-profile  Status comparison profile slice: basic | standard | advanced | unknown | all
   --compare-time  Status comparison time-of-day slice: morning | afternoon | evening | night | unknown | all
   --compare-limit Status comparison row limit (positive integer)
   --backup        Back up config.toml and stats.toml to current directory or DIR

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -438,7 +438,7 @@ fn classify_compare_profile_arg(
     {
         let value = require_nonempty_key_value(
             next,
-            "`--compare-profile` requires `classic`, `deep-work`, `custom`, `unknown`, or `all`.",
+            "`--compare-profile` requires `basic`, `standard`, `advanced`, `unknown`, or `all`.",
         )?;
         return Ok((
             ParsedToken::CompareProfile(parse_compare_profile_value(value)?),
@@ -446,7 +446,7 @@ fn classify_compare_profile_arg(
         ));
     }
     Err(invalid_usage(
-        "`--compare-profile` requires a value. Use `--compare-profile=classic|deep-work|custom|unknown|all`.",
+        "`--compare-profile` requires a value. Use `--compare-profile=basic|standard|advanced|unknown|all`.",
     ))
 }
 
@@ -952,7 +952,7 @@ fn classify_weekday_rules_set_arg(
         ));
     }
     Err(invalid_usage(
-        "`--weekday-rules-set` requires a JSON payload. Use `--weekday-rules-set='[{\"day\":\"mon\",\"profile\":\"deep-work\",\"blocklist_profile\":\"Work\",\"session_template\":\"Deep Flow\"}]'`.",
+        "`--weekday-rules-set` requires a JSON payload. Use `--weekday-rules-set='[{\"day\":\"mon\",\"profile\":\"standard\",\"blocklist_profile\":\"Work\",\"session_template\":\"Deep Flow\"}]'`.",
     ))
 }
 
@@ -1320,7 +1320,7 @@ fn parse_compare_profile_key_value_arg(arg: &str) -> Result<Option<ParsedToken>,
     if let Some(value) = arg.strip_prefix("--compare-profile=") {
         let value = require_nonempty_key_value(
             value,
-            "`--compare-profile=` requires `classic`, `deep-work`, `custom`, `unknown`, or `all`.",
+            "`--compare-profile=` requires `basic`, `standard`, `advanced`, `unknown`, or `all`.",
         )?;
         return Ok(Some(ParsedToken::CompareProfile(
             parse_compare_profile_value(value)?,

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -754,11 +754,11 @@ pub(super) fn finalize_cli_action(
 
 pub(super) fn parse_profile_id(value: &str) -> Result<ProfileId, String> {
     match value.trim().to_ascii_lowercase().as_str() {
-        "classic" => Ok(ProfileId::Classic),
-        "deep-work" | "deep_work" | "deepwork" => Ok(ProfileId::DeepWork),
-        "custom" => Ok(ProfileId::Custom),
+        "basic" | "classic" => Ok(ProfileId::Classic),
+        "standard" | "deep-work" | "deep_work" | "deepwork" => Ok(ProfileId::DeepWork),
+        "advanced" | "custom" => Ok(ProfileId::Custom),
         _ => Err(invalid_usage(&format!(
-            "Invalid profile `{value}`. Use `classic`, `deep-work`, or `custom`."
+            "Invalid profile `{value}`. Use `basic`, `standard`, or `advanced`."
         ))),
     }
 }
@@ -934,7 +934,7 @@ pub(super) fn parse_weekday_rules_value(
 ) -> Result<Vec<WeekdayProfileRuleConfig>, String> {
     let rules = serde_json::from_str::<Vec<WeekdayProfileRuleConfig>>(value).map_err(|error| {
         invalid_usage(&format!(
-            "Invalid weekday-rules JSON payload: {error}. Use `--weekday-rules-set='[{{\"day\":\"mon\",\"profile\":\"deep-work\",\"blocklist_profile\":\"Work\",\"session_template\":\"Deep Flow\"}}]'`."
+            "Invalid weekday-rules JSON payload: {error}. Use `--weekday-rules-set='[{{\"day\":\"mon\",\"profile\":\"standard\",\"blocklist_profile\":\"Work\",\"session_template\":\"Deep Flow\"}}]'`."
         ))
     })?;
     validate_weekday_rules_value(&rules)?;
@@ -1342,12 +1342,12 @@ pub(super) fn parse_compare_by_value(value: &str) -> Result<ComparisonDimension,
 pub(super) fn parse_compare_profile_value(value: &str) -> Result<Option<ProfileBucket>, String> {
     match value.trim().to_ascii_lowercase().as_str() {
         "all" => Ok(None),
-        "classic" => Ok(Some(ProfileBucket::Classic)),
-        "deep-work" | "deep_work" | "deepwork" => Ok(Some(ProfileBucket::DeepWork)),
-        "custom" => Ok(Some(ProfileBucket::Custom)),
+        "basic" | "classic" => Ok(Some(ProfileBucket::Classic)),
+        "standard" | "deep-work" | "deep_work" | "deepwork" => Ok(Some(ProfileBucket::DeepWork)),
+        "advanced" | "custom" => Ok(Some(ProfileBucket::Custom)),
         "unknown" => Ok(Some(ProfileBucket::Unknown)),
         _ => Err(invalid_usage(&format!(
-            "Invalid compare profile `{value}`. Use `classic`, `deep-work`, `custom`, `unknown`, or `all`."
+            "Invalid compare profile `{value}`. Use `basic`, `standard`, `advanced`, `unknown`, or `all`."
         ))),
     }
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -539,9 +539,9 @@ fn resolve_profile_spec(profile: ProfileId, custom: &CustomProfileConfig) -> Pro
 
 pub(super) fn profile_id(profile: ProfileId) -> &'static str {
     match profile {
-        ProfileId::Classic => "classic",
-        ProfileId::DeepWork => "deep-work",
-        ProfileId::Custom => "custom",
+        ProfileId::Classic => "basic",
+        ProfileId::DeepWork => "standard",
+        ProfileId::Custom => "advanced",
     }
 }
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -3299,7 +3299,7 @@ fn build_status_output_uses_recovery_snapshot_for_live_state() {
     assert_eq!(output.live.selected_task_label.as_deref(), Some("Docs"));
     assert_eq!(output.live.focus_intention.as_deref(), Some("Write docs"));
     assert_eq!(output.live.task_note.as_deref(), Some("API section"));
-    assert_eq!(output.live.selected_profile.id, "deep-work");
+    assert_eq!(output.live.selected_profile.id, "standard");
     assert!(output.live.recovery_error.is_none());
     assert_eq!(output.session.pomodoros_completed, 3);
     assert_eq!(output.session.focused_minutes, 199);

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ use paths::{app_dir_with_env, stats_app_dir_with_env};
 #[cfg(test)]
 use paths::{config_dir_from_env, stats_state_dir_from_env};
 
-const CURRENT_CONFIG_SCHEMA_VERSION: u32 = 1;
+const CURRENT_CONFIG_SCHEMA_VERSION: u32 = 2;
 const LEGACY_CONFIG_SCHEMA_VERSION: u32 = 0;
 const SCHEDULE_TIME_STEP_MIN_MINUTES: u16 = 1;
 const SCHEDULE_TIME_STEP_MAX_MINUTES: u16 = 60;
@@ -949,29 +949,34 @@ impl ProfileAutomationConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ProfileAutomationSettingsConfig {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub classic: Option<ProfileAutomationConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deep_work: Option<ProfileAutomationConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom: Option<ProfileAutomationConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "classic")]
+    pub basic: Option<ProfileAutomationConfig>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "deep_work",
+        alias = "deep-work"
+    )]
+    pub standard: Option<ProfileAutomationConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "custom")]
+    pub advanced: Option<ProfileAutomationConfig>,
 }
 
 impl ProfileAutomationSettingsConfig {
     fn with_shared_defaults(shared: ProfileAutomationConfig) -> Self {
         let shared = Some(shared.normalized());
         Self {
-            classic: shared.clone(),
-            deep_work: shared.clone(),
-            custom: shared,
+            basic: shared.clone(),
+            standard: shared.clone(),
+            advanced: shared,
         }
     }
 
     fn normalized_with_fallback(&self, fallback: &ProfileAutomationConfig) -> Self {
         Self {
-            classic: Some(self.for_profile(ProfileId::Classic, fallback).normalized()),
-            deep_work: Some(self.for_profile(ProfileId::DeepWork, fallback).normalized()),
-            custom: Some(self.for_profile(ProfileId::Custom, fallback).normalized()),
+            basic: Some(self.for_profile(ProfileId::Classic, fallback).normalized()),
+            standard: Some(self.for_profile(ProfileId::DeepWork, fallback).normalized()),
+            advanced: Some(self.for_profile(ProfileId::Custom, fallback).normalized()),
         }
     }
 
@@ -981,9 +986,9 @@ impl ProfileAutomationSettingsConfig {
         fallback: &ProfileAutomationConfig,
     ) -> ProfileAutomationConfig {
         let configured = match profile {
-            ProfileId::Classic => self.classic.clone(),
-            ProfileId::DeepWork => self.deep_work.clone(),
-            ProfileId::Custom => self.custom.clone(),
+            ProfileId::Classic => self.basic.clone(),
+            ProfileId::DeepWork => self.standard.clone(),
+            ProfileId::Custom => self.advanced.clone(),
         };
         configured.unwrap_or_else(|| fallback.clone()).normalized()
     }
@@ -991,9 +996,9 @@ impl ProfileAutomationSettingsConfig {
     pub fn set_for_profile(&mut self, profile: ProfileId, config: ProfileAutomationConfig) {
         let value = Some(config.normalized());
         match profile {
-            ProfileId::Classic => self.classic = value,
-            ProfileId::DeepWork => self.deep_work = value,
-            ProfileId::Custom => self.custom = value,
+            ProfileId::Classic => self.basic = value,
+            ProfileId::DeepWork => self.standard = value,
+            ProfileId::Custom => self.advanced = value,
         }
     }
 }
@@ -1898,29 +1903,28 @@ fn default_history_dashboard_card_order() -> Vec<HistoryKpiCardId> {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "kebab-case")]
 pub enum ProfileId {
+    #[serde(rename = "basic")]
     Classic,
+    #[serde(rename = "standard")]
     DeepWork,
     #[default]
+    #[serde(rename = "advanced")]
     Custom,
 }
 
 impl ProfileId {
     fn from_config_value(value: &str) -> Self {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "classic" => Self::Classic,
-            "deep-work" | "deep_work" | "deepwork" => Self::DeepWork,
-            "custom" => Self::Custom,
-            _ => Self::Custom,
-        }
+        canonical_profile_id_token(value)
+            .map(profile_id_for_token)
+            .unwrap_or(Self::Custom)
     }
 
     pub fn label(self) -> &'static str {
         match self {
-            ProfileId::Classic => "Classic",
-            ProfileId::DeepWork => "Deep Work",
-            ProfileId::Custom => "Custom",
+            ProfileId::Classic => "Basic",
+            ProfileId::DeepWork => "Standard",
+            ProfileId::Custom => "Advanced",
         }
     }
 }
@@ -1932,6 +1936,24 @@ impl<'de> Deserialize<'de> for ProfileId {
     {
         let value = String::deserialize(deserializer)?;
         Ok(Self::from_config_value(&value))
+    }
+}
+
+fn canonical_profile_id_token(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "basic" | "classic" => Some("basic"),
+        "standard" | "deep-work" | "deep_work" | "deepwork" => Some("standard"),
+        "advanced" | "custom" => Some("advanced"),
+        _ => None,
+    }
+}
+
+fn profile_id_for_token(token: &str) -> ProfileId {
+    match token {
+        "basic" => ProfileId::Classic,
+        "standard" => ProfileId::DeepWork,
+        "advanced" => ProfileId::Custom,
+        _ => ProfileId::Custom,
     }
 }
 
@@ -2383,14 +2405,14 @@ fn detect_legacy_config_deprecation_warnings(config: &AppConfig) -> Vec<String> 
         .profile_automation
         .as_ref()
         .map(|settings| {
-            settings.classic.is_none() || settings.deep_work.is_none() || settings.custom.is_none()
+            settings.basic.is_none() || settings.standard.is_none() || settings.advanced.is_none()
         })
         .unwrap_or(true);
     let legacy_automation_in_use =
         legacy_automation_values_configured && profile_automation_incomplete;
     if legacy_automation_in_use {
         warnings.push(
-            "Deprecated top-level automation fields (`notifications`, `auto_start`, `strict_mode`, `recurring_schedule`) are in use. Move them under `[profile_automation.<profile>]`.".to_string(),
+            "Deprecated top-level automation fields (`notifications`, `auto_start`, `strict_mode`, `recurring_schedule`) are in use. Move them under `[profile_automation.<preset>]`.".to_string(),
         );
     }
 
@@ -2417,6 +2439,7 @@ fn migrate_config_toml_step(
 ) -> Option<toml::Value> {
     match from_schema_version {
         LEGACY_CONFIG_SCHEMA_VERSION => migrate_config_toml_legacy_to_v1(config_toml),
+        1 => migrate_config_toml_v1_to_v2(config_toml),
         _ => None,
     }
 }
@@ -2428,6 +2451,104 @@ fn migrate_config_toml_legacy_to_v1(mut config_toml: toml::Value) -> Option<toml
         toml::Value::Integer(i64::from(CURRENT_CONFIG_SCHEMA_VERSION)),
     );
     Some(config_toml)
+}
+
+fn migrate_config_toml_v1_to_v2(mut config_toml: toml::Value) -> Option<toml::Value> {
+    let table = config_toml.as_table_mut()?;
+    migrate_profile_value_in_table(table, "selected_profile");
+    migrate_profile_automation_preset_keys(table);
+    migrate_profile_value_in_array_table(table, "session_templates", "profile");
+    migrate_profile_value_in_array_table(table, "weekday_profile_rules", "profile");
+    migrate_automation_trigger_action_profiles(table);
+    table.insert(
+        "schema_version".to_string(),
+        toml::Value::Integer(i64::from(CURRENT_CONFIG_SCHEMA_VERSION)),
+    );
+    Some(config_toml)
+}
+
+fn migrate_profile_value_in_array_table(
+    table: &mut toml::map::Map<String, toml::Value>,
+    array_key: &str,
+    field_key: &str,
+) {
+    let Some(array) = table
+        .get_mut(array_key)
+        .and_then(|value| value.as_array_mut())
+    else {
+        return;
+    };
+    for entry in array {
+        let Some(entry_table) = entry.as_table_mut() else {
+            continue;
+        };
+        migrate_profile_value_in_table(entry_table, field_key);
+    }
+}
+
+fn migrate_profile_value_in_table(
+    table: &mut toml::map::Map<String, toml::Value>,
+    field_key: &str,
+) {
+    let Some(value) = table.get_mut(field_key) else {
+        return;
+    };
+    let Some(raw) = value.as_str() else {
+        return;
+    };
+    let Some(mapped) = canonical_profile_id_token(raw) else {
+        return;
+    };
+    *value = toml::Value::String(mapped.to_string());
+}
+
+fn migrate_profile_automation_preset_keys(table: &mut toml::map::Map<String, toml::Value>) {
+    let Some(profile_automation) = table
+        .get_mut("profile_automation")
+        .and_then(|value| value.as_table_mut())
+    else {
+        return;
+    };
+    migrate_table_key(profile_automation, "classic", "basic");
+    migrate_table_key(profile_automation, "deep_work", "standard");
+    migrate_table_key(profile_automation, "deep-work", "standard");
+    migrate_table_key(profile_automation, "custom", "advanced");
+}
+
+fn migrate_table_key(
+    table: &mut toml::map::Map<String, toml::Value>,
+    old_key: &str,
+    new_key: &str,
+) {
+    if table.contains_key(new_key) {
+        let _ = table.remove(old_key);
+        return;
+    }
+    let Some(value) = table.remove(old_key) else {
+        return;
+    };
+    table.insert(new_key.to_string(), value);
+}
+
+fn migrate_automation_trigger_action_profiles(table: &mut toml::map::Map<String, toml::Value>) {
+    let Some(triggers) = table
+        .get_mut("automation_triggers")
+        .and_then(|value| value.as_array_mut())
+    else {
+        return;
+    };
+    for entry in triggers {
+        let Some(entry_table) = entry.as_table_mut() else {
+            continue;
+        };
+        let Some(action_table) = entry_table
+            .get_mut("action")
+            .and_then(|action| action.as_table_mut())
+        else {
+            continue;
+        };
+        migrate_profile_value_in_table(action_table, "profile");
+    }
 }
 
 #[cfg_attr(test, allow(dead_code))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2520,14 +2520,30 @@ fn migrate_table_key(
     old_key: &str,
     new_key: &str,
 ) {
-    if table.contains_key(new_key) {
-        let _ = table.remove(old_key);
-        return;
-    }
     let Some(value) = table.remove(old_key) else {
         return;
     };
+    if let Some(existing) = table.get_mut(new_key) {
+        merge_toml_value_prefer_existing(existing, value);
+        return;
+    }
     table.insert(new_key.to_string(), value);
+}
+
+fn merge_toml_value_prefer_existing(existing: &mut toml::Value, incoming: toml::Value) {
+    let (toml::Value::Table(existing_table), toml::Value::Table(incoming_table)) =
+        (existing, incoming)
+    else {
+        return;
+    };
+
+    for (key, incoming_value) in incoming_table {
+        if let Some(existing_value) = existing_table.get_mut(&key) {
+            merge_toml_value_prefer_existing(existing_value, incoming_value);
+        } else {
+            existing_table.insert(key, incoming_value);
+        }
+    }
 }
 
 fn migrate_automation_trigger_action_profiles(table: &mut toml::map::Map<String, toml::Value>) {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -192,7 +192,7 @@ fn round_trip_full_config() {
         },
         calendar_sync: CalendarSyncConfig::default(),
         profile_automation: Some(ProfileAutomationSettingsConfig {
-            classic: Some(ProfileAutomationConfig {
+            basic: Some(ProfileAutomationConfig {
                 notifications: NotificationConfig {
                     enabled: true,
                     sound: false,
@@ -204,7 +204,7 @@ fn round_trip_full_config() {
                 strict_mode: false,
                 recurring_schedule: RecurringScheduleConfig::default(),
             }),
-            deep_work: Some(ProfileAutomationConfig {
+            standard: Some(ProfileAutomationConfig {
                 notifications: NotificationConfig {
                     enabled: true,
                     sound: true,
@@ -228,7 +228,7 @@ fn round_trip_full_config() {
                     }],
                 },
             }),
-            custom: Some(ProfileAutomationConfig {
+            advanced: Some(ProfileAutomationConfig {
                 notifications: NotificationConfig::default(),
                 auto_start: AutoStartConfig::default(),
                 strict_mode: false,
@@ -1494,6 +1494,92 @@ fn load_with_env_migrates_explicit_legacy_schema_version() {
 }
 
 #[test]
+fn migrate_config_toml_v1_to_v2_maps_profile_ids_and_profile_automation_keys() {
+    let v1: toml::Value = toml::from_str(
+        r#"
+schema_version = 1
+selected_profile = "deep-work"
+
+[[session_templates]]
+name = "Template"
+task_label = "Task"
+profile = "custom"
+blocklist_profile = "Default"
+
+[[weekday_profile_rules]]
+day = "mon"
+profile = "classic"
+blocklist_profile = "Default"
+
+[[automation_triggers]]
+trigger = { type = "focus_completed" }
+action = { type = "apply_defaults", profile = "deep_work", blocklist_profile = "Default" }
+
+[profile_automation.classic]
+strict_mode = false
+
+[profile_automation.deep_work]
+strict_mode = true
+
+[profile_automation.custom]
+strict_mode = false
+"#,
+    )
+    .unwrap();
+    let migrated = migrate_config_toml_to_current(v1).expect("v1 payload should migrate to v2");
+    let root = migrated.as_table().expect("root should be a table");
+
+    assert_eq!(
+        root.get("schema_version").and_then(toml::Value::as_integer),
+        Some(i64::from(CURRENT_CONFIG_SCHEMA_VERSION))
+    );
+    assert_eq!(
+        root.get("selected_profile").and_then(toml::Value::as_str),
+        Some("standard")
+    );
+
+    let profile_automation = root
+        .get("profile_automation")
+        .and_then(toml::Value::as_table)
+        .expect("profile_automation should be a table");
+    assert!(profile_automation.get("basic").is_some());
+    assert!(profile_automation.get("standard").is_some());
+    assert!(profile_automation.get("advanced").is_some());
+    assert!(profile_automation.get("classic").is_none());
+    assert!(profile_automation.get("deep_work").is_none());
+    assert!(profile_automation.get("custom").is_none());
+
+    let session_template_profile = root
+        .get("session_templates")
+        .and_then(toml::Value::as_array)
+        .and_then(|array| array.first())
+        .and_then(toml::Value::as_table)
+        .and_then(|template| template.get("profile"))
+        .and_then(toml::Value::as_str);
+    assert_eq!(session_template_profile, Some("advanced"));
+
+    let weekday_rule_profile = root
+        .get("weekday_profile_rules")
+        .and_then(toml::Value::as_array)
+        .and_then(|array| array.first())
+        .and_then(toml::Value::as_table)
+        .and_then(|rule| rule.get("profile"))
+        .and_then(toml::Value::as_str);
+    assert_eq!(weekday_rule_profile, Some("basic"));
+
+    let automation_trigger_profile = root
+        .get("automation_triggers")
+        .and_then(toml::Value::as_array)
+        .and_then(|array| array.first())
+        .and_then(toml::Value::as_table)
+        .and_then(|trigger| trigger.get("action"))
+        .and_then(toml::Value::as_table)
+        .and_then(|action| action.get("profile"))
+        .and_then(toml::Value::as_str);
+    assert_eq!(automation_trigger_profile, Some("standard"));
+}
+
+#[test]
 fn load_with_env_leniently_parses_newer_schema_version() {
     let temp_base = unique_temp_base("future-version");
     let app_dir = temp_base.join("focustime");
@@ -2044,9 +2130,9 @@ fn normalize_selected_profile_automation_keeps_top_level_legacy_fields() {
         recurring_schedule: RecurringScheduleConfig::default(),
         strict_mode: false,
         profile_automation: Some(ProfileAutomationSettingsConfig {
-            classic: Some(classic),
-            deep_work: Some(deep_work.clone()),
-            custom: None,
+            basic: Some(classic),
+            standard: Some(deep_work.clone()),
+            advanced: None,
         }),
         ..AppConfig::default()
     }
@@ -2093,9 +2179,9 @@ fn normalize_legacy_automation_fields_do_not_override_profile_automation() {
         strict_mode: false,
         recurring_schedule: RecurringScheduleConfig::default(),
         profile_automation: Some(ProfileAutomationSettingsConfig {
-            classic: None,
-            deep_work: Some(deep_work.clone()),
-            custom: None,
+            basic: None,
+            standard: Some(deep_work.clone()),
+            advanced: None,
         }),
         ..AppConfig::default()
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1580,6 +1580,76 @@ strict_mode = false
 }
 
 #[test]
+fn migrate_config_toml_v1_to_v2_merges_legacy_profile_automation_into_existing_preset_key() {
+    let v1: toml::Value = toml::from_str(
+        r#"
+schema_version = 1
+
+[profile_automation.standard]
+strict_mode = true
+[profile_automation.standard.notifications]
+enabled = false
+
+[profile_automation.deep_work]
+strict_mode = false
+[profile_automation.deep_work.notifications]
+enabled = true
+sound = true
+[profile_automation.deep_work.auto_start]
+focus_to_break = true
+break_to_focus = true
+"#,
+    )
+    .unwrap();
+
+    let migrated = migrate_config_toml_to_current(v1).expect("v1 payload should migrate to v2");
+    let profile_automation = migrated
+        .as_table()
+        .and_then(|root| root.get("profile_automation"))
+        .and_then(toml::Value::as_table)
+        .expect("profile_automation should be a table");
+
+    let standard = profile_automation
+        .get("standard")
+        .and_then(toml::Value::as_table)
+        .expect("standard profile automation should exist");
+    let notifications = standard
+        .get("notifications")
+        .and_then(toml::Value::as_table)
+        .expect("notifications should exist");
+    let auto_start = standard
+        .get("auto_start")
+        .and_then(toml::Value::as_table)
+        .expect("auto_start should exist");
+
+    assert_eq!(
+        standard.get("strict_mode").and_then(toml::Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        notifications.get("enabled").and_then(toml::Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        notifications.get("sound").and_then(toml::Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        auto_start
+            .get("focus_to_break")
+            .and_then(toml::Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        auto_start
+            .get("break_to_focus")
+            .and_then(toml::Value::as_bool),
+        Some(true)
+    );
+    assert!(profile_automation.get("deep_work").is_none());
+}
+
+#[test]
 fn load_with_env_leniently_parses_newer_schema_version() {
     let temp_base = unique_temp_base("future-version");
     let app_dir = temp_base.join("focustime");

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -35,7 +35,7 @@ mod trends;
 const STATS_FILE_NAME: &str = "stats.toml";
 const JSON_EXPORT_FILE_NAME: &str = "focustime-stats.json";
 const CSV_EXPORT_FILE_NAME: &str = "focustime-stats.csv";
-const EXPORT_SCHEMA_VERSION: u32 = 7;
+const EXPORT_SCHEMA_VERSION: u32 = 8;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -516,29 +516,37 @@ pub struct SessionInterruptionEvent {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
 pub enum ProfileBucket {
+    #[serde(rename = "basic", alias = "classic")]
     Classic,
+    #[serde(
+        rename = "standard",
+        alias = "deep_work",
+        alias = "deep-work",
+        alias = "deepwork"
+    )]
     DeepWork,
+    #[serde(rename = "advanced", alias = "custom")]
     Custom,
+    #[serde(rename = "unknown")]
     Unknown,
 }
 
 impl ProfileBucket {
     pub fn label(self) -> &'static str {
         match self {
-            Self::Classic => "Classic",
-            Self::DeepWork => "Deep Work",
-            Self::Custom => "Custom",
+            Self::Classic => "Basic",
+            Self::DeepWork => "Standard",
+            Self::Custom => "Advanced",
             Self::Unknown => "Unknown",
         }
     }
 
     pub fn id(self) -> &'static str {
         match self {
-            Self::Classic => "classic",
-            Self::DeepWork => "deep_work",
-            Self::Custom => "custom",
+            Self::Classic => "basic",
+            Self::DeepWork => "standard",
+            Self::Custom => "advanced",
             Self::Unknown => "unknown",
         }
     }

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -1699,12 +1699,12 @@ fn productivity_comparison_applies_task_and_time_filters() {
     assert_eq!(rows.len(), 2);
     let classic = rows
         .iter()
-        .find(|row| row.label == "Classic")
-        .expect("classic row should be present");
+        .find(|row| row.label == "Basic")
+        .expect("basic row should be present");
     let deep_work = rows
         .iter()
-        .find(|row| row.label == "Deep Work")
-        .expect("deep work row should be present");
+        .find(|row| row.label == "Standard")
+        .expect("standard row should be present");
     assert_eq!(classic.sessions_completed, 1);
     assert_eq!(classic.focused_minutes(), 30);
     assert_eq!(classic.focus_share_pct, 60);
@@ -1830,7 +1830,7 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
     assert_eq!(sessions[0]["focus_intention"], "Project A");
     assert_eq!(sessions[0]["task_note"], "Project A");
     assert_eq!(sessions[0]["focused_minutes"], 30);
-    assert_eq!(sessions[0]["profile"], "classic");
+    assert_eq!(sessions[0]["profile"], "basic");
     assert_eq!(interruptions[0]["reason"], "manual_skip");
     assert_eq!(interruptions[0]["remaining_secs"], 600);
     assert_eq!(interruptions[0]["task_label"], "Project A");
@@ -1857,7 +1857,7 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
             .iter()
             .any(|entry| entry.get("focus_score_pct").is_some())
     );
-    assert_eq!(profile_effectiveness[0]["profile"], "Classic");
+    assert_eq!(profile_effectiveness[0]["profile"], "Basic");
     assert_eq!(
         profile_effectiveness[0]["average_focused_minutes_per_session"],
         30
@@ -1885,12 +1885,12 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
         .lines()
         .find(|line| line.contains(",focus_session,"))
         .expect("focus session row should be present");
-    assert!(focus_session_line.contains(",Classic,"));
+    assert!(focus_session_line.contains(",Basic,"));
     let interruption_line = csv
         .lines()
         .find(|line| line.contains(",session_interruption,"))
         .expect("session interruption row should be present");
-    assert!(interruption_line.contains(",Classic,"));
+    assert!(interruption_line.contains(",Basic,"));
     assert!(csv_header.contains("comparison_dimension"));
     assert!(csv_header.contains("comparison_label"));
     assert!(csv_header.contains("time_of_day_bucket"));
@@ -1927,7 +1927,7 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
         EXPORT_SCHEMA_VERSION
     )));
     assert!(csv.contains(&format!("{},history_kpi", EXPORT_SCHEMA_VERSION)));
-    assert!(csv.contains("Classic,1,1,"));
+    assert!(csv.contains("Basic,1,1,"));
 
     #[derive(serde::Deserialize)]
     struct CsvKpiRow {


### PR DESCRIPTION
## What

- Reworks preset/profile configuration around exactly three IDs: `basic`, `standard`, and `advanced`.
- Adds config schema migration (`v1 -> v2`) that remaps legacy values (`classic`, `deep-work`, `custom`) and migrates `[profile_automation.*]` keys to preset-based keys.
- Updates CLI profile parsing/help/status output and stats profile buckets to the new preset IDs, while still accepting legacy aliases for compatibility.
- Updates README examples and terminology, and refreshes affected config/app/cli/stats tests.

## Why

Issue #381 is focused on reducing configuration complexity and cognitive load by standardizing setup on three presets, while keeping existing user configs safe during migration.

Closes #381.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs, examples, and CLI/TUI help to use preset terminology (Basic/Standard/Advanced) and clarified automation/notification examples and schema v2 snippets.

* **New Features**
  * Config schema bumped v1→v2 with automatic migration for existing configs; examples and presets updated accordingly.

* **Bug Fixes**
  * CLI, status output, and exports consistently use new preset identifiers.

* **Tests**
  * Test expectations and fixtures updated to match renamed presets and migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->