### PR TITLE
Add replacement guidance for low-value feature paths

### DIFF
--- a/FEATURE_INVENTORY.json
+++ b/FEATURE_INVENTORY.json
@@ -33,10 +33,10 @@
     ]
   },
   "summary": {
-    "total_features": 27,
+    "total_features": 28,
     "keep_count": 13,
     "merge_count": 14,
-    "remove_count": 0,
+    "remove_count": 1,
     "by_surface": [
       {
         "surface": "timer",
@@ -56,7 +56,7 @@
       },
       {
         "surface": "integration",
-        "feature_count": 4
+        "feature_count": 5
       }
     ],
     "covered_cli_flags": [
@@ -97,6 +97,7 @@
       "--daemon-status",
       "--daemon-stop",
       "--diagnostics",
+      "--dry-run",
       "--export",
       "--feature-inventory",
       "--focus-intention",
@@ -110,6 +111,7 @@
       "--history-dashboard-order",
       "--history-dashboard-pin",
       "--history-dashboard-unpin",
+      "--migrate",
       "--next",
       "--pause",
       "--profile",
@@ -127,6 +129,9 @@
       "--status",
       "--stop",
       "--strict",
+      "--sync-backup",
+      "--sync-passphrase",
+      "--sync-restore",
       "--task",
       "--task-goal",
       "--task-note",
@@ -583,6 +588,26 @@
       "maintenance_cost": 4.25,
       "value_to_maintenance_ratio": 0.71,
       "recommendation": "merge"
+    },
+    {
+      "feature_id": "retired-low-value-command-guidance",
+      "name": "Retired low-value command guidance",
+      "surface": "integration",
+      "description": "Keep retired migration-window and encrypted sync command paths mapped to supported replacement workflows.",
+      "cli_flags": [
+        "--migrate",
+        "--dry-run",
+        "--sync-backup",
+        "--sync-restore",
+        "--sync-passphrase"
+      ],
+      "value": 1,
+      "complexity": 4,
+      "support_burden": 4,
+      "failure_impact": 2,
+      "maintenance_cost": 3.5,
+      "value_to_maintenance_ratio": 0.29,
+      "recommendation": "remove"
     },
     {
       "feature_id": "setup-diagnostics-and-health-signals",

--- a/FEATURE_INVENTORY.md
+++ b/FEATURE_INVENTORY.md
@@ -14,16 +14,16 @@
 
 ## Summary
 
-- Total features: 27
+- Total features: 28
 - Keep: 13
 - Merge: 14
-- Remove: 0
+- Remove: 1
 - Surface coverage:
   - Timer: 6
   - Schedule: 5
   - Blocker: 5
   - Stats: 7
-  - Integration: 4
+  - Integration: 5
 
 ## Release phase mapping (v0.14.x)
 
@@ -60,5 +60,6 @@
 | `usage-signal-inspection` | Stats | 3 | 2.00 | 1.50 | merge | --usage-signals |
 | `calendar-busy-window-sync` | Integration | 3 | 3.75 | 0.80 | merge | --calendar-sync |
 | `daemon-api-lifecycle` | Integration | 3 | 4.25 | 0.71 | merge | --daemon-start, --daemon-status, --daemon-stop, --daemon-port |
+| `retired-low-value-command-guidance` | Integration | 1 | 3.50 | 0.29 | remove | --migrate, --dry-run, --sync-backup, --sync-restore, --sync-passphrase |
 | `setup-diagnostics-and-health-signals` | Integration | 3 | 2.75 | 1.09 | merge | --diagnostics, --config-doctor, --config-migrate, --config-migrate-apply |
 | `wakatime-heartbeat-pipeline` | Integration | 4 | 3.00 | 1.33 | keep | (none) |

--- a/README.md
+++ b/README.md
@@ -344,13 +344,14 @@ Retired low-value command surfaces and replacements:
 
 | Retired commands | Replacement behavior |
 | --- | --- |
+| `--migrate`, `--dry-run` | Use `--config-migrate` to preview config changes and `--config-migrate-apply` to write migrated config with a backup. |
 | `--sync-backup`, `--sync-restore` | Use `--backup` and `--restore` for portable recovery and migration workflows. |
 | `--sync-passphrase` | No direct replacement; encrypted sync/backups are no longer supported. |
 
 ### CLI JSON/error contract
 
 - `--json` success responses are emitted to `stdout` as JSON and exit with code `0`.
-- `--json` failures are emitted to `stdout` as JSON (no mixed human text) and exit with a non-zero code.
+- `--json` failures are emitted to `stdout` as JSON (no mixed human text) and exit with a non-zero code; removed command paths include replacement guidance in `error.hint`.
 - `--status --watch --json` emits newline-delimited compact JSON snapshots continuously until interrupted, then exits cleanly after the current snapshot.
 - Text-mode failures are emitted to `stderr` for interactive readability.
 

--- a/REGRESSION_MATRIX.md
+++ b/REGRESSION_MATRIX.md
@@ -26,7 +26,7 @@ in the normal release readiness command set.
 | v0.15.x | Cleanup roadmap documentation names supported replacements before additional overlapping paths are merged or retired. | Release docs | `v015_cleanup_docs_keep_matrix_and_release_guidance_aligned` |
 | v0.15.x | Deprecated config compatibility fields stay visible in diagnostics with canonical replacement guidance. | Config diagnostics | `v015_deprecated_config_paths_report_supported_replacements` |
 | v0.15.x | Merged legacy profile names continue to migrate to canonical presets (`basic`, `standard`, `advanced`). | Config migration | `v015_merged_profile_paths_keep_migration_guidance` |
-| v0.15.x | Removed migration-window and encrypted sync flags stay unavailable and emit targeted JSON replacement guidance. | Removed command | `v015_removed_command_paths_keep_targeted_json_guidance` |
+| v0.15.x | Removed migration-window and encrypted sync flags stay unavailable and emit targeted JSON `error.hint` replacement guidance. | Removed command | `v015_removed_command_paths_keep_targeted_json_guidance` |
 
 ## Release Readiness
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,15 +65,15 @@ use output::{
     print_usage_signals_command_output, print_weekday_rules_command_output,
 };
 use parsing::{
-    finalize_cli_action, invalid_usage, parse_automation_triggers_value, parse_compare_by_value,
-    parse_compare_limit_value, parse_compare_profile_value, parse_compare_time_of_day_value,
-    parse_daemon_port, parse_daemon_port_option, parse_global_tokens, parse_goal_carry_value,
-    parse_goal_value, parse_history_dashboard_order_value, parse_history_kpi_card_id,
-    parse_monthly_goal_value, parse_primary_command, parse_profile_id, parse_schedule_value,
-    parse_site_edit_value, parse_status_comparison_options, parse_strict_value,
-    parse_task_goal_value, parse_theme_preset, parse_watch_interval_option,
-    parse_watch_interval_secs, parse_weekday_rules_value, parse_weekly_goal_value,
-    require_nonempty_key_value,
+    finalize_cli_action, first_removed_option_guidance, invalid_usage,
+    parse_automation_triggers_value, parse_compare_by_value, parse_compare_limit_value,
+    parse_compare_profile_value, parse_compare_time_of_day_value, parse_daemon_port,
+    parse_daemon_port_option, parse_global_tokens, parse_goal_carry_value, parse_goal_value,
+    parse_history_dashboard_order_value, parse_history_kpi_card_id, parse_monthly_goal_value,
+    parse_primary_command, parse_profile_id, parse_schedule_value, parse_site_edit_value,
+    parse_status_comparison_options, parse_strict_value, parse_task_goal_value, parse_theme_preset,
+    parse_watch_interval_option, parse_watch_interval_secs, parse_weekday_rules_value,
+    parse_weekly_goal_value, require_nonempty_key_value,
 };
 #[cfg(test)]
 use status::build_status_output;
@@ -239,6 +239,13 @@ Options:
   --calendar-sync  Refresh calendar busy-window cache from configured ICS feeds
   --export        Export stats to current directory or DIR
   --feature-inventory  Export feature inventory scoring report to current directory or DIR
+
+Retired/legacy command guidance:
+  --migrate, --dry-run       Use --config-migrate to preview config migrations or --config-migrate-apply to write a migrated config with backup
+  --sync-backup              Use --backup for local portable recovery workflows
+  --sync-restore             Use --restore for local portable recovery workflows
+  --sync-passphrase          No direct replacement; encrypted sync/backups are no longer supported
+
   --json          Emit machine-readable JSON output
   -h, --help      Show this help"#;
 
@@ -1223,8 +1230,13 @@ where
         })
         .collect::<Result<_, _>>()?;
     let tokens = classify_args(&args).map_err(|message| usage_error(output_hint, message))?;
-    let (show_help, output) =
-        parse_global_tokens(&tokens).map_err(|message| usage_error(output_hint, message))?;
+    let (show_help, output) = parse_global_tokens(&tokens).map_err(|message| {
+        if let Some(guidance) = first_removed_option_guidance(&tokens) {
+            usage_error_with_hint(output_hint, message, guidance.replacement)
+        } else {
+            usage_error(output_hint, message)
+        }
+    })?;
     let primary = parse_primary_command(&tokens).map_err(|message| usage_error(output, message))?;
     let daemon_port =
         parse_daemon_port_option(&tokens).map_err(|message| usage_error(output, message))?;
@@ -1279,6 +1291,17 @@ pub(crate) fn emit_cli_error(error: &CliError) -> Result<(), String> {
 
 fn usage_error(output: OutputMode, message: String) -> CliError {
     let message = UserMessage::usage(message);
+    CliError {
+        kind: CliErrorKind::Usage,
+        output,
+        code: message.code,
+        message: message.message,
+        hint: message.hint,
+    }
+}
+
+fn usage_error_with_hint(output: OutputMode, message: String, hint: impl Into<String>) -> CliError {
+    let message = UserMessage::with_hint("cli.usage", message, hint);
     CliError {
         kind: CliErrorKind::Usage,
         output,

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -124,29 +124,48 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
     Ok((show_help, output))
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct RemovedOptionGuidance {
+    pub(super) summary: &'static str,
+    pub(super) replacement: &'static str,
+}
+
+pub(super) fn first_removed_option_guidance(
+    tokens: &[ParsedToken],
+) -> Option<RemovedOptionGuidance> {
+    tokens.iter().find_map(|token| match token {
+        ParsedToken::UnknownOption(option) => removed_option_replacement_guidance(option),
+        _ => None,
+    })
+}
+
 fn unknown_option_message(option: &str) -> String {
     let guidance = removed_option_replacement_guidance(option);
     match guidance {
-        Some(guidance) => format!("Unknown option `{option}`. {guidance}"),
+        Some(guidance) => format!("Unknown option `{option}`. {}", guidance.summary),
         None => format!("Unknown option `{option}`."),
     }
 }
 
-fn removed_option_replacement_guidance(option: &str) -> Option<&'static str> {
+fn removed_option_replacement_guidance(option: &str) -> Option<RemovedOptionGuidance> {
     let flag = option.split('=').next().unwrap_or(option);
     match flag {
-        "--migrate" | "--dry-run" => Some(
-            "This migration-window flag was removed; use `--config-migrate` to preview config migrations.",
-        ),
-        "--sync-backup" => Some(
-            "Encrypted sync backups were removed; use `--backup` for local portable recovery workflows.",
-        ),
-        "--sync-restore" => Some(
-            "Encrypted sync restores were removed; use `--restore` for local portable recovery workflows.",
-        ),
-        "--sync-passphrase" => {
-            Some("Encrypted sync passphrases were removed and have no direct replacement.")
-        }
+        "--migrate" | "--dry-run" => Some(RemovedOptionGuidance {
+            summary: "This migration-window flag was removed.",
+            replacement: "Use `--config-migrate` to preview config migrations or `--config-migrate-apply` to write migrated config with a backup.",
+        }),
+        "--sync-backup" => Some(RemovedOptionGuidance {
+            summary: "Encrypted sync backups were removed.",
+            replacement: "Use `--backup` for local portable recovery workflows.",
+        }),
+        "--sync-restore" => Some(RemovedOptionGuidance {
+            summary: "Encrypted sync restores were removed.",
+            replacement: "Use `--restore` for local portable recovery workflows.",
+        }),
+        "--sync-passphrase" => Some(RemovedOptionGuidance {
+            summary: "Encrypted sync passphrases were removed.",
+            replacement: "no direct replacement is available because encrypted sync/backups are no longer supported.",
+        }),
         _ => None,
     }
 }

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -133,10 +133,16 @@ pub(super) struct RemovedOptionGuidance {
 pub(super) fn first_removed_option_guidance(
     tokens: &[ParsedToken],
 ) -> Option<RemovedOptionGuidance> {
-    tokens.iter().find_map(|token| match token {
-        ParsedToken::UnknownOption(option) => removed_option_replacement_guidance(option),
-        _ => None,
-    })
+    for token in tokens {
+        match token {
+            ParsedToken::UnknownOption(option) => {
+                return removed_option_replacement_guidance(option);
+            }
+            ParsedToken::Positional(_) => return None,
+            _ => {}
+        }
+    }
+    None
 }
 
 fn unknown_option_message(option: &str) -> String {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2119,6 +2119,20 @@ fn parse_with_contract_marks_json_usage_errors() {
 }
 
 #[test]
+fn parse_with_contract_adds_replacement_hint_for_removed_options() {
+    let error = parse_with_contract(&["--sync-restore", "--json"]).unwrap_err();
+    assert_eq!(error.kind, CliErrorKind::Usage);
+    assert_eq!(error.output, OutputMode::Json);
+    assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert_eq!(error.code, "cli.usage");
+    assert!(error.message.contains("Unknown option `--sync-restore`"));
+    assert_eq!(
+        error.hint.as_deref(),
+        Some("Use `--restore` for local portable recovery workflows.")
+    );
+}
+
+#[test]
 fn parse_with_contract_detects_json_on_early_parse_failures() {
     let error = parse_with_contract(&["--schedule-set", "--json"]).unwrap_err();
     assert_eq!(error.kind, CliErrorKind::Usage);

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2133,6 +2133,17 @@ fn parse_with_contract_adds_replacement_hint_for_removed_options() {
 }
 
 #[test]
+fn parse_with_contract_scopes_replacement_hint_to_first_unknown_option() {
+    let error = parse_with_contract(&["--unknown-flag", "--sync-restore", "--json"]).unwrap_err();
+    assert_eq!(error.kind, CliErrorKind::Usage);
+    assert_eq!(error.output, OutputMode::Json);
+    assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert_eq!(error.code, "cli.usage");
+    assert!(error.message.contains("Unknown option `--unknown-flag`"));
+    assert!(error.hint.is_none());
+}
+
+#[test]
 fn parse_with_contract_detects_json_on_early_parse_failures() {
     let error = parse_with_contract(&["--schedule-set", "--json"]).unwrap_err();
     assert_eq!(error.kind, CliErrorKind::Usage);

--- a/src/feature_inventory.rs
+++ b/src/feature_inventory.rs
@@ -464,6 +464,23 @@ const FEATURE_SEEDS: &[FeatureSeed] = &[
         failure_impact: 5,
     },
     FeatureSeed {
+        feature_id: "retired-low-value-command-guidance",
+        name: "Retired low-value command guidance",
+        surface: FeatureSurface::Integration,
+        description: "Keep retired migration-window and encrypted sync command paths mapped to supported replacement workflows.",
+        cli_flags: &[
+            "--migrate",
+            "--dry-run",
+            "--sync-backup",
+            "--sync-restore",
+            "--sync-passphrase",
+        ],
+        value: 1,
+        complexity: 4,
+        support_burden: 4,
+        failure_impact: 2,
+    },
+    FeatureSeed {
         feature_id: "daemon-api-lifecycle",
         name: "Daemon API lifecycle",
         surface: FeatureSurface::Integration,
@@ -1015,15 +1032,24 @@ mod tests {
     fn collect_usage_option_flags() -> HashSet<String> {
         crate::cli::usage_text()
             .lines()
-            .filter_map(|line| {
+            .flat_map(|line| {
                 let trimmed = line.trim_start();
                 if !trimmed.starts_with("--") {
-                    return None;
+                    return Vec::new();
                 }
 
-                let raw_flag = trimmed.split_whitespace().next()?;
-                let normalized = raw_flag.split('=').next().unwrap_or(raw_flag);
-                Some(normalized.to_string())
+                trimmed
+                    .split_whitespace()
+                    .take_while(|token| token.starts_with("--"))
+                    .map(|raw_flag| {
+                        raw_flag
+                            .trim_end_matches(',')
+                            .split('=')
+                            .next()
+                            .unwrap_or(raw_flag)
+                            .to_string()
+                    })
+                    .collect::<Vec<_>>()
             })
             .collect::<HashSet<_>>()
     }

--- a/tests/v014_regression_matrix.rs
+++ b/tests/v014_regression_matrix.rs
@@ -159,14 +159,17 @@ fn v014_removed_cli_surfaces_stay_retired_with_json_usage_errors() {
         let error_message = payload["error"]["message"]
             .as_str()
             .expect("error message should be a string");
+        let error_hint = payload["error"]["hint"]
+            .as_str()
+            .expect("removed flag error should include a replacement hint");
         assert!(
             error_message.contains(case.removed_flag),
             "removed flag {} should be named in its error",
             case.removed_flag
         );
         assert!(
-            error_message.contains(case.replacement_hint),
-            "removed flag {} should include replacement guidance `{}`",
+            error_hint.contains(case.replacement_hint),
+            "removed flag {} should include replacement hint `{}`",
             case.removed_flag,
             case.replacement_hint
         );

--- a/tests/v015_cleanup_regression.rs
+++ b/tests/v015_cleanup_regression.rs
@@ -251,15 +251,31 @@ fn v015_removed_command_paths_keep_targeted_json_guidance() {
         let message = payload["error"]["message"]
             .as_str()
             .expect("error message should be a string");
+        let hint = payload["error"]["hint"]
+            .as_str()
+            .expect("removed flag should include a replacement hint");
         assert!(
             message.contains(flag.split('=').next().unwrap_or(flag)),
             "removed flag should be named in its error: {message}"
         );
         assert!(
-            message.contains(replacement),
-            "removed flag should include replacement `{replacement}`: {message}"
+            hint.contains(replacement),
+            "removed flag should include replacement hint `{replacement}`: {hint}"
         );
     }
+}
+
+#[test]
+fn v015_removed_command_text_errors_keep_the_same_replacement_guidance() {
+    let env = TestEnv::new("removed-commands-text");
+
+    let output = env.run(&["--sync-backup"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = stderr_text(&output);
+    assert!(stderr.contains("Unknown option `--sync-backup`"));
+    assert!(stderr.contains("Hint: Use `--backup` for local portable recovery workflows."));
 }
 
 fn focustime_bin_path() -> PathBuf {


### PR DESCRIPTION
## What

Add targeted replacement guidance for retired low-value CLI paths by surfacing supported alternatives in text errors, JSON `error.hint`, CLI help, regression coverage, and cleanup docs.

Closes #438.

## Why

Deprecated and retired cleanup paths should consistently point users to supported workflows, so removed migration-window and encrypted sync command surfaces now share the same replacement guidance across CLI and documentation. 

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now reports retired/removed flags with clear replacement guidance, surfaced in both normal and JSON error outputs.

* **Documentation**
  * Docs updated to list retired CLI commands, recommended replacements, and the JSON error contract (pure JSON on failure; replacement guidance in error.hint).

* **Tests**
  * Added/updated tests to verify replacement guidance appears correctly in JSON and plain-text error flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->