### PR TITLE
WakaTime offline queue with retry backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,8 +738,9 @@ The diagnostics screen reports:
 - blocking preview summary and backend target details
 - remediation guidance when hosts or command backend readiness is insufficient
 - WakaTime config status (`~/.wakatime.cfg` and `api_key` availability)
-- WakaTime runtime queue/retry status (`idle`, `queued`, `replaying`,
-  `retrying`, `error`, and related pending counts/backoff details)
+- WakaTime runtime queue/retry status (`not configured`, `idle`,
+  `tracking`, `sending`, `queued`, `replaying`, `retrying`, `error`, and
+  related pending counts/backoff details)
 
 Blocking backend policy is deterministic:
 

--- a/README.md
+++ b/README.md
@@ -738,6 +738,8 @@ The diagnostics screen reports:
 - blocking preview summary and backend target details
 - remediation guidance when hosts or command backend readiness is insufficient
 - WakaTime config status (`~/.wakatime.cfg` and `api_key` availability)
+- WakaTime runtime queue/retry status (`idle`, `queued`, `replaying`,
+  `retrying`, `error`, and related pending counts/backoff details)
 
 Blocking backend policy is deterministic:
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -748,6 +748,7 @@ impl App {
             &blocker,
             setup_deprecation_warnings.clone(),
             feature_flags.integrations.is_enabled("wakatime"),
+            integrations.wakatime_runtime_state(),
         );
         let history_dashboard_selected_card = history_dashboard
             .card_order

--- a/src/app/feedback_diagnostics.rs
+++ b/src/app/feedback_diagnostics.rs
@@ -134,6 +134,7 @@ impl App {
         );
     }
 
+    /// Refreshes setup diagnostics and preserves the current WakaTime runtime state.
     pub(super) fn refresh_setup_diagnostics(&mut self) {
         let deprecation_warnings =
             crate::app::setup_deprecation_warnings(&self.config_deprecation_warnings, &self.stats);

--- a/src/app/feedback_diagnostics.rs
+++ b/src/app/feedback_diagnostics.rs
@@ -137,10 +137,12 @@ impl App {
     pub(super) fn refresh_setup_diagnostics(&mut self) {
         let deprecation_warnings =
             crate::app::setup_deprecation_warnings(&self.config_deprecation_warnings, &self.stats);
+        let wakatime_runtime_state = self.wakatime_runtime_state();
         self.setup_diagnostics = SetupDiagnostics::collect(
             &self.blocker,
             deprecation_warnings,
             self.feature_flags.integrations.is_enabled("wakatime"),
+            wakatime_runtime_state,
         );
         self.refresh_blocking_preview();
     }

--- a/src/app/setup_diagnostics.rs
+++ b/src/app/setup_diagnostics.rs
@@ -1,7 +1,7 @@
 use crate::blocker::{
     BlockingBackendKind, BlockingPreviewAction, HostsFileDiagnostics, SiteBlocker,
 };
-use crate::wakatime::{WakatimeConfigStatus, WakatimeTracker};
+use crate::wakatime::{WakatimeConfigStatus, WakatimeRuntimeState, WakatimeTracker};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SetupCheckLevel {
@@ -41,6 +41,7 @@ pub(crate) struct SetupDiagnostics {
     pub(crate) hosts_write_capability: SetupCheck,
     pub(crate) command_backend: SetupCheck,
     pub(crate) wakatime_config: SetupCheck,
+    pub(crate) wakatime_runtime: SetupCheck,
     pub(crate) deprecation_warnings: Vec<String>,
 }
 
@@ -49,6 +50,7 @@ impl SetupDiagnostics {
         blocker: &SiteBlocker,
         deprecation_warnings: Vec<String>,
         wakatime_integration_enabled: bool,
+        wakatime_runtime_state: WakatimeRuntimeState,
     ) -> Self {
         let hosts_diagnostics = blocker.hosts_file_diagnostics();
         let backend_status = blocker.backend_status();
@@ -82,6 +84,8 @@ impl SetupDiagnostics {
         } else {
             SetupCheck::ok("Disabled by integration framework configuration.".to_string())
         };
+        let wakatime_runtime =
+            wakatime_runtime_check(wakatime_integration_enabled, &wakatime_runtime_state);
         Self {
             hosts_file_path,
             backend_policy,
@@ -91,6 +95,7 @@ impl SetupDiagnostics {
             hosts_write_capability,
             command_backend,
             wakatime_config,
+            wakatime_runtime,
             deprecation_warnings,
         }
     }
@@ -177,6 +182,44 @@ fn command_backend_check(blocker: &SiteBlocker) -> SetupCheck {
             "Blocked: command backend unavailable ({error}). Configure commands or use hosts backend."
         )),
     }
+}
+
+fn wakatime_runtime_check(
+    wakatime_integration_enabled: bool,
+    state: &WakatimeRuntimeState,
+) -> SetupCheck {
+    if !wakatime_integration_enabled {
+        return SetupCheck::ok("Disabled by integration framework configuration.");
+    }
+    match state {
+        WakatimeRuntimeState::NotConfigured => SetupCheck::warning(
+            "Not configured: WakaTime heartbeats and offline queue replay are inactive",
+        ),
+        WakatimeRuntimeState::Idle => SetupCheck::ok("Idle: no queued WakaTime heartbeats"),
+        WakatimeRuntimeState::Tracking => SetupCheck::ok("Tracking: no queued WakaTime heartbeats"),
+        WakatimeRuntimeState::Sending => SetupCheck::ok("Sending: heartbeat request in flight"),
+        WakatimeRuntimeState::Queued { pending } => SetupCheck::warning(format!(
+            "Queued: {pending} WakaTime heartbeat{} pending replay",
+            plural_suffix(*pending)
+        )),
+        WakatimeRuntimeState::Replaying { pending } => SetupCheck::warning(format!(
+            "Replaying: {pending} WakaTime heartbeat{} pending, oldest first",
+            plural_suffix(*pending)
+        )),
+        WakatimeRuntimeState::Retrying {
+            attempt,
+            max_attempts,
+            next_backoff_secs,
+            error,
+        } => SetupCheck::warning(format!(
+            "Retrying: attempt {attempt}/{max_attempts}, next retry in {next_backoff_secs}s ({error})"
+        )),
+        WakatimeRuntimeState::Error(error) => SetupCheck::warning(format!("Error: {error}")),
+    }
+}
+
+fn plural_suffix(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
 }
 
 fn hosts_write_capability_check(hosts_diagnostics: &HostsFileDiagnostics) -> SetupCheck {

--- a/src/app/setup_diagnostics.rs
+++ b/src/app/setup_diagnostics.rs
@@ -46,6 +46,7 @@ pub(crate) struct SetupDiagnostics {
 }
 
 impl SetupDiagnostics {
+    /// Collects setup diagnostics, including WakaTime queue/retry runtime status.
     pub(super) fn collect(
         blocker: &SiteBlocker,
         deprecation_warnings: Vec<String>,
@@ -184,6 +185,7 @@ fn command_backend_check(blocker: &SiteBlocker) -> SetupCheck {
     }
 }
 
+/// Converts the current WakaTime runtime state into a user-facing setup check.
 fn wakatime_runtime_check(
     wakatime_integration_enabled: bool,
     state: &WakatimeRuntimeState,
@@ -218,6 +220,7 @@ fn wakatime_runtime_check(
     }
 }
 
+/// Returns the suffix needed to pluralize heartbeat status messages.
 fn plural_suffix(count: usize) -> &'static str {
     if count == 1 { "" } else { "s" }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4876,6 +4876,7 @@ fn poll_wakatime_status_transitions_queued_backlog_to_replaying() {
 }
 
 #[test]
+/// Verifies setup diagnostics expose queued WakaTime heartbeats as a warning.
 fn setup_diagnostics_reports_wakatime_offline_queue_status() {
     let mut app = App::default();
     app.replace_wakatime_tracker_for_tests(WakatimeTracker::new_configured_for_tests());

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4876,6 +4876,28 @@ fn poll_wakatime_status_transitions_queued_backlog_to_replaying() {
 }
 
 #[test]
+fn setup_diagnostics_reports_wakatime_offline_queue_status() {
+    let mut app = App::default();
+    app.replace_wakatime_tracker_for_tests(WakatimeTracker::new_configured_for_tests());
+    app.wakatime_tracker_mut_for_tests()
+        .expect("wakatime tracker should be available")
+        .set_pending_heartbeats_for_tests(3);
+
+    app.refresh_setup_diagnostics();
+
+    assert_eq!(
+        app.setup_diagnostics.wakatime_runtime.level,
+        SetupCheckLevel::Warning
+    );
+    assert!(
+        app.setup_diagnostics
+            .wakatime_runtime
+            .message
+            .contains("Queued: 3 WakaTime heartbeats pending replay")
+    );
+}
+
+#[test]
 fn focus_does_not_start_without_selected_task_label() {
     let mut app = App::default();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1039,6 +1039,7 @@ struct DiagnosticsCommandOutput {
     blocking_permissions: SetupCheckOutput,
     hosts_write_capability: SetupCheckOutput,
     wakatime_config: SetupCheckOutput,
+    wakatime_runtime: SetupCheckOutput,
     deprecation_warnings: Vec<String>,
 }
 

--- a/src/cli/output/diagnostics.rs
+++ b/src/cli/output/diagnostics.rs
@@ -145,6 +145,7 @@ pub(in crate::cli) fn print_diagnostics_command_output(payload: &DiagnosticsComm
     print_diagnostics_check("Blocking permissions", &payload.blocking_permissions);
     print_diagnostics_check("Hosts write capability", &payload.hosts_write_capability);
     print_diagnostics_check("WakaTime config", &payload.wakatime_config);
+    print_diagnostics_check("WakaTime runtime", &payload.wakatime_runtime);
     if payload.deprecation_warnings.is_empty() {
         println!("Deprecation warnings: none");
     } else {
@@ -171,6 +172,7 @@ pub(in crate::cli) fn build_diagnostics_command_output(
         blocking_permissions: setup_check_output(&diagnostics.blocking_permissions),
         hosts_write_capability: setup_check_output(&diagnostics.hosts_write_capability),
         wakatime_config: setup_check_output(&diagnostics.wakatime_config),
+        wakatime_runtime: setup_check_output(&diagnostics.wakatime_runtime),
         deprecation_warnings: diagnostics.deprecation_warnings.clone(),
     }
 }

--- a/src/cli/output/diagnostics.rs
+++ b/src/cli/output/diagnostics.rs
@@ -134,6 +134,7 @@ fn config_health_severity_id(severity: crate::config::ConfigHealthSeverity) -> &
     }
 }
 
+/// Prints setup diagnostics checks, including WakaTime config and runtime status.
 pub(in crate::cli) fn print_diagnostics_command_output(payload: &DiagnosticsCommandOutput) {
     println!("Hosts file: {}", payload.hosts_file_path);
     println!(
@@ -160,6 +161,7 @@ fn print_diagnostics_check(label: &str, check: &SetupCheckOutput) {
     println!("{label}: {} ({})", check.message, check.level);
 }
 
+/// Builds the serializable diagnostics payload used by text and JSON output.
 pub(in crate::cli) fn build_diagnostics_command_output(
     diagnostics: &SetupDiagnostics,
 ) -> DiagnosticsCommandOutput {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -892,6 +892,7 @@ fn diagnostics_output_includes_deprecation_warnings_field() {
 }
 
 #[test]
+/// Verifies diagnostics JSON/text payloads retain WakaTime runtime status.
 fn diagnostics_output_includes_wakatime_runtime_status() {
     let mut app = App::default();
     app.setup_diagnostics.wakatime_runtime = SetupCheck {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -892,6 +892,22 @@ fn diagnostics_output_includes_deprecation_warnings_field() {
 }
 
 #[test]
+fn diagnostics_output_includes_wakatime_runtime_status() {
+    let mut app = App::default();
+    app.setup_diagnostics.wakatime_runtime = SetupCheck {
+        level: SetupCheckLevel::Warning,
+        message: "Queued: 2 WakaTime heartbeats pending replay".to_string(),
+    };
+    let payload = build_diagnostics_command_output(&app.setup_diagnostics);
+
+    assert_eq!(payload.wakatime_runtime.level, "warning");
+    assert_eq!(
+        payload.wakatime_runtime.message,
+        "Queued: 2 WakaTime heartbeats pending replay"
+    );
+}
+
+#[test]
 fn diagnostics_output_includes_deprecation_warnings() {
     let mut app = App::default();
     app.setup_diagnostics.deprecation_warnings = vec![

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -7,6 +7,7 @@ use crate::ui::{
 const DEPRECATION_WARNING_PANEL_LINES: usize = 4;
 const MAX_VISIBLE_DEPRECATION_WARNINGS: usize = DEPRECATION_WARNING_PANEL_LINES - 2;
 
+/// Renders the setup diagnostics panel with blocking and WakaTime health checks.
 pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
     let area = frame.area();
     let outer = centered_rect(72, 68, area);

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -30,6 +30,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             Constraint::Length(2),                                      // blocking permissions
             Constraint::Length(2),                                      // hosts write capability
             Constraint::Length(2),                                      // wakatime config status
+            Constraint::Length(2),                                      // wakatime runtime status
             Constraint::Length(DEPRECATION_WARNING_PANEL_LINES as u16), // deprecation warnings
             Constraint::Length(1),                                      // preview summary
             Constraint::Min(0),                                         // preview section
@@ -88,6 +89,13 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         "WakaTime config status",
         &app.setup_diagnostics.wakatime_config,
     );
+    render_setup_check(
+        frame,
+        app,
+        inner[8],
+        "WakaTime runtime status",
+        &app.setup_diagnostics.wakatime_runtime,
+    );
     let deprecation_lines = if app.setup_diagnostics.deprecation_warnings.is_empty() {
         vec![Line::from("Deprecation warnings: none")]
     } else {
@@ -113,7 +121,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         Paragraph::new(deprecation_lines)
             .style(Style::default().fg(app_color(app, Color::Yellow)))
             .wrap(Wrap { trim: true }),
-        inner[8],
+        inner[9],
     );
 
     let (preview_summary, preview_style) = if let Some(error) = app.blocking_preview.error.as_ref()
@@ -155,7 +163,7 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
         Paragraph::new(preview_summary)
             .alignment(Alignment::Left)
             .style(preview_style),
-        inner[9],
+        inner[10],
     );
 
     let preview_section_text = if app.blocking_preview.error.is_some() {
@@ -178,13 +186,13 @@ pub(super) fn render_setup_diagnostics(frame: &mut Frame, app: &App) {
             )
             .style(Style::default().fg(app_color(app, Color::Gray)))
             .wrap(Wrap { trim: false }),
-        inner[10],
+        inner[11],
     );
 
     render_hint_lines(
         frame,
         app,
-        inner[11],
+        inner[12],
         vec![
             Line::from(format!(
                 "Diagnostics: {} Refresh checks + preview",


### PR DESCRIPTION
## What

Surface WakaTime runtime queue/retry status in setup diagnostics and CLI diagnostics output.

Closes #390.

## Why

WakaTime heartbeats already have durable offline queueing and retry behavior, but diagnostics only reported config readiness. This makes queued/replaying/retrying/error states observable when network issues prevent submissions.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WakaTime runtime status diagnostics showing runtime state (idle/tracking/sending/queued/replaying/retrying/error) and pending heartbeat counts in the app UI and CLI diagnostics.

* **Documentation**
  * Expanded README setup diagnostics with WakaTime runtime state taxonomy, pending counts, and backoff details.

* **Tests**
  * Added unit tests covering WakaTime runtime status diagnostics and CLI output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->