### PR TITLE
Simplify runtime state and event flow

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -190,6 +190,28 @@ fn profile_for_index(index: usize) -> ProfileId {
         .unwrap_or(PROFILE_IDS[PROFILE_IDS.len() - 1])
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TimerActivity {
+    focus_active: bool,
+    focus_running: bool,
+}
+
+impl TimerActivity {
+    fn from_timer(timer: &TimerState) -> Self {
+        Self::from_parts(timer.phase, timer.status)
+    }
+
+    fn from_parts(phase: TimerPhase, status: TimerStatus) -> Self {
+        let focus_active = phase == TimerPhase::Focus && status != TimerStatus::Idle;
+        let focus_running = phase == TimerPhase::Focus && status == TimerStatus::Running;
+        debug_assert!(!focus_running || focus_active);
+        Self {
+            focus_active,
+            focus_running,
+        }
+    }
+}
+
 fn blocklist_profile_index(profiles: &[BlocklistProfileConfig], selected_name: &str) -> usize {
     profiles
         .iter()
@@ -1512,12 +1534,16 @@ impl App {
         self.focus_session_active_for_current_state() && !self.break_glass_override_active_now()
     }
 
+    fn timer_activity(&self) -> TimerActivity {
+        TimerActivity::from_timer(&self.timer)
+    }
+
     fn focus_running_for_current_state(&self) -> bool {
-        self.timer.phase == TimerPhase::Focus && self.timer.status == TimerStatus::Running
+        self.timer_activity().focus_running
     }
 
     fn focus_session_active_for_current_state(&self) -> bool {
-        self.timer.phase == TimerPhase::Focus && self.timer.status != TimerStatus::Idle
+        self.timer_activity().focus_active
     }
 
     fn should_auto_start_transition(

--- a/src/app/profile_management.rs
+++ b/src/app/profile_management.rs
@@ -93,10 +93,7 @@ impl App {
             profile_spec.long_break_secs,
             profile_spec.long_break_interval,
         );
-        self.active_focus_task_label = None;
-        self.active_focus_intention = None;
-        self.active_focus_task_note = None;
-        self.active_focus_profile = None;
+        self.clear_focus_runtime();
         self.selected_profile = profile;
         self.profile_selection_index = profile_index(profile);
         self.apply_automation_for_profile(profile);

--- a/src/app/timer_flow.rs
+++ b/src/app/timer_flow.rs
@@ -1,7 +1,7 @@
 use crate::app::automation_triggers::AutomationTriggerEvent;
 use crate::app::{
     App, FocusStartOutcome, FocusStartTemplateMode, Local, SessionInterruptionReason,
-    ShortcutAction, TimerPhase, TimerState, TimerStatus, current_day_key,
+    ShortcutAction, TimerActivity, TimerPhase, TimerState, TimerStatus, current_day_key,
 };
 
 impl App {
@@ -46,14 +46,10 @@ impl App {
         completed_focus_secs: u64,
         is_catchup: bool,
     ) {
+        let previous_activity = TimerActivity::from_parts(completed_phase, TimerStatus::Running);
         self.pending_timer_action = None;
         if self.should_record_completed_focus_session(completed_phase, is_catchup) {
             self.record_completed_focus_session(completed_focus_secs);
-            self.active_focus_task_label = None;
-            self.active_focus_intention = None;
-            self.active_focus_task_note = None;
-            self.clear_timer_note_input();
-            self.active_focus_profile = None;
         }
 
         let blocked_focus_autostart =
@@ -67,14 +63,7 @@ impl App {
             self.fire_timer_lifecycle_automation_events(completed_phase, TimerStatus::Running);
         }
 
-        if self.timer.phase != TimerPhase::Focus {
-            self.active_focus_task_label = None;
-            self.active_focus_intention = None;
-            self.active_focus_task_note = None;
-            self.clear_timer_note_input();
-            self.active_focus_profile = None;
-            self.break_glass_expires_at = None;
-        }
+        self.sync_focus_runtime_for_activity_change(previous_activity);
         self.apply_blocking_for_phase();
     }
 
@@ -92,12 +81,6 @@ impl App {
         }
 
         self.timer.status = TimerStatus::Running;
-        if self.timer.phase == TimerPhase::Focus {
-            self.active_focus_task_label = self.selected_task_label.clone();
-            self.active_focus_intention = self.selected_task_label.clone();
-            self.active_focus_task_note = self.selected_task_label.clone();
-            self.active_focus_profile = Some(self.selected_profile);
-        }
         false
     }
 
@@ -154,28 +137,18 @@ impl App {
         let previous_status = self.timer.status;
         self.pending_timer_action = None;
         action(&mut self.timer);
+        let previous_activity = TimerActivity {
+            focus_active: was_focus_active,
+            focus_running: previous_phase == TimerPhase::Focus
+                && previous_status == TimerStatus::Running,
+        };
         let is_focus_active = self.focus_session_active_for_current_state();
         if let Some(context) = interruption_context
             && !is_focus_active
         {
             self.record_session_interruption_event(context);
         }
-        if !was_focus_active && is_focus_active {
-            self.active_focus_task_label = self.selected_task_label.clone();
-            self.active_focus_intention = self.selected_task_label.clone();
-            self.active_focus_task_note = self.selected_task_label.clone();
-            self.clear_timer_note_input();
-            self.active_focus_profile = Some(self.selected_profile);
-            self.schedule_armed_occurrence_key = None;
-            self.clear_schedule_delay_state();
-        } else if was_focus_active && !is_focus_active {
-            self.active_focus_task_label = None;
-            self.active_focus_intention = None;
-            self.active_focus_task_note = None;
-            self.clear_timer_note_input();
-            self.active_focus_profile = None;
-            self.break_glass_expires_at = None;
-        }
+        self.sync_focus_runtime_for_activity_change(previous_activity);
         self.fire_timer_lifecycle_automation_events(previous_phase, previous_status);
         self.apply_blocking_for_phase();
         self.sync_recovery_snapshot();
@@ -220,6 +193,39 @@ impl App {
                 }
             }
         }
+    }
+
+    fn sync_focus_runtime_for_activity_change(&mut self, previous_activity: TimerActivity) {
+        let current_activity = self.timer_activity();
+        match (
+            previous_activity.focus_active,
+            current_activity.focus_active,
+        ) {
+            (false, true) => self.start_focus_runtime(),
+            (true, false) => {
+                self.clear_focus_runtime();
+                self.break_glass_expires_at = None;
+            }
+            _ => {}
+        }
+    }
+
+    fn start_focus_runtime(&mut self) {
+        self.active_focus_task_label = self.selected_task_label.clone();
+        self.active_focus_intention = self.selected_task_label.clone();
+        self.active_focus_task_note = self.selected_task_label.clone();
+        self.clear_timer_note_input();
+        self.active_focus_profile = Some(self.selected_profile);
+        self.schedule_armed_occurrence_key = None;
+        self.clear_schedule_delay_state();
+    }
+
+    pub(super) fn clear_focus_runtime(&mut self) {
+        self.active_focus_task_label = None;
+        self.active_focus_intention = None;
+        self.active_focus_task_note = None;
+        self.clear_timer_note_input();
+        self.active_focus_profile = None;
     }
 
     pub(super) fn record_focus_elapsed(&mut self, elapsed_secs: u64) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use std::{
 use crossterm::{
     event::{
         self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event,
+        Event, KeyEvent,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -41,6 +41,70 @@ use cli::{
 /// RAII guard that restores the terminal on drop, ensuring cleanup on any exit path.
 struct TerminalGuard {
     terminal: Terminal<CrosstermBackend<io::Stdout>>,
+}
+
+#[derive(Debug)]
+enum RuntimeEvent {
+    Key(KeyEvent),
+    Paste(String),
+    TimerElapsed(TimerElapsed),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TimerElapsed {
+    elapsed_secs: u64,
+    is_catchup: bool,
+}
+
+struct RuntimeClock {
+    tick_rate: Duration,
+    last_tick: Instant,
+    tick_accumulator_ms: u64,
+}
+
+impl RuntimeClock {
+    fn new(tick_rate: Duration) -> Self {
+        Self {
+            tick_rate,
+            last_tick: Instant::now(),
+            tick_accumulator_ms: 0,
+        }
+    }
+
+    fn poll_timeout(&self) -> Duration {
+        self.tick_rate
+            .checked_sub(self.last_tick.elapsed())
+            .unwrap_or(Duration::ZERO)
+    }
+
+    fn timer_elapsed_if_due(&mut self, timer_running: bool) -> Option<TimerElapsed> {
+        if self.last_tick.elapsed() < self.tick_rate {
+            return None;
+        }
+
+        let elapsed_ms = self.last_tick.elapsed().as_millis() as u64;
+        self.last_tick = Instant::now();
+        self.advance_by(timer_running, elapsed_ms)
+    }
+
+    fn advance_by(&mut self, timer_running: bool, elapsed_ms: u64) -> Option<TimerElapsed> {
+        if !timer_running {
+            self.tick_accumulator_ms = 0;
+            return None;
+        }
+
+        self.tick_accumulator_ms += elapsed_ms;
+        let elapsed_secs = self.tick_accumulator_ms / 1000;
+        self.tick_accumulator_ms %= 1000;
+        if elapsed_secs == 0 {
+            return None;
+        }
+
+        Some(TimerElapsed {
+            elapsed_secs,
+            is_catchup: elapsed_secs > 1,
+        })
+    }
 }
 
 impl TerminalGuard {
@@ -126,20 +190,18 @@ fn main() -> io::Result<()> {
 }
 
 fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) -> io::Result<()> {
-    let tick_rate = Duration::from_millis(100);
-    let mut last_tick = Instant::now();
-    let mut tick_accumulator: u64 = 0; // milliseconds accumulated towards next second
+    let mut clock = RuntimeClock::new(Duration::from_millis(100));
 
     loop {
         app.poll_wakatime_status();
         terminal.draw(|frame| ui::render(frame, &app))?;
 
-        let timeout = tick_rate
-            .checked_sub(last_tick.elapsed())
-            .unwrap_or(Duration::ZERO);
-
-        handle_terminal_event(&mut app, timeout)?;
-        tick_timer_if_due(&mut app, &mut last_tick, &mut tick_accumulator, tick_rate);
+        if let Some(event) = read_terminal_event(clock.poll_timeout())? {
+            dispatch_runtime_event(&mut app, event);
+        }
+        if let Some(elapsed) = clock.timer_elapsed_if_due(app.is_running()) {
+            dispatch_runtime_event(&mut app, RuntimeEvent::TimerElapsed(elapsed));
+        }
 
         if app.should_quit {
             break;
@@ -149,53 +211,78 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
     Ok(())
 }
 
-fn handle_terminal_event(app: &mut App, timeout: Duration) -> io::Result<()> {
+fn read_terminal_event(timeout: Duration) -> io::Result<Option<RuntimeEvent>> {
     if !event::poll(timeout)? {
-        return Ok(());
+        return Ok(None);
     }
 
-    match event::read()? {
-        Event::Key(key) if should_handle_key(&key) => app.handle_key(key),
-        Event::Paste(text) => app.handle_paste(text),
-        _ => {}
-    }
-    Ok(())
+    let event = match event::read()? {
+        Event::Key(key) if should_handle_key(&key) => Some(RuntimeEvent::Key(key)),
+        Event::Paste(text) => Some(RuntimeEvent::Paste(text)),
+        _ => None,
+    };
+    Ok(event)
 }
 
-fn tick_timer_if_due(
-    app: &mut App,
-    last_tick: &mut Instant,
-    tick_accumulator: &mut u64,
-    tick_rate: Duration,
-) {
-    if last_tick.elapsed() < tick_rate {
-        return;
+fn dispatch_runtime_event(app: &mut App, event: RuntimeEvent) {
+    match event {
+        RuntimeEvent::Key(key) => app.handle_key(key),
+        RuntimeEvent::Paste(text) => app.handle_paste(text),
+        RuntimeEvent::TimerElapsed(elapsed) => advance_running_timer(app, elapsed),
     }
-
-    let elapsed_ms = last_tick.elapsed().as_millis() as u64;
-    *last_tick = Instant::now();
-    if !app.is_running() {
-        *tick_accumulator = 0;
-        return;
-    }
-
-    advance_running_timer(app, tick_accumulator, elapsed_ms);
 }
 
-fn advance_running_timer(app: &mut App, tick_accumulator: &mut u64, elapsed_ms: u64) {
-    *tick_accumulator += elapsed_ms;
-    let mut elapsed_secs: u64 = 0;
-    while *tick_accumulator >= 1000 {
-        *tick_accumulator -= 1000;
-        elapsed_secs += 1;
-    }
-    let is_catchup = elapsed_secs > 1;
-    for _ in 0..elapsed_secs {
-        app.on_tick(is_catchup);
+fn advance_running_timer(app: &mut App, elapsed: TimerElapsed) {
+    for _ in 0..elapsed.elapsed_secs {
+        app.on_tick(elapsed.is_catchup);
     }
     // Advance WakaTime once per UI frame to avoid burst heartbeats
     // after a suspend/resume catch-up.
-    if elapsed_secs > 0 {
-        app.on_wakatime_elapsed(elapsed_secs);
+    app.on_wakatime_elapsed(elapsed.elapsed_secs);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_clock_accumulates_subsecond_ticks() {
+        let mut clock = RuntimeClock::new(Duration::from_millis(100));
+
+        assert_eq!(clock.advance_by(true, 400), None);
+        assert_eq!(
+            clock.advance_by(true, 600),
+            Some(TimerElapsed {
+                elapsed_secs: 1,
+                is_catchup: false,
+            })
+        );
+    }
+
+    #[test]
+    fn runtime_clock_marks_multi_second_catchup() {
+        let mut clock = RuntimeClock::new(Duration::from_millis(100));
+
+        assert_eq!(
+            clock.advance_by(true, 2500),
+            Some(TimerElapsed {
+                elapsed_secs: 2,
+                is_catchup: true,
+            })
+        );
+        assert_eq!(clock.tick_accumulator_ms, 500);
+    }
+
+    #[test]
+    fn runtime_clock_clears_accumulator_when_timer_is_not_running() {
+        let mut clock = RuntimeClock::new(Duration::from_millis(100));
+
+        assert_eq!(clock.advance_by(true, 900), None);
+        assert_eq!(clock.advance_by(false, 500), None);
+        assert_eq!(
+            clock.advance_by(true, 500),
+            None,
+            "stale partial time must not leak into a newly started timer"
+        );
     }
 }


### PR DESCRIPTION
## What

Refactor the TUI runtime loop and focus-session state transitions so runtime events and focus activity invariants are easier to trace.

Closes #395.

## Why

The previous flow kept timer tick accumulation in loose loop variables and repeated focus runtime start/cleanup logic across multiple transition paths. This centralizes those responsibilities to reduce coupling and make state/event behavior clearer.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential focus state issues when switching profiles by ensuring proper cleanup of focus-related runtime state.

* **Chores**
  * Refactored internal timer state management and terminal event dispatch system to improve code maintainability and reliability.

* **Tests**
  * Added comprehensive unit tests for timer clock logic covering sub-second accumulation and catch-up detection edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->