### PR TITLE
Add v0.15.x cleanup regression matrix coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **v0.15.x cleanup roadmap and deprecation notices (#436):** documented the release-facing cleanup direction for overlapping feature paths and named the supported replacement behavior for deprecated or retired surfaces.
+- **v0.15.x cleanup regression coverage (#437):** added focused matrix coverage for cleanup docs, deprecated config diagnostics, merged profile migrations, and removed command guidance.
 
 ## [0.15.0] - 2026-06-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ focused cleanup regression gate:
 
 ```sh
 cargo test --test v014_regression_matrix
+cargo test --test v015_cleanup_regression
 ```
 
 Keep [REGRESSION_MATRIX.md](REGRESSION_MATRIX.md) aligned with any feature path

--- a/REGRESSION_MATRIX.md
+++ b/REGRESSION_MATRIX.md
@@ -1,14 +1,15 @@
 # Cleanup Regression Matrix
 
 This matrix protects feature paths that were merged, deprecated, or removed during
-the v0.14.x and v0.15.x cleanup cycles. The focused gate is:
+the v0.14.x and v0.15.x cleanup cycles. The focused gates are:
 
 ```sh
 cargo test --test v014_regression_matrix
+cargo test --test v015_cleanup_regression
 ```
 
-The focused gate is also covered by `cargo test --all`, so it runs in CI and in
-the normal release readiness command set.
+The focused gates are also covered by `cargo test --all`, so they run in CI and
+in the normal release readiness command set.
 
 ## Coverage
 
@@ -22,7 +23,10 @@ the normal release readiness command set.
 | v0.14.3 | Retired encrypted sync flags stay unavailable and point users to local backup/restore guidance in release notes. | Removed command | `v014_removed_cli_surfaces_stay_retired_with_json_usage_errors` |
 | v0.14.4 | Facade/submodule splits preserve public command, config, and runtime contracts. | Command/config/runtime | `cargo test --all` plus the focused matrix gate |
 | v0.15.0 | Config migration previews preserve exact output and removed command guidance remains targeted to supported replacements. | Command/config | `v014_config_migration_preview_and_apply_cover_merged_profile_presets` plus `v014_removed_cli_surfaces_stay_retired_with_json_usage_errors` |
-| v0.15.x | Cleanup roadmap documentation names supported replacements before additional overlapping paths are merged or retired. | Release docs | README roadmap, CHANGELOG entry, and contributor release checklist review plus the focused matrix gate when behavior changes |
+| v0.15.x | Cleanup roadmap documentation names supported replacements before additional overlapping paths are merged or retired. | Release docs | `v015_cleanup_docs_keep_matrix_and_release_guidance_aligned` |
+| v0.15.x | Deprecated config compatibility fields stay visible in diagnostics with canonical replacement guidance. | Config diagnostics | `v015_deprecated_config_paths_report_supported_replacements` |
+| v0.15.x | Merged legacy profile names continue to migrate to canonical presets (`basic`, `standard`, `advanced`). | Config migration | `v015_merged_profile_paths_keep_migration_guidance` |
+| v0.15.x | Removed migration-window and encrypted sync flags stay unavailable and emit targeted JSON replacement guidance. | Removed command | `v015_removed_command_paths_keep_targeted_json_guidance` |
 
 ## Release Readiness
 
@@ -31,6 +35,7 @@ or facade/submodule work:
 
 ```sh
 cargo test --test v014_regression_matrix
+cargo test --test v015_cleanup_regression
 ```
 
 Then run the full CI-equivalent release checks:

--- a/tests/v015_cleanup_regression.rs
+++ b/tests/v015_cleanup_regression.rs
@@ -1,0 +1,294 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde_json::Value;
+
+static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+struct TestEnv {
+    root: PathBuf,
+}
+
+impl TestEnv {
+    fn new(label: &str) -> Self {
+        let unique = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "focustime-v015-cleanup-{label}-{}-{now}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("failed to create temp test directory");
+        Self { root }
+    }
+
+    fn app_data_dir(&self) -> PathBuf {
+        self.root.join("focustime")
+    }
+
+    fn config_path(&self) -> PathBuf {
+        self.app_data_dir().join("config.toml")
+    }
+
+    fn write_config(&self, content: &str) {
+        fs::create_dir_all(self.app_data_dir()).expect("failed to create app data directory");
+        fs::write(self.config_path(), content).expect("failed to write config");
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        let capture_id = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let stdout_path = self.root.join(format!("command-stdout-{capture_id}.log"));
+        let stderr_path = self.root.join(format!("command-stderr-{capture_id}.log"));
+        let stdout_file = fs::File::create(&stdout_path).expect("failed to create stdout capture");
+        let stderr_file = fs::File::create(&stderr_path).expect("failed to create stderr capture");
+        let mut command = Command::new(focustime_bin_path());
+        command.args(args);
+        command.current_dir(&self.root);
+        command.env("APPDATA", &self.root);
+        command.env("LOCALAPPDATA", self.root.join("localappdata"));
+        command.env("XDG_CONFIG_HOME", &self.root);
+        command.env("XDG_STATE_HOME", self.root.join(".state"));
+        command.env("XDG_DATA_HOME", self.root.join(".data"));
+        command.env("HOME", &self.root);
+        command.stdout(Stdio::from(stdout_file));
+        command.stderr(Stdio::from(stderr_file));
+        let status = command
+            .status()
+            .expect("failed to run focustime integration command");
+        let stdout = fs::read(&stdout_path).expect("failed to read stdout capture");
+        let stderr = fs::read(&stderr_path).expect("failed to read stderr capture");
+        let _ = fs::remove_file(stdout_path);
+        let _ = fs::remove_file(stderr_path);
+        Output {
+            status,
+            stdout,
+            stderr,
+        }
+    }
+}
+
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+#[test]
+fn v015_cleanup_docs_keep_matrix_and_release_guidance_aligned() {
+    let matrix = include_str!("../REGRESSION_MATRIX.md");
+    let readme = include_str!("../README.md");
+    let changelog = include_str!("../CHANGELOG.md");
+    let contributing = include_str!("../CONTRIBUTING.md");
+
+    for required in [
+        "v0.15.x",
+        "Cleanup roadmap documentation names supported replacements",
+        "Deprecated config compatibility fields stay visible in diagnostics",
+        "Merged legacy profile names continue to migrate to canonical presets",
+        "Removed migration-window and encrypted sync flags stay unavailable",
+        "cargo test --test v015_cleanup_regression",
+    ] {
+        assert!(
+            matrix.contains(required),
+            "regression matrix should include `{required}`"
+        );
+    }
+
+    for required in [
+        "### v0.15.x cleanup roadmap",
+        "Legacy timer duration fields",
+        "Legacy automation and blocklist top-level fields",
+        "Removed migration-window flags (`--migrate`, `--dry-run`)",
+        "Retired encrypted sync flags (`--sync-backup`, `--sync-restore`, `--sync-passphrase`)",
+        "Duplicate schedule/session start entry points",
+    ] {
+        assert!(
+            readme.contains(required),
+            "README cleanup roadmap should include `{required}`"
+        );
+    }
+
+    assert!(changelog.contains("v0.15.x cleanup roadmap and deprecation notices"));
+    assert!(contributing.contains("cargo test --test v015_cleanup_regression"));
+    assert!(contributing.contains("v0.15.x cleanup releases"));
+}
+
+#[test]
+fn v015_deprecated_config_paths_report_supported_replacements() {
+    let env = TestEnv::new("deprecated-config");
+    env.write_config(
+        r#"
+schema_version = 2
+focus_secs = 1800
+short_break_secs = 360
+long_break_secs = 1200
+long_break_interval = 3
+blocked_sites = ["youtube.com"]
+strict_mode = true
+
+[notifications]
+enabled = true
+sound = true
+"#,
+    );
+
+    let output = env.run(&["--config-doctor", "--json"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload = parse_json_stdout(&output);
+    assert_eq!(payload["action"], "config-doctor");
+    assert_eq!(payload["status"], "warning");
+    let findings = payload["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_finding_contains_all(
+        findings,
+        "config.deprecated_field_in_use",
+        &["focus_secs", "[custom_profile]"],
+    );
+    assert_finding_contains_all(
+        findings,
+        "config.deprecated_field_in_use",
+        &["notifications", "[profile_automation.<preset>]"],
+    );
+    assert_finding_contains_all(
+        findings,
+        "config.deprecated_field_in_use",
+        &["blocked_sites", "blocklist profile"],
+    );
+}
+
+#[test]
+fn v015_merged_profile_paths_keep_migration_guidance() {
+    let env = TestEnv::new("merged-profiles");
+    env.write_config(
+        r#"
+schema_version = 1
+selected_profile = "deep_work"
+
+[[session_templates]]
+name = "Classic Flow"
+profile = "classic"
+
+[profile_automation.custom]
+strict_mode = true
+"#,
+    );
+
+    let output = env.run(&["--config-migrate", "--json"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stderr_text(&output).trim().is_empty());
+
+    let payload = parse_json_stdout(&output);
+    assert_eq!(payload["action"], "config-migrate");
+    assert_eq!(payload["changed"], true);
+    assert!(
+        payload["steps"]
+            .as_array()
+            .expect("steps should be an array")
+            .iter()
+            .any(|step| step["from_schema_version"] == 1 && step["to_schema_version"] == 2)
+    );
+    let findings = payload["findings"]
+        .as_array()
+        .expect("findings should be an array");
+    assert_finding_contains_all(
+        findings,
+        "config.legacy_profile_token",
+        &["selected_profile", "standard"],
+    );
+    assert_finding_contains_all(
+        findings,
+        "config.legacy_profile_token",
+        &["session_templates[0].profile", "basic"],
+    );
+    assert_finding_contains_all(
+        findings,
+        "config.legacy_profile_token",
+        &[
+            "[profile_automation.custom]",
+            "[profile_automation.advanced]",
+        ],
+    );
+    assert!(findings.iter().all(|finding| {
+        finding["remediation"].as_str().is_some_and(|remediation| {
+            remediation.contains("basic")
+                && remediation.contains("standard")
+                && remediation.contains("advanced")
+        })
+    }));
+}
+
+#[test]
+fn v015_removed_command_paths_keep_targeted_json_guidance() {
+    let env = TestEnv::new("removed-commands");
+
+    for (flag, replacement) in [
+        ("--migrate", "--config-migrate"),
+        ("--dry-run", "--config-migrate"),
+        ("--sync-backup", "--backup"),
+        ("--sync-restore", "--restore"),
+        ("--sync-passphrase=secret", "no direct replacement"),
+    ] {
+        let output = env.run(&[flag, "--json"]);
+        assert_eq!(output.status.code(), Some(2));
+        assert!(
+            stderr_text(&output).trim().is_empty(),
+            "JSON usage errors should stay on stdout for {flag}"
+        );
+        let payload = parse_json_stdout(&output);
+        assert_eq!(payload["ok"], false);
+        assert_eq!(payload["error"]["kind"], "usage");
+        assert_eq!(payload["error"]["exit_code"], 2);
+        let message = payload["error"]["message"]
+            .as_str()
+            .expect("error message should be a string");
+        assert!(
+            message.contains(flag.split('=').next().unwrap_or(flag)),
+            "removed flag should be named in its error: {message}"
+        );
+        assert!(
+            message.contains(replacement),
+            "removed flag should include replacement `{replacement}`: {message}"
+        );
+    }
+}
+
+fn focustime_bin_path() -> PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_focustime")
+        .map(PathBuf::from)
+        .expect("CARGO_BIN_EXE_focustime not set")
+}
+
+fn parse_json_stdout(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("stdout should be JSON")
+}
+
+fn stderr_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+fn assert_finding_contains_all(findings: &[Value], code: &str, needles: &[&str]) {
+    assert!(
+        findings.iter().any(|finding| {
+            if finding["code"] != code {
+                return false;
+            }
+            let haystack = format!(
+                "{}\n{}",
+                finding["message"].as_str().unwrap_or_default(),
+                finding["remediation"].as_str().unwrap_or_default()
+            );
+            needles.iter().all(|needle| haystack.contains(needle))
+        }),
+        "expected finding `{code}` containing {needles:?} in {findings:#?}"
+    );
+}


### PR DESCRIPTION
## What

Add focused v0.15.x cleanup regression coverage and align the release matrix/checklist around the new focused gate.

Closes #437.

## Why

The v0.15.x cleanup roadmap names several deprecated, merged, and removed command/config paths. This PR makes those paths part of a dedicated regression gate so release readiness guidance and supported replacement behavior stay aligned.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added integration tests validating v0.15 cleanup behaviors, including configuration migration and deprecated field diagnostics with JSON reporting.

* **Documentation**
  * Updated regression matrix and contributing guidelines to document cleanup test coverage and updated release procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->