### PR TITLE
Reduce public API surface and visibility scope

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -77,8 +77,8 @@ mod weekday_rules;
 
 use history_dashboard_cache::HistoryDashboardCache;
 #[cfg(test)]
-pub use history_dashboard_cache::HistoryDashboardCacheStats;
-pub use history_dashboard_cache::HistoryDashboardViewData;
+pub(crate) use history_dashboard_cache::HistoryDashboardCacheStats;
+pub(crate) use history_dashboard_cache::HistoryDashboardViewData;
 pub(crate) use history_goals::weekly_daily_goal_allocation_for_context;
 pub(crate) use profile_edit::{
     CUSTOM_DURATION_STEP_SECS, DAILY_GOAL_MINUTES_STEP,
@@ -106,13 +106,13 @@ pub(crate) use profile_edit::{
     PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX, PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX,
     PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX, ProfileEditSnapshot,
 };
-pub use setup_diagnostics::{
+pub(crate) use setup_diagnostics::{
     BlockingPreviewSnapshot, SetupCheck, SetupCheckLevel, SetupDiagnostics,
 };
 use shortcuts::ShortcutBindings;
-pub use shortcuts::{NavigationAction, ShortcutAction};
+pub(crate) use shortcuts::{NavigationAction, ShortcutAction};
 
-pub const PROFILE_IDS: [ProfileId; 3] =
+pub(crate) const PROFILE_IDS: [ProfileId; 3] =
     [ProfileId::Classic, ProfileId::DeepWork, ProfileId::Custom];
 const DEFAULT_BLOCKLIST_PROFILE_NAME: &str = "Default";
 const DEFAULT_BLOCKLIST_CATEGORY_NAME: &str = "General";
@@ -123,7 +123,7 @@ const SCHEDULE_DAY_TOKENS: [&str; 7] = ["mon", "tue", "wed", "thu", "fri", "sat"
 const SCHEDULE_DAY_LABELS: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AppMode {
+pub(crate) enum AppMode {
     Timer,
     SiteManager,
     ProfileManager,
@@ -329,13 +329,13 @@ struct FocusInterruptionContext {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SiteInputMode {
+pub(crate) enum SiteInputMode {
     Add,
     Edit,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SiteListMode {
+pub(crate) enum SiteListMode {
     Blocklist,
     Allowlist,
 }
@@ -348,7 +348,7 @@ impl SiteListMode {
         }
     }
 
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Blocklist => "Blocklist",
             Self::Allowlist => "Allowlist",
@@ -357,7 +357,7 @@ impl SiteListMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BlocklistProfileInputMode {
+pub(crate) enum BlocklistProfileInputMode {
     Create,
     Rename,
     CreateCategory,
@@ -365,7 +365,7 @@ pub enum BlocklistProfileInputMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PlannerInputMode {
+pub(crate) enum PlannerInputMode {
     Add,
     Rename,
     CreateTemplate,
@@ -373,100 +373,100 @@ pub enum PlannerInputMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PlannerPane {
+pub(crate) enum PlannerPane {
     Tasks,
     Templates,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SiteFeedbackLevel {
+pub(crate) enum SiteFeedbackLevel {
     Success,
     Warning,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HistoryFeedbackLevel {
+pub(crate) enum HistoryFeedbackLevel {
     Success,
     Warning,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PlannerFeedbackLevel {
+pub(crate) enum PlannerFeedbackLevel {
     Success,
     Warning,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SiteFeedback {
-    pub level: SiteFeedbackLevel,
-    pub message: String,
+pub(crate) struct SiteFeedback {
+    pub(crate) level: SiteFeedbackLevel,
+    pub(crate) message: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PlannerFeedback {
-    pub level: PlannerFeedbackLevel,
-    pub message: String,
+pub(crate) struct PlannerFeedback {
+    pub(crate) level: PlannerFeedbackLevel,
+    pub(crate) message: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HistoryFeedback {
-    pub level: HistoryFeedbackLevel,
-    pub message: String,
+pub(crate) struct HistoryFeedback {
+    pub(crate) level: HistoryFeedbackLevel,
+    pub(crate) message: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct GoalProgress {
-    pub completed: u64,
-    pub target: u64,
-    pub ratio: f64,
+pub(crate) struct GoalProgress {
+    pub(crate) completed: u64,
+    pub(crate) target: u64,
+    pub(crate) ratio: f64,
 }
 
 impl GoalProgress {
-    pub fn is_configured(self) -> bool {
+    pub(crate) fn is_configured(self) -> bool {
         self.target > 0
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct DailyGoalProgress {
-    pub minutes: GoalProgress,
-    pub pomodoros: GoalProgress,
+pub(crate) struct DailyGoalProgress {
+    pub(crate) minutes: GoalProgress,
+    pub(crate) pomodoros: GoalProgress,
 }
 
 impl DailyGoalProgress {
-    pub fn has_any_target(self) -> bool {
+    pub(crate) fn has_any_target(self) -> bool {
         self.minutes.is_configured() || self.pomodoros.is_configured()
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WeeklyDailyAllocationDay {
-    pub day: NaiveDate,
-    pub minutes_target: u64,
-    pub pomodoros_target: u32,
-    pub allocatable: bool,
-    pub weight_minutes: u64,
+pub(crate) struct WeeklyDailyAllocationDay {
+    pub(crate) day: NaiveDate,
+    pub(crate) minutes_target: u64,
+    pub(crate) pomodoros_target: u32,
+    pub(crate) allocatable: bool,
+    pub(crate) weight_minutes: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WeeklyDailyGoalAllocation {
-    pub week_target: DailyGoalSnapshot,
-    pub completed_minutes: u64,
-    pub completed_pomodoros: u32,
-    pub remaining_minutes: u64,
-    pub remaining_pomodoros: u32,
-    pub remaining_days_in_week: usize,
-    pub allocatable_days: usize,
-    pub uses_schedule_weights: bool,
-    pub daily_targets: Vec<WeeklyDailyAllocationDay>,
+pub(crate) struct WeeklyDailyGoalAllocation {
+    pub(crate) week_target: DailyGoalSnapshot,
+    pub(crate) completed_minutes: u64,
+    pub(crate) completed_pomodoros: u32,
+    pub(crate) remaining_minutes: u64,
+    pub(crate) remaining_pomodoros: u32,
+    pub(crate) remaining_days_in_week: usize,
+    pub(crate) allocatable_days: usize,
+    pub(crate) uses_schedule_weights: bool,
+    pub(crate) daily_targets: Vec<WeeklyDailyAllocationDay>,
 }
 
 impl WeeklyDailyGoalAllocation {
-    pub fn has_any_target(&self) -> bool {
+    pub(crate) fn has_any_target(&self) -> bool {
         self.week_target.has_any_target()
     }
 
-    pub fn today_target(&self) -> DailyGoalSnapshot {
+    pub(crate) fn today_target(&self) -> DailyGoalSnapshot {
         self.daily_targets
             .first()
             .map(|target| DailyGoalSnapshot {
@@ -477,35 +477,35 @@ impl WeeklyDailyGoalAllocation {
     }
 }
 
-pub struct App {
-    pub timer: TimerState,
-    pub should_quit: bool,
-    pub mode: AppMode,
-    pub blocker: SiteBlocker,
+pub(crate) struct App {
+    pub(crate) timer: TimerState,
+    pub(crate) should_quit: bool,
+    pub(crate) mode: AppMode,
+    pub(crate) blocker: SiteBlocker,
     /// Text being typed for add/import or edit site input.
-    pub site_input: String,
+    pub(crate) site_input: String,
     /// Whether the user is currently typing a new site.
-    pub site_input_active: bool,
+    pub(crate) site_input_active: bool,
     site_edit_index: Option<usize>,
-    pub blocklist_profiles: Vec<BlocklistProfileConfig>,
+    pub(crate) blocklist_profiles: Vec<BlocklistProfileConfig>,
     active_blocklist_profile: usize,
-    pub session_templates: Vec<SessionTemplateConfig>,
+    pub(crate) session_templates: Vec<SessionTemplateConfig>,
     active_session_template: Option<usize>,
-    pub blocklist_profile_input: String,
-    pub blocklist_profile_input_active: bool,
+    pub(crate) blocklist_profile_input: String,
+    pub(crate) blocklist_profile_input_active: bool,
     blocklist_profile_input_mode: Option<BlocklistProfileInputMode>,
-    pub site_feedback: Option<SiteFeedback>,
-    pub task_labels: Vec<String>,
-    pub selected_task_label: Option<String>,
+    pub(crate) site_feedback: Option<SiteFeedback>,
+    pub(crate) task_labels: Vec<String>,
+    pub(crate) selected_task_label: Option<String>,
     task_label_favorites: BTreeSet<String>,
     task_label_archived: BTreeSet<String>,
-    pub planner_selection_index: usize,
-    pub planner_template_selection_index: usize,
-    pub planner_pane: PlannerPane,
-    pub planner_input: String,
-    pub planner_input_active: bool,
-    pub planner_input_mode: Option<PlannerInputMode>,
-    pub planner_feedback: Option<PlannerFeedback>,
+    pub(crate) planner_selection_index: usize,
+    pub(crate) planner_template_selection_index: usize,
+    pub(crate) planner_pane: PlannerPane,
+    pub(crate) planner_input: String,
+    pub(crate) planner_input_active: bool,
+    pub(crate) planner_input_mode: Option<PlannerInputMode>,
+    pub(crate) planner_feedback: Option<PlannerFeedback>,
     active_focus_task_label: Option<String>,
     active_focus_intention: Option<String>,
     active_focus_task_note: Option<String>,
@@ -514,16 +514,16 @@ pub struct App {
     active_focus_profile: Option<ProfileId>,
     site_list_mode: SiteListMode,
     /// Index of the highlighted site in the SiteManager list.
-    pub selected_site: usize,
+    pub(crate) selected_site: usize,
     /// Last error from a block/unblock operation (e.g. permission denied).
-    pub block_error: Option<String>,
-    pub setup_diagnostics: SetupDiagnostics,
-    pub blocking_preview: BlockingPreviewSnapshot,
+    pub(crate) block_error: Option<String>,
+    pub(crate) setup_diagnostics: SetupDiagnostics,
+    pub(crate) blocking_preview: BlockingPreviewSnapshot,
     /// Last error from persisting timer/site configuration.
-    pub config_error: Option<String>,
+    pub(crate) config_error: Option<String>,
     /// Last error from persisting focus stats.
-    pub stats_error: Option<String>,
-    pub history_feedback: Option<HistoryFeedback>,
+    pub(crate) stats_error: Option<String>,
+    pub(crate) history_feedback: Option<HistoryFeedback>,
     history_comparison_dimension: ComparisonDimension,
     history_task_filter: Option<String>,
     history_profile_filter: Option<ProfileBucket>,
@@ -532,9 +532,9 @@ pub struct App {
     history_dashboard_pinned_cards: Vec<HistoryKpiCardId>,
     history_dashboard_selected_card: HistoryKpiCardId,
     history_dashboard_cache: RefCell<HistoryDashboardCache>,
-    pub phase_notification: Option<String>,
+    pub(crate) phase_notification: Option<String>,
     integrations: IntegrationRuntime,
-    pub selected_profile: ProfileId,
+    pub(crate) selected_profile: ProfileId,
     selected_theme_preset: ThemePreset,
     feature_flags: FeatureFlagsConfig,
     config_deprecation_warnings: Vec<String>,
@@ -542,10 +542,10 @@ pub struct App {
     automation_triggers: Vec<AutomationTriggerRuleConfig>,
     automation_trigger_last_fired_minute: HashMap<usize, i64>,
     weekday_profile_rules: Vec<WeekdayProfileRuleConfig>,
-    pub custom_profile: CustomProfileConfig,
-    pub profile_selection_index: usize,
-    pub profile_edit_active: bool,
-    pub profile_edit_field: usize,
+    pub(crate) custom_profile: CustomProfileConfig,
+    pub(crate) profile_selection_index: usize,
+    pub(crate) profile_edit_active: bool,
+    pub(crate) profile_edit_field: usize,
     profile_edit_schedule_window: usize,
     profile_edit_schedule_day: usize,
     profile_edit_schedule_exception: usize,
@@ -570,7 +570,7 @@ pub struct App {
     last_active_schedule_occurrence_key: Option<String>,
     last_weekday_profile_sync_day: Option<NaiveDate>,
     current_frame_now: DateTime<Local>,
-    pub strict_mode: bool,
+    pub(crate) strict_mode: bool,
     break_glass_duration_secs: u64,
     break_glass_expires_at: Option<Instant>,
     temporary_allowlist_entries: Vec<TemporaryAllowlistEntry>,
@@ -591,7 +591,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         #[cfg(test)]
         {
             Self::from_config(AppConfig::default())
@@ -849,7 +849,7 @@ impl App {
     }
 
     #[cfg(test)]
-    pub fn from_config_for_tests(config: AppConfig) -> Self {
+    pub(crate) fn from_config_for_tests(config: AppConfig) -> Self {
         Self::from_config(config)
     }
 
@@ -858,7 +858,7 @@ impl App {
     /// Must be called **once per main-loop UI frame** (not once per catch-up
     /// tick) so that a burst of back-filled timer ticks after a
     /// suspend/resume cannot trigger multiple rapid heartbeats.
-    pub fn on_wakatime_elapsed(&mut self, elapsed_secs: u64) {
+    pub(crate) fn on_wakatime_elapsed(&mut self, elapsed_secs: u64) {
         if self.timer.phase == TimerPhase::Focus && self.timer.status == TimerStatus::Running {
             if let Err(error) = self
                 .integrations
@@ -871,7 +871,7 @@ impl App {
 
     /// Applies any completed async WakaTime heartbeat results to tracker state.
     /// Intended to be called once per UI frame.
-    pub fn poll_wakatime_status(&mut self) {
+    pub(crate) fn poll_wakatime_status(&mut self) {
         let now = Local::now();
         self.current_frame_now = now;
         self.sync_today_goal_snapshot();
@@ -888,19 +888,19 @@ impl App {
         self.sync_time_based_automation_triggers(now);
     }
 
-    pub fn selected_profile_name(&self) -> &'static str {
+    pub(crate) fn selected_profile_name(&self) -> &'static str {
         self.selected_profile.label()
     }
 
-    pub fn selected_theme_preset(&self) -> ThemePreset {
+    pub(crate) fn selected_theme_preset(&self) -> ThemePreset {
         self.selected_theme_preset
     }
 
-    pub fn wakatime_runtime_state(&self) -> WakatimeRuntimeState {
+    pub(crate) fn wakatime_runtime_state(&self) -> WakatimeRuntimeState {
         self.integrations.wakatime_runtime_state()
     }
 
-    pub fn wakatime_last_successful_heartbeat_epoch_secs(&self) -> Option<u64> {
+    pub(crate) fn wakatime_last_successful_heartbeat_epoch_secs(&self) -> Option<u64> {
         self.integrations
             .wakatime_last_successful_heartbeat_epoch_secs()
     }
@@ -952,7 +952,7 @@ impl App {
         self.calendar_busy_windows = windows;
     }
 
-    pub fn current_task_label(&self) -> Option<&str> {
+    pub(crate) fn current_task_label(&self) -> Option<&str> {
         if self.focus_session_active_for_current_state() {
             self.active_focus_task_label
                 .as_deref()
@@ -962,7 +962,7 @@ impl App {
         }
     }
 
-    pub fn current_task_note(&self) -> Option<&str> {
+    pub(crate) fn current_task_note(&self) -> Option<&str> {
         if !self.focus_session_active_for_current_state() {
             return None;
         }
@@ -972,11 +972,11 @@ impl App {
             .or(self.selected_task_label.as_deref())
     }
 
-    pub fn can_edit_session_note(&self) -> bool {
+    pub(crate) fn can_edit_session_note(&self) -> bool {
         self.focus_session_active_for_current_state()
     }
 
-    pub fn timer_note_input_active(&self) -> bool {
+    pub(crate) fn timer_note_input_active(&self) -> bool {
         self.timer_note_input_active
     }
 
@@ -984,31 +984,31 @@ impl App {
         self.shortcuts.matches(action, key)
     }
 
-    pub fn shortcut_hint(&self, action: ShortcutAction) -> String {
+    pub(crate) fn shortcut_hint(&self, action: ShortcutAction) -> String {
         self.shortcuts.hint(action)
     }
 
-    pub fn shortcut_label(&self, action: ShortcutAction) -> String {
+    pub(crate) fn shortcut_label(&self, action: ShortcutAction) -> String {
         self.shortcuts.label(action)
     }
 
-    pub fn navigation_matches(&self, action: NavigationAction, key: &KeyEvent) -> bool {
+    pub(crate) fn navigation_matches(&self, action: NavigationAction, key: &KeyEvent) -> bool {
         self.shortcuts.navigation_matches(action, key)
     }
 
-    pub fn navigation_hint(&self, action: NavigationAction) -> String {
+    pub(crate) fn navigation_hint(&self, action: NavigationAction) -> String {
         self.shortcuts.navigation_hint(action)
     }
 
-    pub fn navigation_label(&self, action: NavigationAction) -> String {
+    pub(crate) fn navigation_label(&self, action: NavigationAction) -> String {
         self.shortcuts.navigation_label(action)
     }
 
-    pub fn timer_note_input_value(&self) -> &str {
+    pub(crate) fn timer_note_input_value(&self) -> &str {
         &self.timer_note_input
     }
 
-    pub fn profile_values(&self, profile: ProfileId) -> (u64, u64, u64, u32) {
+    pub(crate) fn profile_values(&self, profile: ProfileId) -> (u64, u64, u64, u32) {
         let spec = profile_spec_for(profile, &self.custom_profile);
         (
             spec.focus_secs,
@@ -1018,7 +1018,7 @@ impl App {
         )
     }
 
-    pub fn profile_summary(&self, profile: ProfileId) -> String {
+    pub(crate) fn profile_summary(&self, profile: ProfileId) -> String {
         let (focus, short_break, long_break, cadence) = self.profile_values(profile);
         format!(
             "{}/{}/{} · every {} focus",
@@ -1029,15 +1029,15 @@ impl App {
         )
     }
 
-    pub fn session_stats(&self) -> SessionStats {
+    pub(crate) fn session_stats(&self) -> SessionStats {
         self.stats.session()
     }
 
-    pub fn today_stats(&self) -> DailyStats {
+    pub(crate) fn today_stats(&self) -> DailyStats {
         self.stats.daily_for(&current_day_key())
     }
 
-    pub fn today_goal_progress(&self) -> DailyGoalProgress {
+    pub(crate) fn today_goal_progress(&self) -> DailyGoalProgress {
         let today = Local::now().date_naive();
         let today_key = today.format("%Y-%m-%d").to_string();
         let today_stats = self.stats.daily_for(&today_key);
@@ -1050,7 +1050,7 @@ impl App {
         )
     }
 
-    pub fn current_week_goal_progress(&self) -> DailyGoalProgress {
+    pub(crate) fn current_week_goal_progress(&self) -> DailyGoalProgress {
         let today = Local::now().date_naive();
         let week = self.stats.weekly_for_day(today);
         let target = self.effective_weekly_goal_snapshot_for_day(today);
@@ -1062,7 +1062,7 @@ impl App {
         )
     }
 
-    pub fn current_month_goal_progress(&self) -> DailyGoalProgress {
+    pub(crate) fn current_month_goal_progress(&self) -> DailyGoalProgress {
         let today = Local::now().date_naive();
         let month = self.stats.monthly_for_day(today);
         let target = self.effective_monthly_goal_snapshot_for_day(today);
@@ -1074,7 +1074,7 @@ impl App {
         )
     }
 
-    pub fn goal_streak(&self) -> GoalStreak {
+    pub(crate) fn goal_streak(&self) -> GoalStreak {
         self.goal_streak_for_day_key(&current_day_key())
     }
 
@@ -1093,7 +1093,7 @@ impl App {
     }
 
     #[allow(dead_code)]
-    pub fn daily_goal_progress_for(&self, stats: DailyStats) -> DailyGoalProgress {
+    pub(crate) fn daily_goal_progress_for(&self, stats: DailyStats) -> DailyGoalProgress {
         goal_progress_for_totals(
             stats.focused_minutes(),
             stats.pomodoros_completed,
@@ -1104,27 +1104,27 @@ impl App {
 
     #[cfg(test)]
     #[allow(dead_code)]
-    pub fn recent_daily_stats(&self, limit: usize) -> Vec<(String, DailyStats)> {
+    pub(crate) fn recent_daily_stats(&self, limit: usize) -> Vec<(String, DailyStats)> {
         self.stats.recent_daily(limit)
     }
 
     #[allow(dead_code)]
-    pub fn recent_weekly_stats(&self, limit: usize) -> Vec<WeeklyStats> {
+    pub(crate) fn recent_weekly_stats(&self, limit: usize) -> Vec<WeeklyStats> {
         self.stats.recent_weekly(limit)
     }
 
     #[allow(dead_code)]
-    pub fn recent_weekly_consistency(&self, limit: usize) -> Vec<WeeklyConsistency> {
+    pub(crate) fn recent_weekly_consistency(&self, limit: usize) -> Vec<WeeklyConsistency> {
         self.stats.recent_weekly_consistency(limit)
     }
 
     #[allow(dead_code)]
-    pub fn latest_weekly_focus_score(&self) -> Option<WeeklyFocusScore> {
+    pub(crate) fn latest_weekly_focus_score(&self) -> Option<WeeklyFocusScore> {
         self.stats.latest_weekly_focus_score()
     }
 
     #[allow(dead_code)]
-    pub fn focus_risk_forecast(&self) -> FocusRiskForecast {
+    pub(crate) fn focus_risk_forecast(&self) -> FocusRiskForecast {
         let today = Local::now().date_naive();
         self.stats.focus_risk_forecast_for_day(
             today,
@@ -1135,62 +1135,62 @@ impl App {
     }
 
     #[allow(dead_code)]
-    pub fn recent_monthly_stats(&self, limit: usize) -> Vec<MonthlyStats> {
+    pub(crate) fn recent_monthly_stats(&self, limit: usize) -> Vec<MonthlyStats> {
         self.stats.recent_monthly(limit)
     }
 
     #[allow(dead_code)]
-    pub fn latest_monthly_heatmap(&self) -> MonthlyHeatmap {
+    pub(crate) fn latest_monthly_heatmap(&self) -> MonthlyHeatmap {
         self.stats.latest_monthly_heatmap()
     }
 
     #[allow(dead_code)]
-    pub fn stats_growth_summary(&self) -> StatsGrowthSummary {
+    pub(crate) fn stats_growth_summary(&self) -> StatsGrowthSummary {
         self.stats.growth_summary()
     }
 
     #[allow(dead_code)]
-    pub fn stats_retention_config(&self) -> StatsRetentionConfig {
+    pub(crate) fn stats_retention_config(&self) -> StatsRetentionConfig {
         self.stats_retention
     }
 
     #[allow(dead_code)]
-    pub fn stats_retention_preview(&self) -> StatsRetentionPruneResult {
+    pub(crate) fn stats_retention_preview(&self) -> StatsRetentionPruneResult {
         self.stats
             .retention_preview(self.stats_retention, Local::now().date_naive())
     }
 
     #[allow(dead_code)]
-    pub fn profile_focus_totals(&self) -> Vec<ProfileTotals> {
+    pub(crate) fn profile_focus_totals(&self) -> Vec<ProfileTotals> {
         self.stats.profile_totals()
     }
 
     #[allow(dead_code)]
-    pub fn profile_effectiveness(&self) -> Vec<ProfileEffectiveness> {
+    pub(crate) fn profile_effectiveness(&self) -> Vec<ProfileEffectiveness> {
         self.stats.profile_effectiveness()
     }
 
     #[allow(dead_code)]
-    pub fn task_focus_totals(&self, limit: usize) -> Vec<TaskTotals> {
+    pub(crate) fn task_focus_totals(&self, limit: usize) -> Vec<TaskTotals> {
         self.stats.task_totals(limit)
     }
 
     #[allow(dead_code)]
-    pub fn task_goal_progress_for_label(&self, label: &str) -> Option<TaskGoalProgress> {
+    pub(crate) fn task_goal_progress_for_label(&self, label: &str) -> Option<TaskGoalProgress> {
         self.stats.task_goal_progress_for_label(label)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn recent_task_trends(&self, limit: usize) -> Vec<TaskTrend> {
+    pub(crate) fn recent_task_trends(&self, limit: usize) -> Vec<TaskTrend> {
         self.stats.recent_task_trends(limit)
     }
 
     #[cfg(test)]
-    pub fn insert_daily_stats_for_tests(&mut self, day_key: &str, stats: DailyStats) {
+    pub(crate) fn insert_daily_stats_for_tests(&mut self, day_key: &str, stats: DailyStats) {
         self.stats.insert_daily_for_tests(day_key, stats);
     }
 
-    pub fn profile_edit_field_value(&self, field_index: usize) -> String {
+    pub(crate) fn profile_edit_field_value(&self, field_index: usize) -> String {
         if (PROFILE_EDIT_SCHEDULE_WINDOW_INDEX..=PROFILE_EDIT_WEEKDAY_RULE_ADD_REMOVE_INDEX)
             .contains(&field_index)
             || (PROFILE_EDIT_AUTOMATION_TRIGGER_INDEX
@@ -1281,15 +1281,15 @@ impl App {
         }
     }
 
-    pub fn strict_mode_enforced_for_focus(&self) -> bool {
+    pub(crate) fn strict_mode_enforced_for_focus(&self) -> bool {
         self.strict_mode && self.focus_session_active_for_current_state()
     }
 
-    pub fn strict_reset_confirmation_pending(&self) -> bool {
+    pub(crate) fn strict_reset_confirmation_pending(&self) -> bool {
         self.pending_timer_action == Some(PendingTimerAction::Reset)
     }
 
-    pub fn site_input_mode(&self) -> SiteInputMode {
+    pub(crate) fn site_input_mode(&self) -> SiteInputMode {
         if self.site_edit_index.is_some() {
             SiteInputMode::Edit
         } else {
@@ -1297,23 +1297,23 @@ impl App {
         }
     }
 
-    pub fn site_list_mode(&self) -> SiteListMode {
+    pub(crate) fn site_list_mode(&self) -> SiteListMode {
         self.site_list_mode
     }
 
-    pub fn active_policy_sites(&self) -> &[String] {
+    pub(crate) fn active_policy_sites(&self) -> &[String] {
         self.active_profile_sites_for_mode(self.site_list_mode)
     }
 
-    pub fn active_policy_site_count(&self) -> usize {
+    pub(crate) fn active_policy_site_count(&self) -> usize {
         self.active_policy_sites().len()
     }
 
-    pub fn effective_blocked_site_count(&self) -> usize {
+    pub(crate) fn effective_blocked_site_count(&self) -> usize {
         self.blocker.sites.len()
     }
 
-    pub fn active_temporary_allowlist_entries(&self) -> Vec<ActiveTemporaryAllowlistEntry> {
+    pub(crate) fn active_temporary_allowlist_entries(&self) -> Vec<ActiveTemporaryAllowlistEntry> {
         active_temporary_allowlist_status_entries_for_profile(
             &self.temporary_allowlist_entries,
             self.active_blocklist_profile_name(),
@@ -1321,36 +1321,36 @@ impl App {
         )
     }
 
-    pub fn active_temporary_allowlist_count(&self) -> usize {
+    pub(crate) fn active_temporary_allowlist_count(&self) -> usize {
         self.active_temporary_allowlist_entries().len()
     }
 
-    pub fn next_temporary_allowlist_expiry_remaining_secs(&self) -> Option<u64> {
+    pub(crate) fn next_temporary_allowlist_expiry_remaining_secs(&self) -> Option<u64> {
         self.active_temporary_allowlist_entries()
             .first()
             .map(|entry| entry.remaining_secs)
     }
 
-    pub fn blocklist_profile_input_mode(&self) -> Option<BlocklistProfileInputMode> {
+    pub(crate) fn blocklist_profile_input_mode(&self) -> Option<BlocklistProfileInputMode> {
         self.blocklist_profile_input_mode
     }
 
-    pub fn active_blocklist_profile_name(&self) -> &str {
+    pub(crate) fn active_blocklist_profile_name(&self) -> &str {
         self.blocklist_profiles
             .get(self.active_blocklist_profile)
             .map(|profile| profile.name.as_str())
             .unwrap_or(DEFAULT_BLOCKLIST_PROFILE_NAME)
     }
 
-    pub fn active_blocklist_profile_position(&self) -> usize {
+    pub(crate) fn active_blocklist_profile_position(&self) -> usize {
         self.active_blocklist_profile.saturating_add(1)
     }
 
-    pub fn blocklist_profile_count(&self) -> usize {
+    pub(crate) fn blocklist_profile_count(&self) -> usize {
         self.blocklist_profiles.len()
     }
 
-    pub fn active_blocklist_category_name(&self) -> &str {
+    pub(crate) fn active_blocklist_category_name(&self) -> &str {
         let Some(profile) = self.blocklist_profiles.get(self.active_blocklist_profile) else {
             return DEFAULT_BLOCKLIST_CATEGORY_NAME;
         };
@@ -1369,7 +1369,7 @@ impl App {
             .unwrap_or(DEFAULT_BLOCKLIST_CATEGORY_NAME)
     }
 
-    pub fn active_blocklist_category_position(&self) -> usize {
+    pub(crate) fn active_blocklist_category_position(&self) -> usize {
         let Some(profile) = self.blocklist_profiles.get(self.active_blocklist_profile) else {
             return 1;
         };
@@ -1379,20 +1379,20 @@ impl App {
         blocklist_category_index(&profile.categories, &profile.selected_category).saturating_add(1)
     }
 
-    pub fn blocklist_category_count(&self) -> usize {
+    pub(crate) fn blocklist_category_count(&self) -> usize {
         self.blocklist_profiles
             .get(self.active_blocklist_profile)
             .map(|profile| profile.categories.len().max(1))
             .unwrap_or(1)
     }
 
-    pub fn active_session_template_name(&self) -> Option<&str> {
+    pub(crate) fn active_session_template_name(&self) -> Option<&str> {
         self.active_session_template
             .and_then(|index| self.session_templates.get(index))
             .map(|template| template.name.as_str())
     }
 
-    pub fn session_template_count(&self) -> usize {
+    pub(crate) fn session_template_count(&self) -> usize {
         self.session_templates.len()
     }
 
@@ -1403,7 +1403,7 @@ impl App {
             .unwrap_or_default()
     }
 
-    pub fn handle_key(&mut self, key: KeyEvent) {
+    pub(crate) fn handle_key(&mut self, key: KeyEvent) {
         match self.mode {
             AppMode::Timer => self.handle_key_timer(key),
             AppMode::SiteManager => self.handle_key_site_manager(key),
@@ -1414,7 +1414,7 @@ impl App {
         }
     }
 
-    pub fn handle_paste(&mut self, text: String) {
+    pub(crate) fn handle_paste(&mut self, text: String) {
         if self.mode == AppMode::Timer && self.timer_note_input_active {
             let sanitized = normalize_timer_note_paste(&text);
             if !sanitized.is_empty() {
@@ -1441,7 +1441,7 @@ impl App {
         self.site_input.push_str(&text);
     }
 
-    pub fn is_running(&self) -> bool {
+    pub(crate) fn is_running(&self) -> bool {
         self.timer.status == TimerStatus::Running
     }
 

--- a/src/app/break_glass.rs
+++ b/src/app/break_glass.rs
@@ -4,11 +4,11 @@ use crate::app::{
 };
 
 impl App {
-    pub fn break_glass_confirmation_pending(&self) -> bool {
+    pub(crate) fn break_glass_confirmation_pending(&self) -> bool {
         self.pending_timer_action == Some(PendingTimerAction::BreakGlassOverride)
     }
 
-    pub fn break_glass_override_remaining_secs(&self) -> Option<u64> {
+    pub(crate) fn break_glass_override_remaining_secs(&self) -> Option<u64> {
         if !self.focus_session_active_for_current_state() {
             return None;
         }
@@ -16,7 +16,7 @@ impl App {
             .map(ceil_duration_secs)
     }
 
-    pub fn break_glass_override_active(&self) -> bool {
+    pub(crate) fn break_glass_override_active(&self) -> bool {
         self.break_glass_override_remaining_secs().is_some()
     }
 

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -5,13 +5,13 @@ use crate::app::{
 };
 
 impl App {
-    pub fn record_command_usage_for_cli(&mut self, surface_id: &str) {
+    pub(crate) fn record_command_usage_for_cli(&mut self, surface_id: &str) {
         if self.stats.record_command_usage(surface_id) {
             self.mark_stats_dirty();
         }
     }
 
-    pub fn start_focus_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn start_focus_for_cli(&mut self) -> Result<(), String> {
         match self.try_start_focus_session(FocusStartTemplateMode::ApplySelectedTemplate)? {
             FocusStartOutcome::Started => Ok(()),
             FocusStartOutcome::MissingTaskLabel => Err(format!(
@@ -24,7 +24,7 @@ impl App {
         }
     }
 
-    pub fn pause_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn pause_for_cli(&mut self) -> Result<(), String> {
         if self.timer.status != TimerStatus::Running {
             return Err("Cannot pause: timer is not running.".to_string());
         }
@@ -32,7 +32,7 @@ impl App {
         Ok(())
     }
 
-    pub fn resume_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn resume_for_cli(&mut self) -> Result<(), String> {
         if self.timer.status != TimerStatus::Paused {
             return Err("Cannot resume: timer is not paused.".to_string());
         }
@@ -40,7 +40,7 @@ impl App {
         Ok(())
     }
 
-    pub fn stop_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn stop_for_cli(&mut self) -> Result<(), String> {
         if self.strict_mode_enforced_for_focus() {
             return Err("Cannot stop: strict mode is active during focus.".to_string());
         }
@@ -54,7 +54,7 @@ impl App {
         Ok(())
     }
 
-    pub fn next_phase_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn next_phase_for_cli(&mut self) -> Result<(), String> {
         if self.strict_mode_enforced_for_focus() {
             return Err(
                 "Cannot skip to next phase: strict mode is active during focus.".to_string(),
@@ -67,7 +67,7 @@ impl App {
         Ok(())
     }
 
-    pub fn schedule_delay_for_cli(&mut self) -> Result<String, String> {
+    pub(crate) fn schedule_delay_for_cli(&mut self) -> Result<String, String> {
         let now = Local::now();
         self.current_frame_now = now;
         let delayed_until = self.delay_active_schedule_start_for_workflow(now)?;
@@ -75,7 +75,7 @@ impl App {
         Ok(delayed_until.format("%H:%M").to_string())
     }
 
-    pub fn trigger_break_glass_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn trigger_break_glass_for_cli(&mut self) -> Result<(), String> {
         if self.break_glass_confirmation_pending() {
             let result = self.confirm_break_glass_override_for_workflow();
             self.sync_wakatime_tracking_for_state();
@@ -87,7 +87,7 @@ impl App {
         self.sync_cli_workflow_state()
     }
 
-    pub fn cancel_break_glass_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn cancel_break_glass_for_cli(&mut self) -> Result<(), String> {
         if !self.break_glass_confirmation_pending() {
             return Err("Cannot cancel break-glass: no confirmation is pending.".to_string());
         }
@@ -95,19 +95,19 @@ impl App {
         self.sync_cli_workflow_state()
     }
 
-    pub fn add_temporary_allowlist_for_cli(
+    pub(crate) fn add_temporary_allowlist_for_cli(
         &mut self,
         input: &str,
     ) -> Result<(usize, usize), String> {
         self.add_temporary_allowlist_entries_for_active_profile_from_input(input)
     }
 
-    pub fn blocking_preview_for_cli(&self) -> Result<BlockingPreview, String> {
+    pub(crate) fn blocking_preview_for_cli(&self) -> Result<BlockingPreview, String> {
         self.compute_blocking_preview()
             .map_err(|error| format!("Failed to generate blocking preview: {error}"))
     }
 
-    pub fn select_task_label_for_cli(&mut self, label: &str) -> Result<bool, String> {
+    pub(crate) fn select_task_label_for_cli(&mut self, label: &str) -> Result<bool, String> {
         let Some(label) = normalize_task_label(label) else {
             return Err("Cannot select task label: label cannot be empty.".to_string());
         };
@@ -139,33 +139,33 @@ impl App {
         Ok(true)
     }
 
-    pub fn selected_profile_id(&self) -> ProfileId {
+    pub(crate) fn selected_profile_id(&self) -> ProfileId {
         self.selected_profile
     }
 
-    pub fn selected_blocklist_profile_name_for_cli(&self) -> String {
+    pub(crate) fn selected_blocklist_profile_name_for_cli(&self) -> String {
         self.active_blocklist_profile_name().to_string()
     }
 
-    pub fn selected_task_label_for_cli(&self) -> Option<String> {
+    pub(crate) fn selected_task_label_for_cli(&self) -> Option<String> {
         self.selected_task_label.clone()
     }
 
-    pub fn focus_intention_for_cli(&self) -> Option<String> {
+    pub(crate) fn focus_intention_for_cli(&self) -> Option<String> {
         if self.focus_session_active_for_current_state() {
             return self.active_focus_intention.clone();
         }
         None
     }
 
-    pub fn task_note_for_cli(&self) -> Option<String> {
+    pub(crate) fn task_note_for_cli(&self) -> Option<String> {
         if self.focus_session_active_for_current_state() {
             return self.active_focus_task_note.clone();
         }
         None
     }
 
-    pub fn set_focus_intention_for_cli(&mut self, value: &str) -> Result<(), String> {
+    pub(crate) fn set_focus_intention_for_cli(&mut self, value: &str) -> Result<(), String> {
         self.ensure_focus_active_for_cli_metadata_update("--focus-intention")?;
         let value = self.resolve_cli_metadata_value(value)?;
         self.active_focus_intention = Some(value);
@@ -173,7 +173,7 @@ impl App {
         Ok(())
     }
 
-    pub fn set_task_note_for_cli(&mut self, value: &str) -> Result<(), String> {
+    pub(crate) fn set_task_note_for_cli(&mut self, value: &str) -> Result<(), String> {
         self.ensure_focus_active_for_cli_metadata_update("--task-note")?;
         let value = self.resolve_cli_metadata_value(value)?;
         self.active_focus_task_note = Some(value);
@@ -181,7 +181,7 @@ impl App {
         Ok(())
     }
 
-    pub fn timer_state_for_cli(&self) -> (TimerPhase, TimerStatus, u64, u32) {
+    pub(crate) fn timer_state_for_cli(&self) -> (TimerPhase, TimerStatus, u64, u32) {
         (
             self.timer.phase,
             self.timer.status,
@@ -190,23 +190,32 @@ impl App {
         )
     }
 
-    pub fn select_session_template_for_cli(&mut self, name: Option<&str>) -> Result<bool, String> {
+    pub(crate) fn select_session_template_for_cli(
+        &mut self,
+        name: Option<&str>,
+    ) -> Result<bool, String> {
         self.select_session_template(name)
     }
 
-    pub fn apply_session_template_for_cli(&mut self, name: Option<&str>) -> Result<bool, String> {
+    pub(crate) fn apply_session_template_for_cli(
+        &mut self,
+        name: Option<&str>,
+    ) -> Result<bool, String> {
         self.apply_session_template(name)
     }
 
-    pub fn create_session_template_for_cli(&mut self, name: &str) -> Result<bool, String> {
+    pub(crate) fn create_session_template_for_cli(&mut self, name: &str) -> Result<bool, String> {
         self.capture_session_template(name)
     }
 
-    pub fn rename_active_session_template_for_cli(&mut self, name: &str) -> Result<bool, String> {
+    pub(crate) fn rename_active_session_template_for_cli(
+        &mut self,
+        name: &str,
+    ) -> Result<bool, String> {
         self.rename_active_session_template(name)
     }
 
-    pub fn delete_active_session_template_for_cli(&mut self) -> Result<bool, String> {
+    pub(crate) fn delete_active_session_template_for_cli(&mut self) -> Result<bool, String> {
         self.delete_active_session_template()
     }
 

--- a/src/app/history_comparison.rs
+++ b/src/app/history_comparison.rs
@@ -26,12 +26,12 @@ fn cycle_optional_selection<T: Clone + PartialEq>(
 }
 
 impl App {
-    pub fn history_comparison_dimension(&self) -> ComparisonDimension {
+    pub(crate) fn history_comparison_dimension(&self) -> ComparisonDimension {
         self.history_comparison_dimension
     }
 
     #[allow(dead_code)]
-    pub fn history_comparison_rows(&self, limit: usize) -> Vec<ProductivityComparisonRow> {
+    pub(crate) fn history_comparison_rows(&self, limit: usize) -> Vec<ProductivityComparisonRow> {
         let filter = ProductivityComparisonFilter {
             task_label: self.history_task_filter.clone(),
             profile: self.history_profile_filter,
@@ -41,7 +41,7 @@ impl App {
             .productivity_comparison(self.history_comparison_dimension, &filter, limit)
     }
 
-    pub fn history_comparison_filter_summary(&self) -> String {
+    pub(crate) fn history_comparison_filter_summary(&self) -> String {
         let task = self
             .history_task_filter
             .as_deref()
@@ -58,15 +58,15 @@ impl App {
         format!("Slices: task {task} · profile {profile} · time {time_of_day}")
     }
 
-    pub fn history_dashboard_card_order(&self) -> &[HistoryKpiCardId] {
+    pub(crate) fn history_dashboard_card_order(&self) -> &[HistoryKpiCardId] {
         &self.history_dashboard_card_order
     }
 
-    pub fn history_dashboard_pinned_cards(&self) -> &[HistoryKpiCardId] {
+    pub(crate) fn history_dashboard_pinned_cards(&self) -> &[HistoryKpiCardId] {
         &self.history_dashboard_pinned_cards
     }
 
-    pub fn history_dashboard_cards(&self) -> Vec<HistoryKpiCardId> {
+    pub(crate) fn history_dashboard_cards(&self) -> Vec<HistoryKpiCardId> {
         let mut cards = self.history_dashboard_pinned_cards.clone();
         for card in &self.history_dashboard_card_order {
             if !cards.contains(card) {
@@ -76,11 +76,11 @@ impl App {
         cards
     }
 
-    pub fn history_dashboard_selected_card(&self) -> HistoryKpiCardId {
+    pub(crate) fn history_dashboard_selected_card(&self) -> HistoryKpiCardId {
         self.history_dashboard_selected_card
     }
 
-    pub fn history_dashboard_card_is_pinned(&self, card: HistoryKpiCardId) -> bool {
+    pub(crate) fn history_dashboard_card_is_pinned(&self, card: HistoryKpiCardId) -> bool {
         self.history_dashboard_pinned_cards.contains(&card)
     }
 

--- a/src/app/history_dashboard_cache.rs
+++ b/src/app/history_dashboard_cache.rs
@@ -13,27 +13,27 @@ use crate::stats::{
 };
 
 #[derive(Debug, Clone)]
-pub struct HistoryDashboardViewData {
-    pub session_stats: SessionStats,
-    pub today_stats: DailyStats,
-    pub daily_goal_progress: DailyGoalProgress,
-    pub weekly_goal_progress: DailyGoalProgress,
-    pub monthly_goal_progress: DailyGoalProgress,
-    pub latest_weekly_focus_score: Option<WeeklyFocusScore>,
-    pub goal_streak: GoalStreak,
-    pub focus_risk_forecast: FocusRiskForecast,
-    pub weekly_daily_goal_allocation: WeeklyDailyGoalAllocation,
-    pub latest_session_interruption: Option<SessionInterruptionEvent>,
-    pub stats_growth_summary: StatsGrowthSummary,
-    pub stats_retention_config: StatsRetentionConfig,
-    pub stats_retention_preview: StatsRetentionPruneResult,
-    pub comparison_filter_summary: String,
-    pub comparison_rows: Vec<ProductivityComparisonRow>,
-    pub task_trends: Vec<TaskTrend>,
-    pub profile_effectiveness: Vec<ProfileEffectiveness>,
-    pub break_glass_overrides: Vec<BreakGlassOverrideEvent>,
-    pub monthly_stats: Vec<MonthlyStats>,
-    pub monthly_heatmap: MonthlyHeatmap,
+pub(crate) struct HistoryDashboardViewData {
+    pub(crate) session_stats: SessionStats,
+    pub(crate) today_stats: DailyStats,
+    pub(crate) daily_goal_progress: DailyGoalProgress,
+    pub(crate) weekly_goal_progress: DailyGoalProgress,
+    pub(crate) monthly_goal_progress: DailyGoalProgress,
+    pub(crate) latest_weekly_focus_score: Option<WeeklyFocusScore>,
+    pub(crate) goal_streak: GoalStreak,
+    pub(crate) focus_risk_forecast: FocusRiskForecast,
+    pub(crate) weekly_daily_goal_allocation: WeeklyDailyGoalAllocation,
+    pub(crate) latest_session_interruption: Option<SessionInterruptionEvent>,
+    pub(crate) stats_growth_summary: StatsGrowthSummary,
+    pub(crate) stats_retention_config: StatsRetentionConfig,
+    pub(crate) stats_retention_preview: StatsRetentionPruneResult,
+    pub(crate) comparison_filter_summary: String,
+    pub(crate) comparison_rows: Vec<ProductivityComparisonRow>,
+    pub(crate) task_trends: Vec<TaskTrend>,
+    pub(crate) profile_effectiveness: Vec<ProfileEffectiveness>,
+    pub(crate) break_glass_overrides: Vec<BreakGlassOverrideEvent>,
+    pub(crate) monthly_stats: Vec<MonthlyStats>,
+    pub(crate) monthly_heatmap: MonthlyHeatmap,
 }
 
 #[derive(Debug, Clone)]
@@ -87,9 +87,9 @@ pub(super) struct HistoryDashboardComparisonSnapshotKey {
 
 #[cfg(test)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct HistoryDashboardCacheStats {
-    pub static_rebuilds: u64,
-    pub comparison_rebuilds: u64,
+pub(crate) struct HistoryDashboardCacheStats {
+    pub(crate) static_rebuilds: u64,
+    pub(crate) comparison_rebuilds: u64,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -103,7 +103,7 @@ pub(super) struct HistoryDashboardCache {
 }
 
 impl App {
-    pub fn history_dashboard_view_data(&self) -> HistoryDashboardViewData {
+    pub(crate) fn history_dashboard_view_data(&self) -> HistoryDashboardViewData {
         let static_key = self.history_dashboard_static_snapshot_key();
         let comparison_key = self.history_dashboard_comparison_snapshot_key();
         let (rebuild_static, rebuild_comparison) = {
@@ -178,7 +178,7 @@ impl App {
     }
 
     #[cfg(test)]
-    pub fn history_dashboard_cache_stats(&self) -> crate::app::HistoryDashboardCacheStats {
+    pub(crate) fn history_dashboard_cache_stats(&self) -> crate::app::HistoryDashboardCacheStats {
         self.history_dashboard_cache.borrow().cache_stats
     }
 

--- a/src/app/history_goals.rs
+++ b/src/app/history_goals.rs
@@ -179,7 +179,7 @@ impl App {
         carry_over_goal_target(base, self.goal_carry_over.monthly, previous)
     }
 
-    pub fn weekly_daily_goal_allocation(&self) -> WeeklyDailyGoalAllocation {
+    pub(crate) fn weekly_daily_goal_allocation(&self) -> WeeklyDailyGoalAllocation {
         let today = Local::now().date_naive();
         self.weekly_daily_goal_allocation_for_day(today)
     }
@@ -220,17 +220,23 @@ impl App {
     }
 
     #[allow(dead_code)]
-    pub fn recent_break_glass_overrides(&self, limit: usize) -> Vec<BreakGlassOverrideEvent> {
+    pub(crate) fn recent_break_glass_overrides(
+        &self,
+        limit: usize,
+    ) -> Vec<BreakGlassOverrideEvent> {
         self.stats.recent_break_glass_overrides(limit)
     }
 
     #[cfg(test)]
-    pub fn recent_session_interruptions(&self, limit: usize) -> Vec<SessionInterruptionEvent> {
+    pub(crate) fn recent_session_interruptions(
+        &self,
+        limit: usize,
+    ) -> Vec<SessionInterruptionEvent> {
         self.stats.recent_session_interruptions(limit)
     }
 
     #[allow(dead_code)]
-    pub fn latest_session_interruption(&self) -> Option<SessionInterruptionEvent> {
+    pub(crate) fn latest_session_interruption(&self) -> Option<SessionInterruptionEvent> {
         self.stats.latest_session_interruption()
     }
 }

--- a/src/app/planner_labels.rs
+++ b/src/app/planner_labels.rs
@@ -3,15 +3,15 @@ use std::collections::BTreeSet;
 use crate::app::{App, task_label_index, task_label_key};
 
 impl App {
-    pub fn is_task_label_favorite(&self, label: &str) -> bool {
+    pub(crate) fn is_task_label_favorite(&self, label: &str) -> bool {
         self.task_label_favorites.contains(&task_label_key(label))
     }
 
-    pub fn is_task_label_archived(&self, label: &str) -> bool {
+    pub(crate) fn is_task_label_archived(&self, label: &str) -> bool {
         self.task_label_archived.contains(&task_label_key(label))
     }
 
-    pub fn planner_labels_for_display(&self) -> Vec<String> {
+    pub(crate) fn planner_labels_for_display(&self) -> Vec<String> {
         let mut favorites = Vec::new();
         let mut others = Vec::new();
         for label in &self.task_labels {
@@ -78,7 +78,7 @@ impl App {
         self.clamp_planner_selection();
     }
 
-    pub fn planner_recent_labels(&self, limit: usize) -> Vec<String> {
+    pub(crate) fn planner_recent_labels(&self, limit: usize) -> Vec<String> {
         if limit == 0 || self.task_labels.is_empty() {
             return Vec::new();
         }

--- a/src/app/profile_edit.rs
+++ b/src/app/profile_edit.rs
@@ -4,7 +4,7 @@ use crate::config::{
     ThemePreset, WakatimeMetadataConfig, WeekdayProfileRuleConfig, WeeklyGoalConfig,
 };
 
-pub const PROFILE_EDIT_FIELD_LABELS: [&str; 52] = [
+pub(crate) const PROFILE_EDIT_FIELD_LABELS: [&str; 52] = [
     "Focus",
     "Short Break",
     "Long Break",

--- a/src/app/schedule_runtime.rs
+++ b/src/app/schedule_runtime.rs
@@ -14,7 +14,7 @@ struct ScheduleShortcutLabels {
 }
 
 impl App {
-    pub fn recurring_schedule_display_texts(&self) -> (String, String) {
+    pub(crate) fn recurring_schedule_display_texts(&self) -> (String, String) {
         self.recurring_schedule_texts_at(self.current_frame_now)
     }
 

--- a/src/app/setup_diagnostics.rs
+++ b/src/app/setup_diagnostics.rs
@@ -4,15 +4,15 @@ use crate::blocker::{
 use crate::wakatime::{WakatimeConfigStatus, WakatimeTracker};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SetupCheckLevel {
+pub(crate) enum SetupCheckLevel {
     Ok,
     Warning,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SetupCheck {
-    pub level: SetupCheckLevel,
-    pub message: String,
+pub(crate) struct SetupCheck {
+    pub(crate) level: SetupCheckLevel,
+    pub(crate) message: String,
 }
 
 impl SetupCheck {
@@ -32,16 +32,16 @@ impl SetupCheck {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SetupDiagnostics {
-    pub hosts_file_path: String,
-    pub backend_policy: String,
-    pub backend_order: String,
-    pub backend_selection: SetupCheck,
-    pub blocking_permissions: SetupCheck,
-    pub hosts_write_capability: SetupCheck,
-    pub command_backend: SetupCheck,
-    pub wakatime_config: SetupCheck,
-    pub deprecation_warnings: Vec<String>,
+pub(crate) struct SetupDiagnostics {
+    pub(crate) hosts_file_path: String,
+    pub(crate) backend_policy: String,
+    pub(crate) backend_order: String,
+    pub(crate) backend_selection: SetupCheck,
+    pub(crate) blocking_permissions: SetupCheck,
+    pub(crate) hosts_write_capability: SetupCheck,
+    pub(crate) command_backend: SetupCheck,
+    pub(crate) wakatime_config: SetupCheck,
+    pub(crate) deprecation_warnings: Vec<String>,
 }
 
 impl SetupDiagnostics {
@@ -97,16 +97,16 @@ impl SetupDiagnostics {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BlockingPreviewSnapshot {
-    pub backend: Option<BlockingBackendKind>,
-    pub backend_target: Option<String>,
-    pub attempted_backends: Vec<BlockingBackendKind>,
-    pub fallback_used: bool,
-    pub action: BlockingPreviewAction,
-    pub would_change: bool,
-    pub effective_blocked_sites_count: usize,
-    pub section: Option<String>,
-    pub error: Option<String>,
+pub(crate) struct BlockingPreviewSnapshot {
+    pub(crate) backend: Option<BlockingBackendKind>,
+    pub(crate) backend_target: Option<String>,
+    pub(crate) attempted_backends: Vec<BlockingBackendKind>,
+    pub(crate) fallback_used: bool,
+    pub(crate) action: BlockingPreviewAction,
+    pub(crate) would_change: bool,
+    pub(crate) effective_blocked_sites_count: usize,
+    pub(crate) section: Option<String>,
+    pub(crate) error: Option<String>,
 }
 
 impl Default for BlockingPreviewSnapshot {

--- a/src/app/shortcuts.rs
+++ b/src/app/shortcuts.rs
@@ -5,7 +5,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use crate::config::ShortcutConfig;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ShortcutAction {
+pub(crate) enum ShortcutAction {
     Quit,
     TimerTogglePause,
     TimerStopReset,
@@ -49,7 +49,7 @@ pub enum ShortcutAction {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum NavigationAction {
+pub(crate) enum NavigationAction {
     MoveUp,
     MoveDown,
     MoveLeft,
@@ -193,18 +193,18 @@ const ALL_NAVIGATION_ACTIONS: [NavigationAction; 8] = [
 ];
 
 #[derive(Debug, Clone)]
-pub struct ShortcutBindings {
+pub(crate) struct ShortcutBindings {
     command_keys: BTreeMap<ShortcutAction, char>,
     navigation_keys: BTreeMap<NavigationAction, ShortcutKey>,
 }
 
 impl ShortcutBindings {
     #[cfg(test)]
-    pub fn from_config(config: &ShortcutConfig) -> Self {
+    pub(crate) fn from_config(config: &ShortcutConfig) -> Self {
         Self::from_config_with_diagnostics(config).0
     }
 
-    pub fn from_config_with_diagnostics(config: &ShortcutConfig) -> (Self, Vec<String>) {
+    pub(crate) fn from_config_with_diagnostics(config: &ShortcutConfig) -> (Self, Vec<String>) {
         let mut diagnostics = Vec::new();
         let quit_key = requested_shortcut_char(config, ShortcutAction::Quit);
         let mut command_keys = BTreeMap::new();
@@ -324,7 +324,7 @@ impl ShortcutBindings {
         )
     }
 
-    pub fn to_config(&self) -> ShortcutConfig {
+    pub(crate) fn to_config(&self) -> ShortcutConfig {
         ShortcutConfig {
             quit: key_token(self.key(ShortcutAction::Quit)),
             timer_toggle_pause: key_token(self.key(ShortcutAction::TimerTogglePause)),
@@ -391,23 +391,23 @@ impl ShortcutBindings {
         }
     }
 
-    pub fn matches(&self, action: ShortcutAction, key: &KeyEvent) -> bool {
+    pub(crate) fn matches(&self, action: ShortcutAction, key: &KeyEvent) -> bool {
         matches!(key.code, KeyCode::Char(code) if code == self.key(action))
     }
 
-    pub fn navigation_matches(&self, action: NavigationAction, key: &KeyEvent) -> bool {
+    pub(crate) fn navigation_matches(&self, action: NavigationAction, key: &KeyEvent) -> bool {
         matches_navigation_key(self.navigation_key(action), key)
     }
 
-    pub fn hint(&self, action: ShortcutAction) -> String {
+    pub(crate) fn hint(&self, action: ShortcutAction) -> String {
         format!("[{}]", self.label(action))
     }
 
-    pub fn navigation_hint(&self, action: NavigationAction) -> String {
+    pub(crate) fn navigation_hint(&self, action: NavigationAction) -> String {
         format!("[{}]", self.navigation_label(action))
     }
 
-    pub fn label(&self, action: ShortcutAction) -> String {
+    pub(crate) fn label(&self, action: ShortcutAction) -> String {
         let key = self.key(action);
         if key == ' ' {
             "Space".to_string()
@@ -416,7 +416,7 @@ impl ShortcutBindings {
         }
     }
 
-    pub fn navigation_label(&self, action: NavigationAction) -> String {
+    pub(crate) fn navigation_label(&self, action: NavigationAction) -> String {
         navigation_key_label(self.navigation_key(action))
     }
 

--- a/src/app/timer_flow.rs
+++ b/src/app/timer_flow.rs
@@ -5,7 +5,7 @@ use crate::app::{
 };
 
 impl App {
-    pub fn on_tick(&mut self, is_catchup: bool) {
+    pub(crate) fn on_tick(&mut self, is_catchup: bool) {
         self.sync_today_goal_snapshot();
         let completed_phase = self.timer.phase;
         let completed_focus_secs = self.timer.focus_secs;

--- a/src/blocker.rs
+++ b/src/blocker.rs
@@ -12,15 +12,15 @@ mod command;
 mod hosts;
 mod rules;
 
-pub use command::CommandBlockingBackend;
+pub(crate) use command::CommandBlockingBackend;
 use command::{apply_command_backend, command_backend_diagnostics, preview_from_command};
 use hosts::{HOSTS_FILE, atomic_write_hosts_to_path, flush_dns_cache, hosts_file_diagnostics_for};
 #[cfg(test)]
 use hosts::{HostsWriteFailStep, set_test_hosts_write_fail_steps};
 
 #[cfg(test)]
-pub use rules::normalize_domain_host;
-pub use rules::{SiteValidationError, domain_rule_matches_host, normalize_domain_rule};
+pub(crate) use rules::normalize_domain_host;
+pub(crate) use rules::{SiteValidationError, domain_rule_matches_host, normalize_domain_rule};
 
 #[cfg(test)]
 thread_local! {
@@ -39,9 +39,9 @@ pub(crate) fn take_test_blocking_action() -> Option<&'static str> {
     TEST_LAST_BLOCKING_ACTION.with(|slot| slot.borrow_mut().take())
 }
 
-pub struct SiteBlocker {
-    pub sites: Vec<String>,
-    pub is_blocking: bool,
+pub(crate) struct SiteBlocker {
+    pub(crate) sites: Vec<String>,
+    pub(crate) is_blocking: bool,
     backend_policy: BlockingBackendPolicy,
     command_backend: CommandBlockingBackend,
     active_backend: Option<BlockingBackendKind>,
@@ -51,37 +51,37 @@ pub struct SiteBlocker {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HostsFileDiagnostics {
-    pub path: String,
-    pub read_error: Option<String>,
-    pub write_error: Option<String>,
+pub(crate) struct HostsFileDiagnostics {
+    pub(crate) path: String,
+    pub(crate) read_error: Option<String>,
+    pub(crate) write_error: Option<String>,
 }
 
 impl HostsFileDiagnostics {
-    pub fn can_read(&self) -> bool {
+    pub(crate) fn can_read(&self) -> bool {
         self.read_error.is_none()
     }
 
-    pub fn can_write(&self) -> bool {
+    pub(crate) fn can_write(&self) -> bool {
         self.write_error.is_none()
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InvalidSiteInput {
-    pub input: String,
-    pub reason: SiteValidationError,
+pub(crate) struct InvalidSiteInput {
+    pub(crate) input: String,
+    pub(crate) reason: SiteValidationError,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct BulkAddResult {
-    pub added: Vec<String>,
-    pub duplicates: Vec<String>,
-    pub invalid: Vec<InvalidSiteInput>,
+pub(crate) struct BulkAddResult {
+    pub(crate) added: Vec<String>,
+    pub(crate) duplicates: Vec<String>,
+    pub(crate) invalid: Vec<InvalidSiteInput>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum EditSiteResult {
+pub(crate) enum EditSiteResult {
     Updated { old: String, new: String },
     Unchanged { hostname: String },
     Duplicate { hostname: String },
@@ -90,26 +90,26 @@ pub enum EditSiteResult {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BlockingIntent {
+pub(crate) enum BlockingIntent {
     Block,
     Unblock,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BlockingPreviewAction {
+pub(crate) enum BlockingPreviewAction {
     Block,
     Unblock,
     NoChange,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BlockingBackendKind {
+pub(crate) enum BlockingBackendKind {
     Hosts,
     Command,
 }
 
 impl BlockingBackendKind {
-    pub fn id(self) -> &'static str {
+    pub(crate) fn id(self) -> &'static str {
         match self {
             BlockingBackendKind::Hosts => "hosts",
             BlockingBackendKind::Command => "command",
@@ -118,7 +118,7 @@ impl BlockingBackendKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum BlockingBackendPolicy {
+pub(crate) enum BlockingBackendPolicy {
     HostsOnly,
     #[default]
     HostsThenCommand,
@@ -127,7 +127,7 @@ pub enum BlockingBackendPolicy {
 }
 
 impl BlockingBackendPolicy {
-    pub fn id(self) -> &'static str {
+    pub(crate) fn id(self) -> &'static str {
         match self {
             BlockingBackendPolicy::HostsOnly => "hosts_only",
             BlockingBackendPolicy::HostsThenCommand => "hosts_then_command",
@@ -151,32 +151,32 @@ impl BlockingBackendPolicy {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BlockingBackendStatus {
-    pub policy: BlockingBackendPolicy,
-    pub order: Vec<BlockingBackendKind>,
-    pub active_backend: Option<BlockingBackendKind>,
-    pub last_backend: Option<BlockingBackendKind>,
-    pub fallback_used: bool,
-    pub last_error: Option<String>,
-    pub command_configured: bool,
+pub(crate) struct BlockingBackendStatus {
+    pub(crate) policy: BlockingBackendPolicy,
+    pub(crate) order: Vec<BlockingBackendKind>,
+    pub(crate) active_backend: Option<BlockingBackendKind>,
+    pub(crate) last_backend: Option<BlockingBackendKind>,
+    pub(crate) fallback_used: bool,
+    pub(crate) last_error: Option<String>,
+    pub(crate) command_configured: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BlockingPreview {
-    pub backend: BlockingBackendKind,
-    pub backend_target: String,
-    pub attempted_backends: Vec<BlockingBackendKind>,
-    pub fallback_used: bool,
-    pub hosts_file_path: String,
-    pub action: BlockingPreviewAction,
-    pub effective_blocked_sites: Vec<String>,
-    pub would_change: bool,
-    pub current_section: Option<String>,
-    pub next_section: Option<String>,
+pub(crate) struct BlockingPreview {
+    pub(crate) backend: BlockingBackendKind,
+    pub(crate) backend_target: String,
+    pub(crate) attempted_backends: Vec<BlockingBackendKind>,
+    pub(crate) fallback_used: bool,
+    pub(crate) hosts_file_path: String,
+    pub(crate) action: BlockingPreviewAction,
+    pub(crate) effective_blocked_sites: Vec<String>,
+    pub(crate) would_change: bool,
+    pub(crate) current_section: Option<String>,
+    pub(crate) next_section: Option<String>,
 }
 
 impl BlockingPreview {
-    pub fn section_for_display(&self) -> Option<&str> {
+    pub(crate) fn section_for_display(&self) -> Option<&str> {
         self.next_section
             .as_deref()
             .or(self.current_section.as_deref())
@@ -184,14 +184,14 @@ impl BlockingPreview {
 }
 
 impl SiteBlocker {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::with_backend_config(
             BlockingBackendPolicy::default(),
             CommandBlockingBackend::default(),
         )
     }
 
-    pub fn with_backend_config(
+    pub(crate) fn with_backend_config(
         backend_policy: BlockingBackendPolicy,
         command_backend: CommandBlockingBackend,
     ) -> Self {
@@ -207,7 +207,7 @@ impl SiteBlocker {
         }
     }
 
-    pub fn backend_status(&self) -> BlockingBackendStatus {
+    pub(crate) fn backend_status(&self) -> BlockingBackendStatus {
         BlockingBackendStatus {
             policy: self.backend_policy,
             order: self.backend_policy.backend_order(),
@@ -219,19 +219,19 @@ impl SiteBlocker {
         }
     }
 
-    pub fn backend_config(&self) -> (BlockingBackendPolicy, CommandBlockingBackend) {
+    pub(crate) fn backend_config(&self) -> (BlockingBackendPolicy, CommandBlockingBackend) {
         (self.backend_policy, self.command_backend.clone())
     }
 
-    pub fn command_backend_diagnostics(&self) -> io::Result<()> {
+    pub(crate) fn command_backend_diagnostics(&self) -> io::Result<()> {
         command_backend_diagnostics(&self.command_backend)
     }
 
-    pub fn add_site(&mut self, site: String) {
+    pub(crate) fn add_site(&mut self, site: String) {
         let _ = self.add_sites_from_input(&site);
     }
 
-    pub fn add_sites_from_input(&mut self, input: &str) -> BulkAddResult {
+    pub(crate) fn add_sites_from_input(&mut self, input: &str) -> BulkAddResult {
         let candidates = split_hostname_candidates(input);
         let mut result = BulkAddResult::default();
         let mut known_sites: HashSet<String> = self.sites.iter().cloned().collect();
@@ -264,7 +264,7 @@ impl SiteBlocker {
         result
     }
 
-    pub fn edit_site_from_input(&mut self, index: usize, input: &str) -> EditSiteResult {
+    pub(crate) fn edit_site_from_input(&mut self, index: usize, input: &str) -> EditSiteResult {
         if index >= self.sites.len() {
             return EditSiteResult::MissingSelection;
         }
@@ -324,18 +324,21 @@ impl SiteBlocker {
         normalize_domain_rule(input)
     }
 
-    pub fn remove_site(&mut self, index: usize) -> Option<String> {
+    pub(crate) fn remove_site(&mut self, index: usize) -> Option<String> {
         if index < self.sites.len() {
             return Some(self.sites.remove(index));
         }
         None
     }
 
-    pub fn hosts_file_diagnostics(&self) -> HostsFileDiagnostics {
+    pub(crate) fn hosts_file_diagnostics(&self) -> HostsFileDiagnostics {
         hosts_file_diagnostics_for(Path::new(HOSTS_FILE))
     }
 
-    pub fn preview_hosts_update(&self, intent: BlockingIntent) -> io::Result<BlockingPreview> {
+    pub(crate) fn preview_hosts_update(
+        &self,
+        intent: BlockingIntent,
+    ) -> io::Result<BlockingPreview> {
         let order = self.backend_order_for_intent(intent);
         let mut errors = Vec::new();
         for (index, backend) in order.iter().copied().enumerate() {
@@ -356,7 +359,7 @@ impl SiteBlocker {
 
     /// Activate blocking by writing entries into the hosts file.
     /// Returns an error if the file is not writable (e.g. needs sudo).
-    pub fn block(&mut self) -> io::Result<()> {
+    pub(crate) fn block(&mut self) -> io::Result<()> {
         #[cfg(test)]
         record_test_blocking_action("block");
 
@@ -381,7 +384,7 @@ impl SiteBlocker {
     /// Remove the focustime block section from the hosts file.
     /// Always attempts to strip any existing block section, even after a crash
     /// left entries behind with is_blocking == false.
-    pub fn unblock(&mut self) -> io::Result<()> {
+    pub(crate) fn unblock(&mut self) -> io::Result<()> {
         #[cfg(test)]
         record_test_blocking_action("unblock");
 
@@ -392,7 +395,7 @@ impl SiteBlocker {
     }
 
     /// Remove block entries on app exit (best-effort).
-    pub fn cleanup(&mut self) {
+    pub(crate) fn cleanup(&mut self) {
         let _ = self.unblock();
     }
 

--- a/src/blocker/command.rs
+++ b/src/blocker/command.rs
@@ -6,14 +6,14 @@ use super::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct CommandBlockingBackend {
-    pub block_command: String,
-    pub unblock_command: String,
-    pub diagnostics_command: String,
+pub(crate) struct CommandBlockingBackend {
+    pub(crate) block_command: String,
+    pub(crate) unblock_command: String,
+    pub(crate) diagnostics_command: String,
 }
 
 impl CommandBlockingBackend {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             block_command: self.block_command.trim().to_string(),
             unblock_command: self.unblock_command.trim().to_string(),
@@ -21,7 +21,7 @@ impl CommandBlockingBackend {
         }
     }
 
-    pub fn is_configured(&self) -> bool {
+    pub(crate) fn is_configured(&self) -> bool {
         !self.block_command.trim().is_empty() && !self.unblock_command.trim().is_empty()
     }
 }

--- a/src/blocker/rules.rs
+++ b/src/blocker/rules.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SiteValidationError {
+pub(crate) enum SiteValidationError {
     EmptyHostname,
     MissingHostname,
     ContainsWhitespace,
@@ -9,7 +9,7 @@ pub enum SiteValidationError {
 }
 
 impl SiteValidationError {
-    pub fn message(self) -> &'static str {
+    pub(crate) fn message(self) -> &'static str {
         match self {
             SiteValidationError::EmptyHostname => "empty hostname",
             SiteValidationError::MissingHostname => "missing hostname",
@@ -21,15 +21,15 @@ impl SiteValidationError {
     }
 }
 
-pub fn normalize_domain_rule(input: &str) -> Result<String, SiteValidationError> {
+pub(crate) fn normalize_domain_rule(input: &str) -> Result<String, SiteValidationError> {
     normalize_domain_like_input(input, true)
 }
 
-pub fn normalize_domain_host(input: &str) -> Result<String, SiteValidationError> {
+pub(crate) fn normalize_domain_host(input: &str) -> Result<String, SiteValidationError> {
     normalize_domain_like_input(input, false)
 }
 
-pub fn domain_rule_matches_host(rule: &str, host: &str) -> bool {
+pub(crate) fn domain_rule_matches_host(rule: &str, host: &str) -> bool {
     let Ok(rule) = normalize_domain_rule(rule) else {
         return false;
     };

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -20,19 +20,19 @@ type PropertyFieldMap = HashMap<String, Vec<(PropertyParams, String)>>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct CalendarBusyWindow {
-    pub source_name: String,
-    pub provider: CalendarProviderConfig,
-    pub summary: String,
-    pub start_epoch_secs: i64,
-    pub end_epoch_secs: i64,
+    pub(crate) source_name: String,
+    pub(crate) provider: CalendarProviderConfig,
+    pub(crate) summary: String,
+    pub(crate) start_epoch_secs: i64,
+    pub(crate) end_epoch_secs: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CalendarSyncResult {
-    pub synced_at_epoch_secs: i64,
-    pub source_count: usize,
-    pub windows: Vec<CalendarBusyWindow>,
-    pub source_errors: Vec<String>,
+    pub(crate) synced_at_epoch_secs: i64,
+    pub(crate) source_count: usize,
+    pub(crate) windows: Vec<CalendarBusyWindow>,
+    pub(crate) source_errors: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -242,7 +242,7 @@ Options:
   -h, --help      Show this help"#;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OutputMode {
+pub(crate) enum OutputMode {
     Text,
     Json,
 }
@@ -253,12 +253,12 @@ const DEFAULT_WATCH_INTERVAL_SECS: u64 = 1;
 const DEFAULT_STATUS_COMPARISON_LIMIT: usize = 6;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StatusComparisonOptions {
-    pub dimension: ComparisonDimension,
-    pub task_label: Option<String>,
-    pub profile: Option<ProfileBucket>,
-    pub time_of_day: Option<TimeOfDayBucket>,
-    pub limit: usize,
+pub(crate) struct StatusComparisonOptions {
+    pub(crate) dimension: ComparisonDimension,
+    pub(crate) task_label: Option<String>,
+    pub(crate) profile: Option<ProfileBucket>,
+    pub(crate) time_of_day: Option<TimeOfDayBucket>,
+    pub(crate) limit: usize,
 }
 
 impl Default for StatusComparisonOptions {
@@ -275,20 +275,20 @@ impl Default for StatusComparisonOptions {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum CliErrorKind {
+pub(crate) enum CliErrorKind {
     Usage,
     Runtime,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CliError {
+pub(crate) struct CliError {
     kind: CliErrorKind,
     output: OutputMode,
     message: String,
 }
 
 impl CliError {
-    pub fn exit_code(&self) -> i32 {
+    pub(crate) fn exit_code(&self) -> i32 {
         match self.kind {
             CliErrorKind::Usage => EXIT_CODE_USAGE_ERROR,
             CliErrorKind::Runtime => EXIT_CODE_RUNTIME_ERROR,
@@ -310,7 +310,7 @@ struct CliErrorPayload {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CommandKind {
+pub(crate) enum CommandKind {
     Start,
     Pause,
     Resume,
@@ -419,13 +419,13 @@ pub enum CommandKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CliCommand {
-    pub kind: CommandKind,
-    pub output: OutputMode,
+pub(crate) struct CliCommand {
+    pub(crate) kind: CommandKind,
+    pub(crate) output: OutputMode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CliAction {
+pub(crate) enum CliAction {
     RunTui,
     RunCommand(CliCommand),
     ShowHelp,
@@ -599,7 +599,7 @@ type ValueArgParser = fn(&[String], usize) -> Result<(ParsedToken, usize), Strin
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum SiteListTarget {
+pub(crate) enum SiteListTarget {
     Blocklist,
     Allowlist,
 }
@@ -614,13 +614,13 @@ impl SiteListTarget {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SiteEditValue {
+pub(crate) struct SiteEditValue {
     previous: String,
     next: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BlocklistProfileCommandKind {
+pub(crate) enum BlocklistProfileCommandKind {
     Select { profile: Option<String> },
     Create { name: String },
     Rename { name: String },
@@ -628,7 +628,7 @@ pub enum BlocklistProfileCommandKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BlocklistCategoryCommandKind {
+pub(crate) enum BlocklistCategoryCommandKind {
     Select { category: Option<String> },
     Create { name: String },
     Rename { name: String },
@@ -636,7 +636,7 @@ pub enum BlocklistCategoryCommandKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BlocklistSiteCommandKind {
+pub(crate) enum BlocklistSiteCommandKind {
     List,
     Add { input: String },
     Edit { value: SiteEditValue },
@@ -644,7 +644,7 @@ pub enum BlocklistSiteCommandKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SessionTemplateCommandKind {
+pub(crate) enum SessionTemplateCommandKind {
     Select { name: Option<String> },
     Apply { name: Option<String> },
     Create { name: String },
@@ -653,7 +653,7 @@ pub enum SessionTemplateCommandKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum HistoryDashboardCommandKind {
+pub(crate) enum HistoryDashboardCommandKind {
     Show,
     Pin { card: HistoryKpiCardId },
     Unpin { card: HistoryKpiCardId },
@@ -1189,19 +1189,19 @@ struct SiteDeleteCommandOutput {
     effective_blocked_sites_count: usize,
 }
 
-pub fn usage_text() -> &'static str {
+pub(crate) fn usage_text() -> &'static str {
     USAGE_TEXT
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
-pub fn parse_args<I>(args: I) -> Result<CliAction, String>
+pub(crate) fn parse_args<I>(args: I) -> Result<CliAction, String>
 where
     I: IntoIterator<Item = OsString>,
 {
     parse_args_with_contract(args).map_err(|error| error.message)
 }
 
-pub fn parse_args_with_contract<I>(args: I) -> Result<CliAction, CliError>
+pub(crate) fn parse_args_with_contract<I>(args: I) -> Result<CliAction, CliError>
 where
     I: IntoIterator<Item = OsString>,
 {
@@ -1237,7 +1237,7 @@ where
     .map_err(|message| usage_error(output, message))
 }
 
-pub fn runtime_error(output: OutputMode, message: String) -> CliError {
+pub(crate) fn runtime_error(output: OutputMode, message: String) -> CliError {
     CliError {
         kind: CliErrorKind::Runtime,
         output,
@@ -1245,7 +1245,7 @@ pub fn runtime_error(output: OutputMode, message: String) -> CliError {
     }
 }
 
-pub fn emit_cli_error(error: &CliError) -> Result<(), String> {
+pub(crate) fn emit_cli_error(error: &CliError) -> Result<(), String> {
     match error.output {
         OutputMode::Text => {
             eprintln!("{}", error.message);
@@ -1270,7 +1270,7 @@ fn usage_error(output: OutputMode, message: String) -> CliError {
     }
 }
 
-pub fn execute_command(cli_command: CliCommand) -> Result<(), String> {
+pub(crate) fn execute_command(cli_command: CliCommand) -> Result<(), String> {
     execute_cli_command(cli_command)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,19 +15,19 @@ mod paths;
 mod shortcuts;
 mod wakatime;
 
-pub use automation::validate_automation_trigger_rules;
+pub(crate) use automation::validate_automation_trigger_rules;
 use automation::{
     normalize_automation_triggers, normalize_trigger_days, normalize_weekday_profile_rules,
     normalize_weekday_token,
 };
-pub use blocklists::{
+pub(crate) use blocklists::{
     BlocklistCategoryConfig, BlocklistProfileConfig, effective_blocked_sites_for_profile,
 };
 use blocklists::{
     default_blocklist_profile_name, make_unique_profile_name, normalize_blocklist_profiles,
     normalize_selected_blocklist_profile,
 };
-pub use diagnostics::{run_config_doctor, run_config_migration_assistant};
+pub(crate) use diagnostics::{run_config_doctor, run_config_migration_assistant};
 #[cfg(test)]
 use diagnostics::{run_config_doctor_with_path, run_config_migration_assistant_with_path};
 #[cfg(test)]
@@ -42,10 +42,10 @@ use paths::env_path_from_value;
 use paths::{app_dir_with_env, stats_app_dir_with_env};
 #[cfg(test)]
 use paths::{config_dir_from_env, stats_state_dir_from_env};
-pub use shortcuts::ShortcutConfig;
+pub(crate) use shortcuts::ShortcutConfig;
 #[allow(unused_imports)]
-pub use wakatime::WakatimeTaskMappingConfig;
-pub use wakatime::{WakatimeMetadataConfig, WakatimeRuntimeConfig};
+pub(crate) use wakatime::WakatimeTaskMappingConfig;
+pub(crate) use wakatime::{WakatimeMetadataConfig, WakatimeRuntimeConfig};
 
 const CURRENT_CONFIG_SCHEMA_VERSION: u32 = 2;
 const LEGACY_CONFIG_SCHEMA_VERSION: u32 = 0;
@@ -65,123 +65,123 @@ const CALENDAR_SYNC_LOOKAHEAD_MAX_DAYS: u16 = 90;
 ///   otherwise `~/.config/focustime/config.toml`
 /// - Windows:      `%APPDATA%\focustime\config.toml`
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AppConfig {
+pub(crate) struct AppConfig {
     /// Duration of a focus session in seconds (legacy load-time compatibility field).
     #[serde(default = "default_focus_secs", skip_serializing)]
-    pub focus_secs: u64,
+    pub(crate) focus_secs: u64,
     /// Duration of a short-break session in seconds (legacy load-time compatibility field).
     #[serde(default = "default_short_break_secs", skip_serializing)]
-    pub short_break_secs: u64,
+    pub(crate) short_break_secs: u64,
     /// Duration of a long-break session in seconds (legacy load-time compatibility field).
     #[serde(default = "default_long_break_secs", skip_serializing)]
-    pub long_break_secs: u64,
+    pub(crate) long_break_secs: u64,
     /// Number of completed focus sessions before a long break.
     #[serde(default = "default_long_break_interval", skip_serializing)]
-    pub long_break_interval: u32,
+    pub(crate) long_break_interval: u32,
     /// Deprecated blocked-sites mirror (legacy load-time compatibility field).
     #[serde(default, skip_serializing)]
-    pub blocked_sites: Vec<String>,
+    pub(crate) blocked_sites: Vec<String>,
     /// Named blocklist profiles.
     ///
     /// Each profile stores a separate blocked-sites list. This field supports
     /// issue #110 and supersedes `blocked_sites` as the primary representation.
     #[serde(default)]
-    pub blocklist_profiles: Vec<BlocklistProfileConfig>,
+    pub(crate) blocklist_profiles: Vec<BlocklistProfileConfig>,
     /// Name of the active blocklist profile.
     #[serde(default = "default_blocklist_profile_name")]
-    pub selected_blocklist_profile: String,
+    pub(crate) selected_blocklist_profile: String,
     /// Blocking backend selection and fallback behavior.
     #[serde(default)]
-    pub blocking_backend: BlockingBackendConfig,
+    pub(crate) blocking_backend: BlockingBackendConfig,
     /// Selected profile identifier.
     #[serde(default)]
-    pub selected_profile: ProfileId,
+    pub(crate) selected_profile: ProfileId,
     /// Editable custom profile persisted by the app.
     ///
     /// When this is absent, the app derives it from the legacy duration fields.
     /// This is the canonical persisted timer-duration surface.
     #[serde(default)]
-    pub custom_profile: Option<CustomProfileConfig>,
+    pub(crate) custom_profile: Option<CustomProfileConfig>,
     /// Weekday smart-switch rules for profile and planning defaults.
     #[serde(default)]
-    pub weekday_profile_rules: Vec<WeekdayProfileRuleConfig>,
+    pub(crate) weekday_profile_rules: Vec<WeekdayProfileRuleConfig>,
     /// Reusable session templates bundling task/profile/blocklist/schedule settings.
     #[serde(default)]
-    pub session_templates: Vec<SessionTemplateConfig>,
+    pub(crate) session_templates: Vec<SessionTemplateConfig>,
     /// Name of the active session template (empty = none selected).
     #[serde(default)]
-    pub selected_session_template: String,
+    pub(crate) selected_session_template: String,
     /// Rule-based automation triggers for time/schedule/runtime events.
     #[serde(default)]
-    pub automation_triggers: Vec<AutomationTriggerRuleConfig>,
+    pub(crate) automation_triggers: Vec<AutomationTriggerRuleConfig>,
     /// Selected UI theme preset.
     #[serde(default)]
-    pub selected_theme_preset: ThemePreset,
+    pub(crate) selected_theme_preset: ThemePreset,
     /// Deprecated top-level automation mirror (legacy load-time compatibility field).
     #[serde(default, skip_serializing)]
-    pub notifications: NotificationConfig,
+    pub(crate) notifications: NotificationConfig,
     /// Deprecated top-level automation mirror (legacy load-time compatibility field).
     #[serde(default, skip_serializing)]
-    pub auto_start: AutoStartConfig,
+    pub(crate) auto_start: AutoStartConfig,
     /// Deprecated top-level automation mirror (legacy load-time compatibility field).
     #[serde(default, skip_serializing)]
-    pub recurring_schedule: RecurringScheduleConfig,
+    pub(crate) recurring_schedule: RecurringScheduleConfig,
     /// Runtime tuning knobs for schedule editing and delay behavior.
     #[serde(default)]
-    pub schedule_runtime: ScheduleRuntimeConfig,
+    pub(crate) schedule_runtime: ScheduleRuntimeConfig,
     /// External calendar sync settings (ICS feeds, including provider feeds).
     #[serde(default)]
-    pub calendar_sync: CalendarSyncConfig,
+    pub(crate) calendar_sync: CalendarSyncConfig,
     /// Profile-scoped automation settings.
     ///
     /// When absent, legacy global automation fields are used as shared defaults
     /// for all profiles during normalization.
     #[serde(default)]
-    pub profile_automation: Option<ProfileAutomationSettingsConfig>,
+    pub(crate) profile_automation: Option<ProfileAutomationSettingsConfig>,
     /// Deprecated top-level automation mirror (legacy load-time compatibility field).
     #[serde(default, skip_serializing)]
-    pub strict_mode: bool,
+    pub(crate) strict_mode: bool,
     /// Duration of a break-glass unblock override in seconds.
     ///
     /// This value is clamped to a non-zero default during normalization.
     #[serde(default = "default_break_glass_duration_secs")]
-    pub break_glass_duration_secs: u64,
+    pub(crate) break_glass_duration_secs: u64,
     /// Daily goal settings for focus minutes and completed pomodoros.
     ///
     /// A value of `0` disables the corresponding goal.
     #[serde(default)]
-    pub daily_goal: DailyGoalConfig,
+    pub(crate) daily_goal: DailyGoalConfig,
     /// Weekly goal settings for focus minutes and completed pomodoros.
     ///
     /// A value of `0` disables the corresponding goal.
     #[serde(default)]
-    pub weekly_goal: WeeklyGoalConfig,
+    pub(crate) weekly_goal: WeeklyGoalConfig,
     /// Monthly goal settings for focus minutes and completed pomodoros.
     ///
     /// A value of `0` disables the corresponding goal.
     #[serde(default)]
-    pub monthly_goal: MonthlyGoalConfig,
+    pub(crate) monthly_goal: MonthlyGoalConfig,
     /// Carry-over behavior for unmet daily/weekly/monthly targets.
     #[serde(default)]
-    pub goal_carry_over: GoalCarryOverConfig,
+    pub(crate) goal_carry_over: GoalCarryOverConfig,
     /// Retention policy for persisted stats history.
     #[serde(default)]
-    pub stats_retention: StatsRetentionConfig,
+    pub(crate) stats_retention: StatsRetentionConfig,
     /// History dashboard KPI card layout (pinning + display order).
     #[serde(default)]
-    pub history_dashboard: HistoryDashboardConfig,
+    pub(crate) history_dashboard: HistoryDashboardConfig,
     /// WakaTime heartbeat metadata labels.
     #[serde(default)]
-    pub wakatime: WakatimeMetadataConfig,
+    pub(crate) wakatime: WakatimeMetadataConfig,
     /// Runtime tuning knobs for WakaTime retry/queue behavior.
     #[serde(default)]
-    pub wakatime_runtime: WakatimeRuntimeConfig,
+    pub(crate) wakatime_runtime: WakatimeRuntimeConfig,
     /// Feature flags used to safely gate compatibility-sensitive behavior.
     #[serde(default)]
-    pub feature_flags: FeatureFlagsConfig,
+    pub(crate) feature_flags: FeatureFlagsConfig,
     /// User-configurable keyboard shortcuts for core TUI command actions.
     #[serde(default)]
-    pub shortcuts: ShortcutConfig,
+    pub(crate) shortcuts: ShortcutConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,7 +203,7 @@ impl AppConfigDisk {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ConfigHealthStatus {
+pub(crate) enum ConfigHealthStatus {
     Ok,
     Warning,
     Error,
@@ -211,59 +211,59 @@ pub enum ConfigHealthStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ConfigHealthSeverity {
+pub(crate) enum ConfigHealthSeverity {
     Warning,
     Error,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ConfigHealthFinding {
-    pub code: String,
-    pub severity: ConfigHealthSeverity,
-    pub message: String,
-    pub remediation: String,
+pub(crate) struct ConfigHealthFinding {
+    pub(crate) code: String,
+    pub(crate) severity: ConfigHealthSeverity,
+    pub(crate) message: String,
+    pub(crate) remediation: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ConfigMigrationStepReport {
-    pub from_schema_version: u32,
-    pub to_schema_version: u32,
-    pub summary: String,
+pub(crate) struct ConfigMigrationStepReport {
+    pub(crate) from_schema_version: u32,
+    pub(crate) to_schema_version: u32,
+    pub(crate) summary: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ConfigDoctorReport {
-    pub action: &'static str,
-    pub config_path: Option<PathBuf>,
-    pub detected_schema_version: Option<u32>,
-    pub current_schema_version: u32,
-    pub status: ConfigHealthStatus,
-    pub migration_steps: Vec<ConfigMigrationStepReport>,
-    pub findings: Vec<ConfigHealthFinding>,
+pub(crate) struct ConfigDoctorReport {
+    pub(crate) action: &'static str,
+    pub(crate) config_path: Option<PathBuf>,
+    pub(crate) detected_schema_version: Option<u32>,
+    pub(crate) current_schema_version: u32,
+    pub(crate) status: ConfigHealthStatus,
+    pub(crate) migration_steps: Vec<ConfigMigrationStepReport>,
+    pub(crate) findings: Vec<ConfigHealthFinding>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ConfigMigrationReport {
-    pub action: &'static str,
-    pub applied: bool,
-    pub config_path: Option<PathBuf>,
-    pub backup_path: Option<PathBuf>,
-    pub detected_schema_version: Option<u32>,
-    pub target_schema_version: u32,
-    pub changed: bool,
-    pub status: ConfigHealthStatus,
-    pub steps: Vec<ConfigMigrationStepReport>,
-    pub findings: Vec<ConfigHealthFinding>,
+pub(crate) struct ConfigMigrationReport {
+    pub(crate) action: &'static str,
+    pub(crate) applied: bool,
+    pub(crate) config_path: Option<PathBuf>,
+    pub(crate) backup_path: Option<PathBuf>,
+    pub(crate) detected_schema_version: Option<u32>,
+    pub(crate) target_schema_version: u32,
+    pub(crate) changed: bool,
+    pub(crate) status: ConfigHealthStatus,
+    pub(crate) steps: Vec<ConfigMigrationStepReport>,
+    pub(crate) findings: Vec<ConfigHealthFinding>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct FeatureFlagsConfig {
+pub(crate) struct FeatureFlagsConfig {
     #[serde(default)]
-    pub integrations: IntegrationFeatureFlagsConfig,
+    pub(crate) integrations: IntegrationFeatureFlagsConfig,
 }
 
 impl FeatureFlagsConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             integrations: self.integrations.normalized(),
         }
@@ -271,13 +271,13 @@ impl FeatureFlagsConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct IntegrationFeatureFlagsConfig {
+pub(crate) struct IntegrationFeatureFlagsConfig {
     #[serde(default = "default_enabled_integrations")]
-    pub enabled: Vec<String>,
+    pub(crate) enabled: Vec<String>,
 }
 
 impl IntegrationFeatureFlagsConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         let mut enabled = Vec::new();
         for integration in &self.enabled {
             let trimmed = integration.trim().to_ascii_lowercase();
@@ -289,7 +289,7 @@ impl IntegrationFeatureFlagsConfig {
         Self { enabled }
     }
 
-    pub fn is_enabled(&self, integration: &str) -> bool {
+    pub(crate) fn is_enabled(&self, integration: &str) -> bool {
         let normalized = integration.trim().to_ascii_lowercase();
         self.enabled
             .iter()
@@ -306,15 +306,15 @@ impl Default for IntegrationFeatureFlagsConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct BlockingBackendConfig {
+pub(crate) struct BlockingBackendConfig {
     #[serde(default)]
-    pub policy: BlockingBackendPolicyConfig,
+    pub(crate) policy: BlockingBackendPolicyConfig,
     #[serde(default)]
-    pub command: CommandBlockingBackendConfig,
+    pub(crate) command: CommandBlockingBackendConfig,
 }
 
 impl BlockingBackendConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             policy: self.policy,
             command: self.command.normalized(),
@@ -324,7 +324,7 @@ impl BlockingBackendConfig {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
-pub enum BlockingBackendPolicyConfig {
+pub(crate) enum BlockingBackendPolicyConfig {
     HostsOnly,
     #[default]
     HostsThenCommand,
@@ -333,17 +333,17 @@ pub enum BlockingBackendPolicyConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct CommandBlockingBackendConfig {
+pub(crate) struct CommandBlockingBackendConfig {
     #[serde(default)]
-    pub block_command: String,
+    pub(crate) block_command: String,
     #[serde(default)]
-    pub unblock_command: String,
+    pub(crate) unblock_command: String,
     #[serde(default)]
-    pub diagnostics_command: String,
+    pub(crate) diagnostics_command: String,
 }
 
 impl CommandBlockingBackendConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             block_command: self.block_command.trim().to_string(),
             unblock_command: self.unblock_command.trim().to_string(),
@@ -353,33 +353,33 @@ impl CommandBlockingBackendConfig {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub struct NotificationConfig {
+pub(crate) struct NotificationConfig {
     #[serde(default = "default_notification_enabled")]
-    pub enabled: bool,
+    pub(crate) enabled: bool,
     #[serde(default)]
-    pub sound: bool,
+    pub(crate) sound: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct AutoStartConfig {
+pub(crate) struct AutoStartConfig {
     #[serde(default)]
-    pub focus_to_break: bool,
+    pub(crate) focus_to_break: bool,
     #[serde(default)]
-    pub break_to_focus: bool,
+    pub(crate) break_to_focus: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct RecurringScheduleConfig {
+pub(crate) struct RecurringScheduleConfig {
     #[serde(default)]
-    pub windows: Vec<RecurringFocusWindowConfig>,
+    pub(crate) windows: Vec<RecurringFocusWindowConfig>,
     #[serde(default)]
-    pub exception_dates: Vec<String>,
+    pub(crate) exception_dates: Vec<String>,
     #[serde(default)]
-    pub one_time_windows: Vec<OneTimeFocusWindowConfig>,
+    pub(crate) one_time_windows: Vec<OneTimeFocusWindowConfig>,
 }
 
 impl RecurringScheduleConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         let windows = self
             .windows
             .iter()
@@ -421,15 +421,15 @@ impl RecurringScheduleConfig {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ScheduleRuntimeConfig {
+pub(crate) struct ScheduleRuntimeConfig {
     #[serde(default = "default_schedule_time_step_minutes")]
-    pub time_step_minutes: u16,
+    pub(crate) time_step_minutes: u16,
     #[serde(default = "default_schedule_delay_secs")]
-    pub delay_secs: u64,
+    pub(crate) delay_secs: u64,
 }
 
 impl ScheduleRuntimeConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             time_step_minutes: self.time_step_minutes.clamp(
                 SCHEDULE_TIME_STEP_MIN_MINUTES,
@@ -452,19 +452,19 @@ impl Default for ScheduleRuntimeConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CalendarSyncConfig {
+pub(crate) struct CalendarSyncConfig {
     #[serde(default)]
-    pub enabled: bool,
+    pub(crate) enabled: bool,
     #[serde(default = "default_calendar_sync_refresh_secs")]
-    pub refresh_secs: u64,
+    pub(crate) refresh_secs: u64,
     #[serde(default = "default_calendar_sync_lookahead_days")]
-    pub lookahead_days: u16,
+    pub(crate) lookahead_days: u16,
     #[serde(default)]
-    pub sources: Vec<CalendarSourceConfig>,
+    pub(crate) sources: Vec<CalendarSourceConfig>,
 }
 
 impl CalendarSyncConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             enabled: self.enabled,
             refresh_secs: self.refresh_secs.clamp(
@@ -492,19 +492,19 @@ impl Default for CalendarSyncConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CalendarSourceConfig {
+pub(crate) struct CalendarSourceConfig {
     #[serde(default)]
-    pub name: String,
+    pub(crate) name: String,
     #[serde(default)]
-    pub provider: CalendarProviderConfig,
+    pub(crate) provider: CalendarProviderConfig,
     #[serde(default)]
-    pub url: String,
+    pub(crate) url: String,
     #[serde(default = "default_calendar_source_enabled")]
-    pub enabled: bool,
+    pub(crate) enabled: bool,
 }
 
 impl CalendarSourceConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             name: self.name.trim().to_string(),
             provider: self.provider,
@@ -516,7 +516,7 @@ impl CalendarSourceConfig {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
-pub enum CalendarProviderConfig {
+pub(crate) enum CalendarProviderConfig {
     #[default]
     Ics,
     Google,
@@ -524,19 +524,19 @@ pub enum CalendarProviderConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct ProfileAutomationConfig {
+pub(crate) struct ProfileAutomationConfig {
     #[serde(default)]
-    pub notifications: NotificationConfig,
+    pub(crate) notifications: NotificationConfig,
     #[serde(default)]
-    pub auto_start: AutoStartConfig,
+    pub(crate) auto_start: AutoStartConfig,
     #[serde(default)]
-    pub strict_mode: bool,
+    pub(crate) strict_mode: bool,
     #[serde(default)]
-    pub recurring_schedule: RecurringScheduleConfig,
+    pub(crate) recurring_schedule: RecurringScheduleConfig,
 }
 
 impl ProfileAutomationConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             notifications: self.notifications,
             auto_start: self.auto_start,
@@ -562,18 +562,18 @@ impl ProfileAutomationConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct ProfileAutomationSettingsConfig {
+pub(crate) struct ProfileAutomationSettingsConfig {
     #[serde(default, skip_serializing_if = "Option::is_none", alias = "classic")]
-    pub basic: Option<ProfileAutomationConfig>,
+    pub(crate) basic: Option<ProfileAutomationConfig>,
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         alias = "deep_work",
         alias = "deep-work"
     )]
-    pub standard: Option<ProfileAutomationConfig>,
+    pub(crate) standard: Option<ProfileAutomationConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none", alias = "custom")]
-    pub advanced: Option<ProfileAutomationConfig>,
+    pub(crate) advanced: Option<ProfileAutomationConfig>,
 }
 
 impl ProfileAutomationSettingsConfig {
@@ -594,7 +594,7 @@ impl ProfileAutomationSettingsConfig {
         }
     }
 
-    pub fn for_profile(
+    pub(crate) fn for_profile(
         &self,
         profile: ProfileId,
         fallback: &ProfileAutomationConfig,
@@ -607,7 +607,7 @@ impl ProfileAutomationSettingsConfig {
         configured.unwrap_or_else(|| fallback.clone()).normalized()
     }
 
-    pub fn set_for_profile(&mut self, profile: ProfileId, config: ProfileAutomationConfig) {
+    pub(crate) fn set_for_profile(&mut self, profile: ProfileId, config: ProfileAutomationConfig) {
         let value = Some(config.normalized());
         match profile {
             ProfileId::Classic => self.basic = value,
@@ -618,15 +618,15 @@ impl ProfileAutomationSettingsConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WeekdayProfileRuleConfig {
+pub(crate) struct WeekdayProfileRuleConfig {
     #[serde(default = "default_weekday_profile_rule_day")]
-    pub day: String,
+    pub(crate) day: String,
     #[serde(default)]
-    pub profile: ProfileId,
+    pub(crate) profile: ProfileId,
     #[serde(default = "default_blocklist_profile_name")]
-    pub blocklist_profile: String,
+    pub(crate) blocklist_profile: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_template: Option<String>,
+    pub(crate) session_template: Option<String>,
 }
 
 impl WeekdayProfileRuleConfig {
@@ -663,9 +663,9 @@ impl Default for WeekdayProfileRuleConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct AutomationTriggerRuleConfig {
-    pub trigger: AutomationTriggerConditionConfig,
-    pub action: AutomationTriggerActionConfig,
+pub(crate) struct AutomationTriggerRuleConfig {
+    pub(crate) trigger: AutomationTriggerConditionConfig,
+    pub(crate) action: AutomationTriggerActionConfig,
 }
 
 impl AutomationTriggerRuleConfig {
@@ -684,7 +684,7 @@ impl AutomationTriggerRuleConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum AutomationTriggerConditionConfig {
+pub(crate) enum AutomationTriggerConditionConfig {
     #[default]
     ScheduleWindowStart,
     ScheduleWindowEnd,
@@ -720,7 +720,7 @@ impl AutomationTriggerConditionConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum AutomationTriggerActionConfig {
+pub(crate) enum AutomationTriggerActionConfig {
     #[default]
     StartFocus,
     DelayScheduleStart {
@@ -768,17 +768,17 @@ impl AutomationTriggerActionConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RecurringFocusWindowConfig {
+pub(crate) struct RecurringFocusWindowConfig {
     #[serde(default = "default_schedule_window_days")]
-    pub days: Vec<String>,
+    pub(crate) days: Vec<String>,
     #[serde(default = "default_schedule_window_start")]
-    pub start: String,
+    pub(crate) start: String,
     #[serde(default = "default_schedule_window_end")]
-    pub end: String,
+    pub(crate) end: String,
 }
 
 impl RecurringFocusWindowConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             days: normalize_schedule_days(&self.days),
             start: normalize_schedule_time_or_default(&self.start, default_schedule_window_start),
@@ -798,17 +798,17 @@ impl Default for RecurringFocusWindowConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct OneTimeFocusWindowConfig {
+pub(crate) struct OneTimeFocusWindowConfig {
     #[serde(default)]
-    pub date: String,
+    pub(crate) date: String,
     #[serde(default = "default_schedule_window_start")]
-    pub start: String,
+    pub(crate) start: String,
     #[serde(default = "default_schedule_window_end")]
-    pub end: String,
+    pub(crate) end: String,
 }
 
 impl OneTimeFocusWindowConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             date: self.date.trim().to_string(),
             start: self.start.trim().to_string(),
@@ -828,51 +828,51 @@ impl Default for OneTimeFocusWindowConfig {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct DailyGoalConfig {
+pub(crate) struct DailyGoalConfig {
     /// Target focused minutes for the current day.
     #[serde(default)]
-    pub minutes: u64,
+    pub(crate) minutes: u64,
     /// Target completed pomodoros for the current day.
     #[serde(default)]
-    pub pomodoros: u32,
+    pub(crate) pomodoros: u32,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct WeeklyGoalConfig {
+pub(crate) struct WeeklyGoalConfig {
     /// Target focused minutes for the current week.
     #[serde(default)]
-    pub minutes: u64,
+    pub(crate) minutes: u64,
     /// Target completed pomodoros for the current week.
     #[serde(default)]
-    pub pomodoros: u32,
+    pub(crate) pomodoros: u32,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct MonthlyGoalConfig {
+pub(crate) struct MonthlyGoalConfig {
     /// Target focused minutes for the current month.
     #[serde(default)]
-    pub minutes: u64,
+    pub(crate) minutes: u64,
     /// Target completed pomodoros for the current month.
     #[serde(default)]
-    pub pomodoros: u32,
+    pub(crate) pomodoros: u32,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct GoalCarryOverConfig {
+pub(crate) struct GoalCarryOverConfig {
     /// When enabled, unmet daily targets are added to the next day's target.
     #[serde(default)]
-    pub daily: bool,
+    pub(crate) daily: bool,
     /// When enabled, unmet weekly targets are added to the next week's target.
     #[serde(default)]
-    pub weekly: bool,
+    pub(crate) weekly: bool,
     /// When enabled, unmet monthly targets are added to the next month's target.
     #[serde(default)]
-    pub monthly: bool,
+    pub(crate) monthly: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
-pub enum StatsRetentionPreset {
+pub(crate) enum StatsRetentionPreset {
     KeepAll,
     Aggressive,
     #[default]
@@ -880,7 +880,7 @@ pub enum StatsRetentionPreset {
 }
 
 impl StatsRetentionPreset {
-    pub fn id(self) -> &'static str {
+    pub(crate) fn id(self) -> &'static str {
         match self {
             Self::KeepAll => "keep_all",
             Self::Balanced => "balanced",
@@ -890,13 +890,13 @@ impl StatsRetentionPreset {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct StatsRetentionConfig {
+pub(crate) struct StatsRetentionConfig {
     #[serde(default)]
-    pub preset: StatsRetentionPreset,
+    pub(crate) preset: StatsRetentionPreset,
 }
 
 impl StatsRetentionConfig {
-    pub fn windows(self) -> StatsRetentionWindows {
+    pub(crate) fn windows(self) -> StatsRetentionWindows {
         match self.preset {
             StatsRetentionPreset::KeepAll => StatsRetentionWindows {
                 keep_daily_days: None,
@@ -927,18 +927,18 @@ impl StatsRetentionConfig {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct StatsRetentionWindows {
-    pub keep_daily_days: Option<u16>,
-    pub keep_focus_sessions_days: Option<u16>,
-    pub keep_session_interruptions_days: Option<u16>,
-    pub keep_break_glass_overrides_days: Option<u16>,
-    pub keep_weekly_goal_snapshots_days: Option<u16>,
-    pub keep_monthly_goal_snapshots_days: Option<u16>,
+pub(crate) struct StatsRetentionWindows {
+    pub(crate) keep_daily_days: Option<u16>,
+    pub(crate) keep_focus_sessions_days: Option<u16>,
+    pub(crate) keep_session_interruptions_days: Option<u16>,
+    pub(crate) keep_break_glass_overrides_days: Option<u16>,
+    pub(crate) keep_weekly_goal_snapshots_days: Option<u16>,
+    pub(crate) keep_monthly_goal_snapshots_days: Option<u16>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
-pub enum HistoryKpiCardId {
+pub(crate) enum HistoryKpiCardId {
     SessionSummary,
     FocusScore,
     GoalStreak,
@@ -952,7 +952,7 @@ pub enum HistoryKpiCardId {
 }
 
 impl HistoryKpiCardId {
-    pub const fn id(self) -> &'static str {
+    pub(crate) const fn id(self) -> &'static str {
         match self {
             Self::SessionSummary => "session_summary",
             Self::FocusScore => "focus_score",
@@ -967,7 +967,7 @@ impl HistoryKpiCardId {
         }
     }
 
-    pub const fn label(self) -> &'static str {
+    pub(crate) const fn label(self) -> &'static str {
         match self {
             Self::SessionSummary => "Session Summary",
             Self::FocusScore => "Focus Score",
@@ -982,7 +982,7 @@ impl HistoryKpiCardId {
         }
     }
 
-    pub const fn all() -> [Self; 9] {
+    pub(crate) const fn all() -> [Self; 9] {
         [
             Self::SessionSummary,
             Self::FocusScore,
@@ -996,7 +996,7 @@ impl HistoryKpiCardId {
         ]
     }
 
-    pub fn from_id(value: &str) -> Option<Self> {
+    pub(crate) fn from_id(value: &str) -> Option<Self> {
         let parsed = Self::from_config_value(value);
         if parsed == Self::Unknown {
             None
@@ -1042,15 +1042,15 @@ impl<'de> Deserialize<'de> for HistoryKpiCardId {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct HistoryDashboardConfig {
+pub(crate) struct HistoryDashboardConfig {
     #[serde(default = "default_history_dashboard_card_order")]
-    pub card_order: Vec<HistoryKpiCardId>,
+    pub(crate) card_order: Vec<HistoryKpiCardId>,
     #[serde(default = "default_history_dashboard_pinned_cards")]
-    pub pinned_cards: Vec<HistoryKpiCardId>,
+    pub(crate) pinned_cards: Vec<HistoryKpiCardId>,
 }
 
 impl HistoryDashboardConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         let card_order = normalize_history_dashboard_card_order(&self.card_order);
         let pinned_cards =
             normalize_history_dashboard_pinned_cards(&self.pinned_cards, &card_order);
@@ -1185,7 +1185,7 @@ fn default_history_dashboard_card_order() -> Vec<HistoryKpiCardId> {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
-pub enum ProfileId {
+pub(crate) enum ProfileId {
     #[serde(rename = "basic")]
     Classic,
     #[serde(rename = "standard")]
@@ -1202,7 +1202,7 @@ impl ProfileId {
             .unwrap_or(Self::Custom)
     }
 
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             ProfileId::Classic => "Basic",
             ProfileId::DeepWork => "Standard",
@@ -1241,7 +1241,7 @@ fn profile_id_for_token(token: &str) -> ProfileId {
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
-pub enum ThemePreset {
+pub(crate) enum ThemePreset {
     #[default]
     Classic,
     HighContrast,
@@ -1263,7 +1263,7 @@ impl ThemePreset {
         }
     }
 
-    pub fn id(self) -> &'static str {
+    pub(crate) fn id(self) -> &'static str {
         match self {
             Self::Classic => "classic",
             Self::HighContrast => "high-contrast",
@@ -1271,7 +1271,7 @@ impl ThemePreset {
         }
     }
 
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Classic => "Classic",
             Self::HighContrast => "High Contrast",
@@ -1279,7 +1279,7 @@ impl ThemePreset {
         }
     }
 
-    pub fn next(self) -> Self {
+    pub(crate) fn next(self) -> Self {
         match self {
             Self::Classic => Self::HighContrast,
             Self::HighContrast => Self::DeuteranopiaFriendly,
@@ -1287,7 +1287,7 @@ impl ThemePreset {
         }
     }
 
-    pub fn previous(self) -> Self {
+    pub(crate) fn previous(self) -> Self {
         match self {
             Self::Classic => Self::DeuteranopiaFriendly,
             Self::HighContrast => Self::Classic,
@@ -1307,19 +1307,19 @@ impl<'de> Deserialize<'de> for ThemePreset {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CustomProfileConfig {
+pub(crate) struct CustomProfileConfig {
     #[serde(default = "default_focus_secs")]
-    pub focus_secs: u64,
+    pub(crate) focus_secs: u64,
     #[serde(default = "default_short_break_secs")]
-    pub short_break_secs: u64,
+    pub(crate) short_break_secs: u64,
     #[serde(default = "default_long_break_secs")]
-    pub long_break_secs: u64,
+    pub(crate) long_break_secs: u64,
     #[serde(default = "default_long_break_interval")]
-    pub long_break_interval: u32,
+    pub(crate) long_break_interval: u32,
 }
 
 impl CustomProfileConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             focus_secs: nonzero_or_default_u64(self.focus_secs, default_focus_secs()),
             short_break_secs: nonzero_or_default_u64(
@@ -1350,21 +1350,21 @@ impl Default for CustomProfileConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SessionTemplateConfig {
+pub(crate) struct SessionTemplateConfig {
     #[serde(default = "default_session_template_name")]
-    pub name: String,
+    pub(crate) name: String,
     #[serde(default)]
-    pub task_label: String,
+    pub(crate) task_label: String,
     #[serde(default)]
-    pub profile: ProfileId,
+    pub(crate) profile: ProfileId,
     #[serde(default = "default_blocklist_profile_name")]
-    pub blocklist_profile: String,
+    pub(crate) blocklist_profile: String,
     #[serde(default)]
-    pub schedule: RecurringScheduleConfig,
+    pub(crate) schedule: RecurringScheduleConfig,
 }
 
 impl SessionTemplateConfig {
-    pub fn normalized_with_blocklists(
+    pub(crate) fn normalized_with_blocklists(
         &self,
         blocklist_profiles: &[BlocklistProfileConfig],
     ) -> Option<Self> {
@@ -1444,7 +1444,7 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
-    pub fn normalized(self) -> Self {
+    pub(crate) fn normalized(self) -> Self {
         self.normalize()
     }
 
@@ -1455,7 +1455,7 @@ impl AppConfig {
     /// Load the config from disk, falling back to [`AppConfig::default`] on any
     /// error (missing file, parse error, corrupt data, etc.).
     #[cfg_attr(test, allow(dead_code))]
-    pub fn load() -> Self {
+    pub(crate) fn load() -> Self {
         Self::load_with_deprecation_warnings().0
     }
 
@@ -1463,7 +1463,7 @@ impl AppConfig {
     ///
     /// If `custom_profile` is not present in the config file, this derives
     /// values from legacy duration fields to preserve user settings.
-    pub fn effective_custom_profile(&self) -> CustomProfileConfig {
+    pub(crate) fn effective_custom_profile(&self) -> CustomProfileConfig {
         self.custom_profile
             .clone()
             .unwrap_or(CustomProfileConfig {
@@ -1475,7 +1475,7 @@ impl AppConfig {
             .normalized()
     }
 
-    pub fn profile_automation_for(&self, profile: ProfileId) -> ProfileAutomationConfig {
+    pub(crate) fn profile_automation_for(&self, profile: ProfileId) -> ProfileAutomationConfig {
         let fallback = ProfileAutomationConfig::default();
         self.profile_automation
             .as_ref()
@@ -1483,7 +1483,7 @@ impl AppConfig {
             .unwrap_or(fallback)
     }
 
-    pub fn set_profile_automation_for(
+    pub(crate) fn set_profile_automation_for(
         &mut self,
         profile: ProfileId,
         automation: ProfileAutomationConfig,
@@ -1532,7 +1532,7 @@ impl AppConfig {
     /// Persist the current config to disk.
     /// Creates parent directories as needed.
     #[cfg_attr(test, allow(dead_code))]
-    pub fn save(&self) -> io::Result<()> {
+    pub(crate) fn save(&self) -> io::Result<()> {
         let path = Self::config_path().ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, "cannot determine config directory")
         })?;

--- a/src/config/automation.rs
+++ b/src/config/automation.rs
@@ -17,7 +17,7 @@ pub(super) fn normalize_automation_triggers(
         .collect()
 }
 
-pub fn validate_automation_trigger_rules(
+pub(crate) fn validate_automation_trigger_rules(
     rules: &[AutomationTriggerRuleConfig],
     blocklist_profiles: &[BlocklistProfileConfig],
     session_templates: &[SessionTemplateConfig],

--- a/src/config/blocklists.rs
+++ b/src/config/blocklists.rs
@@ -5,15 +5,15 @@ use crate::blocker::{domain_rule_matches_host, normalize_domain_rule};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct BlocklistProfileConfig {
+pub(crate) struct BlocklistProfileConfig {
     #[serde(default = "default_blocklist_profile_name")]
-    pub name: String,
+    pub(crate) name: String,
     /// Deprecated flat mirror of categorized blocklist rules.
     ///
     /// Canonical rules live in `categories[*].sites`; this field is maintained
     /// for load-time compatibility and helper surfaces still reading flat lists.
     #[serde(default)]
-    pub sites: Vec<String>,
+    pub(crate) sites: Vec<String>,
     /// Deprecated flat mirror of categorized allowlist rules.
     ///
     /// Canonical rules live in `categories[*].allowlist_sites`.
@@ -21,23 +21,23 @@ pub struct BlocklistProfileConfig {
     ///
     /// Effective focus blocking is computed as `sites - allowlist_sites`.
     #[serde(default)]
-    pub allowlist_sites: Vec<String>,
+    pub(crate) allowlist_sites: Vec<String>,
     /// Category-organized block/allow rules.
     #[serde(default)]
-    pub categories: Vec<BlocklistCategoryConfig>,
+    pub(crate) categories: Vec<BlocklistCategoryConfig>,
     /// Name of the selected category inside this profile.
     #[serde(default = "default_blocklist_category_name")]
-    pub selected_category: String,
+    pub(crate) selected_category: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct BlocklistCategoryConfig {
+pub(crate) struct BlocklistCategoryConfig {
     #[serde(default = "default_blocklist_category_name")]
-    pub name: String,
+    pub(crate) name: String,
     #[serde(default)]
-    pub sites: Vec<String>,
+    pub(crate) sites: Vec<String>,
     #[serde(default)]
-    pub allowlist_sites: Vec<String>,
+    pub(crate) allowlist_sites: Vec<String>,
 }
 
 impl Default for BlocklistProfileConfig {
@@ -62,7 +62,7 @@ impl Default for BlocklistCategoryConfig {
     }
 }
 
-pub fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
+pub(crate) fn effective_blocked_sites_for_profile(profile: &BlocklistProfileConfig) -> Vec<String> {
     let allowlist_rules: Vec<String> = all_allowlist_rules_for_profile(profile)
         .iter()
         .filter_map(|rule| normalize_domain_rule(rule).ok())

--- a/src/config/diagnostics.rs
+++ b/src/config/diagnostics.rs
@@ -71,7 +71,7 @@ fn write_migrated_config_with_backup(
     Ok(backup_path)
 }
 
-pub fn run_config_doctor() -> ConfigDoctorReport {
+pub(crate) fn run_config_doctor() -> ConfigDoctorReport {
     run_config_doctor_with_path(AppConfig::config_path())
 }
 
@@ -270,7 +270,7 @@ pub(super) fn run_config_doctor_with_path(config_path: Option<PathBuf>) -> Confi
     }
 }
 
-pub fn run_config_migration_assistant(apply: bool) -> ConfigMigrationReport {
+pub(crate) fn run_config_migration_assistant(apply: bool) -> ConfigMigrationReport {
     run_config_migration_assistant_with_path(apply, AppConfig::config_path())
 }
 

--- a/src/config/shortcuts.rs
+++ b/src/config/shortcuts.rs
@@ -1,107 +1,107 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ShortcutConfig {
+pub(crate) struct ShortcutConfig {
     #[serde(default = "default_shortcut_quit")]
-    pub quit: String,
+    pub(crate) quit: String,
     #[serde(default = "default_shortcut_timer_toggle_pause")]
-    pub timer_toggle_pause: String,
+    pub(crate) timer_toggle_pause: String,
     #[serde(default = "default_shortcut_timer_stop_reset")]
-    pub timer_stop_reset: String,
+    pub(crate) timer_stop_reset: String,
     #[serde(default = "default_shortcut_timer_next_phase")]
-    pub timer_next_phase: String,
+    pub(crate) timer_next_phase: String,
     #[serde(default = "default_shortcut_open_site_manager")]
-    pub open_site_manager: String,
+    pub(crate) open_site_manager: String,
     #[serde(default = "default_shortcut_open_profile_manager")]
-    pub open_profile_manager: String,
+    pub(crate) open_profile_manager: String,
     #[serde(default = "default_shortcut_open_session_planner")]
-    pub open_session_planner: String,
+    pub(crate) open_session_planner: String,
     #[serde(default = "default_shortcut_open_stats_history")]
-    pub open_stats_history: String,
+    pub(crate) open_stats_history: String,
     #[serde(default = "default_shortcut_open_setup_diagnostics")]
-    pub open_setup_diagnostics: String,
+    pub(crate) open_setup_diagnostics: String,
     #[serde(default = "default_shortcut_timer_edit_note")]
-    pub timer_edit_note: String,
+    pub(crate) timer_edit_note: String,
     #[serde(default = "default_shortcut_break_glass_override")]
-    pub break_glass_override: String,
+    pub(crate) break_glass_override: String,
     #[serde(default = "default_shortcut_delay_schedule_start")]
-    pub delay_schedule_start: String,
+    pub(crate) delay_schedule_start: String,
     #[serde(default = "default_shortcut_back_site_manager")]
-    pub back_site_manager: String,
+    pub(crate) back_site_manager: String,
     #[serde(default = "default_shortcut_toggle_site_list_mode")]
-    pub toggle_site_list_mode: String,
+    pub(crate) toggle_site_list_mode: String,
     #[serde(default = "default_shortcut_site_add")]
-    pub site_add: String,
+    pub(crate) site_add: String,
     #[serde(default = "default_shortcut_site_edit")]
-    pub site_edit: String,
+    pub(crate) site_edit: String,
     #[serde(default = "default_shortcut_site_delete")]
-    pub site_delete: String,
+    pub(crate) site_delete: String,
     #[serde(default = "default_shortcut_select_previous_blocklist_profile")]
-    pub select_previous_blocklist_profile: String,
+    pub(crate) select_previous_blocklist_profile: String,
     #[serde(default = "default_shortcut_select_next_blocklist_profile")]
-    pub select_next_blocklist_profile: String,
+    pub(crate) select_next_blocklist_profile: String,
     #[serde(default = "default_shortcut_create_blocklist_profile")]
-    pub create_blocklist_profile: String,
+    pub(crate) create_blocklist_profile: String,
     #[serde(default = "default_shortcut_rename_blocklist_profile")]
-    pub rename_blocklist_profile: String,
+    pub(crate) rename_blocklist_profile: String,
     #[serde(default = "default_shortcut_delete_blocklist_profile")]
-    pub delete_blocklist_profile: String,
+    pub(crate) delete_blocklist_profile: String,
     #[serde(default = "default_shortcut_back_session_planner")]
-    pub back_session_planner: String,
+    pub(crate) back_session_planner: String,
     #[serde(default = "default_shortcut_planner_add")]
-    pub planner_add: String,
+    pub(crate) planner_add: String,
     #[serde(default = "default_shortcut_planner_rename")]
-    pub planner_rename: String,
+    pub(crate) planner_rename: String,
     #[serde(default = "default_shortcut_planner_favorite")]
-    pub planner_favorite: String,
+    pub(crate) planner_favorite: String,
     #[serde(default = "default_shortcut_planner_archive")]
-    pub planner_archive: String,
+    pub(crate) planner_archive: String,
     #[serde(default = "default_shortcut_planner_delete")]
-    pub planner_delete: String,
+    pub(crate) planner_delete: String,
     #[serde(default = "default_shortcut_planner_select_recent")]
-    pub planner_select_recent: String,
+    pub(crate) planner_select_recent: String,
     #[serde(default = "default_shortcut_back_profile_manager")]
-    pub back_profile_manager: String,
+    pub(crate) back_profile_manager: String,
     #[serde(default = "default_shortcut_profile_edit")]
-    pub profile_edit: String,
+    pub(crate) profile_edit: String,
     #[serde(default = "default_shortcut_back_stats_history")]
-    pub back_stats_history: String,
+    pub(crate) back_stats_history: String,
     #[serde(default = "default_shortcut_export_stats_history")]
-    pub export_stats_history: String,
+    pub(crate) export_stats_history: String,
     #[serde(default = "default_shortcut_history_dashboard_select_previous")]
-    pub history_dashboard_select_previous: String,
+    pub(crate) history_dashboard_select_previous: String,
     #[serde(default = "default_shortcut_history_dashboard_select_next")]
-    pub history_dashboard_select_next: String,
+    pub(crate) history_dashboard_select_next: String,
     #[serde(default = "default_shortcut_history_dashboard_toggle_pin")]
-    pub history_dashboard_toggle_pin: String,
+    pub(crate) history_dashboard_toggle_pin: String,
     #[serde(default = "default_shortcut_history_dashboard_move_left")]
-    pub history_dashboard_move_left: String,
+    pub(crate) history_dashboard_move_left: String,
     #[serde(default = "default_shortcut_history_dashboard_move_right")]
-    pub history_dashboard_move_right: String,
+    pub(crate) history_dashboard_move_right: String,
     #[serde(default = "default_shortcut_back_setup_diagnostics")]
-    pub back_setup_diagnostics: String,
+    pub(crate) back_setup_diagnostics: String,
     #[serde(default = "default_shortcut_refresh_setup_diagnostics")]
-    pub refresh_setup_diagnostics: String,
+    pub(crate) refresh_setup_diagnostics: String,
     #[serde(default = "default_shortcut_navigate_up")]
-    pub navigate_up: String,
+    pub(crate) navigate_up: String,
     #[serde(default = "default_shortcut_navigate_down")]
-    pub navigate_down: String,
+    pub(crate) navigate_down: String,
     #[serde(default = "default_shortcut_navigate_left")]
-    pub navigate_left: String,
+    pub(crate) navigate_left: String,
     #[serde(default = "default_shortcut_navigate_right")]
-    pub navigate_right: String,
+    pub(crate) navigate_right: String,
     #[serde(default = "default_shortcut_confirm")]
-    pub confirm: String,
+    pub(crate) confirm: String,
     #[serde(default = "default_shortcut_cancel")]
-    pub cancel: String,
+    pub(crate) cancel: String,
     #[serde(default = "default_shortcut_delete")]
-    pub delete: String,
+    pub(crate) delete: String,
     #[serde(default = "default_shortcut_backspace")]
-    pub backspace: String,
+    pub(crate) backspace: String,
 }
 
 impl ShortcutConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             quit: normalize_shortcut_token(&self.quit, &default_shortcut_quit()),
             timer_toggle_pause: normalize_shortcut_token(

--- a/src/config/wakatime.rs
+++ b/src/config/wakatime.rs
@@ -12,27 +12,27 @@ const WAKATIME_RETRY_BACKOFF_MAX_SECS: u64 = 300;
 const WAKATIME_RETRY_BACKOFF_MAX_ENTRIES: usize = 8;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WakatimeTaskMappingConfig {
+pub(crate) struct WakatimeTaskMappingConfig {
     #[serde(default)]
-    pub task_label: String,
+    pub(crate) task_label: String,
     #[serde(default)]
-    pub project: Option<String>,
+    pub(crate) project: Option<String>,
     #[serde(default)]
-    pub language: Option<String>,
+    pub(crate) language: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WakatimeRuntimeConfig {
+pub(crate) struct WakatimeRuntimeConfig {
     #[serde(default = "default_wakatime_retry_backoff_secs")]
-    pub retry_backoff_secs: Vec<u64>,
+    pub(crate) retry_backoff_secs: Vec<u64>,
     #[serde(default = "default_wakatime_queue_capacity")]
-    pub queue_capacity: usize,
+    pub(crate) queue_capacity: usize,
     #[serde(default = "default_wakatime_queue_retry_delay_secs")]
-    pub queue_retry_delay_secs: u64,
+    pub(crate) queue_retry_delay_secs: u64,
 }
 
 impl WakatimeRuntimeConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             retry_backoff_secs: normalize_wakatime_retry_backoff_secs(&self.retry_backoff_secs),
             queue_capacity: self
@@ -56,17 +56,17 @@ impl Default for WakatimeRuntimeConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct WakatimeMetadataConfig {
+pub(crate) struct WakatimeMetadataConfig {
     #[serde(default = "default_wakatime_project")]
-    pub project: String,
+    pub(crate) project: String,
     #[serde(default = "default_wakatime_language")]
-    pub language: String,
+    pub(crate) language: String,
     #[serde(default)]
-    pub task_mappings: Vec<WakatimeTaskMappingConfig>,
+    pub(crate) task_mappings: Vec<WakatimeTaskMappingConfig>,
 }
 
 impl WakatimeMetadataConfig {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             project: normalize_nonempty_or_default_string(
                 &self.project,
@@ -80,7 +80,10 @@ impl WakatimeMetadataConfig {
         }
     }
 
-    pub fn task_mapping_for_label(&self, task_label: &str) -> Option<&WakatimeTaskMappingConfig> {
+    pub(crate) fn task_mapping_for_label(
+        &self,
+        task_label: &str,
+    ) -> Option<&WakatimeTaskMappingConfig> {
         let task_label = task_label.trim();
         if task_label.is_empty() {
             return None;
@@ -90,7 +93,7 @@ impl WakatimeMetadataConfig {
             .find(|mapping| mapping.task_label.eq_ignore_ascii_case(task_label))
     }
 
-    pub fn resolved_project_language_for_task_label(
+    pub(crate) fn resolved_project_language_for_task_label(
         &self,
         task_label: Option<&str>,
     ) -> (String, String) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -31,30 +31,30 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 const DETACHED_PROCESS: u32 = 0x0000_0008;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DaemonConnectionInfo {
-    pub pid: u32,
-    pub host: String,
-    pub port: u16,
-    pub started_at_epoch_secs: i64,
+pub(crate) struct DaemonConnectionInfo {
+    pub(crate) pid: u32,
+    pub(crate) host: String,
+    pub(crate) port: u16,
+    pub(crate) started_at_epoch_secs: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DaemonStartResult {
-    pub already_running: bool,
-    pub info: DaemonConnectionInfo,
+pub(crate) struct DaemonStartResult {
+    pub(crate) already_running: bool,
+    pub(crate) info: DaemonConnectionInfo,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DaemonStatusResult {
-    pub running: bool,
-    pub info: Option<DaemonConnectionInfo>,
+pub(crate) struct DaemonStatusResult {
+    pub(crate) running: bool,
+    pub(crate) info: Option<DaemonConnectionInfo>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DaemonStopResult {
-    pub was_running: bool,
-    pub stopped: bool,
-    pub info: Option<DaemonConnectionInfo>,
+pub(crate) struct DaemonStopResult {
+    pub(crate) was_running: bool,
+    pub(crate) stopped: bool,
+    pub(crate) info: Option<DaemonConnectionInfo>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -86,11 +86,11 @@ impl Drop for DaemonStateGuard {
     }
 }
 
-pub fn is_daemon_child_process() -> bool {
+pub(crate) fn is_daemon_child_process() -> bool {
     std::env::var_os(DAEMON_CHILD_ENV).is_some()
 }
 
-pub fn start_background(port: Option<u16>) -> Result<DaemonStartResult, String> {
+pub(crate) fn start_background(port: Option<u16>) -> Result<DaemonStartResult, String> {
     let status = status()?;
     if status.running {
         return Ok(DaemonStartResult {
@@ -109,7 +109,7 @@ pub fn start_background(port: Option<u16>) -> Result<DaemonStartResult, String> 
     })
 }
 
-pub fn status() -> Result<DaemonStatusResult, String> {
+pub(crate) fn status() -> Result<DaemonStatusResult, String> {
     let Some(state) = load_state_file()? else {
         return Ok(DaemonStatusResult {
             running: false,
@@ -129,7 +129,7 @@ pub fn status() -> Result<DaemonStatusResult, String> {
     }
 }
 
-pub fn stop() -> Result<DaemonStopResult, String> {
+pub(crate) fn stop() -> Result<DaemonStopResult, String> {
     let Some(state) = load_state_file()? else {
         return Ok(DaemonStopResult {
             was_running: false,
@@ -171,7 +171,7 @@ pub fn stop() -> Result<DaemonStopResult, String> {
     })
 }
 
-pub fn run_foreground(port: Option<u16>) -> Result<(), String> {
+pub(crate) fn run_foreground(port: Option<u16>) -> Result<(), String> {
     if let Some(existing_state) = load_state_file()? {
         if ping_health_with_retry(&existing_state).is_ok() {
             return Err(format!(

--- a/src/feature_inventory.rs
+++ b/src/feature_inventory.rs
@@ -6,8 +6,8 @@ use std::{
 
 use serde::Serialize;
 
-pub const FEATURE_INVENTORY_JSON_FILE_NAME: &str = "FEATURE_INVENTORY.json";
-pub const FEATURE_INVENTORY_MARKDOWN_FILE_NAME: &str = "FEATURE_INVENTORY.md";
+pub(crate) const FEATURE_INVENTORY_JSON_FILE_NAME: &str = "FEATURE_INVENTORY.json";
+pub(crate) const FEATURE_INVENTORY_MARKDOWN_FILE_NAME: &str = "FEATURE_INVENTORY.md";
 
 const SCHEMA_VERSION: u8 = 4;
 const COMPLEXITY_WEIGHT: f64 = 0.40;
@@ -22,7 +22,7 @@ const TIE_BREAK_REMOVE_SIGNAL_MAX: u8 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
-pub enum FeatureSurface {
+pub(crate) enum FeatureSurface {
     Timer,
     Schedule,
     Blocker,
@@ -32,7 +32,7 @@ pub enum FeatureSurface {
 
 impl FeatureSurface {
     #[cfg(test)]
-    pub const ALL: [Self; 5] = [
+    pub(crate) const ALL: [Self; 5] = [
         Self::Timer,
         Self::Schedule,
         Self::Blocker,
@@ -56,7 +56,7 @@ impl std::fmt::Display for FeatureSurface {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum FeatureRecommendation {
+pub(crate) enum FeatureRecommendation {
     Keep,
     Merge,
     Remove,
@@ -73,77 +73,77 @@ impl FeatureRecommendation {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct FeatureInventoryReport {
-    pub schema_version: u8,
-    pub scoring_model: FeatureScoringModel,
-    pub summary: FeatureInventorySummary,
-    pub features: Vec<FeatureInventoryEntry>,
+pub(crate) struct FeatureInventoryReport {
+    pub(crate) schema_version: u8,
+    pub(crate) scoring_model: FeatureScoringModel,
+    pub(crate) summary: FeatureInventorySummary,
+    pub(crate) features: Vec<FeatureInventoryEntry>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct FeatureScoringModel {
-    pub score_min: u8,
-    pub score_max: u8,
-    pub complexity_weight: f64,
-    pub support_burden_weight: f64,
-    pub failure_impact_weight: f64,
-    pub keep_min_value: u8,
-    pub keep_min_delta: f64,
-    pub remove_max_delta: f64,
-    pub tie_break_model: TieBreakModel,
-    pub release_phase_mapping: Vec<RecommendationReleasePhase>,
+pub(crate) struct FeatureScoringModel {
+    pub(crate) score_min: u8,
+    pub(crate) score_max: u8,
+    pub(crate) complexity_weight: f64,
+    pub(crate) support_burden_weight: f64,
+    pub(crate) failure_impact_weight: f64,
+    pub(crate) keep_min_value: u8,
+    pub(crate) keep_min_delta: f64,
+    pub(crate) remove_max_delta: f64,
+    pub(crate) tie_break_model: TieBreakModel,
+    pub(crate) release_phase_mapping: Vec<RecommendationReleasePhase>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct TieBreakModel {
-    pub boundary_epsilon: f64,
-    pub keep_signal_min: u8,
-    pub remove_signal_max: u8,
+pub(crate) struct TieBreakModel {
+    pub(crate) boundary_epsilon: f64,
+    pub(crate) keep_signal_min: u8,
+    pub(crate) remove_signal_max: u8,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct RecommendationReleasePhase {
-    pub recommendation: FeatureRecommendation,
-    pub phase: &'static str,
-    pub objective: &'static str,
+pub(crate) struct RecommendationReleasePhase {
+    pub(crate) recommendation: FeatureRecommendation,
+    pub(crate) phase: &'static str,
+    pub(crate) objective: &'static str,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct FeatureInventorySummary {
-    pub total_features: usize,
-    pub keep_count: usize,
-    pub merge_count: usize,
-    pub remove_count: usize,
-    pub by_surface: Vec<SurfaceSummary>,
-    pub covered_cli_flags: Vec<String>,
+pub(crate) struct FeatureInventorySummary {
+    pub(crate) total_features: usize,
+    pub(crate) keep_count: usize,
+    pub(crate) merge_count: usize,
+    pub(crate) remove_count: usize,
+    pub(crate) by_surface: Vec<SurfaceSummary>,
+    pub(crate) covered_cli_flags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct SurfaceSummary {
-    pub surface: FeatureSurface,
-    pub feature_count: usize,
+pub(crate) struct SurfaceSummary {
+    pub(crate) surface: FeatureSurface,
+    pub(crate) feature_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct FeatureInventoryEntry {
-    pub feature_id: String,
-    pub name: String,
-    pub surface: FeatureSurface,
-    pub description: String,
-    pub cli_flags: Vec<String>,
-    pub value: u8,
-    pub complexity: u8,
-    pub support_burden: u8,
-    pub failure_impact: u8,
-    pub maintenance_cost: f64,
-    pub value_to_maintenance_ratio: f64,
-    pub recommendation: FeatureRecommendation,
+pub(crate) struct FeatureInventoryEntry {
+    pub(crate) feature_id: String,
+    pub(crate) name: String,
+    pub(crate) surface: FeatureSurface,
+    pub(crate) description: String,
+    pub(crate) cli_flags: Vec<String>,
+    pub(crate) value: u8,
+    pub(crate) complexity: u8,
+    pub(crate) support_burden: u8,
+    pub(crate) failure_impact: u8,
+    pub(crate) maintenance_cost: f64,
+    pub(crate) value_to_maintenance_ratio: f64,
+    pub(crate) recommendation: FeatureRecommendation,
 }
 
 #[derive(Debug, Clone)]
-pub struct FeatureInventoryExportPaths {
-    pub json_path: PathBuf,
-    pub markdown_path: PathBuf,
+pub(crate) struct FeatureInventoryExportPaths {
+    pub(crate) json_path: PathBuf,
+    pub(crate) markdown_path: PathBuf,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -519,7 +519,7 @@ const FEATURE_SEEDS: &[FeatureSeed] = &[
     },
 ];
 
-pub fn build_feature_inventory_report() -> FeatureInventoryReport {
+pub(crate) fn build_feature_inventory_report() -> FeatureInventoryReport {
     build_feature_inventory_report_for_version(env!("CARGO_PKG_VERSION"))
 }
 
@@ -561,7 +561,7 @@ pub(crate) fn build_feature_inventory_report_for_version(
     }
 }
 
-pub fn export_feature_inventory_report(
+pub(crate) fn export_feature_inventory_report(
     dir: &Path,
     report: &FeatureInventoryReport,
 ) -> io::Result<FeatureInventoryExportPaths> {
@@ -585,7 +585,7 @@ pub fn export_feature_inventory_report(
     })
 }
 
-pub fn render_markdown_report(report: &FeatureInventoryReport) -> String {
+pub(crate) fn render_markdown_report(report: &FeatureInventoryReport) -> String {
     let model = &report.scoring_model;
     let tie_break = &model.tie_break_model;
     let mut markdown = String::new();

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -14,12 +14,12 @@ const WAKATIME_CAPABILITIES: [IntegrationCapability; 5] = [
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum IntegrationId {
+pub(crate) enum IntegrationId {
     Wakatime,
 }
 
 impl IntegrationId {
-    pub fn config_name(self) -> &'static str {
+    pub(crate) fn config_name(self) -> &'static str {
         match self {
             Self::Wakatime => WAKATIME_PLUGIN_NAME,
         }
@@ -34,7 +34,7 @@ impl IntegrationId {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum IntegrationCapability {
+pub(crate) enum IntegrationCapability {
     FocusLifecycleHooks,
     FocusElapsedHooks,
     TaskMetadataHooks,
@@ -43,13 +43,13 @@ pub enum IntegrationCapability {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct IntegrationDescriptor {
-    pub id: IntegrationId,
-    pub capabilities: &'static [IntegrationCapability],
+pub(crate) struct IntegrationDescriptor {
+    pub(crate) id: IntegrationId,
+    pub(crate) capabilities: &'static [IntegrationCapability],
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum IntegrationLifecycleEvent {
+pub(crate) enum IntegrationLifecycleEvent {
     Poll,
     FocusStateChanged { focus_running: bool },
     FocusElapsed { elapsed_secs: u64 },
@@ -77,12 +77,12 @@ struct LoadedIntegration {
     plugin: Box<dyn IntegrationPlugin>,
 }
 
-pub struct IntegrationRuntime {
+pub(crate) struct IntegrationRuntime {
     integrations: Vec<LoadedIntegration>,
 }
 
 impl IntegrationRuntime {
-    pub fn load(
+    pub(crate) fn load(
         enabled_plugins: &[String],
         wakatime_metadata: WakatimeHeartbeatMetadata,
         wakatime_runtime: WakatimeRuntimeOptions,
@@ -111,7 +111,7 @@ impl IntegrationRuntime {
         (Self { integrations }, warnings)
     }
 
-    pub fn dispatch_lifecycle_event(
+    pub(crate) fn dispatch_lifecycle_event(
         &mut self,
         event: IntegrationLifecycleEvent,
     ) -> Result<(), String> {
@@ -140,20 +140,20 @@ impl IntegrationRuntime {
         }
     }
 
-    pub fn set_wakatime_metadata(&mut self, metadata: WakatimeHeartbeatMetadata) {
+    pub(crate) fn set_wakatime_metadata(&mut self, metadata: WakatimeHeartbeatMetadata) {
         let Some(plugin) = self.wakatime_plugin_mut() else {
             return;
         };
         plugin.set_metadata(metadata);
     }
 
-    pub fn wakatime_runtime_state(&self) -> WakatimeRuntimeState {
+    pub(crate) fn wakatime_runtime_state(&self) -> WakatimeRuntimeState {
         self.wakatime_plugin()
             .map(|plugin| plugin.tracker().runtime_state())
             .unwrap_or(WakatimeRuntimeState::NotConfigured)
     }
 
-    pub fn wakatime_last_successful_heartbeat_epoch_secs(&self) -> Option<u64> {
+    pub(crate) fn wakatime_last_successful_heartbeat_epoch_secs(&self) -> Option<u64> {
         self.wakatime_plugin()
             .and_then(|plugin| plugin.tracker().last_successful_heartbeat_epoch_secs())
     }

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -11,16 +11,16 @@ use crate::timer::TimerPhase;
 
 const NOTIFICATION_TITLE: &str = "focustime";
 
-pub struct PhaseNotifier {
+pub(crate) struct PhaseNotifier {
     settings: NotificationConfig,
 }
 
 impl PhaseNotifier {
-    pub fn new(settings: NotificationConfig) -> Self {
+    pub(crate) fn new(settings: NotificationConfig) -> Self {
         Self { settings }
     }
 
-    pub fn notify_phase_completion(
+    pub(crate) fn notify_phase_completion(
         &self,
         completed_phase: TimerPhase,
         next_phase: TimerPhase,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -9,9 +9,9 @@ mod occurrence;
 mod parsing;
 
 #[allow(unused_imports)]
-pub use conflicts::inspect_schedule_conflicts;
-pub use conflicts::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
-pub use occurrence::{
+pub(crate) use conflicts::inspect_schedule_conflicts;
+pub(crate) use conflicts::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
+pub(crate) use occurrence::{
     active_occurrence, active_one_time_occurrence, next_occurrence_after,
     next_one_time_occurrence_after, occurrence_key, pick_active_occurrence, pick_next_occurrence,
 };
@@ -19,65 +19,69 @@ pub use occurrence::{
 use parsing::{parse_exception_date, parse_time_minutes, parse_weekdays};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RecurringWindow {
+pub(crate) struct RecurringWindow {
     days: Vec<Weekday>,
     start_minutes: u16,
     end_minutes: u16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OneTimeWindow {
-    pub date: NaiveDate,
+pub(crate) struct OneTimeWindow {
+    pub(crate) date: NaiveDate,
     start_minutes: u16,
     end_minutes: u16,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WindowOccurrenceKind {
+pub(crate) enum WindowOccurrenceKind {
     Recurring,
     OneTime,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WindowOccurrence {
-    pub kind: WindowOccurrenceKind,
-    pub window_index: usize,
-    pub start: DateTime<Local>,
-    pub end: DateTime<Local>,
+pub(crate) struct WindowOccurrence {
+    pub(crate) kind: WindowOccurrenceKind,
+    pub(crate) window_index: usize,
+    pub(crate) start: DateTime<Local>,
+    pub(crate) end: DateTime<Local>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ScheduleConflictContext {
+pub(crate) enum ScheduleConflictContext {
     Weekday(Weekday),
     Date(NaiveDate),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ScheduleConflict {
-    pub first_kind: WindowOccurrenceKind,
-    pub first_window_index: usize,
-    pub second_kind: WindowOccurrenceKind,
-    pub second_window_index: usize,
-    pub context: ScheduleConflictContext,
-    pub overlap_start_minutes: u16,
-    pub overlap_end_minutes: u16,
+pub(crate) struct ScheduleConflict {
+    pub(crate) first_kind: WindowOccurrenceKind,
+    pub(crate) first_window_index: usize,
+    pub(crate) second_kind: WindowOccurrenceKind,
+    pub(crate) second_window_index: usize,
+    pub(crate) context: ScheduleConflictContext,
+    pub(crate) overlap_start_minutes: u16,
+    pub(crate) overlap_end_minutes: u16,
 }
 
-pub fn compile_windows(config_windows: &[RecurringFocusWindowConfig]) -> Vec<RecurringWindow> {
+pub(crate) fn compile_windows(
+    config_windows: &[RecurringFocusWindowConfig],
+) -> Vec<RecurringWindow> {
     config_windows
         .iter()
         .filter_map(RecurringWindow::from_config)
         .collect()
 }
 
-pub fn compile_one_time_windows(config_windows: &[OneTimeFocusWindowConfig]) -> Vec<OneTimeWindow> {
+pub(crate) fn compile_one_time_windows(
+    config_windows: &[OneTimeFocusWindowConfig],
+) -> Vec<OneTimeWindow> {
     config_windows
         .iter()
         .filter_map(OneTimeWindow::from_config)
         .collect()
 }
 
-pub fn compile_exception_dates(config_dates: &[String]) -> HashSet<NaiveDate> {
+pub(crate) fn compile_exception_dates(config_dates: &[String]) -> HashSet<NaiveDate> {
     config_dates
         .iter()
         .filter_map(|value| parse_exception_date(value))

--- a/src/schedule/conflicts.rs
+++ b/src/schedule/conflicts.rs
@@ -9,7 +9,7 @@ use super::{
     WindowOccurrenceKind, compile_exception_dates, compile_one_time_windows, compile_windows,
 };
 
-pub fn inspect_schedule_conflicts_from_config(
+pub(crate) fn inspect_schedule_conflicts_from_config(
     schedule: &RecurringScheduleConfig,
 ) -> Vec<ScheduleConflict> {
     let recurring_windows = compile_windows(&schedule.windows);
@@ -22,7 +22,7 @@ pub fn inspect_schedule_conflicts_from_config(
     )
 }
 
-pub fn inspect_schedule_conflicts(
+pub(crate) fn inspect_schedule_conflicts(
     recurring_windows: &[RecurringWindow],
     one_time_windows: &[OneTimeWindow],
     recurring_exception_dates: &HashSet<NaiveDate>,
@@ -40,7 +40,7 @@ pub fn inspect_schedule_conflicts(
     conflicts
 }
 
-pub fn format_schedule_conflict(conflict: &ScheduleConflict) -> String {
+pub(crate) fn format_schedule_conflict(conflict: &ScheduleConflict) -> String {
     let context = match conflict.context {
         ScheduleConflictContext::Weekday(day) => day_token(day).to_uppercase(),
         ScheduleConflictContext::Date(date) => date.format("%Y-%m-%d").to_string(),

--- a/src/schedule/occurrence.rs
+++ b/src/schedule/occurrence.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, TimeZo
 
 use super::{OneTimeWindow, RecurringWindow, WindowOccurrence, WindowOccurrenceKind};
 
-pub fn occurrence_key(occurrence: &WindowOccurrence) -> String {
+pub(crate) fn occurrence_key(occurrence: &WindowOccurrence) -> String {
     let kind_key = match occurrence.kind {
         WindowOccurrenceKind::Recurring => "r",
         WindowOccurrenceKind::OneTime => "o",
@@ -16,7 +16,7 @@ pub fn occurrence_key(occurrence: &WindowOccurrence) -> String {
     )
 }
 
-pub fn active_occurrence(
+pub(crate) fn active_occurrence(
     now: DateTime<Local>,
     windows: &[RecurringWindow],
     exception_dates: &HashSet<NaiveDate>,
@@ -62,7 +62,7 @@ pub fn active_occurrence(
     selected
 }
 
-pub fn next_occurrence_after(
+pub(crate) fn next_occurrence_after(
     now: DateTime<Local>,
     windows: &[RecurringWindow],
     exception_dates: &HashSet<NaiveDate>,
@@ -111,7 +111,7 @@ pub fn next_occurrence_after(
     selected
 }
 
-pub fn active_one_time_occurrence(
+pub(crate) fn active_one_time_occurrence(
     now: DateTime<Local>,
     windows: &[OneTimeWindow],
 ) -> Option<WindowOccurrence> {
@@ -153,7 +153,7 @@ pub fn active_one_time_occurrence(
     selected
 }
 
-pub fn next_one_time_occurrence_after(
+pub(crate) fn next_one_time_occurrence_after(
     now: DateTime<Local>,
     windows: &[OneTimeWindow],
 ) -> Option<WindowOccurrence> {
@@ -186,7 +186,7 @@ pub fn next_one_time_occurrence_after(
     selected
 }
 
-pub fn pick_active_occurrence(
+pub(crate) fn pick_active_occurrence(
     first: Option<WindowOccurrence>,
     second: Option<WindowOccurrence>,
 ) -> Option<WindowOccurrence> {
@@ -204,7 +204,7 @@ pub fn pick_active_occurrence(
     }
 }
 
-pub fn pick_next_occurrence(
+pub(crate) fn pick_next_occurrence(
     first: Option<WindowOccurrence>,
     second: Option<WindowOccurrence>,
 ) -> Option<WindowOccurrence> {

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -27,14 +27,14 @@ const WORKFLOW_STATE_FILE_NAME: &str = "workflow-state.toml";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub enum RecoveryTimerPhase {
+pub(crate) enum RecoveryTimerPhase {
     Focus,
     ShortBreak,
     LongBreak,
 }
 
 impl RecoveryTimerPhase {
-    pub fn from_timer_phase(phase: TimerPhase) -> Self {
+    pub(crate) fn from_timer_phase(phase: TimerPhase) -> Self {
         match phase {
             TimerPhase::Focus => Self::Focus,
             TimerPhase::ShortBreak => Self::ShortBreak,
@@ -42,7 +42,7 @@ impl RecoveryTimerPhase {
         }
     }
 
-    pub fn to_timer_phase(self) -> TimerPhase {
+    pub(crate) fn to_timer_phase(self) -> TimerPhase {
         match self {
             Self::Focus => TimerPhase::Focus,
             Self::ShortBreak => TimerPhase::ShortBreak,
@@ -53,14 +53,14 @@ impl RecoveryTimerPhase {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub enum RecoveryTimerStatus {
+pub(crate) enum RecoveryTimerStatus {
     Idle,
     Running,
     Paused,
 }
 
 impl RecoveryTimerStatus {
-    pub fn from_timer_status(status: TimerStatus) -> Self {
+    pub(crate) fn from_timer_status(status: TimerStatus) -> Self {
         match status {
             TimerStatus::Idle => Self::Idle,
             TimerStatus::Running => Self::Running,
@@ -68,7 +68,7 @@ impl RecoveryTimerStatus {
         }
     }
 
-    pub fn to_timer_status(self) -> TimerStatus {
+    pub(crate) fn to_timer_status(self) -> TimerStatus {
         match self {
             Self::Idle => TimerStatus::Idle,
             Self::Running => TimerStatus::Running,
@@ -78,55 +78,55 @@ impl RecoveryTimerStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct InProgressSessionSnapshot {
-    pub phase: RecoveryTimerPhase,
-    pub status: RecoveryTimerStatus,
-    pub remaining_secs: u64,
+pub(crate) struct InProgressSessionSnapshot {
+    pub(crate) phase: RecoveryTimerPhase,
+    pub(crate) status: RecoveryTimerStatus,
+    pub(crate) remaining_secs: u64,
     #[serde(default)]
-    pub pomodoros_completed: u32,
-    pub selected_task_label: Option<String>,
+    pub(crate) pomodoros_completed: u32,
+    pub(crate) selected_task_label: Option<String>,
     #[serde(default)]
-    pub focus_intention: Option<String>,
+    pub(crate) focus_intention: Option<String>,
     #[serde(default)]
-    pub task_note: Option<String>,
-    pub selected_profile: ProfileId,
+    pub(crate) task_note: Option<String>,
+    pub(crate) selected_profile: ProfileId,
     #[serde(default)]
-    pub captured_at_epoch_secs: Option<i64>,
+    pub(crate) captured_at_epoch_secs: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct WorkflowStateSnapshot {
+pub(crate) struct WorkflowStateSnapshot {
     #[serde(default)]
-    pub schedule_delayed_occurrence_key: Option<String>,
+    pub(crate) schedule_delayed_occurrence_key: Option<String>,
     #[serde(default)]
-    pub schedule_delay_until_epoch_secs: Option<i64>,
+    pub(crate) schedule_delay_until_epoch_secs: Option<i64>,
     #[serde(default)]
-    pub schedule_armed_occurrence_key: Option<String>,
+    pub(crate) schedule_armed_occurrence_key: Option<String>,
     #[serde(default)]
-    pub last_schedule_occurrence_key: Option<String>,
+    pub(crate) last_schedule_occurrence_key: Option<String>,
     #[serde(default)]
-    pub break_glass_expires_at_epoch_secs: Option<i64>,
+    pub(crate) break_glass_expires_at_epoch_secs: Option<i64>,
     #[serde(default)]
-    pub break_glass_confirmation_pending: bool,
+    pub(crate) break_glass_confirmation_pending: bool,
     #[serde(default)]
-    pub strict_reset_confirmation_pending: bool,
+    pub(crate) strict_reset_confirmation_pending: bool,
     #[serde(default)]
-    pub temporary_allowlist_entries: Vec<WorkflowTemporaryAllowlistEntrySnapshot>,
+    pub(crate) temporary_allowlist_entries: Vec<WorkflowTemporaryAllowlistEntrySnapshot>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct WorkflowTemporaryAllowlistEntrySnapshot {
+pub(crate) struct WorkflowTemporaryAllowlistEntrySnapshot {
     #[serde(default)]
-    pub profile: String,
+    pub(crate) profile: String,
     #[serde(default)]
-    pub site: String,
+    pub(crate) site: String,
     #[serde(default)]
-    pub expires_at_epoch_secs: i64,
+    pub(crate) expires_at_epoch_secs: i64,
 }
 
 impl InProgressSessionSnapshot {
     #[allow(dead_code)]
-    pub fn from_timer_state_with_metadata(
+    pub(crate) fn from_timer_state_with_metadata(
         timer: &TimerState,
         selected_task_label: Option<String>,
         focus_intention: Option<String>,
@@ -156,34 +156,34 @@ impl InProgressSessionSnapshot {
         })
     }
 
-    pub fn phase(&self) -> TimerPhase {
+    pub(crate) fn phase(&self) -> TimerPhase {
         self.phase.to_timer_phase()
     }
 
-    pub fn status(&self) -> TimerStatus {
+    pub(crate) fn status(&self) -> TimerStatus {
         self.status.to_timer_status()
     }
 
-    pub fn normalized_task_label(&self) -> Option<String> {
+    pub(crate) fn normalized_task_label(&self) -> Option<String> {
         self.selected_task_label
             .as_deref()
             .and_then(normalize_task_label)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn normalized_focus_intention(&self) -> Option<String> {
+    pub(crate) fn normalized_focus_intention(&self) -> Option<String> {
         self.focus_intention
             .as_deref()
             .and_then(normalize_metadata_text)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn normalized_task_note(&self) -> Option<String> {
+    pub(crate) fn normalized_task_note(&self) -> Option<String> {
         self.task_note.as_deref().and_then(normalize_metadata_text)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn validate_for_timer(&self, timer: &TimerState) -> Result<(), String> {
+    pub(crate) fn validate_for_timer(&self, timer: &TimerState) -> Result<(), String> {
         if !matches!(
             self.status,
             RecoveryTimerStatus::Running | RecoveryTimerStatus::Paused
@@ -207,7 +207,7 @@ impl InProgressSessionSnapshot {
         Ok(())
     }
 
-    pub fn reconcile_elapsed_for_timer(&self, timer: &TimerState) -> Self {
+    pub(crate) fn reconcile_elapsed_for_timer(&self, timer: &TimerState) -> Self {
         let Some(now_epoch_secs) = current_epoch_secs() else {
             return self.clone();
         };
@@ -215,7 +215,7 @@ impl InProgressSessionSnapshot {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn reconcile_elapsed_for_timer_at_epoch_secs(
+    pub(crate) fn reconcile_elapsed_for_timer_at_epoch_secs(
         &self,
         timer: &TimerState,
         now_epoch_secs: i64,
@@ -262,7 +262,7 @@ impl InProgressSessionSnapshot {
 }
 
 #[cfg(not(test))]
-pub fn load() -> Result<Option<InProgressSessionSnapshot>, String> {
+pub(crate) fn load() -> Result<Option<InProgressSessionSnapshot>, String> {
     let path = recovery_path().map_err(|e| format!("session recovery path failed: {e}"))?;
     match fs::read_to_string(path) {
         Ok(content) => toml::from_str(&content)
@@ -274,7 +274,7 @@ pub fn load() -> Result<Option<InProgressSessionSnapshot>, String> {
 }
 
 #[cfg(not(test))]
-pub fn save(snapshot: &InProgressSessionSnapshot) -> io::Result<()> {
+pub(crate) fn save(snapshot: &InProgressSessionSnapshot) -> io::Result<()> {
     let path = recovery_path()?;
     let content = toml::to_string_pretty(snapshot)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -282,7 +282,7 @@ pub fn save(snapshot: &InProgressSessionSnapshot) -> io::Result<()> {
 }
 
 #[cfg(not(test))]
-pub fn clear() -> io::Result<()> {
+pub(crate) fn clear() -> io::Result<()> {
     let path = recovery_path()?;
     match fs::remove_file(path) {
         Ok(()) => Ok(()),
@@ -292,7 +292,7 @@ pub fn clear() -> io::Result<()> {
 }
 
 #[cfg(not(test))]
-pub fn load_workflow_state() -> Result<Option<WorkflowStateSnapshot>, String> {
+pub(crate) fn load_workflow_state() -> Result<Option<WorkflowStateSnapshot>, String> {
     let path = workflow_state_path().map_err(|e| format!("workflow state path failed: {e}"))?;
     match fs::read_to_string(path) {
         Ok(content) => toml::from_str(&content)
@@ -304,7 +304,7 @@ pub fn load_workflow_state() -> Result<Option<WorkflowStateSnapshot>, String> {
 }
 
 #[cfg(not(test))]
-pub fn save_workflow_state(snapshot: &WorkflowStateSnapshot) -> io::Result<()> {
+pub(crate) fn save_workflow_state(snapshot: &WorkflowStateSnapshot) -> io::Result<()> {
     let path = workflow_state_path()?;
     let content = toml::to_string_pretty(snapshot)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -312,7 +312,7 @@ pub fn save_workflow_state(snapshot: &WorkflowStateSnapshot) -> io::Result<()> {
 }
 
 #[cfg(not(test))]
-pub fn clear_workflow_state() -> io::Result<()> {
+pub(crate) fn clear_workflow_state() -> io::Result<()> {
     let path = workflow_state_path()?;
     match fs::remove_file(path) {
         Ok(()) => Ok(()),
@@ -423,12 +423,12 @@ thread_local! {
 }
 
 #[cfg(test)]
-pub fn load() -> Result<Option<InProgressSessionSnapshot>, String> {
+pub(crate) fn load() -> Result<Option<InProgressSessionSnapshot>, String> {
     TEST_LOAD_OVERRIDE.with(|slot| slot.borrow_mut().take().unwrap_or(Ok(None)))
 }
 
 #[cfg(test)]
-pub fn save(snapshot: &InProgressSessionSnapshot) -> io::Result<()> {
+pub(crate) fn save(snapshot: &InProgressSessionSnapshot) -> io::Result<()> {
     TEST_SAVED_SNAPSHOT.with(|slot| {
         *slot.borrow_mut() = Some(snapshot.clone());
     });
@@ -436,7 +436,7 @@ pub fn save(snapshot: &InProgressSessionSnapshot) -> io::Result<()> {
 }
 
 #[cfg(test)]
-pub fn clear() -> io::Result<()> {
+pub(crate) fn clear() -> io::Result<()> {
     TEST_SAVED_SNAPSHOT.with(|slot| {
         *slot.borrow_mut() = None;
     });
@@ -444,7 +444,7 @@ pub fn clear() -> io::Result<()> {
 }
 
 #[cfg(test)]
-pub fn load_workflow_state() -> Result<Option<WorkflowStateSnapshot>, String> {
+pub(crate) fn load_workflow_state() -> Result<Option<WorkflowStateSnapshot>, String> {
     let override_value = TEST_WORKFLOW_LOAD_OVERRIDE.with(|slot| slot.borrow_mut().take());
     if let Some(result) = override_value {
         return result;
@@ -457,7 +457,7 @@ pub fn load_workflow_state() -> Result<Option<WorkflowStateSnapshot>, String> {
 }
 
 #[cfg(test)]
-pub fn save_workflow_state(snapshot: &WorkflowStateSnapshot) -> io::Result<()> {
+pub(crate) fn save_workflow_state(snapshot: &WorkflowStateSnapshot) -> io::Result<()> {
     TEST_SAVED_WORKFLOW_SNAPSHOT.with(|slot| {
         *slot.borrow_mut() = Some(snapshot.clone());
     });
@@ -465,7 +465,7 @@ pub fn save_workflow_state(snapshot: &WorkflowStateSnapshot) -> io::Result<()> {
 }
 
 #[cfg(test)]
-pub fn clear_workflow_state() -> io::Result<()> {
+pub(crate) fn clear_workflow_state() -> io::Result<()> {
     TEST_SAVED_WORKFLOW_SNAPSHOT.with(|slot| {
         *slot.borrow_mut() = None;
     });

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -39,48 +39,48 @@ const EXPORT_SCHEMA_VERSION: u32 = 8;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct StatsLoadOptions {}
+pub(crate) struct StatsLoadOptions {}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct StatsSaveOptions {}
+pub(crate) struct StatsSaveOptions {}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct SessionStats {
-    pub pomodoros_completed: u32,
-    pub focused_seconds: u64,
+pub(crate) struct SessionStats {
+    pub(crate) pomodoros_completed: u32,
+    pub(crate) focused_seconds: u64,
 }
 
 impl SessionStats {
-    pub fn focused_minutes(self) -> u64 {
+    pub(crate) fn focused_minutes(self) -> u64 {
         self.focused_seconds / 60
     }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct DailyGoalSnapshot {
+pub(crate) struct DailyGoalSnapshot {
     #[serde(default)]
-    pub minutes: u64,
+    pub(crate) minutes: u64,
     #[serde(default)]
-    pub pomodoros: u32,
+    pub(crate) pomodoros: u32,
 }
 
 impl DailyGoalSnapshot {
-    pub fn has_any_target(self) -> bool {
+    pub(crate) fn has_any_target(self) -> bool {
         self.minutes > 0 || self.pomodoros > 0
     }
 
-    pub fn is_met_by_totals(self, focused_minutes: u64, pomodoros_completed: u32) -> bool {
+    pub(crate) fn is_met_by_totals(self, focused_minutes: u64, pomodoros_completed: u32) -> bool {
         self.has_any_target()
             && (self.minutes == 0 || focused_minutes >= self.minutes)
             && (self.pomodoros == 0 || pomodoros_completed >= self.pomodoros)
     }
 
-    pub fn is_met_by(self, stats: DailyStats) -> bool {
+    pub(crate) fn is_met_by(self, stats: DailyStats) -> bool {
         self.is_met_by_totals(stats.focused_minutes(), stats.pomodoros_completed)
     }
 }
 
-pub fn carry_over_goal_target(
+pub(crate) fn carry_over_goal_target(
     base: DailyGoalSnapshot,
     carry_enabled: bool,
     previous: Option<(DailyGoalSnapshot, u64, u32)>,
@@ -108,55 +108,55 @@ pub fn carry_over_goal_target(
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct GoalStreak {
-    pub current: u32,
-    pub best: u32,
+pub(crate) struct GoalStreak {
+    pub(crate) current: u32,
+    pub(crate) best: u32,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct WeeklyStats {
-    pub year: i32,
-    pub week: u32,
-    pub pomodoros_completed: u32,
-    pub focused_seconds: u64,
+pub(crate) struct WeeklyStats {
+    pub(crate) year: i32,
+    pub(crate) week: u32,
+    pub(crate) pomodoros_completed: u32,
+    pub(crate) focused_seconds: u64,
 }
 
 impl WeeklyStats {
-    pub fn focused_minutes(self) -> u64 {
+    pub(crate) fn focused_minutes(self) -> u64 {
         self.focused_seconds / 60
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WeeklyConsistency {
-    pub year: i32,
-    pub week: u32,
-    pub week_label: String,
-    pub active_days: u8,
-    pub consistency_score_pct: u8,
+pub(crate) struct WeeklyConsistency {
+    pub(crate) year: i32,
+    pub(crate) week: u32,
+    pub(crate) week_label: String,
+    pub(crate) active_days: u8,
+    pub(crate) consistency_score_pct: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WeeklyFocusScore {
-    pub year: i32,
-    pub week: u32,
-    pub week_label: String,
-    pub active_days: u8,
-    pub consistency_score_pct: u8,
-    pub completion_score_pct: Option<u8>,
-    pub focus_score_pct: Option<u8>,
+pub(crate) struct WeeklyFocusScore {
+    pub(crate) year: i32,
+    pub(crate) week: u32,
+    pub(crate) week_label: String,
+    pub(crate) active_days: u8,
+    pub(crate) consistency_score_pct: u8,
+    pub(crate) completion_score_pct: Option<u8>,
+    pub(crate) focus_score_pct: Option<u8>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum FocusRiskLevel {
+pub(crate) enum FocusRiskLevel {
     Low,
     Medium,
     High,
 }
 
 impl FocusRiskLevel {
-    pub fn from_score(score_pct: u8) -> Self {
+    pub(crate) fn from_score(score_pct: u8) -> Self {
         if score_pct >= 70 {
             Self::High
         } else if score_pct >= 40 {
@@ -166,7 +166,7 @@ impl FocusRiskLevel {
         }
     }
 
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Low => "low",
             Self::Medium => "medium",
@@ -174,7 +174,7 @@ impl FocusRiskLevel {
         }
     }
 
-    pub fn triggers_alert(self) -> bool {
+    pub(crate) fn triggers_alert(self) -> bool {
         matches!(self, Self::Medium | Self::High)
     }
 
@@ -189,14 +189,14 @@ impl FocusRiskLevel {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum GoalPeriod {
+pub(crate) enum GoalPeriod {
     Daily,
     Weekly,
     Monthly,
 }
 
 impl GoalPeriod {
-    pub fn short_label(self) -> &'static str {
+    pub(crate) fn short_label(self) -> &'static str {
         match self {
             Self::Daily => "D",
             Self::Weekly => "W",
@@ -206,44 +206,44 @@ impl GoalPeriod {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct FocusRiskSignal {
-    pub label: String,
-    pub value: String,
+pub(crate) struct FocusRiskSignal {
+    pub(crate) label: String,
+    pub(crate) value: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct GoalRiskForecast {
-    pub period: GoalPeriod,
-    pub configured: bool,
-    pub met: bool,
-    pub completion_pct: Option<u8>,
-    pub risk_score_pct: u8,
-    pub risk_level: FocusRiskLevel,
-    pub signals: Vec<FocusRiskSignal>,
+pub(crate) struct GoalRiskForecast {
+    pub(crate) period: GoalPeriod,
+    pub(crate) configured: bool,
+    pub(crate) met: bool,
+    pub(crate) completion_pct: Option<u8>,
+    pub(crate) risk_score_pct: u8,
+    pub(crate) risk_level: FocusRiskLevel,
+    pub(crate) signals: Vec<FocusRiskSignal>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct StreakRiskForecast {
-    pub configured: bool,
-    pub current_streak: u32,
-    pub best_streak: u32,
-    pub today_goal_met: bool,
-    pub recent_goal_reliability_pct: u8,
-    pub risk_score_pct: u8,
-    pub risk_level: FocusRiskLevel,
-    pub signals: Vec<FocusRiskSignal>,
+pub(crate) struct StreakRiskForecast {
+    pub(crate) configured: bool,
+    pub(crate) current_streak: u32,
+    pub(crate) best_streak: u32,
+    pub(crate) today_goal_met: bool,
+    pub(crate) recent_goal_reliability_pct: u8,
+    pub(crate) risk_score_pct: u8,
+    pub(crate) risk_level: FocusRiskLevel,
+    pub(crate) signals: Vec<FocusRiskSignal>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct FocusRiskForecast {
-    pub daily_goal: GoalRiskForecast,
-    pub weekly_goal: GoalRiskForecast,
-    pub monthly_goal: GoalRiskForecast,
-    pub streak: StreakRiskForecast,
+pub(crate) struct FocusRiskForecast {
+    pub(crate) daily_goal: GoalRiskForecast,
+    pub(crate) weekly_goal: GoalRiskForecast,
+    pub(crate) monthly_goal: GoalRiskForecast,
+    pub(crate) streak: StreakRiskForecast,
 }
 
 impl FocusRiskForecast {
-    pub fn highest_risk_level(&self) -> FocusRiskLevel {
+    pub(crate) fn highest_risk_level(&self) -> FocusRiskLevel {
         let mut level = self.daily_goal.risk_level;
         for candidate in [
             self.weekly_goal.risk_level,
@@ -257,7 +257,7 @@ impl FocusRiskForecast {
         level
     }
 
-    pub fn alert_active(&self) -> bool {
+    pub(crate) fn alert_active(&self) -> bool {
         let highest_level = self.highest_risk_level();
         if highest_level.triggers_alert() && matches!(highest_level, FocusRiskLevel::High) {
             return true;
@@ -291,90 +291,90 @@ impl FocusRiskForecast {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct FocusRiskCalibrationMetrics {
-    pub sample_count: u32,
-    pub alert_count: u32,
-    pub true_positive_alerts: u32,
-    pub false_positive_alerts: u32,
-    pub precision_pct: u8,
-    pub missed_warning_count: u32,
-    pub missed_warning_rate_pct: u8,
+pub(crate) struct FocusRiskCalibrationMetrics {
+    pub(crate) sample_count: u32,
+    pub(crate) alert_count: u32,
+    pub(crate) true_positive_alerts: u32,
+    pub(crate) false_positive_alerts: u32,
+    pub(crate) precision_pct: u8,
+    pub(crate) missed_warning_count: u32,
+    pub(crate) missed_warning_rate_pct: u8,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct MonthlyStats {
-    pub year: i32,
-    pub month: u32,
-    pub pomodoros_completed: u32,
-    pub focused_seconds: u64,
+pub(crate) struct MonthlyStats {
+    pub(crate) year: i32,
+    pub(crate) month: u32,
+    pub(crate) pomodoros_completed: u32,
+    pub(crate) focused_seconds: u64,
 }
 
 impl MonthlyStats {
-    pub fn focused_minutes(self) -> u64 {
+    pub(crate) fn focused_minutes(self) -> u64 {
         self.focused_seconds / 60
     }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct HeatmapDayStats {
-    pub day: u32,
-    pub pomodoros_completed: u32,
-    pub focused_seconds: u64,
+pub(crate) struct HeatmapDayStats {
+    pub(crate) day: u32,
+    pub(crate) pomodoros_completed: u32,
+    pub(crate) focused_seconds: u64,
 }
 
 impl HeatmapDayStats {
-    pub fn focused_minutes(self) -> u64 {
+    pub(crate) fn focused_minutes(self) -> u64 {
         self.focused_seconds / 60
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MonthlyHeatmap {
-    pub year: i32,
-    pub month: u32,
-    pub first_weekday_monday0: u32,
-    pub days_in_month: u32,
-    pub max_focused_minutes: u64,
-    pub days: Vec<HeatmapDayStats>,
+pub(crate) struct MonthlyHeatmap {
+    pub(crate) year: i32,
+    pub(crate) month: u32,
+    pub(crate) first_weekday_monday0: u32,
+    pub(crate) days_in_month: u32,
+    pub(crate) max_focused_minutes: u64,
+    pub(crate) days: Vec<HeatmapDayStats>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct DailyStats {
+pub(crate) struct DailyStats {
     #[serde(default)]
-    pub pomodoros_completed: u32,
+    pub(crate) pomodoros_completed: u32,
     #[serde(default)]
-    pub focused_seconds: u64,
+    pub(crate) focused_seconds: u64,
     #[serde(default)]
-    pub goal: Option<DailyGoalSnapshot>,
+    pub(crate) goal: Option<DailyGoalSnapshot>,
 }
 
 impl DailyStats {
-    pub fn focused_minutes(self) -> u64 {
+    pub(crate) fn focused_minutes(self) -> u64 {
         self.focused_seconds / 60
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExportedStatsFiles {
-    pub json_path: PathBuf,
-    pub csv_path: PathBuf,
+pub(crate) struct ExportedStatsFiles {
+    pub(crate) json_path: PathBuf,
+    pub(crate) csv_path: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HistoryKpiExportContext {
-    pub reference_day: NaiveDate,
-    pub daily_goal: DailyGoalSnapshot,
-    pub weekly_goal: DailyGoalSnapshot,
-    pub monthly_goal: DailyGoalSnapshot,
-    pub carry_over_daily: bool,
-    pub carry_over_weekly: bool,
-    pub carry_over_monthly: bool,
-    pub recurring_schedule: RecurringScheduleConfig,
-    pub stats_retention: StatsRetentionConfig,
-    pub comparison_dimension: ComparisonDimension,
-    pub comparison_task_filter: Option<String>,
-    pub comparison_profile_filter: Option<ProfileBucket>,
-    pub comparison_time_of_day_filter: Option<TimeOfDayBucket>,
+pub(crate) struct HistoryKpiExportContext {
+    pub(crate) reference_day: NaiveDate,
+    pub(crate) daily_goal: DailyGoalSnapshot,
+    pub(crate) weekly_goal: DailyGoalSnapshot,
+    pub(crate) monthly_goal: DailyGoalSnapshot,
+    pub(crate) carry_over_daily: bool,
+    pub(crate) carry_over_weekly: bool,
+    pub(crate) carry_over_monthly: bool,
+    pub(crate) recurring_schedule: RecurringScheduleConfig,
+    pub(crate) stats_retention: StatsRetentionConfig,
+    pub(crate) comparison_dimension: ComparisonDimension,
+    pub(crate) comparison_task_filter: Option<String>,
+    pub(crate) comparison_profile_filter: Option<ProfileBucket>,
+    pub(crate) comparison_time_of_day_filter: Option<TimeOfDayBucket>,
 }
 
 impl Default for HistoryKpiExportContext {
@@ -398,32 +398,32 @@ impl Default for HistoryKpiExportContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct StatsGrowthSection {
-    pub name: String,
-    pub record_count: usize,
-    pub estimated_bytes: u64,
+pub(crate) struct StatsGrowthSection {
+    pub(crate) name: String,
+    pub(crate) record_count: usize,
+    pub(crate) estimated_bytes: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct StatsGrowthSummary {
-    pub total_record_count: usize,
-    pub estimated_bytes: u64,
-    pub sections: Vec<StatsGrowthSection>,
-    pub high_volume_sections: Vec<StatsGrowthSection>,
+pub(crate) struct StatsGrowthSummary {
+    pub(crate) total_record_count: usize,
+    pub(crate) estimated_bytes: u64,
+    pub(crate) sections: Vec<StatsGrowthSection>,
+    pub(crate) high_volume_sections: Vec<StatsGrowthSection>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
-pub struct StatsRetentionPruneResult {
-    pub daily_removed: usize,
-    pub focus_sessions_removed: usize,
-    pub session_interruptions_removed: usize,
-    pub break_glass_overrides_removed: usize,
-    pub weekly_goal_snapshots_removed: usize,
-    pub monthly_goal_snapshots_removed: usize,
+pub(crate) struct StatsRetentionPruneResult {
+    pub(crate) daily_removed: usize,
+    pub(crate) focus_sessions_removed: usize,
+    pub(crate) session_interruptions_removed: usize,
+    pub(crate) break_glass_overrides_removed: usize,
+    pub(crate) weekly_goal_snapshots_removed: usize,
+    pub(crate) monthly_goal_snapshots_removed: usize,
 }
 
 impl StatsRetentionPruneResult {
-    pub fn total_removed(self) -> usize {
+    pub(crate) fn total_removed(self) -> usize {
         self.daily_removed
             .saturating_add(self.focus_sessions_removed)
             .saturating_add(self.session_interruptions_removed)
@@ -432,65 +432,65 @@ impl StatsRetentionPruneResult {
             .saturating_add(self.monthly_goal_snapshots_removed)
     }
 
-    pub fn any_removed(self) -> bool {
+    pub(crate) fn any_removed(self) -> bool {
         self.total_removed() > 0
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct UsageSignalEntry {
-    pub surface: String,
-    pub count: u64,
-    pub share_pct: u8,
+pub(crate) struct UsageSignalEntry {
+    pub(crate) surface: String,
+    pub(crate) count: u64,
+    pub(crate) share_pct: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct UsageSignalSummary {
-    pub total_events: u64,
-    pub unique_surfaces: usize,
-    pub top: Vec<UsageSignalEntry>,
-    pub rare: Vec<UsageSignalEntry>,
+pub(crate) struct UsageSignalSummary {
+    pub(crate) total_events: u64,
+    pub(crate) unique_surfaces: usize,
+    pub(crate) top: Vec<UsageSignalEntry>,
+    pub(crate) rare: Vec<UsageSignalEntry>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct UsageSignalsSummary {
-    pub commands: UsageSignalSummary,
-    pub screens: UsageSignalSummary,
+pub(crate) struct UsageSignalsSummary {
+    pub(crate) commands: UsageSignalSummary,
+    pub(crate) screens: UsageSignalSummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FocusSessionRecord {
-    pub date: String,
-    pub task_label: String,
+pub(crate) struct FocusSessionRecord {
+    pub(crate) date: String,
+    pub(crate) task_label: String,
     #[serde(default)]
-    pub focus_intention: String,
+    pub(crate) focus_intention: String,
     #[serde(default)]
-    pub task_note: String,
-    pub focused_seconds: u64,
+    pub(crate) task_note: String,
+    pub(crate) focused_seconds: u64,
     #[serde(default)]
-    pub profile: Option<ProfileId>,
+    pub(crate) profile: Option<ProfileId>,
     #[serde(default)]
-    pub completion_timestamp_epoch_secs: Option<u64>,
+    pub(crate) completion_timestamp_epoch_secs: Option<u64>,
     #[serde(default)]
-    pub completion_time_of_day_bucket: Option<TimeOfDayBucket>,
+    pub(crate) completion_time_of_day_bucket: Option<TimeOfDayBucket>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FocusSessionMetadata<'a> {
-    pub task_label: Option<&'a str>,
-    pub focus_intention: Option<&'a str>,
-    pub task_note: Option<&'a str>,
+pub(crate) struct FocusSessionMetadata<'a> {
+    pub(crate) task_label: Option<&'a str>,
+    pub(crate) focus_intention: Option<&'a str>,
+    pub(crate) task_note: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum SessionInterruptionReason {
+pub(crate) enum SessionInterruptionReason {
     ManualStop,
     ManualSkip,
 }
 
 impl SessionInterruptionReason {
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::ManualStop => "stop/reset",
             Self::ManualSkip => "skip/next",
@@ -499,24 +499,24 @@ impl SessionInterruptionReason {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SessionInterruptionEvent {
-    pub timestamp_epoch_secs: u64,
-    pub date: String,
-    pub reason: SessionInterruptionReason,
+pub(crate) struct SessionInterruptionEvent {
+    pub(crate) timestamp_epoch_secs: u64,
+    pub(crate) date: String,
+    pub(crate) reason: SessionInterruptionReason,
     #[serde(default)]
-    pub task_label: Option<String>,
+    pub(crate) task_label: Option<String>,
     #[serde(default)]
-    pub focus_intention: Option<String>,
+    pub(crate) focus_intention: Option<String>,
     #[serde(default)]
-    pub task_note: Option<String>,
+    pub(crate) task_note: Option<String>,
     #[serde(default)]
-    pub remaining_secs: u64,
+    pub(crate) remaining_secs: u64,
     #[serde(default)]
-    pub profile: Option<ProfileId>,
+    pub(crate) profile: Option<ProfileId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum ProfileBucket {
+pub(crate) enum ProfileBucket {
     #[serde(rename = "basic", alias = "classic")]
     Classic,
     #[serde(
@@ -533,7 +533,7 @@ pub enum ProfileBucket {
 }
 
 impl ProfileBucket {
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Classic => "Basic",
             Self::DeepWork => "Standard",
@@ -542,7 +542,7 @@ impl ProfileBucket {
         }
     }
 
-    pub fn id(self) -> &'static str {
+    pub(crate) fn id(self) -> &'static str {
         match self {
             Self::Classic => "basic",
             Self::DeepWork => "standard",
@@ -554,7 +554,7 @@ impl ProfileBucket {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum TimeOfDayBucket {
+pub(crate) enum TimeOfDayBucket {
     Morning,
     Afternoon,
     Evening,
@@ -563,7 +563,7 @@ pub enum TimeOfDayBucket {
 }
 
 impl TimeOfDayBucket {
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Morning => "Morning",
             Self::Afternoon => "Afternoon",
@@ -573,7 +573,7 @@ impl TimeOfDayBucket {
         }
     }
 
-    pub fn id(self) -> &'static str {
+    pub(crate) fn id(self) -> &'static str {
         match self {
             Self::Morning => "morning",
             Self::Afternoon => "afternoon",
@@ -583,7 +583,7 @@ impl TimeOfDayBucket {
         }
     }
 
-    pub fn from_hour(hour: u32) -> Self {
+    pub(crate) fn from_hour(hour: u32) -> Self {
         match hour {
             5..=11 => Self::Morning,
             12..=16 => Self::Afternoon,
@@ -596,14 +596,14 @@ impl TimeOfDayBucket {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ComparisonDimension {
+pub(crate) enum ComparisonDimension {
     TaskLabel,
     Profile,
     TimeOfDay,
 }
 
 impl ComparisonDimension {
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::TaskLabel => "Task",
             Self::Profile => "Profile",
@@ -611,7 +611,7 @@ impl ComparisonDimension {
         }
     }
 
-    pub fn id(self) -> &'static str {
+    pub(crate) fn id(self) -> &'static str {
         match self {
             Self::TaskLabel => "task_label",
             Self::Profile => "profile",
@@ -621,30 +621,30 @@ impl ComparisonDimension {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct ProductivityComparisonFilter {
-    pub task_label: Option<String>,
-    pub profile: Option<ProfileBucket>,
-    pub time_of_day: Option<TimeOfDayBucket>,
+pub(crate) struct ProductivityComparisonFilter {
+    pub(crate) task_label: Option<String>,
+    pub(crate) profile: Option<ProfileBucket>,
+    pub(crate) time_of_day: Option<TimeOfDayBucket>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ProductivityComparisonRow {
-    pub dimension: ComparisonDimension,
-    pub label: String,
-    pub task_label: Option<String>,
-    pub profile: Option<ProfileBucket>,
-    pub time_of_day: Option<TimeOfDayBucket>,
-    pub sessions_completed: u32,
-    pub focused_seconds: u64,
-    pub focus_share_pct: u8,
+pub(crate) struct ProductivityComparisonRow {
+    pub(crate) dimension: ComparisonDimension,
+    pub(crate) label: String,
+    pub(crate) task_label: Option<String>,
+    pub(crate) profile: Option<ProfileBucket>,
+    pub(crate) time_of_day: Option<TimeOfDayBucket>,
+    pub(crate) sessions_completed: u32,
+    pub(crate) focused_seconds: u64,
+    pub(crate) focus_share_pct: u8,
 }
 
 impl ProductivityComparisonRow {
-    pub fn focused_minutes(&self) -> u64 {
+    pub(crate) fn focused_minutes(&self) -> u64 {
         self.focused_seconds / 60
     }
 
-    pub fn average_focused_minutes_per_session(&self) -> u64 {
+    pub(crate) fn average_focused_minutes_per_session(&self) -> u64 {
         if self.sessions_completed == 0 {
             return 0;
         }
@@ -654,34 +654,34 @@ impl ProductivityComparisonRow {
 
 #[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ProfileTotals {
-    pub profile: ProfileBucket,
-    pub pomodoros_completed: u32,
-    pub focused_seconds: u64,
+pub(crate) struct ProfileTotals {
+    pub(crate) profile: ProfileBucket,
+    pub(crate) pomodoros_completed: u32,
+    pub(crate) focused_seconds: u64,
 }
 
 impl ProfileTotals {
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn focused_minutes(self) -> u64 {
+    pub(crate) fn focused_minutes(self) -> u64 {
         self.focused_seconds / 60
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ProfileEffectiveness {
-    pub profile: ProfileBucket,
-    pub sessions_completed: u32,
-    pub focused_seconds: u64,
-    pub active_days: u32,
-    pub focus_share_pct: u8,
+pub(crate) struct ProfileEffectiveness {
+    pub(crate) profile: ProfileBucket,
+    pub(crate) sessions_completed: u32,
+    pub(crate) focused_seconds: u64,
+    pub(crate) active_days: u32,
+    pub(crate) focus_share_pct: u8,
 }
 
 impl ProfileEffectiveness {
-    pub fn focused_minutes(self) -> u64 {
+    pub(crate) fn focused_minutes(self) -> u64 {
         self.focused_seconds / 60
     }
 
-    pub fn average_focused_minutes_per_session(self) -> u64 {
+    pub(crate) fn average_focused_minutes_per_session(self) -> u64 {
         if self.sessions_completed == 0 {
             return 0;
         }
@@ -690,58 +690,58 @@ impl ProfileEffectiveness {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TaskTotals {
-    pub task_label: String,
-    pub pomodoros_completed: u32,
-    pub focused_seconds: u64,
+pub(crate) struct TaskTotals {
+    pub(crate) task_label: String,
+    pub(crate) pomodoros_completed: u32,
+    pub(crate) focused_seconds: u64,
 }
 
 impl TaskTotals {
-    pub fn focused_minutes(&self) -> u64 {
+    pub(crate) fn focused_minutes(&self) -> u64 {
         self.focused_seconds / 60
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TaskTrend {
-    pub task_label: String,
-    pub recent_pomodoros_completed: u32,
-    pub recent_focused_seconds: u64,
-    pub previous_pomodoros_completed: u32,
-    pub previous_focused_seconds: u64,
+pub(crate) struct TaskTrend {
+    pub(crate) task_label: String,
+    pub(crate) recent_pomodoros_completed: u32,
+    pub(crate) recent_focused_seconds: u64,
+    pub(crate) previous_pomodoros_completed: u32,
+    pub(crate) previous_focused_seconds: u64,
 }
 
 impl TaskTrend {
-    pub fn recent_focused_minutes(&self) -> u64 {
+    pub(crate) fn recent_focused_minutes(&self) -> u64 {
         self.recent_focused_seconds / 60
     }
 
-    pub fn previous_focused_minutes(&self) -> u64 {
+    pub(crate) fn previous_focused_minutes(&self) -> u64 {
         self.previous_focused_seconds / 60
     }
 
-    pub fn delta_focused_seconds(&self) -> i64 {
+    pub(crate) fn delta_focused_seconds(&self) -> i64 {
         let recent = i128::from(self.recent_focused_seconds);
         let previous = i128::from(self.previous_focused_seconds);
         (recent - previous).clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64
     }
 
-    pub fn delta_focused_minutes(&self) -> i64 {
+    pub(crate) fn delta_focused_minutes(&self) -> i64 {
         self.delta_focused_seconds() / 60
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TaskGoalProgress {
-    pub task_label: String,
-    pub target: DailyGoalSnapshot,
-    pub pomodoros_completed: u32,
-    pub focused_seconds: u64,
-    pub met: bool,
+pub(crate) struct TaskGoalProgress {
+    pub(crate) task_label: String,
+    pub(crate) target: DailyGoalSnapshot,
+    pub(crate) pomodoros_completed: u32,
+    pub(crate) focused_seconds: u64,
+    pub(crate) met: bool,
 }
 
 impl TaskGoalProgress {
-    pub fn focused_minutes(&self) -> u64 {
+    pub(crate) fn focused_minutes(&self) -> u64 {
         self.focused_seconds / 60
     }
 }
@@ -770,11 +770,11 @@ struct ProfileEffectivenessAccumulator {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct BreakGlassOverrideEvent {
-    pub timestamp_epoch_secs: u64,
-    pub date: String,
-    pub task_label: Option<String>,
-    pub duration_seconds: u64,
+pub(crate) struct BreakGlassOverrideEvent {
+    pub(crate) timestamp_epoch_secs: u64,
+    pub(crate) date: String,
+    pub(crate) task_label: Option<String>,
+    pub(crate) duration_seconds: u64,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -1119,7 +1119,7 @@ struct PersistedStats {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct FocusStats {
+pub(crate) struct FocusStats {
     session: SessionStats,
     daily: BTreeMap<String, DailyStats>,
     weekly_goal_snapshots: BTreeMap<String, DailyGoalSnapshot>,
@@ -1136,7 +1136,7 @@ pub struct FocusStats {
     screen_usage_counts: BTreeMap<String, u64>,
 }
 
-pub fn current_day_key() -> String {
+pub(crate) fn current_day_key() -> String {
     chrono::Local::now()
         .date_naive()
         .format("%Y-%m-%d")

--- a/src/stats/analytics.rs
+++ b/src/stats/analytics.rs
@@ -25,7 +25,7 @@ use support::{
 };
 
 impl FocusStats {
-    pub fn weekly_for_day(&self, day: chrono::NaiveDate) -> WeeklyStats {
+    pub(crate) fn weekly_for_day(&self, day: chrono::NaiveDate) -> WeeklyStats {
         let week = day.iso_week();
         let mut totals = WeeklyStats {
             year: week.year(),
@@ -48,7 +48,7 @@ impl FocusStats {
         totals
     }
 
-    pub fn monthly_for_day(&self, day: chrono::NaiveDate) -> MonthlyStats {
+    pub(crate) fn monthly_for_day(&self, day: chrono::NaiveDate) -> MonthlyStats {
         let mut totals = MonthlyStats {
             year: day.year(),
             month: day.month(),
@@ -69,7 +69,7 @@ impl FocusStats {
         totals
     }
 
-    pub fn weekly_goal_snapshot_for_day(
+    pub(crate) fn weekly_goal_snapshot_for_day(
         &self,
         day: chrono::NaiveDate,
     ) -> Option<DailyGoalSnapshot> {
@@ -77,7 +77,7 @@ impl FocusStats {
         self.weekly_goal_snapshots.get(&key).copied()
     }
 
-    pub fn monthly_goal_snapshot_for_day(
+    pub(crate) fn monthly_goal_snapshot_for_day(
         &self,
         day: chrono::NaiveDate,
     ) -> Option<DailyGoalSnapshot> {
@@ -85,7 +85,7 @@ impl FocusStats {
         self.monthly_goal_snapshots.get(&key).copied()
     }
 
-    pub fn weekly_focus_score_for_day(&self, day: chrono::NaiveDate) -> WeeklyFocusScore {
+    pub(crate) fn weekly_focus_score_for_day(&self, day: chrono::NaiveDate) -> WeeklyFocusScore {
         let iso_week = day.iso_week();
         let year = iso_week.year();
         let week = iso_week.week();
@@ -115,32 +115,32 @@ impl FocusStats {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn recent_weekly(&self, limit: usize) -> Vec<WeeklyStats> {
+    pub(crate) fn recent_weekly(&self, limit: usize) -> Vec<WeeklyStats> {
         let mut weekly = self.weekly_stats();
         weekly.reverse();
         weekly.truncate(limit);
         weekly
     }
 
-    pub fn recent_weekly_consistency(&self, limit: usize) -> Vec<WeeklyConsistency> {
+    pub(crate) fn recent_weekly_consistency(&self, limit: usize) -> Vec<WeeklyConsistency> {
         let mut weekly = self.weekly_consistency_stats();
         weekly.reverse();
         weekly.truncate(limit);
         weekly
     }
 
-    pub fn recent_weekly_focus_scores(&self, limit: usize) -> Vec<WeeklyFocusScore> {
+    pub(crate) fn recent_weekly_focus_scores(&self, limit: usize) -> Vec<WeeklyFocusScore> {
         let mut weekly = self.weekly_focus_score_stats();
         weekly.reverse();
         weekly.truncate(limit);
         weekly
     }
 
-    pub fn latest_weekly_focus_score(&self) -> Option<WeeklyFocusScore> {
+    pub(crate) fn latest_weekly_focus_score(&self) -> Option<WeeklyFocusScore> {
         self.recent_weekly_focus_scores(1).into_iter().next()
     }
 
-    pub fn focus_risk_forecast_for_day(
+    pub(crate) fn focus_risk_forecast_for_day(
         &self,
         day: chrono::NaiveDate,
         daily_goal: DailyGoalSnapshot,
@@ -190,7 +190,7 @@ impl FocusStats {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn focus_risk_calibration_metrics_for_day(
+    pub(crate) fn focus_risk_calibration_metrics_for_day(
         &self,
         day: chrono::NaiveDate,
         daily_goal: DailyGoalSnapshot,
@@ -268,14 +268,14 @@ impl FocusStats {
         }
     }
 
-    pub fn recent_monthly(&self, limit: usize) -> Vec<MonthlyStats> {
+    pub(crate) fn recent_monthly(&self, limit: usize) -> Vec<MonthlyStats> {
         let mut monthly = self.monthly_stats();
         monthly.reverse();
         monthly.truncate(limit);
         monthly
     }
 
-    pub fn latest_monthly_heatmap(&self) -> MonthlyHeatmap {
+    pub(crate) fn latest_monthly_heatmap(&self) -> MonthlyHeatmap {
         let (year, month) = self.latest_recorded_month_key().unwrap_or_else(|| {
             let now = chrono::Local::now().date_naive();
             (now.year(), now.month())
@@ -284,7 +284,7 @@ impl FocusStats {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn profile_totals(&self) -> Vec<ProfileTotals> {
+    pub(crate) fn profile_totals(&self) -> Vec<ProfileTotals> {
         let mut by_profile: BTreeMap<ProfileBucket, ProfileTotals> = BTreeMap::new();
         for session in &self.focus_sessions {
             let profile = profile_bucket_for(session.profile);
@@ -310,7 +310,7 @@ impl FocusStats {
         totals
     }
 
-    pub fn profile_effectiveness(&self) -> Vec<ProfileEffectiveness> {
+    pub(crate) fn profile_effectiveness(&self) -> Vec<ProfileEffectiveness> {
         let mut by_profile: BTreeMap<ProfileBucket, ProfileEffectivenessAccumulator> =
             BTreeMap::new();
         let mut total_focused_seconds: u64 = 0;
@@ -353,7 +353,7 @@ impl FocusStats {
         effectiveness
     }
 
-    pub fn productivity_comparison(
+    pub(crate) fn productivity_comparison(
         &self,
         dimension: ComparisonDimension,
         filter: &ProductivityComparisonFilter,
@@ -637,7 +637,7 @@ impl FocusStats {
         }
     }
 
-    pub fn growth_summary(&self) -> StatsGrowthSummary {
+    pub(crate) fn growth_summary(&self) -> StatsGrowthSummary {
         let mut sections = vec![
             stats_growth_section("daily", self.daily.len(), &self.daily),
             stats_growth_section(
@@ -723,7 +723,7 @@ impl FocusStats {
         }
     }
 
-    pub fn apply_retention_policy(
+    pub(crate) fn apply_retention_policy(
         &mut self,
         retention: StatsRetentionConfig,
         reference_day: chrono::NaiveDate,
@@ -786,7 +786,7 @@ impl FocusStats {
         result
     }
 
-    pub fn retention_preview(
+    pub(crate) fn retention_preview(
         &self,
         retention: StatsRetentionConfig,
         reference_day: chrono::NaiveDate,
@@ -795,7 +795,7 @@ impl FocusStats {
         cloned.apply_retention_policy(retention, reference_day)
     }
 
-    pub fn usage_signal_summary(&self, limit: usize) -> UsageSignalsSummary {
+    pub(crate) fn usage_signal_summary(&self, limit: usize) -> UsageSignalsSummary {
         let limit = limit.max(1);
         UsageSignalsSummary {
             commands: usage_signal_summary_for_counts(&self.command_usage_counts, limit),

--- a/src/stats/export.rs
+++ b/src/stats/export.rs
@@ -19,11 +19,11 @@ use crate::stats::{
 
 impl FocusStats {
     #[allow(dead_code)]
-    pub fn export_to_dir(&self, dir: &Path) -> io::Result<ExportedStatsFiles> {
+    pub(crate) fn export_to_dir(&self, dir: &Path) -> io::Result<ExportedStatsFiles> {
         self.export_to_dir_with_context(dir, &HistoryKpiExportContext::default())
     }
 
-    pub fn export_to_dir_with_context(
+    pub(crate) fn export_to_dir_with_context(
         &self,
         dir: &Path,
         context: &HistoryKpiExportContext,

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -13,23 +13,23 @@ use crate::stats::{
 impl FocusStats {
     #[cfg(test)]
     #[allow(dead_code)]
-    pub fn load() -> Result<Self, String> {
+    pub(crate) fn load() -> Result<Self, String> {
         Self::load_with_options(StatsLoadOptions::default())
     }
 
     #[cfg(test)]
-    pub fn load_with_options(_options: StatsLoadOptions) -> Result<Self, String> {
+    pub(crate) fn load_with_options(_options: StatsLoadOptions) -> Result<Self, String> {
         Ok(Self::default())
     }
 
     #[cfg(not(test))]
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn load() -> Result<Self, String> {
+    pub(crate) fn load() -> Result<Self, String> {
         Self::load_with_options(StatsLoadOptions::default())
     }
 
     #[cfg(not(test))]
-    pub fn load_with_options(options: StatsLoadOptions) -> Result<Self, String> {
+    pub(crate) fn load_with_options(options: StatsLoadOptions) -> Result<Self, String> {
         Self::try_load(options)
     }
 
@@ -169,7 +169,7 @@ impl FocusStats {
         }
     }
 
-    pub fn save_with_options(&self, _options: StatsSaveOptions) -> io::Result<()> {
+    pub(crate) fn save_with_options(&self, _options: StatsSaveOptions) -> io::Result<()> {
         let path = stats_path().ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, "cannot determine stats directory")
         })?;

--- a/src/stats/planner.rs
+++ b/src/stats/planner.rs
@@ -5,31 +5,31 @@ use crate::stats::{
 };
 
 impl FocusStats {
-    pub fn session(&self) -> SessionStats {
+    pub(crate) fn session(&self) -> SessionStats {
         self.session
     }
 
-    pub fn daily_for(&self, day_key: &str) -> DailyStats {
+    pub(crate) fn daily_for(&self, day_key: &str) -> DailyStats {
         self.daily.get(day_key).copied().unwrap_or_default()
     }
 
-    pub fn daily_entry(&self, day_key: &str) -> Option<DailyStats> {
+    pub(crate) fn daily_entry(&self, day_key: &str) -> Option<DailyStats> {
         self.daily.get(day_key).copied()
     }
 
-    pub fn task_planner_state(&self) -> (Vec<String>, Option<String>) {
+    pub(crate) fn task_planner_state(&self) -> (Vec<String>, Option<String>) {
         (self.task_labels.clone(), self.selected_task_label.clone())
     }
 
-    pub fn task_label_favorites(&self) -> Vec<String> {
+    pub(crate) fn task_label_favorites(&self) -> Vec<String> {
         planner_state_labels_for_keys(&self.task_label_favorites, &self.task_labels)
     }
 
-    pub fn task_label_archived(&self) -> Vec<String> {
+    pub(crate) fn task_label_archived(&self) -> Vec<String> {
         planner_state_labels_for_keys(&self.task_label_archived, &self.task_labels)
     }
 
-    pub fn set_task_goal_target(
+    pub(crate) fn set_task_goal_target(
         &mut self,
         label: &str,
         target: DailyGoalSnapshot,
@@ -53,7 +53,7 @@ impl FocusStats {
         Ok(canonical)
     }
 
-    pub fn remove_task_goal_target(&mut self, label: &str) -> bool {
+    pub(crate) fn remove_task_goal_target(&mut self, label: &str) -> bool {
         let Some(normalized) = normalize_task_label(label) else {
             return false;
         };
@@ -63,7 +63,11 @@ impl FocusStats {
             .is_some()
     }
 
-    pub fn rename_task_goal_target(&mut self, previous_label: &str, next_label: &str) -> bool {
+    pub(crate) fn rename_task_goal_target(
+        &mut self,
+        previous_label: &str,
+        next_label: &str,
+    ) -> bool {
         let Some(previous_normalized) = normalize_task_label(previous_label) else {
             return false;
         };
@@ -87,7 +91,7 @@ impl FocusStats {
         true
     }
 
-    pub fn task_goal_progress_for_label(&self, label: &str) -> Option<TaskGoalProgress> {
+    pub(crate) fn task_goal_progress_for_label(&self, label: &str) -> Option<TaskGoalProgress> {
         let normalized = normalize_task_label(label)?;
         let task_label = canonical_task_label(&self.task_labels, &normalized).unwrap_or(normalized);
         let key = task_label.to_ascii_lowercase();
@@ -109,7 +113,7 @@ impl FocusStats {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn task_goal_progress(&self, limit: usize) -> Vec<TaskGoalProgress> {
+    pub(crate) fn task_goal_progress(&self, limit: usize) -> Vec<TaskGoalProgress> {
         if limit == 0 {
             return Vec::new();
         }
@@ -151,7 +155,7 @@ impl FocusStats {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn update_task_planner_state(
+    pub(crate) fn update_task_planner_state(
         &mut self,
         labels: Vec<String>,
         selected: Option<String>,
@@ -164,7 +168,7 @@ impl FocusStats {
         )
     }
 
-    pub fn update_task_planner_state_with_label_states(
+    pub(crate) fn update_task_planner_state_with_label_states(
         &mut self,
         labels: Vec<String>,
         selected: Option<String>,

--- a/src/stats/recording.rs
+++ b/src/stats/recording.rs
@@ -7,7 +7,7 @@ use crate::stats::{
 use chrono::Timelike;
 
 impl FocusStats {
-    pub fn record_focus_elapsed(
+    pub(crate) fn record_focus_elapsed(
         &mut self,
         day_key: &str,
         elapsed_secs: u64,
@@ -23,11 +23,11 @@ impl FocusStats {
         daily.goal = Some(goal);
     }
 
-    pub fn record_completed_pomodoro(&mut self, day_key: &str, goal: DailyGoalSnapshot) {
+    pub(crate) fn record_completed_pomodoro(&mut self, day_key: &str, goal: DailyGoalSnapshot) {
         self.record_completed_pomodoro_with_task(day_key, goal, None, 0, None);
     }
 
-    pub fn record_completed_pomodoro_with_task(
+    pub(crate) fn record_completed_pomodoro_with_task(
         &mut self,
         day_key: &str,
         goal: DailyGoalSnapshot,
@@ -48,7 +48,7 @@ impl FocusStats {
         );
     }
 
-    pub fn record_completed_pomodoro_with_metadata(
+    pub(crate) fn record_completed_pomodoro_with_metadata(
         &mut self,
         day_key: &str,
         goal: DailyGoalSnapshot,
@@ -66,7 +66,7 @@ impl FocusStats {
         );
     }
 
-    pub fn record_completed_pomodoro_with_metadata_at(
+    pub(crate) fn record_completed_pomodoro_with_metadata_at(
         &mut self,
         day_key: &str,
         goal: DailyGoalSnapshot,
@@ -108,7 +108,7 @@ impl FocusStats {
         }
     }
 
-    pub fn record_break_glass_override_event(
+    pub(crate) fn record_break_glass_override_event(
         &mut self,
         day_key: &str,
         timestamp_epoch_secs: u64,
@@ -134,7 +134,7 @@ impl FocusStats {
         });
     }
 
-    pub fn record_session_interruption_event(
+    pub(crate) fn record_session_interruption_event(
         &mut self,
         day_key: &str,
         timestamp_epoch_secs: u64,
@@ -164,7 +164,7 @@ impl FocusStats {
         });
     }
 
-    pub fn sync_goal_snapshot(&mut self, day_key: &str, goal: DailyGoalSnapshot) -> bool {
+    pub(crate) fn sync_goal_snapshot(&mut self, day_key: &str, goal: DailyGoalSnapshot) -> bool {
         let daily = self.daily.entry(day_key.to_string()).or_default();
 
         if daily.goal == Some(goal) {
@@ -175,7 +175,7 @@ impl FocusStats {
         true
     }
 
-    pub fn sync_weekly_goal_snapshot(
+    pub(crate) fn sync_weekly_goal_snapshot(
         &mut self,
         day: chrono::NaiveDate,
         goal: DailyGoalSnapshot,
@@ -188,7 +188,7 @@ impl FocusStats {
         true
     }
 
-    pub fn sync_monthly_goal_snapshot(
+    pub(crate) fn sync_monthly_goal_snapshot(
         &mut self,
         day: chrono::NaiveDate,
         goal: DailyGoalSnapshot,
@@ -201,16 +201,16 @@ impl FocusStats {
         true
     }
 
-    pub fn record_command_usage(&mut self, surface_id: &str) -> bool {
+    pub(crate) fn record_command_usage(&mut self, surface_id: &str) -> bool {
         record_usage_count(&mut self.command_usage_counts, surface_id)
     }
 
-    pub fn record_screen_usage(&mut self, surface_id: &str) -> bool {
+    pub(crate) fn record_screen_usage(&mut self, surface_id: &str) -> bool {
         record_usage_count(&mut self.screen_usage_counts, surface_id)
     }
 
     #[cfg(test)]
-    pub fn command_usage_count(&self, surface_id: &str) -> u64 {
+    pub(crate) fn command_usage_count(&self, surface_id: &str) -> u64 {
         let key = surface_id.trim().to_ascii_lowercase();
         if key.is_empty() {
             return 0;

--- a/src/stats/trends.rs
+++ b/src/stats/trends.rs
@@ -6,7 +6,7 @@ use crate::stats::{
 };
 
 impl FocusStats {
-    pub fn recent_task_labels(&self, limit: usize) -> Vec<String> {
+    pub(crate) fn recent_task_labels(&self, limit: usize) -> Vec<String> {
         if limit == 0 {
             return Vec::new();
         }
@@ -45,7 +45,7 @@ impl FocusStats {
 
     #[cfg(test)]
     #[allow(dead_code)]
-    pub fn recent_daily(&self, limit: usize) -> Vec<(String, DailyStats)> {
+    pub(crate) fn recent_daily(&self, limit: usize) -> Vec<(String, DailyStats)> {
         self.daily
             .iter()
             .rev()
@@ -54,7 +54,7 @@ impl FocusStats {
             .collect()
     }
 
-    pub fn task_totals(&self, limit: usize) -> Vec<TaskTotals> {
+    pub(crate) fn task_totals(&self, limit: usize) -> Vec<TaskTotals> {
         if limit == 0 {
             return Vec::new();
         }
@@ -90,7 +90,7 @@ impl FocusStats {
         totals
     }
 
-    pub fn recent_task_trends(&self, limit: usize) -> Vec<TaskTrend> {
+    pub(crate) fn recent_task_trends(&self, limit: usize) -> Vec<TaskTrend> {
         if limit == 0 {
             return Vec::new();
         }
@@ -103,7 +103,10 @@ impl FocusStats {
         trends
     }
 
-    pub fn recent_break_glass_overrides(&self, limit: usize) -> Vec<BreakGlassOverrideEvent> {
+    pub(crate) fn recent_break_glass_overrides(
+        &self,
+        limit: usize,
+    ) -> Vec<BreakGlassOverrideEvent> {
         self.break_glass_overrides
             .iter()
             .rev()
@@ -113,7 +116,10 @@ impl FocusStats {
     }
 
     #[cfg(test)]
-    pub fn recent_session_interruptions(&self, limit: usize) -> Vec<SessionInterruptionEvent> {
+    pub(crate) fn recent_session_interruptions(
+        &self,
+        limit: usize,
+    ) -> Vec<SessionInterruptionEvent> {
         self.session_interruptions
             .iter()
             .rev()
@@ -122,7 +128,7 @@ impl FocusStats {
             .collect()
     }
 
-    pub fn latest_session_interruption(&self) -> Option<SessionInterruptionEvent> {
+    pub(crate) fn latest_session_interruption(&self) -> Option<SessionInterruptionEvent> {
         self.session_interruptions
             .iter()
             .max_by_key(|event| event.timestamp_epoch_secs)
@@ -219,12 +225,12 @@ impl FocusStats {
     }
 
     #[cfg(test)]
-    pub fn insert_daily_for_tests(&mut self, day_key: &str, stats: DailyStats) {
+    pub(crate) fn insert_daily_for_tests(&mut self, day_key: &str, stats: DailyStats) {
         self.daily.insert(day_key.to_string(), stats);
     }
 
     #[cfg(test)]
-    pub fn goal_streak(
+    pub(crate) fn goal_streak(
         &self,
         today: chrono::NaiveDate,
         current_goal: DailyGoalSnapshot,

--- a/src/task_labels.rs
+++ b/src/task_labels.rs
@@ -1,4 +1,4 @@
-pub fn normalize_task_label(input: &str) -> Option<String> {
+pub(crate) fn normalize_task_label(input: &str) -> Option<String> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         None
@@ -7,13 +7,13 @@ pub fn normalize_task_label(input: &str) -> Option<String> {
     }
 }
 
-pub fn task_label_index(labels: &[String], label: &str) -> Option<usize> {
+pub(crate) fn task_label_index(labels: &[String], label: &str) -> Option<usize> {
     labels
         .iter()
         .position(|existing| existing.eq_ignore_ascii_case(label))
 }
 
-pub fn canonical_task_label(labels: &[String], label: &str) -> Option<String> {
+pub(crate) fn canonical_task_label(labels: &[String], label: &str) -> Option<String> {
     task_label_index(labels, label).map(|index| labels[index].clone())
 }
 

--- a/src/temporary_allowlist.rs
+++ b/src/temporary_allowlist.rs
@@ -5,29 +5,29 @@ use serde::{Deserialize, Serialize};
 use crate::blocker::SiteBlocker;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct TemporaryAllowlistEntry {
+pub(crate) struct TemporaryAllowlistEntry {
     #[serde(default)]
-    pub profile: String,
+    pub(crate) profile: String,
     #[serde(default)]
-    pub site: String,
+    pub(crate) site: String,
     #[serde(default)]
-    pub expires_at_epoch_secs: i64,
+    pub(crate) expires_at_epoch_secs: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ParsedTemporaryAllowlistSpec {
-    pub site: String,
-    pub duration_secs: u64,
+pub(crate) struct ParsedTemporaryAllowlistSpec {
+    pub(crate) site: String,
+    pub(crate) duration_secs: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ActiveTemporaryAllowlistEntry {
-    pub site: String,
-    pub remaining_secs: u64,
-    pub expires_at_epoch_secs: i64,
+pub(crate) struct ActiveTemporaryAllowlistEntry {
+    pub(crate) site: String,
+    pub(crate) remaining_secs: u64,
+    pub(crate) expires_at_epoch_secs: i64,
 }
 
-pub fn parse_temporary_allowlist_specs(
+pub(crate) fn parse_temporary_allowlist_specs(
     input: &str,
 ) -> Result<Vec<ParsedTemporaryAllowlistSpec>, String> {
     let mut parsed: Vec<ParsedTemporaryAllowlistSpec> = Vec::new();
@@ -73,7 +73,7 @@ pub fn parse_temporary_allowlist_specs(
     Ok(parsed)
 }
 
-pub fn prune_expired_temporary_allowlist_entries(
+pub(crate) fn prune_expired_temporary_allowlist_entries(
     entries: &mut Vec<TemporaryAllowlistEntry>,
     now_epoch_secs: i64,
 ) -> usize {
@@ -86,7 +86,7 @@ pub fn prune_expired_temporary_allowlist_entries(
     original_len.saturating_sub(entries.len())
 }
 
-pub fn upsert_temporary_allowlist_entries(
+pub(crate) fn upsert_temporary_allowlist_entries(
     entries: &mut Vec<TemporaryAllowlistEntry>,
     profile: &str,
     specs: &[ParsedTemporaryAllowlistSpec],
@@ -139,7 +139,7 @@ pub fn upsert_temporary_allowlist_entries(
     (added, refreshed)
 }
 
-pub fn active_temporary_allowlist_sites_for_profile(
+pub(crate) fn active_temporary_allowlist_sites_for_profile(
     entries: &[TemporaryAllowlistEntry],
     profile: &str,
     now_epoch_secs: i64,
@@ -150,7 +150,7 @@ pub fn active_temporary_allowlist_sites_for_profile(
         .collect()
 }
 
-pub fn active_temporary_allowlist_status_entries_for_profile(
+pub(crate) fn active_temporary_allowlist_status_entries_for_profile(
     entries: &[TemporaryAllowlistEntry],
     profile: &str,
     now_epoch_secs: i64,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,17 +1,17 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TimerPhase {
+pub(crate) enum TimerPhase {
     Focus,
     ShortBreak,
     LongBreak,
 }
 
-pub const DEFAULT_FOCUS_SECS: u64 = 25 * 60;
-pub const DEFAULT_SHORT_BREAK_SECS: u64 = 5 * 60;
-pub const DEFAULT_LONG_BREAK_SECS: u64 = 15 * 60;
-pub const DEFAULT_LONG_BREAK_INTERVAL: u32 = 4;
+pub(crate) const DEFAULT_FOCUS_SECS: u64 = 25 * 60;
+pub(crate) const DEFAULT_SHORT_BREAK_SECS: u64 = 5 * 60;
+pub(crate) const DEFAULT_LONG_BREAK_SECS: u64 = 15 * 60;
+pub(crate) const DEFAULT_LONG_BREAK_INTERVAL: u32 = 4;
 
 impl TimerPhase {
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             TimerPhase::Focus => "Focus",
             TimerPhase::ShortBreak => "Short Break",
@@ -20,7 +20,7 @@ impl TimerPhase {
     }
 
     /// Duration of the phase in seconds.
-    pub fn duration_secs(self) -> u64 {
+    pub(crate) fn duration_secs(self) -> u64 {
         match self {
             TimerPhase::Focus => DEFAULT_FOCUS_SECS,
             TimerPhase::ShortBreak => DEFAULT_SHORT_BREAK_SECS,
@@ -30,32 +30,32 @@ impl TimerPhase {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TimerStatus {
+pub(crate) enum TimerStatus {
     Idle,
     Running,
     Paused,
 }
 
 #[derive(Debug)]
-pub struct TimerState {
-    pub phase: TimerPhase,
-    pub status: TimerStatus,
+pub(crate) struct TimerState {
+    pub(crate) phase: TimerPhase,
+    pub(crate) status: TimerStatus,
     /// Seconds remaining in the current phase.
-    pub remaining_secs: u64,
+    pub(crate) remaining_secs: u64,
     /// Number of completed focus sessions.
-    pub pomodoros_completed: u32,
+    pub(crate) pomodoros_completed: u32,
     /// Configured duration for the focus phase.
-    pub focus_secs: u64,
+    pub(crate) focus_secs: u64,
     /// Configured duration for the short-break phase.
-    pub short_break_secs: u64,
+    pub(crate) short_break_secs: u64,
     /// Configured duration for the long-break phase.
-    pub long_break_secs: u64,
+    pub(crate) long_break_secs: u64,
     /// Number of completed focus sessions before a long break.
-    pub long_break_interval: u32,
+    pub(crate) long_break_interval: u32,
 }
 
 impl TimerState {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::with_profile(
             TimerPhase::Focus.duration_secs(),
             TimerPhase::ShortBreak.duration_secs(),
@@ -66,7 +66,11 @@ impl TimerState {
 
     /// Create a timer with custom phase durations (all in seconds).
     #[cfg(test)]
-    pub fn with_durations(focus_secs: u64, short_break_secs: u64, long_break_secs: u64) -> Self {
+    pub(crate) fn with_durations(
+        focus_secs: u64,
+        short_break_secs: u64,
+        long_break_secs: u64,
+    ) -> Self {
         Self::with_profile(
             focus_secs,
             short_break_secs,
@@ -76,7 +80,7 @@ impl TimerState {
     }
 
     /// Create a timer with custom phase durations and long-break cadence.
-    pub fn with_profile(
+    pub(crate) fn with_profile(
         focus_secs: u64,
         short_break_secs: u64,
         long_break_secs: u64,
@@ -128,7 +132,7 @@ impl TimerState {
     }
 
     /// Advance the timer by one second. Returns true if the phase just ended.
-    pub fn tick(&mut self) -> bool {
+    pub(crate) fn tick(&mut self) -> bool {
         if self.status != TimerStatus::Running {
             return false;
         }
@@ -155,7 +159,7 @@ impl TimerState {
     }
 
     /// Skip to the next phase immediately (does not count as a completed session).
-    pub fn next_phase(&mut self) {
+    pub(crate) fn next_phase(&mut self) {
         let next_phase = if self.phase == TimerPhase::Focus {
             let next_focus_count = self.pomodoros_completed.saturating_add(1);
             self.break_phase_for_focus_count(next_focus_count)
@@ -166,11 +170,11 @@ impl TimerState {
     }
 
     /// Reset the current phase back to its full duration and stop.
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.set_phase_idle(self.phase);
     }
 
-    pub fn toggle_pause(&mut self) {
+    pub(crate) fn toggle_pause(&mut self) {
         self.status = match self.status {
             TimerStatus::Idle | TimerStatus::Paused => TimerStatus::Running,
             TimerStatus::Running => TimerStatus::Paused,
@@ -178,7 +182,7 @@ impl TimerState {
     }
 
     /// Progress as a value in [0.0, 1.0] where 1.0 means full time remaining.
-    pub fn progress(&self) -> f64 {
+    pub(crate) fn progress(&self) -> f64 {
         let total_secs = self.phase_duration(self.phase);
         if total_secs == 0 {
             return 0.0;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -65,7 +65,7 @@ const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 6] = [
     ("Appearance", &PROFILE_EDIT_GROUP_APPEARANCE),
 ];
 
-pub fn render(frame: &mut Frame, app: &App) {
+pub(crate) fn render(frame: &mut Frame, app: &App) {
     match app.mode {
         AppMode::Timer => render_timer(frame, app),
         AppMode::SiteManager => render_site_manager(frame, app),

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -36,7 +36,7 @@ const DEFAULT_HEARTBEAT_PROJECT: &str = "focustime";
 const DEFAULT_HEARTBEAT_LANGUAGE: &str = "Pomodoro";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum WakatimeRuntimeState {
+pub(crate) enum WakatimeRuntimeState {
     NotConfigured,
     Idle,
     Tracking,
@@ -57,7 +57,7 @@ pub enum WakatimeRuntimeState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WakatimeConfigStatus {
+pub(crate) enum WakatimeConfigStatus {
     Configured,
     MissingConfigFile,
     MissingApiKey,
@@ -66,20 +66,20 @@ pub enum WakatimeConfigStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WakatimeConfigDiagnostics {
-    pub config_path: Option<String>,
-    pub status: WakatimeConfigStatus,
-    pub detail: String,
+pub(crate) struct WakatimeConfigDiagnostics {
+    pub(crate) config_path: Option<String>,
+    pub(crate) status: WakatimeConfigStatus,
+    pub(crate) detail: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WakatimeHeartbeatMetadata {
-    pub project: String,
-    pub language: String,
+pub(crate) struct WakatimeHeartbeatMetadata {
+    pub(crate) project: String,
+    pub(crate) language: String,
 }
 
 impl WakatimeHeartbeatMetadata {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         Self {
             project: normalize_nonempty_or_default(&self.project, DEFAULT_HEARTBEAT_PROJECT),
             language: normalize_nonempty_or_default(&self.language, DEFAULT_HEARTBEAT_LANGUAGE),
@@ -97,14 +97,14 @@ impl Default for WakatimeHeartbeatMetadata {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WakatimeRuntimeOptions {
-    pub retry_backoff_secs: Vec<u64>,
-    pub queue_capacity: usize,
-    pub queue_retry_delay_secs: u64,
+pub(crate) struct WakatimeRuntimeOptions {
+    pub(crate) retry_backoff_secs: Vec<u64>,
+    pub(crate) queue_capacity: usize,
+    pub(crate) queue_retry_delay_secs: u64,
 }
 
 impl WakatimeRuntimeOptions {
-    pub fn normalized(&self) -> Self {
+    pub(crate) fn normalized(&self) -> Self {
         let retry_backoff_secs = self
             .retry_backoff_secs
             .iter()
@@ -178,7 +178,7 @@ enum HeartbeatEvent {
 }
 
 /// Tracks WakaTime heartbeats during Focus sessions.
-pub struct WakatimeTracker {
+pub(crate) struct WakatimeTracker {
     api_key: Option<String>,
     api_url: String,
     /// Seconds elapsed since the last heartbeat was sent.
@@ -221,14 +221,14 @@ pub struct WakatimeTracker {
 }
 
 impl WakatimeTracker {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::new_with_settings(
             WakatimeHeartbeatMetadata::default(),
             WakatimeRuntimeOptions::default(),
         )
     }
 
-    pub fn new_with_settings(
+    pub(crate) fn new_with_settings(
         metadata: WakatimeHeartbeatMetadata,
         runtime: WakatimeRuntimeOptions,
     ) -> Self {
@@ -264,11 +264,11 @@ impl WakatimeTracker {
     }
 
     /// Returns `true` if actively sending heartbeats for a focus session.
-    pub fn is_tracking(&self) -> bool {
+    pub(crate) fn is_tracking(&self) -> bool {
         self.tracking
     }
 
-    pub fn runtime_state(&self) -> WakatimeRuntimeState {
+    pub(crate) fn runtime_state(&self) -> WakatimeRuntimeState {
         if self.api_key.is_none() {
             return WakatimeRuntimeState::NotConfigured;
         }
@@ -306,7 +306,7 @@ impl WakatimeTracker {
         }
     }
 
-    pub fn config_diagnostics() -> WakatimeConfigDiagnostics {
+    pub(crate) fn config_diagnostics() -> WakatimeConfigDiagnostics {
         let Some(config_path) = WakatimeConfig::config_file_path() else {
             return WakatimeConfigDiagnostics {
                 config_path: None,
@@ -317,11 +317,11 @@ impl WakatimeTracker {
         config_diagnostics_from_read_result(config_path.clone(), fs::read_to_string(config_path))
     }
 
-    pub fn last_successful_heartbeat_epoch_secs(&self) -> Option<u64> {
+    pub(crate) fn last_successful_heartbeat_epoch_secs(&self) -> Option<u64> {
         self.last_successful_heartbeat_epoch_secs
     }
 
-    pub fn pending_heartbeat_count(&self) -> usize {
+    pub(crate) fn pending_heartbeat_count(&self) -> usize {
         self.queued_heartbeats.len()
             + usize::from(self.heartbeat_in_flight && self.in_flight_from_queue)
     }
@@ -414,7 +414,7 @@ impl WakatimeTracker {
     }
 
     /// Drains heartbeat events from worker threads and updates tracker status.
-    pub fn poll_events(&mut self) {
+    pub(crate) fn poll_events(&mut self) {
         let mut queue_state_changed = false;
         while let Ok(event) = self.result_rx.try_recv() {
             match event {
@@ -474,7 +474,7 @@ impl WakatimeTracker {
     /// Called when a focus session starts (timer transitions to Running in Focus phase).
     /// Sends an immediate heartbeat and resets the interval counter.
     /// Does nothing if no API key is configured.
-    pub fn on_focus_start(&mut self) {
+    pub(crate) fn on_focus_start(&mut self) {
         if self.api_key.is_none() {
             return;
         }
@@ -488,7 +488,7 @@ impl WakatimeTracker {
     /// Sends at most one heartbeat per call regardless of how large `secs` is,
     /// so that a burst of catch-up ticks after a suspend/resume does not
     /// trigger multiple rapid HTTP requests.
-    pub fn tick_elapsed(&mut self, secs: u64) {
+    pub(crate) fn tick_elapsed(&mut self, secs: u64) {
         self.poll_events();
         if !self.tracking || secs == 0 {
             return;
@@ -503,11 +503,11 @@ impl WakatimeTracker {
     }
 
     /// Called when the focus session pauses, stops, or moves to a break phase.
-    pub fn on_focus_stop(&mut self) {
+    pub(crate) fn on_focus_stop(&mut self) {
         self.set_tracking_state(false);
     }
 
-    pub fn set_heartbeat_metadata(&mut self, metadata: WakatimeHeartbeatMetadata) {
+    pub(crate) fn set_heartbeat_metadata(&mut self, metadata: WakatimeHeartbeatMetadata) {
         self.heartbeat_metadata = metadata.normalized();
     }
 


### PR DESCRIPTION
## What

Reduce the public API surface across internal Rust modules by narrowing implementation-only items to crate-local visibility.

Closes #391.

## Why

This tightens module boundaries and makes stable cross-domain interfaces easier to reason about.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements to enhance long-term maintainability and reduce the public API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->