### PR TITLE
Prepare v0.14.4 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.14.3 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.14.4 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -116,7 +116,7 @@ When preparing a release update, keep these files aligned:
 - `README.md` release automation and latest-release references
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
-- Release tag examples in docs use the current target release version (for example, `v0.14.3`)
+- Release tag examples in docs use the current target release version (for example, `v0.14.4`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,5 +148,5 @@ sequenceDiagram
   owns it.
 - For release docs updates, keep architecture-facing terminology aligned with the
   module names and responsibility language used in `README.md`, `CHANGELOG.md`,
-  and release tag examples in contributor-facing docs (for example, `v0.14.3`
+  and release tag examples in contributor-facing docs (for example, `v0.14.4`
   for this release cycle).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.4] - 2026-06-05
+
+### Added
+
+- **Shared CLI user message contract (#420):** added reusable CLI-facing message types so runtime errors and command output guidance can stay consistent across command paths.
+
+### Changed
+
+- **Facade and submodule extraction sweep (#417):** split oversized app, CLI, config, schedule, blocker, WakaTime, and stats modules into focused submodules while preserving the public facade boundaries.
+- **Internal API visibility tightening (#418):** narrowed config, blocking, schedule, stats, app, CLI, and UI helper visibility so cross-module APIs stay explicit and implementation details remain private by default.
+- **Typed runtime errors and focus flow cleanup (#420, #421):** introduced typed app runtime errors, clarified the runtime event loop, and centralized focus runtime state for a smaller and more predictable session flow.
+- **Dependency maintenance (#416, #419):** bumped `crate-ci/typos` from `1.47.0` to `1.47.2` and `chrono` from `0.4.44` to `0.4.45`.
+
+### Fixed
+
+- **Split-module regression fixes (#417):** restored schedule conflict inspector re-exports, treated case-only profile renames as no-ops, and removed a redundant WakaTime parser semicolon after the module split.
+
 ## [0.14.3] - 2026-06-02
 
 ### Added
@@ -395,7 +412,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.14.3...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.14.4...HEAD
+[0.14.4]: https://github.com/utilForever/focustime/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/utilForever/focustime/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/utilForever/focustime/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/utilForever/focustime/compare/v0.14.0...v0.14.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ The project uses Conventional Commit-style release commits:
 
 Before preparing a release commit, make sure all CI jobs pass for the release changes.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.14.3`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.14.4`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -969,12 +969,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.14.3`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.14.4`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.14.3](https://github.com/utilForever/focustime/releases/tag/v0.14.3).
+The latest stable release is [v0.14.4](https://github.com/utilForever/focustime/releases/tag/v0.14.4).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the `v0.14.4` release update.

Closes #422.

## Why

This keeps the release metadata, changelog, and contributor-facing release references aligned for the next patch release.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change
- [x] Site blocking behavior was verified for this change
- [x] WakaTime integration behavior was verified for this change
- [x] I added or updated tests for changed behavior

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release examples and version references across documentation files.
  * Added changelog entry for version 0.14.4 with updates to CLI contracts, internal API refinements, typed runtime errors, and dependency maintenance.

* **Chores**
  * Version bumped to 0.14.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->