### PR TITLE
Prepare v0.15.0 Release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.14.4 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.15.0 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -117,7 +117,7 @@ When preparing a release update, keep these files aligned:
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
 - `REGRESSION_MATRIX.md` merged/deprecated/removed feature-path coverage
-- Release tag examples in docs use the current target release version (for example, `v0.14.4`)
+- Release tag examples in docs use the current target release version (for example, `v0.15.0`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,5 +148,5 @@ sequenceDiagram
   owns it.
 - For release docs updates, keep architecture-facing terminology aligned with the
   module names and responsibility language used in `README.md`, `CHANGELOG.md`,
-  and release tag examples in contributor-facing docs (for example, `v0.14.4`
+  and release tag examples in contributor-facing docs (for example, `v0.15.0`
   for this release cycle).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-06
+
+### Added
+
+- **WakaTime runtime diagnostics (#426):** added setup/CLI diagnostics for runtime queue and retry states, including pending heartbeat counts, replay/backoff status, and error visibility.
+- **Focused v0.14 regression matrix (#427):** added a release-readiness regression matrix and dedicated gate for merged, deprecated, and removed v0.14.x feature paths.
+
+### Changed
+
+- **Dependency maintenance (#424):** bumped `ratatui` from `0.30.0` to `0.30.1`.
+
+### Fixed
+
+- **Session recovery hardening (#425):** made interrupted timer transition recovery deterministic and wrapped recovery snapshots in an integrity-checked persistence envelope to avoid restoring corrupted or partial state.
+- **Removed CLI option guidance (#427):** improved errors for retired command surfaces so removed options point users to supported replacement workflows.
+
 ## [0.14.4] - 2026-06-05
 
 ### Added
@@ -412,7 +428,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.14.4...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/utilForever/focustime/compare/v0.14.4...v0.15.0
 [0.14.4]: https://github.com/utilForever/focustime/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/utilForever/focustime/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/utilForever/focustime/compare/v0.14.1...v0.14.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ cargo test --test v014_regression_matrix
 Keep [REGRESSION_MATRIX.md](REGRESSION_MATRIX.md) aligned with any feature path
 that is merged, deprecated, or removed during release preparation.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.14.4`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.15.0`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.14.4"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -972,12 +972,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.14.4`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.15.0`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.14.4](https://github.com/utilForever/focustime/releases/tag/v0.14.4).
+The latest stable release is [v0.15.0](https://github.com/utilForever/focustime/releases/tag/v0.15.0).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/REGRESSION_MATRIX.md
+++ b/REGRESSION_MATRIX.md
@@ -21,6 +21,7 @@ the normal release readiness command set.
 | v0.14.3 | Retired migration-window flags stay unavailable. | Removed command | `v014_removed_cli_surfaces_stay_retired_with_json_usage_errors` |
 | v0.14.3 | Retired encrypted sync flags stay unavailable and point users to local backup/restore guidance in release notes. | Removed command | `v014_removed_cli_surfaces_stay_retired_with_json_usage_errors` |
 | v0.14.4 | Facade/submodule splits preserve public command, config, and runtime contracts. | Command/config/runtime | `cargo test --all` plus the focused matrix gate |
+| v0.15.0 | Config migration previews preserve exact output and removed command guidance remains targeted to supported replacements. | Command/config | `v014_config_migration_preview_and_apply_cover_merged_profile_presets` plus `v014_removed_cli_surfaces_stay_retired_with_json_usage_errors` |
 
 ## Release Readiness
 


### PR DESCRIPTION
## What

Prepare the v0.15.0 release by bumping package metadata, adding release notes, aligning release references, and updating the regression matrix.

Closes #428.

## Why

The release documentation and package version need to point at the v0.15.0 target so tagged release automation and contributor-facing guidance stay aligned.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (not applicable; release metadata/docs only)
- [x] Site blocking behavior was verified for this change (not applicable; release metadata/docs only)
- [x] WakaTime integration behavior was verified for this change (not applicable; release metadata/docs only)
- [x] I added or updated tests for changed behavior (not applicable; release metadata/docs only)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (not applicable; none added)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (`cargo audit` was attempted locally, but the installed `cargo-audit` exits before running because `openssl@1.1` dylibs are missing)
- [x] Breaking behavior changes are clearly described in this PR (not applicable; no breaking behavior changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WakaTime runtime diagnostics support.

* **Improvements**
  * Hardened session recovery.
  * Enhanced guidance for retired CLI options.

* **Updates**
  * Updated ratatui dependency.

* **Documentation**
  * Updated release notes and version references for v0.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->