### PR TITLE
Document cleanup roadmap and deprecation notices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,10 +113,10 @@ When preparing a release update, keep these files aligned:
 
 - `Cargo.toml` package version
 - `Cargo.lock` root `focustime` package version
-- `README.md` release automation and latest-release references
+- `README.md` release automation, cleanup roadmap, deprecation notices, and latest-release references
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
-- `REGRESSION_MATRIX.md` merged/deprecated/removed feature-path coverage
+- `REGRESSION_MATRIX.md` merged/deprecated/removed feature-path coverage and supported replacement behavior
 - Release tag examples in docs use the current target release version (for example, `v0.15.0`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **v0.15.x cleanup roadmap and deprecation notices (#436):** documented the release-facing cleanup direction for overlapping feature paths and named the supported replacement behavior for deprecated or retired surfaces.
+
 ## [0.15.0] - 2026-06-06
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ The project uses Conventional Commit-style release commits:
 
 Before preparing a release commit, make sure all CI jobs pass for the release changes.
 For cleanup, deprecation, migration, or facade/submodule work, also run the
-focused v0.14.x regression gate:
+focused cleanup regression gate:
 
 ```sh
 cargo test --test v014_regression_matrix
@@ -93,6 +93,9 @@ cargo test --test v014_regression_matrix
 
 Keep [REGRESSION_MATRIX.md](REGRESSION_MATRIX.md) aligned with any feature path
 that is merged, deprecated, or removed during release preparation.
+For v0.15.x cleanup releases, also keep the README roadmap, changelog entry, and
+deprecation notices aligned so every deprecated or retired path names supported
+replacement behavior before the tag is created.
 
 To publish a release artifact set, create and push a `v*` tag (for example, `v0.15.0`).
 The release workflow will:

--- a/README.md
+++ b/README.md
@@ -311,6 +311,33 @@ Milestone policy:
 - **Unreleased/main branch:** config migration assistant + doctor commands are available (`--config-migrate`, `--config-migrate-apply`, `--config-doctor`).
 - **v0.12.0:** remove legacy field/path compatibility after the warning window
 
+### v0.15.x cleanup roadmap
+
+The v0.15.x line continues the cleanup work started in v0.14.x by reducing
+overlapping command and config paths while keeping supported behavior available
+through canonical surfaces. The guiding rule is that a path is only retired when
+release notes and diagnostics name the replacement behavior.
+
+Roadmap direction:
+
+- Keep profile-oriented timer settings as the primary timer configuration path.
+- Keep one focus-entry runtime path for scheduled, templated, and manual starts.
+- Keep config migration and doctor commands as the supported way to inspect and
+  repair stale configuration.
+- Keep local backup/restore workflows as the supported portable recovery path.
+- Keep cleanup candidates tracked in the feature inventory before they are
+  merged or retired.
+
+Early deprecation notices:
+
+| Deprecated or overlapping path | Supported replacement behavior |
+| --- | --- |
+| Legacy timer duration fields (`focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval`) | Use `[custom_profile]`, profile presets, and `--profile`; run `--config-migrate` or `--config-migrate-apply` when stale keys are reported. |
+| Legacy automation and blocklist top-level fields | Use per-profile automation tables, `[[blocklist_profiles]]`, and `selected_blocklist_profile`; inspect with `--config-doctor`. |
+| Removed migration-window flags (`--migrate`, `--dry-run`) | Use `--config-migrate` to preview config changes and `--config-migrate-apply` to write migrated config with a backup. |
+| Retired encrypted sync flags (`--sync-backup`, `--sync-restore`, `--sync-passphrase`) | Use `--backup` and `--restore` for local portable recovery; there is no direct passphrase replacement because encrypted sync is retired. |
+| Duplicate schedule/session start entry points | Select the task/profile/blocklist/schedule or apply a session template, then start focus through the unified timer flow with `--start` or the TUI. |
+
 ### Low-value feature retirements
 
 Retired low-value command surfaces and replacements:

--- a/REGRESSION_MATRIX.md
+++ b/REGRESSION_MATRIX.md
@@ -1,7 +1,7 @@
-# v0.14.x Regression Matrix
+# Cleanup Regression Matrix
 
 This matrix protects feature paths that were merged, deprecated, or removed during
-the v0.14.x cleanup cycle. The focused gate is:
+the v0.14.x and v0.15.x cleanup cycles. The focused gate is:
 
 ```sh
 cargo test --test v014_regression_matrix
@@ -22,6 +22,7 @@ the normal release readiness command set.
 | v0.14.3 | Retired encrypted sync flags stay unavailable and point users to local backup/restore guidance in release notes. | Removed command | `v014_removed_cli_surfaces_stay_retired_with_json_usage_errors` |
 | v0.14.4 | Facade/submodule splits preserve public command, config, and runtime contracts. | Command/config/runtime | `cargo test --all` plus the focused matrix gate |
 | v0.15.0 | Config migration previews preserve exact output and removed command guidance remains targeted to supported replacements. | Command/config | `v014_config_migration_preview_and_apply_cover_merged_profile_presets` plus `v014_removed_cli_surfaces_stay_retired_with_json_usage_errors` |
+| v0.15.x | Cleanup roadmap documentation names supported replacements before additional overlapping paths are merged or retired. | Release docs | README roadmap, CHANGELOG entry, and contributor release checklist review plus the focused matrix gate when behavior changes |
 
 ## Release Readiness
 
@@ -41,5 +42,8 @@ cargo clippy --all-targets -- -D warnings
 cargo test --all
 ```
 
-When a v0.14.x feature is merged, deprecated, or removed, add a row here and add
-or update the matching focused test before preparing the release commit.
+When a v0.14.x or v0.15.x feature is merged, deprecated, or removed, add a row
+here and add or update the matching focused test before preparing the release
+commit. Documentation-only roadmap updates should still keep README,
+CHANGELOG.md, CONTRIBUTING.md, and this matrix aligned with supported
+replacement behavior.


### PR DESCRIPTION
## What

Document the v0.15.x cleanup roadmap and early deprecation notices for overlapping or retired feature paths.

Closes #436.

## Why

Issue #436 asks for release-facing cleanup guidance that explains the v0.15.x direction and names supported replacement behavior before additional paths are consolidated or retired.

## Checklist

### Required

- [ ] `cargo check --all` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable; documentation-only change)
- [x] Site blocking behavior was verified for this change (if applicable; documentation-only change)
- [x] WakaTime integration behavior was verified for this change (if applicable; documentation-only change)
- [x] I added or updated tests for changed behavior (if applicable; documentation-only change)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable; none added)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed; documentation-only change)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced v0.15.x cleanup roadmap with deprecation notices for overlapping features and migration guidance.
  * Updated release documentation standards to ensure alignment of roadmap, changelog, and deprecation information across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->