### PR TITLE
Standardize typed error model and user-facing messages

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -55,6 +55,7 @@ use crate::wakatime::{WakatimeHeartbeatMetadata, WakatimeRuntimeOptions, Wakatim
 mod automation_triggers;
 mod break_glass;
 mod cli_api;
+mod error;
 mod feedback_diagnostics;
 mod history_comparison;
 mod history_dashboard_cache;
@@ -75,6 +76,7 @@ mod temporary_allowlist;
 mod timer_flow;
 mod weekday_rules;
 
+pub(crate) use error::{AppError, AppResult};
 use history_dashboard_cache::HistoryDashboardCache;
 #[cfg(test)]
 pub(crate) use history_dashboard_cache::HistoryDashboardCacheStats;

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -1,6 +1,6 @@
 use crate::app::{
-    App, BlockingPreview, FocusStartOutcome, FocusStartTemplateMode, Local, ProfileId,
-    SessionInterruptionReason, ShortcutAction, TimerPhase, TimerState, TimerStatus,
+    App, AppError, AppResult, BlockingPreview, FocusStartOutcome, FocusStartTemplateMode, Local,
+    ProfileId, SessionInterruptionReason, ShortcutAction, TimerPhase, TimerState, TimerStatus,
     normalize_task_label, task_label_index,
 };
 
@@ -11,41 +11,41 @@ impl App {
         }
     }
 
-    pub(crate) fn start_focus_for_cli(&mut self) -> Result<(), String> {
-        match self.try_start_focus_session(FocusStartTemplateMode::ApplySelectedTemplate)? {
+    pub(crate) fn start_focus_for_cli(&mut self) -> AppResult<()> {
+        match self
+            .try_start_focus_session(FocusStartTemplateMode::ApplySelectedTemplate)
+            .map_err(AppError::workflow)?
+        {
             FocusStartOutcome::Started => Ok(()),
-            FocusStartOutcome::MissingTaskLabel => Err(format!(
-                "Cannot start focus: select a task label first (run TUI and press {}).",
-                self.shortcut_hint(ShortcutAction::OpenSessionPlanner)
-            )),
-            FocusStartOutcome::NotIdleFocusPhase => {
-                Err("Cannot start focus: timer is not idle in focus phase.".to_string())
-            }
+            FocusStartOutcome::MissingTaskLabel => Err(AppError::MissingTaskLabel {
+                shortcut_hint: self.shortcut_hint(ShortcutAction::OpenSessionPlanner),
+            }),
+            FocusStartOutcome::NotIdleFocusPhase => Err(AppError::TimerNotIdleFocusPhase),
         }
     }
 
-    pub(crate) fn pause_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn pause_for_cli(&mut self) -> AppResult<()> {
         if self.timer.status != TimerStatus::Running {
-            return Err("Cannot pause: timer is not running.".to_string());
+            return Err(AppError::TimerNotRunning { action: "pause" });
         }
         self.update_timer_and_sync(TimerState::toggle_pause);
         Ok(())
     }
 
-    pub(crate) fn resume_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn resume_for_cli(&mut self) -> AppResult<()> {
         if self.timer.status != TimerStatus::Paused {
-            return Err("Cannot resume: timer is not paused.".to_string());
+            return Err(AppError::TimerNotPaused);
         }
         self.update_timer_and_sync(TimerState::toggle_pause);
         Ok(())
     }
 
-    pub(crate) fn stop_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn stop_for_cli(&mut self) -> AppResult<()> {
         if self.strict_mode_enforced_for_focus() {
-            return Err("Cannot stop: strict mode is active during focus.".to_string());
+            return Err(AppError::StrictModeActive { action: "stop" });
         }
         if self.timer.status == TimerStatus::Idle {
-            return Err("Cannot stop: timer is already idle.".to_string());
+            return Err(AppError::TimerAlreadyIdle);
         }
         self.update_timer_and_sync_with_reason(
             TimerState::reset,
@@ -54,11 +54,11 @@ impl App {
         Ok(())
     }
 
-    pub(crate) fn next_phase_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn next_phase_for_cli(&mut self) -> AppResult<()> {
         if self.strict_mode_enforced_for_focus() {
-            return Err(
-                "Cannot skip to next phase: strict mode is active during focus.".to_string(),
-            );
+            return Err(AppError::StrictModeActive {
+                action: "skip to next phase",
+            });
         }
         self.update_timer_and_sync_with_reason(
             TimerState::next_phase,
@@ -67,7 +67,7 @@ impl App {
         Ok(())
     }
 
-    pub(crate) fn schedule_delay_for_cli(&mut self) -> Result<String, String> {
+    pub(crate) fn schedule_delay_for_cli(&mut self) -> AppResult<String> {
         let now = Local::now();
         self.current_frame_now = now;
         let delayed_until = self.delay_active_schedule_start_for_workflow(now)?;
@@ -75,7 +75,7 @@ impl App {
         Ok(delayed_until.format("%H:%M").to_string())
     }
 
-    pub(crate) fn trigger_break_glass_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn trigger_break_glass_for_cli(&mut self) -> AppResult<()> {
         if self.break_glass_confirmation_pending() {
             let result = self.confirm_break_glass_override_for_workflow();
             self.sync_wakatime_tracking_for_state();
@@ -84,42 +84,47 @@ impl App {
             return Ok(());
         }
         self.arm_break_glass_override_for_workflow()?;
-        self.sync_cli_workflow_state()
+        self.sync_cli_workflow_state()?;
+        Ok(())
     }
 
-    pub(crate) fn cancel_break_glass_for_cli(&mut self) -> Result<(), String> {
+    pub(crate) fn cancel_break_glass_for_cli(&mut self) -> AppResult<()> {
         if !self.break_glass_confirmation_pending() {
-            return Err("Cannot cancel break-glass: no confirmation is pending.".to_string());
+            return Err(AppError::BreakGlassNoConfirmation);
         }
         self.pending_timer_action = None;
-        self.sync_cli_workflow_state()
+        self.sync_cli_workflow_state()?;
+        Ok(())
     }
 
     pub(crate) fn add_temporary_allowlist_for_cli(
         &mut self,
         input: &str,
-    ) -> Result<(usize, usize), String> {
+    ) -> AppResult<(usize, usize)> {
         self.add_temporary_allowlist_entries_for_active_profile_from_input(input)
+            .map_err(AppError::workflow)
     }
 
-    pub(crate) fn blocking_preview_for_cli(&self) -> Result<BlockingPreview, String> {
+    pub(crate) fn blocking_preview_for_cli(&self) -> AppResult<BlockingPreview> {
         self.compute_blocking_preview()
-            .map_err(|error| format!("Failed to generate blocking preview: {error}"))
+            .map_err(|error| AppError::BlockingPreviewFailed {
+                source: error.to_string(),
+            })
     }
 
-    pub(crate) fn select_task_label_for_cli(&mut self, label: &str) -> Result<bool, String> {
+    pub(crate) fn select_task_label_for_cli(&mut self, label: &str) -> AppResult<bool> {
         let Some(label) = normalize_task_label(label) else {
-            return Err("Cannot select task label: label cannot be empty.".to_string());
+            return Err(AppError::TaskLabelEmpty);
         };
 
         if let Some(existing_index) = task_label_index(&self.task_labels, &label) {
             let Some(existing_label) = self.task_labels.get(existing_index).cloned() else {
-                return Err("Cannot select task label: label lookup failed.".to_string());
+                return Err(AppError::TaskLabelLookupFailed);
             };
             if self.is_task_label_archived(&existing_label) {
-                return Err(format!(
-                    "Cannot select archived task label `{existing_label}`. Unarchive it in Session Planner first."
-                ));
+                return Err(AppError::ArchivedTaskLabel {
+                    label: existing_label,
+                });
             }
             self.planner_selection_index = existing_index;
             self.selected_task_label = Some(existing_label.clone());
@@ -165,7 +170,7 @@ impl App {
         None
     }
 
-    pub(crate) fn set_focus_intention_for_cli(&mut self, value: &str) -> Result<(), String> {
+    pub(crate) fn set_focus_intention_for_cli(&mut self, value: &str) -> AppResult<()> {
         self.ensure_focus_active_for_cli_metadata_update("--focus-intention")?;
         let value = self.resolve_cli_metadata_value(value)?;
         self.active_focus_intention = Some(value);
@@ -173,7 +178,7 @@ impl App {
         Ok(())
     }
 
-    pub(crate) fn set_task_note_for_cli(&mut self, value: &str) -> Result<(), String> {
+    pub(crate) fn set_task_note_for_cli(&mut self, value: &str) -> AppResult<()> {
         self.ensure_focus_active_for_cli_metadata_update("--task-note")?;
         let value = self.resolve_cli_metadata_value(value)?;
         self.active_focus_task_note = Some(value);
@@ -193,46 +198,43 @@ impl App {
     pub(crate) fn select_session_template_for_cli(
         &mut self,
         name: Option<&str>,
-    ) -> Result<bool, String> {
+    ) -> AppResult<bool> {
         self.select_session_template(name)
+            .map_err(AppError::workflow)
     }
 
-    pub(crate) fn apply_session_template_for_cli(
-        &mut self,
-        name: Option<&str>,
-    ) -> Result<bool, String> {
+    pub(crate) fn apply_session_template_for_cli(&mut self, name: Option<&str>) -> AppResult<bool> {
         self.apply_session_template(name)
+            .map_err(AppError::workflow)
     }
 
-    pub(crate) fn create_session_template_for_cli(&mut self, name: &str) -> Result<bool, String> {
+    pub(crate) fn create_session_template_for_cli(&mut self, name: &str) -> AppResult<bool> {
         self.capture_session_template(name)
+            .map_err(AppError::workflow)
     }
 
-    pub(crate) fn rename_active_session_template_for_cli(
-        &mut self,
-        name: &str,
-    ) -> Result<bool, String> {
+    pub(crate) fn rename_active_session_template_for_cli(&mut self, name: &str) -> AppResult<bool> {
         self.rename_active_session_template(name)
+            .map_err(AppError::workflow)
     }
 
-    pub(crate) fn delete_active_session_template_for_cli(&mut self) -> Result<bool, String> {
+    pub(crate) fn delete_active_session_template_for_cli(&mut self) -> AppResult<bool> {
         self.delete_active_session_template()
+            .map_err(AppError::workflow)
     }
 
-    fn ensure_focus_active_for_cli_metadata_update(&self, command: &str) -> Result<(), String> {
+    fn ensure_focus_active_for_cli_metadata_update(&self, command: &'static str) -> AppResult<()> {
         if self.focus_session_active_for_current_state() {
             Ok(())
         } else {
-            Err(format!(
-                "Cannot set session metadata with `{command}`: focus session is not active or paused."
-            ))
+            Err(AppError::SessionMetadataInactive { command })
         }
     }
 
-    fn resolve_cli_metadata_value(&self, value: &str) -> Result<String, String> {
+    fn resolve_cli_metadata_value(&self, value: &str) -> AppResult<String> {
         normalize_task_label(value)
             .or_else(|| self.active_focus_task_label.clone())
             .or_else(|| self.selected_task_label.clone())
-            .ok_or_else(|| "Cannot set session metadata: no task label is selected.".to_string())
+            .ok_or(AppError::SessionMetadataMissingTaskLabel)
     }
 }

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -1,0 +1,146 @@
+use std::fmt;
+
+use crate::error::{UserFacingError, UserMessage};
+
+pub(crate) type AppResult<T> = Result<T, AppError>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AppError {
+    MissingTaskLabel { shortcut_hint: String },
+    TimerNotIdleFocusPhase,
+    TimerNotRunning { action: &'static str },
+    TimerNotPaused,
+    StrictModeActive { action: &'static str },
+    TimerAlreadyIdle,
+    BreakGlassNoConfirmation,
+    SessionMetadataInactive { command: &'static str },
+    SessionMetadataMissingTaskLabel,
+    TaskLabelEmpty,
+    TaskLabelLookupFailed,
+    ArchivedTaskLabel { label: String },
+    BlockingPreviewFailed { source: String },
+    WorkflowFailed { source: String },
+}
+
+impl AppError {
+    pub(crate) fn workflow(source: impl Into<String>) -> Self {
+        Self::WorkflowFailed {
+            source: source.into(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, needle: &str) -> bool {
+        self.user_message().message.contains(needle)
+    }
+}
+
+impl UserFacingError for AppError {
+    fn user_message(&self) -> UserMessage {
+        match self {
+            Self::MissingTaskLabel { shortcut_hint } => UserMessage::with_hint(
+                "app.focus.missing_task_label",
+                format!(
+                    "Cannot start focus: select a task label first (run TUI and press {shortcut_hint})."
+                ),
+                "Select a task with `focustime --task LABEL`, then run `focustime --start` again.",
+            ),
+            Self::TimerNotIdleFocusPhase => UserMessage::with_hint(
+                "app.timer.not_idle_focus_phase",
+                "Cannot start focus: timer is not idle in focus phase.",
+                "Stop or finish the current phase before starting a new focus session.",
+            ),
+            Self::TimerNotRunning { action } => UserMessage::with_hint(
+                "app.timer.not_running",
+                format!("Cannot {action}: timer is not running."),
+                "Start a focus session first with `focustime --start`.",
+            ),
+            Self::TimerNotPaused => UserMessage::with_hint(
+                "app.timer.not_paused",
+                "Cannot resume: timer is not paused.",
+                "Pause a running session with `focustime --pause` before resuming.",
+            ),
+            Self::StrictModeActive { action } => UserMessage::with_hint(
+                "app.timer.strict_mode_active",
+                format!("Cannot {action}: strict mode is active during focus."),
+                "Disable strict mode or wait until the focus phase ends.",
+            ),
+            Self::TimerAlreadyIdle => UserMessage::with_hint(
+                "app.timer.already_idle",
+                "Cannot stop: timer is already idle.",
+                "Start a focus session before stopping it.",
+            ),
+            Self::BreakGlassNoConfirmation => UserMessage::with_hint(
+                "app.break_glass.no_confirmation",
+                "Cannot cancel break-glass: no confirmation is pending.",
+                "Trigger break-glass first before trying to cancel the pending confirmation.",
+            ),
+            Self::SessionMetadataInactive { command } => UserMessage::with_hint(
+                "app.session_metadata.inactive",
+                format!(
+                    "Cannot set session metadata with `{command}`: focus session is not active or paused."
+                ),
+                "Start or pause a focus session before setting session metadata.",
+            ),
+            Self::SessionMetadataMissingTaskLabel => UserMessage::with_hint(
+                "app.session_metadata.missing_task_label",
+                "Cannot set session metadata: no task label is selected.",
+                "Select a task with `focustime --task LABEL` first.",
+            ),
+            Self::TaskLabelEmpty => UserMessage::with_hint(
+                "app.task_label.empty",
+                "Cannot select task label: label cannot be empty.",
+                "Pass a non-empty label, for example `focustime --task Docs`.",
+            ),
+            Self::TaskLabelLookupFailed => UserMessage::new(
+                "app.task_label.lookup_failed",
+                "Cannot select task label: label lookup failed.",
+            ),
+            Self::ArchivedTaskLabel { label } => UserMessage::with_hint(
+                "app.task_label.archived",
+                format!(
+                    "Cannot select archived task label `{label}`. Unarchive it in Session Planner first."
+                ),
+                "Open Session Planner and unarchive the task before selecting it from the CLI.",
+            ),
+            Self::BlockingPreviewFailed { source } => UserMessage::with_hint(
+                "app.blocking_preview.failed",
+                format!("Failed to generate blocking preview: {source}"),
+                "Run `focustime --diagnostics` to inspect blocking backend setup.",
+            ),
+            Self::WorkflowFailed { source } => UserMessage::new("app.workflow.failed", source),
+        }
+    }
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.user_message().message)
+    }
+}
+
+impl std::error::Error for AppError {}
+
+impl From<String> for AppError {
+    fn from(source: String) -> Self {
+        Self::workflow(source)
+    }
+}
+
+impl From<AppError> for UserMessage {
+    fn from(error: AppError) -> Self {
+        error.user_message()
+    }
+}
+
+impl PartialEq<&str> for AppError {
+    fn eq(&self, other: &&str) -> bool {
+        self.user_message().message == *other
+    }
+}
+
+impl PartialEq<String> for AppError {
+    fn eq(&self, other: &String) -> bool {
+        self.user_message().message == *other
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6,6 +6,7 @@ use crate::config::{
     CalendarProviderConfig, FeatureFlagsConfig, HistoryDashboardConfig, HistoryKpiCardId,
     ShortcutConfig, StatsRetentionConfig, WeekdayProfileRuleConfig,
 };
+use crate::error::UserFacingError;
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
 };
@@ -5134,6 +5135,12 @@ fn cli_pause_requires_running_timer() {
     let error = app.pause_for_cli().unwrap_err();
 
     assert_eq!(error, "Cannot pause: timer is not running.");
+    let message = error.user_message();
+    assert_eq!(message.code, "app.timer.not_running");
+    assert_eq!(
+        message.hint.as_deref(),
+        Some("Start a focus session first with `focustime --start`.")
+    );
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,7 @@ use crate::config::{
     RecurringFocusWindowConfig, RecurringScheduleConfig, ThemePreset, WeekdayProfileRuleConfig,
     WeeklyGoalConfig,
 };
+use crate::error::UserMessage;
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 use crate::session_recovery;
 use crate::stats::{
@@ -284,7 +285,9 @@ pub(crate) enum CliErrorKind {
 pub(crate) struct CliError {
     kind: CliErrorKind,
     output: OutputMode,
+    code: &'static str,
     message: String,
+    hint: Option<String>,
 }
 
 impl CliError {
@@ -306,7 +309,10 @@ struct CliErrorEnvelope {
 struct CliErrorPayload {
     kind: CliErrorKind,
     exit_code: i32,
+    code: &'static str,
     message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hint: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1237,11 +1243,14 @@ where
     .map_err(|message| usage_error(output, message))
 }
 
-pub(crate) fn runtime_error(output: OutputMode, message: String) -> CliError {
+pub(crate) fn runtime_error(output: OutputMode, message: impl Into<UserMessage>) -> CliError {
+    let message = message.into();
     CliError {
         kind: CliErrorKind::Runtime,
         output,
-        message,
+        code: message.code,
+        message: message.message,
+        hint: message.hint,
     }
 }
 
@@ -1249,6 +1258,9 @@ pub(crate) fn emit_cli_error(error: &CliError) -> Result<(), String> {
     match error.output {
         OutputMode::Text => {
             eprintln!("{}", error.message);
+            if let Some(hint) = &error.hint {
+                eprintln!("Hint: {hint}");
+            }
             Ok(())
         }
         OutputMode::Json => print_json(&CliErrorEnvelope {
@@ -1256,21 +1268,26 @@ pub(crate) fn emit_cli_error(error: &CliError) -> Result<(), String> {
             error: CliErrorPayload {
                 kind: error.kind,
                 exit_code: error.exit_code(),
+                code: error.code,
                 message: error.message.clone(),
+                hint: error.hint.clone(),
             },
         }),
     }
 }
 
 fn usage_error(output: OutputMode, message: String) -> CliError {
+    let message = UserMessage::usage(message);
     CliError {
         kind: CliErrorKind::Usage,
         output,
-        message,
+        code: message.code,
+        message: message.message,
+        hint: message.hint,
     }
 }
 
-pub(crate) fn execute_command(cli_command: CliCommand) -> Result<(), String> {
+pub(crate) fn execute_command(cli_command: CliCommand) -> Result<(), UserMessage> {
     execute_cli_command(cli_command)
 }
 

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::app::App;
 use crate::config::validate_automation_trigger_rules;
+use crate::error::UserMessage;
 
 #[cfg(test)]
 use crate::cli::StatusComparisonOptions;
@@ -67,7 +68,9 @@ use status::execute_status_command;
 #[cfg(test)]
 use status::{WATCH_INTERRUPTED, next_watch_deadline, wait_for_next_watch_tick};
 
-pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String> {
+type CliExecuteResult<T> = Result<T, UserMessage>;
+
+pub(super) fn execute_cli_command(cli_command: CliCommand) -> CliExecuteResult<()> {
     if let Some(surface_id) = command_usage_surface_id(&cli_command.kind)
         && !command_usage_records_via_app(&cli_command.kind)
     {
@@ -81,9 +84,15 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         CommandKind::Resume => execute_resume_command(cli_command.output),
         CommandKind::Stop => execute_stop_command(cli_command.output),
         CommandKind::Next => execute_next_command(cli_command.output),
-        CommandKind::DaemonStart { port } => execute_daemon_start_command(port, cli_command.output),
-        CommandKind::DaemonStatus => execute_daemon_status_command(cli_command.output),
-        CommandKind::DaemonStop => execute_daemon_stop_command(cli_command.output),
+        CommandKind::DaemonStart { port } => {
+            execute_daemon_start_command(port, cli_command.output).map_err(UserMessage::from)
+        }
+        CommandKind::DaemonStatus => {
+            execute_daemon_status_command(cli_command.output).map_err(UserMessage::from)
+        }
+        CommandKind::DaemonStop => {
+            execute_daemon_stop_command(cli_command.output).map_err(UserMessage::from)
+        }
         CommandKind::Task { label } => execute_task_command(label, cli_command.output),
         CommandKind::TaskGoal { label, goal } => {
             execute_task_goal_command(label, goal, cli_command.output)
@@ -119,32 +128,50 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         CommandKind::ScheduleDelay => execute_schedule_delay_command(cli_command.output),
         CommandKind::BreakGlassTrigger => execute_break_glass_trigger_command(cli_command.output),
         CommandKind::BreakGlassCancel => execute_break_glass_cancel_command(cli_command.output),
-        CommandKind::ConfigDoctor => execute_config_doctor_command(cli_command.output),
-        CommandKind::ConfigMigrate { apply } => {
-            execute_config_migrate_command(apply, cli_command.output)
+        CommandKind::ConfigDoctor => {
+            execute_config_doctor_command(cli_command.output).map_err(UserMessage::from)
         }
-        CommandKind::Diagnostics => execute_diagnostics_command(cli_command.output),
+        CommandKind::ConfigMigrate { apply } => {
+            execute_config_migrate_command(apply, cli_command.output).map_err(UserMessage::from)
+        }
+        CommandKind::Diagnostics => {
+            execute_diagnostics_command(cli_command.output).map_err(UserMessage::from)
+        }
         CommandKind::BlockingPreview => execute_blocking_preview_command(cli_command.output),
-        CommandKind::UsageSignals => execute_usage_signals_command(cli_command.output),
+        CommandKind::UsageSignals => {
+            execute_usage_signals_command(cli_command.output).map_err(UserMessage::from)
+        }
         CommandKind::Status {
             watch_interval_secs,
             comparison,
-        } => execute_status_command(cli_command.output, watch_interval_secs, comparison),
-        CommandKind::Backup { dir } => execute_backup_command(dir, cli_command.output),
-        CommandKind::Restore { dir } => execute_restore_command(dir, cli_command.output),
-        CommandKind::CalendarSync => execute_calendar_sync_command(cli_command.output),
-        CommandKind::Export { dir } => execute_export_command(dir, cli_command.output),
+        } => execute_status_command(cli_command.output, watch_interval_secs, comparison)
+            .map_err(UserMessage::from),
+        CommandKind::Backup { dir } => {
+            execute_backup_command(dir, cli_command.output).map_err(UserMessage::from)
+        }
+        CommandKind::Restore { dir } => {
+            execute_restore_command(dir, cli_command.output).map_err(UserMessage::from)
+        }
+        CommandKind::CalendarSync => {
+            execute_calendar_sync_command(cli_command.output).map_err(UserMessage::from)
+        }
+        CommandKind::Export { dir } => {
+            execute_export_command(dir, cli_command.output).map_err(UserMessage::from)
+        }
         CommandKind::FeatureInventory { dir } => {
-            execute_feature_inventory_command(dir, cli_command.output)
+            execute_feature_inventory_command(dir, cli_command.output).map_err(UserMessage::from)
         }
         CommandKind::BlocklistProfile { command } => {
             execute_blocklist_profile_command(command, cli_command.output)
+                .map_err(UserMessage::from)
         }
         CommandKind::BlocklistCategory { command } => {
             execute_blocklist_category_command(command, cli_command.output)
+                .map_err(UserMessage::from)
         }
         CommandKind::BlocklistSites { target, command } => {
             execute_blocklist_sites_command(target, command, cli_command.output)
+                .map_err(UserMessage::from)
         }
         CommandKind::AllowlistSiteAddTemporary { input } => {
             execute_allowlist_site_add_temporary_command(input, cli_command.output)
@@ -154,6 +181,7 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> Result<(), String>
         }
         CommandKind::HistoryDashboard { command } => {
             execute_history_dashboard_command(command, cli_command.output)
+                .map_err(UserMessage::from)
         }
     }
 }
@@ -239,42 +267,47 @@ fn record_command_usage_direct(surface_id: &str) -> Result<(), String> {
         .map_err(|error| format!("Failed to save usage signals: {error}"))
 }
 
-fn execute_start_command(output: OutputMode) -> Result<(), String> {
+fn execute_start_command(output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("start");
     app.start_focus_for_cli()?;
-    emit_timer_command_output("start", &app, output)
+    emit_timer_command_output("start", &app, output)?;
+    Ok(())
 }
 
-fn execute_pause_command(output: OutputMode) -> Result<(), String> {
+fn execute_pause_command(output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("pause");
     app.pause_for_cli()?;
-    emit_timer_command_output("pause", &app, output)
+    emit_timer_command_output("pause", &app, output)?;
+    Ok(())
 }
 
-fn execute_resume_command(output: OutputMode) -> Result<(), String> {
+fn execute_resume_command(output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("resume");
     app.resume_for_cli()?;
-    emit_timer_command_output("resume", &app, output)
+    emit_timer_command_output("resume", &app, output)?;
+    Ok(())
 }
 
-fn execute_stop_command(output: OutputMode) -> Result<(), String> {
+fn execute_stop_command(output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("stop");
     app.stop_for_cli()?;
-    emit_timer_command_output("stop", &app, output)
+    emit_timer_command_output("stop", &app, output)?;
+    Ok(())
 }
 
-fn execute_next_command(output: OutputMode) -> Result<(), String> {
+fn execute_next_command(output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("next");
     app.next_phase_for_cli()?;
-    emit_timer_command_output("next", &app, output)
+    emit_timer_command_output("next", &app, output)?;
+    Ok(())
 }
 
-fn execute_task_command(label: String, output: OutputMode) -> Result<(), String> {
+fn execute_task_command(label: String, output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("task");
     let created = app.select_task_label_for_cli(&label)?;
@@ -309,7 +342,7 @@ fn execute_task_goal_command(
     label: Option<String>,
     goal: Option<DailyGoalConfig>,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let config = AppConfig::load().normalized();
     let mut stats = FocusStats::load_with_options(stats_load_options(&config))?;
     let selected_task_label = stats.task_planner_state().1;
@@ -363,7 +396,7 @@ fn execute_task_goal_command(
 fn execute_focus_intention_command(
     value: Option<String>,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("focus-intention");
     let mut updated = false;
@@ -371,10 +404,11 @@ fn execute_focus_intention_command(
         app.set_focus_intention_for_cli(&value)?;
         updated = true;
     }
-    emit_session_metadata_command_output("focus-intention", updated, &app, output)
+    emit_session_metadata_command_output("focus-intention", updated, &app, output)?;
+    Ok(())
 }
 
-fn execute_task_note_command(value: Option<String>, output: OutputMode) -> Result<(), String> {
+fn execute_task_note_command(value: Option<String>, output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("task-note");
     let mut updated = false;
@@ -382,13 +416,14 @@ fn execute_task_note_command(value: Option<String>, output: OutputMode) -> Resul
         app.set_task_note_for_cli(&value)?;
         updated = true;
     }
-    emit_session_metadata_command_output("task-note", updated, &app, output)
+    emit_session_metadata_command_output("task-note", updated, &app, output)?;
+    Ok(())
 }
 
 fn execute_allowlist_site_add_temporary_command(
     input: String,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("allowlist-site-add-temporary");
     let (added, refreshed) = app.add_temporary_allowlist_for_cli(&input)?;
@@ -418,7 +453,7 @@ fn execute_allowlist_site_add_temporary_command(
 fn execute_session_template_command(
     command: SessionTemplateCommandKind,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("session-template");
     let (action, updated) = match command {
@@ -479,7 +514,7 @@ fn build_session_template_command_output(
     }
 }
 
-fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Result<(), String> {
+fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(profile) = profile {
@@ -513,7 +548,7 @@ fn execute_profile_command(profile: Option<ProfileId>, output: OutputMode) -> Re
     Ok(())
 }
 
-fn execute_theme_command(preset: Option<ThemePreset>, output: OutputMode) -> Result<(), String> {
+fn execute_theme_command(preset: Option<ThemePreset>, output: OutputMode) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(preset) = preset {
@@ -537,7 +572,7 @@ fn execute_theme_command(preset: Option<ThemePreset>, output: OutputMode) -> Res
     Ok(())
 }
 
-fn execute_goal_command(goal: Option<DailyGoalConfig>, output: OutputMode) -> Result<(), String> {
+fn execute_goal_command(goal: Option<DailyGoalConfig>, output: OutputMode) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(goal) = goal {
@@ -565,7 +600,7 @@ fn execute_goal_command(goal: Option<DailyGoalConfig>, output: OutputMode) -> Re
 fn execute_weekly_goal_command(
     goal: Option<WeeklyGoalConfig>,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(goal) = goal {
@@ -593,7 +628,7 @@ fn execute_weekly_goal_command(
 fn execute_monthly_goal_command(
     goal: Option<MonthlyGoalConfig>,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(goal) = goal {
@@ -618,7 +653,7 @@ fn execute_monthly_goal_command(
     Ok(())
 }
 
-fn execute_goal_carry_command(enabled: Option<bool>, output: OutputMode) -> Result<(), String> {
+fn execute_goal_carry_command(enabled: Option<bool>, output: OutputMode) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(enabled) = enabled {
@@ -643,7 +678,7 @@ fn execute_goal_carry_command(enabled: Option<bool>, output: OutputMode) -> Resu
 fn execute_weekly_goal_carry_command(
     enabled: Option<bool>,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(enabled) = enabled {
@@ -668,7 +703,7 @@ fn execute_weekly_goal_carry_command(
 fn execute_monthly_goal_carry_command(
     enabled: Option<bool>,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(enabled) = enabled {
@@ -690,7 +725,7 @@ fn execute_monthly_goal_carry_command(
     Ok(())
 }
 
-fn execute_strict_command(enabled: Option<bool>, output: OutputMode) -> Result<(), String> {
+fn execute_strict_command(enabled: Option<bool>, output: OutputMode) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(enabled) = enabled {
@@ -720,7 +755,7 @@ fn execute_strict_command(enabled: Option<bool>, output: OutputMode) -> Result<(
 fn execute_schedule_command(
     schedule: Option<RecurringScheduleConfig>,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(schedule) = schedule {
@@ -750,7 +785,7 @@ fn execute_schedule_command(
 fn execute_weekday_rules_command(
     rules: Option<Vec<WeekdayProfileRuleConfig>>,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(rules) = rules {
@@ -777,7 +812,7 @@ fn execute_weekday_rules_command(
 fn execute_automation_triggers_command(
     rules: Option<Vec<AutomationTriggerRuleConfig>>,
     output: OutputMode,
-) -> Result<(), String> {
+) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
     if let Some(rules) = rules {
@@ -816,25 +851,28 @@ fn validate_and_normalize_automation_triggers(
     Ok(normalized.normalized().automation_triggers)
 }
 
-fn execute_schedule_delay_command(output: OutputMode) -> Result<(), String> {
+fn execute_schedule_delay_command(output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("schedule-delay");
     let delayed_until = app.schedule_delay_for_cli()?;
-    emit_schedule_delay_command_output("schedule-delay", delayed_until, &app, output)
+    emit_schedule_delay_command_output("schedule-delay", delayed_until, &app, output)?;
+    Ok(())
 }
 
-fn execute_break_glass_trigger_command(output: OutputMode) -> Result<(), String> {
+fn execute_break_glass_trigger_command(output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("break-glass-trigger");
     app.trigger_break_glass_for_cli()?;
-    emit_break_glass_command_output("break-glass-trigger", &app, output)
+    emit_break_glass_command_output("break-glass-trigger", &app, output)?;
+    Ok(())
 }
 
-fn execute_break_glass_cancel_command(output: OutputMode) -> Result<(), String> {
+fn execute_break_glass_cancel_command(output: OutputMode) -> CliExecuteResult<()> {
     let mut app = App::new();
     app.record_command_usage_for_cli("break-glass-cancel");
     app.cancel_break_glass_for_cli()?;
-    emit_break_glass_command_output("break-glass-cancel", &app, output)
+    emit_break_glass_command_output("break-glass-cancel", &app, output)?;
+    Ok(())
 }
 
 fn emit_timer_command_output(

--- a/src/cli/execute/diagnostics.rs
+++ b/src/cli/execute/diagnostics.rs
@@ -7,6 +7,7 @@ use crate::cli::{
     print_usage_signals_command_output,
 };
 use crate::config::{run_config_doctor, run_config_migration_assistant};
+use crate::error::UserMessage;
 
 use super::data::stats_load_options;
 
@@ -44,7 +45,7 @@ pub(super) fn execute_diagnostics_command(output: OutputMode) -> Result<(), Stri
     Ok(())
 }
 
-pub(super) fn execute_blocking_preview_command(output: OutputMode) -> Result<(), String> {
+pub(super) fn execute_blocking_preview_command(output: OutputMode) -> Result<(), UserMessage> {
     let mut app = App::new();
     app.record_command_usage_for_cli("blocking-preview");
     let preview = app.blocking_preview_for_cli()?;

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2097,6 +2097,7 @@ fn parse_with_contract_marks_json_usage_errors() {
     assert_eq!(error.kind, CliErrorKind::Usage);
     assert_eq!(error.output, OutputMode::Json);
     assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert_eq!(error.code, "cli.usage");
     assert!(error.message.contains("Unknown option"));
 }
 
@@ -2106,6 +2107,7 @@ fn parse_with_contract_detects_json_on_early_parse_failures() {
     assert_eq!(error.kind, CliErrorKind::Usage);
     assert_eq!(error.output, OutputMode::Json);
     assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert_eq!(error.code, "cli.usage");
     assert!(
         error
             .message
@@ -2119,6 +2121,7 @@ fn parse_with_contract_marks_json_usage_errors_from_key_value_parsing() {
     assert_eq!(error.kind, CliErrorKind::Usage);
     assert_eq!(error.output, OutputMode::Json);
     assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert_eq!(error.code, "cli.usage");
     assert!(error.message.contains("Invalid goal"));
 }
 
@@ -2128,10 +2131,33 @@ fn parse_with_contract_marks_json_usage_errors_from_finalize_step() {
     assert_eq!(error.kind, CliErrorKind::Usage);
     assert_eq!(error.output, OutputMode::Json);
     assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert_eq!(error.code, "cli.usage");
     assert!(
         error
             .message
             .contains("`--watch` is only valid with `--status`.")
+    );
+}
+
+#[test]
+fn runtime_error_preserves_user_message_code_and_hint() {
+    let error = runtime_error(
+        OutputMode::Json,
+        crate::error::UserMessage::with_hint(
+            "app.timer.not_running",
+            "Cannot pause: timer is not running.",
+            "Start a focus session first with `focustime --start`.",
+        ),
+    );
+
+    assert_eq!(error.kind, CliErrorKind::Runtime);
+    assert_eq!(error.output, OutputMode::Json);
+    assert_eq!(error.exit_code(), EXIT_CODE_RUNTIME_ERROR);
+    assert_eq!(error.code, "app.timer.not_running");
+    assert_eq!(error.message, "Cannot pause: timer is not running.");
+    assert_eq!(
+        error.hint.as_deref(),
+        Some("Start a focus session first with `focustime --start`.")
     );
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,8 +14,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 
-use crate::app::App;
+use crate::app::{App, AppResult};
 use crate::config::app_data_path;
+use crate::error::{UserFacingError, UserMessage};
 use crate::timer::{TimerPhase, TimerStatus};
 
 const DAEMON_STATE_FILE_NAME: &str = "daemon-state.toml";
@@ -439,7 +440,7 @@ fn handle_api_request(mut request: Request, app: &mut App, token: &str) -> Resul
                     }),
                 )?,
                 Err(error) => {
-                    respond_error(request, 400, "invalid_request", error)?;
+                    respond_user_message_error(request, 400, error.user_message())?;
                 }
             }
             Ok(false)
@@ -454,7 +455,7 @@ fn handle_api_request(mut request: Request, app: &mut App, token: &str) -> Resul
                         "state": api_timer_state(app)
                     }),
                 )?,
-                Err(error) => respond_error(request, 400, "invalid_request", error)?,
+                Err(error) => respond_user_message_error(request, 400, error.user_message())?,
             }
             Ok(false)
         }
@@ -468,7 +469,7 @@ fn handle_api_request(mut request: Request, app: &mut App, token: &str) -> Resul
                         "state": api_timer_state(app)
                     }),
                 )?,
-                Err(error) => respond_error(request, 400, "invalid_request", error)?,
+                Err(error) => respond_user_message_error(request, 400, error.user_message())?,
             }
             Ok(false)
         }
@@ -481,7 +482,7 @@ fn handle_api_request(mut request: Request, app: &mut App, token: &str) -> Resul
                         "state": api_timer_state(app)
                     }),
                 )?,
-                Err(error) => respond_error(request, 400, "invalid_request", error)?,
+                Err(error) => respond_user_message_error(request, 400, error.user_message())?,
             }
             Ok(false)
         }
@@ -517,22 +518,22 @@ fn handle_api_request(mut request: Request, app: &mut App, token: &str) -> Resul
 fn run_timer_action(
     request: Request,
     app: &mut App,
-    action: fn(&mut App) -> Result<(), String>,
+    action: fn(&mut App) -> AppResult<()>,
 ) -> Result<(), String> {
     match action(app) {
         Ok(()) => respond_ok(request, api_timer_state(app)),
-        Err(error) => respond_error(request, 400, "invalid_request", error),
+        Err(error) => respond_user_message_error(request, 400, error.user_message()),
     }
 }
 
 fn run_workflow_action(
     request: Request,
     app: &mut App,
-    action: fn(&mut App) -> Result<(), String>,
+    action: fn(&mut App) -> AppResult<()>,
 ) -> Result<(), String> {
     match action(app) {
         Ok(()) => respond_ok(request, json!({ "state": api_timer_state(app) })),
-        Err(error) => respond_error(request, 400, "invalid_request", error),
+        Err(error) => respond_user_message_error(request, 400, error.user_message()),
     }
 }
 
@@ -597,16 +598,35 @@ fn respond_ok(request: Request, data: serde_json::Value) -> Result<(), String> {
     respond_json(request, 200, json!({ "ok": true, "data": data }))
 }
 
-fn respond_error(request: Request, status: u16, code: &str, message: String) -> Result<(), String> {
+fn respond_error(
+    request: Request,
+    status: u16,
+    code: &'static str,
+    message: String,
+) -> Result<(), String> {
+    respond_user_message_error(request, status, UserMessage::new(code, message))
+}
+
+fn respond_user_message_error(
+    request: Request,
+    status: u16,
+    message: UserMessage,
+) -> Result<(), String> {
+    let mut error = json!({
+        "code": message.code,
+        "message": message.message,
+    });
+    if let Some(hint) = message.hint
+        && let Some(error) = error.as_object_mut()
+    {
+        error.insert("hint".to_string(), json!(hint));
+    }
     respond_json(
         request,
         status,
         json!({
             "ok": false,
-            "error": {
-                "code": code,
-                "message": message
-            }
+            "error": error
         }),
     )
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,55 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct UserMessage {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) hint: Option<String>,
+}
+
+impl UserMessage {
+    pub(crate) fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            hint: None,
+        }
+    }
+
+    pub(crate) fn with_hint(
+        code: &'static str,
+        message: impl Into<String>,
+        hint: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            hint: Some(hint.into()),
+        }
+    }
+
+    pub(crate) fn runtime(message: impl Into<String>) -> Self {
+        Self::new("runtime.error", message)
+    }
+
+    pub(crate) fn usage(message: impl Into<String>) -> Self {
+        Self::new("cli.usage", message)
+    }
+}
+
+impl From<String> for UserMessage {
+    fn from(message: String) -> Self {
+        Self::runtime(message)
+    }
+}
+
+impl From<&str> for UserMessage {
+    fn from(message: &str) -> Self {
+        Self::runtime(message)
+    }
+}
+
+pub(crate) trait UserFacingError {
+    fn user_message(&self) -> UserMessage;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod calendar;
 mod cli;
 mod config;
 mod daemon;
+mod error;
 mod feature_inventory;
 mod integration;
 mod notifications;


### PR DESCRIPTION
## What

Standardize CLI/runtime user-facing errors around typed message contracts with stable error codes and optional actionable hints.

Closes #389.

## Why

This gives CLI, app runtime paths, and daemon API responses a shared shape for equivalent failures while preserving the existing human-readable messages.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR