### PR TITLE
Reduce usage-signal command surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Blocking preview diagnostics merge (#440):** moved backend-selected blocking preview details into the canonical `--diagnostics` output model and marked the standalone `--blocking-preview` path with replacement guidance.
+- **Usage-signal surface reduction (#441):** deprecated standalone `--usage-signals` output in favor of `--feature-inventory` cleanup reporting while keeping raw usage counts as internal cleanup inputs.
 - **Consolidated diagnostics workflow (#439):** expanded `--diagnostics` into the canonical setup/config health/migration guidance workflow while keeping focused config doctor and migration commands available.
 
 ## [0.15.1] - 2026-06-08

--- a/FEATURE_INVENTORY.json
+++ b/FEATURE_INVENTORY.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "scoring_model": {
     "score_min": 1,
     "score_max": 5,
@@ -141,6 +141,20 @@
       "--weekday-rules",
       "--weekday-rules-set"
     ]
+  },
+  "cleanup_signal_support": {
+    "retained_dimensions": [
+      "commands",
+      "screens"
+    ],
+    "retained_summary_fields": [
+      "total_events",
+      "unique_surfaces",
+      "top",
+      "rare"
+    ],
+    "deprecated_cli_flag": "--usage-signals",
+    "replacement_cli_flag": "--feature-inventory"
   },
   "features": [
     {
@@ -540,19 +554,19 @@
       "recommendation": "keep"
     },
     {
-      "feature_id": "usage-signal-inspection",
-      "name": "Usage signal inspection",
+      "feature_id": "usage-signal-cleanup-support",
+      "name": "Usage signal cleanup support",
       "surface": "stats",
-      "description": "Review command and screen frequency summaries to guide feature cleanup decisions.",
+      "description": "Keep command and screen frequency summaries available as internal inputs for feature cleanup and inventory decisions.",
       "cli_flags": [
         "--usage-signals"
       ],
       "value": 3,
       "complexity": 2,
-      "support_burden": 2,
-      "failure_impact": 2,
-      "maintenance_cost": 2.0,
-      "value_to_maintenance_ratio": 1.5,
+      "support_burden": 1,
+      "failure_impact": 1,
+      "maintenance_cost": 1.4,
+      "value_to_maintenance_ratio": 2.14,
       "recommendation": "merge"
     },
     {

--- a/FEATURE_INVENTORY.md
+++ b/FEATURE_INVENTORY.md
@@ -25,6 +25,13 @@
   - Stats: 7
   - Integration: 5
 
+## Cleanup signal support
+
+- Usage-signal dimensions retained: commands, screens
+- Usage-signal summary fields retained: total_events, unique_surfaces, top, rare
+- Deprecated standalone access: `--usage-signals`
+- Supported reporting workflow: `--feature-inventory`
+
 ## Release phase mapping (v0.14.x)
 
 - keep: Phase 1: Stabilize — Preserve and harden high-confidence capabilities throughout v0.14.x.
@@ -57,7 +64,7 @@
 | `stats-export-artifacts` | Stats | 4 | 2.65 | 1.51 | keep | --export |
 | `status-comparison-slicing` | Stats | 3 | 3.35 | 0.90 | merge | --compare-by, --compare-task, --compare-profile, --compare-time, --compare-limit |
 | `status-snapshot-and-streaming` | Stats | 5 | 3.65 | 1.37 | keep | --status, --watch |
-| `usage-signal-inspection` | Stats | 3 | 2.00 | 1.50 | merge | --usage-signals |
+| `usage-signal-cleanup-support` | Stats | 3 | 1.40 | 2.14 | merge | --usage-signals |
 | `calendar-busy-window-sync` | Integration | 3 | 3.75 | 0.80 | merge | --calendar-sync |
 | `daemon-api-lifecycle` | Integration | 3 | 4.25 | 0.71 | merge | --daemon-start, --daemon-status, --daemon-stop, --daemon-port |
 | `retired-low-value-command-guidance` | Integration | 1 | 3.50 | 0.29 | remove | --migrate, --dry-run, --sync-backup, --sync-restore, --sync-passphrase |

--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ cargo run -- --config-migrate-apply --json
 cargo run -- --blocking-preview
 cargo run -- --blocking-preview --json
 
+# Deprecated standalone usage-signal path; use --feature-inventory for cleanup reporting
+cargo run -- --usage-signals
+cargo run -- --usage-signals --json
+
 # Show status (text or JSON, including growth/retention signals, live timer/session fields, active temporary allowlist entries, latest interruption summary, and `selected_task_goal` in JSON)
 cargo run -- --status
 cargo run -- --status --json
@@ -340,6 +344,7 @@ Early deprecation notices:
 | Legacy timer duration fields (`focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval`) | Use `[custom_profile]`, profile presets, and `--profile`; run `--config-migrate` or `--config-migrate-apply` when stale keys are reported. |
 | Legacy automation and blocklist top-level fields | Use per-profile automation tables, `[[blocklist_profiles]]`, and `selected_blocklist_profile`; inspect with `--config-doctor`. |
 | Standalone blocking preview command (`--blocking-preview`) | Use `--diagnostics` for blocking preview details alongside setup/config health; older automation receives replacement guidance. |
+| Standalone usage-signal command (`--usage-signals`) | Use `--feature-inventory` for cleanup reporting; raw command/screen frequency summaries remain internal cleanup inputs. |
 | Removed migration-window flags (`--migrate`, `--dry-run`) | Use `--config-migrate` to preview config changes and `--config-migrate-apply` to write migrated config with a backup. |
 | Retired encrypted sync flags (`--sync-backup`, `--sync-restore`, `--sync-passphrase`) | Use `--backup` and `--restore` for local portable recovery; there is no direct passphrase replacement because encrypted sync is retired. |
 | Duplicate schedule/session start entry points | Select the task/profile/blocklist/schedule or apply a session template, then start focus through the unified timer flow with `--start` or the TUI. |
@@ -787,6 +792,11 @@ focustime --diagnostics --json
 The standalone `focustime --blocking-preview` path remains as deprecated
 replacement-guided output for older automation; new scripts should read the
 `blocking_preview` section from `focustime --diagnostics --json`.
+
+The standalone `focustime --usage-signals` path remains as deprecated
+replacement-guided output for older automation; cleanup scripts should use
+`focustime --feature-inventory --json` and treat raw usage-signal summaries as
+internal cleanup inputs.
 
 Blocking backend policy is deterministic:
 

--- a/REGRESSION_MATRIX.md
+++ b/REGRESSION_MATRIX.md
@@ -29,6 +29,7 @@ in the normal release readiness command set.
 | v0.15.1 | Removed migration-window and encrypted sync flags stay unavailable and emit targeted JSON `error.hint` replacement guidance. | Removed command | `v015_removed_command_paths_keep_targeted_json_guidance` |
 | Unreleased | Setup diagnostics, config doctor, and migration preview guidance stay available from one canonical CLI diagnostics workflow. | Config diagnostics | `diagnostics_output_includes_config_health_and_migration_guidance` |
 | Unreleased | Backend-selected blocking preview details are available from `--diagnostics`, while standalone preview output points to the canonical replacement. | Blocking diagnostics | `diagnostics_json_includes_blocking_preview_payload` plus `blocking_preview_json_emits_payload_on_stdout` |
+| Unreleased | Raw usage-signal inspection stays deprecated and points cleanup/reporting workflows to feature inventory output. | Usage cleanup | `usage_signals_json_emits_deprecated_replacement_payload` plus committed feature inventory coverage |
 
 ## Release Readiness
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,8 +23,7 @@ use crate::session_recovery;
 use crate::stats::{
     ComparisonDimension, DailyGoalSnapshot, FocusRiskForecast, FocusStats,
     ProductivityComparisonRow, ProfileBucket, SessionInterruptionEvent, StatsGrowthSummary,
-    StatsRetentionPruneResult, TimeOfDayBucket, UsageSignalsSummary, carry_over_goal_target,
-    current_day_key,
+    StatsRetentionPruneResult, TimeOfDayBucket, carry_over_goal_target, current_day_key,
 };
 use crate::timer::{
     DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL, DEFAULT_LONG_BREAK_SECS,
@@ -156,7 +155,6 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --config-migrate-apply [--json]
   focustime --diagnostics [--json]
   focustime --blocking-preview [--json]
-  focustime --usage-signals [--json]
   focustime --status [--watch[=SECONDS]] [--compare-by=task|profile|time-of-day] [--compare-task=LABEL|all] [--compare-profile=basic|standard|advanced|unknown|all] [--compare-time=morning|afternoon|evening|night|unknown|all] [--compare-limit=N] [--json]
   focustime --backup[=DIR] [--json]
   focustime --restore[=DIR] [--json]
@@ -227,7 +225,6 @@ Options:
   --config-migrate-apply  Apply config migration assistant changes and write migrated config.toml
   --diagnostics   Show setup diagnostics, blocking preview details, config health, and migration guidance
   --blocking-preview  Deprecated: use --diagnostics to preview backend-selected blocking changes without writing
-  --usage-signals  Show local command/screen usage summary (top + rare surfaces)
   --status        Print status summary (includes live timer/session fields and latest interruption)
   --watch         Stream periodic status updates (status command only; default 1s)
   --compare-by    Status comparison dimension: task | profile | time-of-day
@@ -243,12 +240,15 @@ Options:
 
 Retired/legacy command guidance:
   --migrate, --dry-run       Use --config-migrate to preview config migrations or --config-migrate-apply to write a migrated config with backup
+  --usage-signals            Deprecated: use --feature-inventory for cleanup reporting; raw usage-signal inspection is no longer a standalone workflow
   --sync-backup              Use --backup for local portable recovery workflows
   --sync-restore             Use --restore for local portable recovery workflows
   --sync-passphrase          No direct replacement; encrypted sync/backups are no longer supported
 
   --json          Emit machine-readable JSON output
   -h, --help      Show this help"#;
+
+const USAGE_SIGNALS_REPLACEMENT: &str = "Use `focustime --feature-inventory` for cleanup reporting; raw usage-signal inspection is no longer a standalone workflow.";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OutputMode {
@@ -1157,7 +1157,8 @@ struct HistoryDashboardCommandOutput {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct UsageSignalsCommandOutput {
     action: &'static str,
-    summary: UsageSignalsSummary,
+    deprecated: bool,
+    replacement: &'static str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/cli/execute/diagnostics.rs
+++ b/src/cli/execute/diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 use crate::cli::{
-    AppConfig, FocusStats, OutputMode, UsageSignalsCommandOutput,
+    OutputMode, USAGE_SIGNALS_REPLACEMENT, UsageSignalsCommandOutput,
     build_blocking_preview_command_output, build_diagnostics_blocking_preview_error,
     build_diagnostics_blocking_preview_output, build_diagnostics_command_output,
     print_blocking_preview_command_output, print_config_doctor_output,
@@ -10,9 +10,6 @@ use crate::cli::{
 use crate::config::{run_config_doctor, run_config_migration_assistant};
 use crate::error::UserMessage;
 
-use super::data::stats_load_options;
-
-const USAGE_SIGNAL_SUMMARY_LIMIT: usize = 5;
 pub(super) fn execute_config_doctor_command(output: OutputMode) -> Result<(), String> {
     let payload = run_config_doctor();
     match output {
@@ -71,12 +68,10 @@ pub(super) fn execute_blocking_preview_command(output: OutputMode) -> Result<(),
 }
 
 pub(super) fn execute_usage_signals_command(output: OutputMode) -> Result<(), String> {
-    let config = AppConfig::load().normalized();
-    let stats = FocusStats::load_with_options(stats_load_options(&config))
-        .map_err(|error| format!("Failed to load stats: {error}"))?;
     let payload = UsageSignalsCommandOutput {
         action: "usage-signals",
-        summary: stats.usage_signal_summary(USAGE_SIGNAL_SUMMARY_LIMIT),
+        deprecated: true,
+        replacement: USAGE_SIGNALS_REPLACEMENT,
     };
     match output {
         OutputMode::Text => print_usage_signals_command_output(&payload),

--- a/src/cli/output/sites.rs
+++ b/src/cli/output/sites.rs
@@ -109,38 +109,8 @@ pub(in crate::cli) fn print_history_dashboard_command_output(
 }
 
 pub(in crate::cli) fn print_usage_signals_command_output(payload: &UsageSignalsCommandOutput) {
-    println!("Usage signals summary:");
-    print_usage_signal_summary("Commands", &payload.summary.commands);
-    print_usage_signal_summary("Screens", &payload.summary.screens);
-}
-
-fn print_usage_signal_summary(label: &str, summary: &crate::stats::UsageSignalSummary) {
-    println!(
-        "{label}: {} events across {} surface(s)",
-        summary.total_events, summary.unique_surfaces
-    );
-    if summary.top.is_empty() {
-        println!("  Top: none");
-    } else {
-        println!("  Top:");
-        for entry in &summary.top {
-            println!(
-                "    - {}: {} ({}%)",
-                entry.surface, entry.count, entry.share_pct
-            );
-        }
-    }
-    if summary.rare.is_empty() {
-        println!("  Rare: none");
-    } else {
-        println!("  Rare:");
-        for entry in &summary.rare {
-            println!(
-                "    - {}: {} ({}%)",
-                entry.surface, entry.count, entry.share_pct
-            );
-        }
-    }
+    println!("Deprecated command: --usage-signals");
+    println!("Replacement: {}", payload.replacement);
 }
 
 pub(in crate::cli) fn print_site_list_command_output(payload: &SiteListCommandOutput) {

--- a/src/cli/output/sites.rs
+++ b/src/cli/output/sites.rs
@@ -1,3 +1,5 @@
+use std::io::{self, Write};
+
 use crate::cli::{
     BlocklistCategoryCommandOutput, BlocklistProfileCommandOutput, HistoryDashboardCommandOutput,
     SessionTemplateCommandOutput, SiteAddCommandOutput, SiteDeleteCommandOutput,
@@ -109,8 +111,17 @@ pub(in crate::cli) fn print_history_dashboard_command_output(
 }
 
 pub(in crate::cli) fn print_usage_signals_command_output(payload: &UsageSignalsCommandOutput) {
-    println!("Deprecated command: --usage-signals");
-    println!("Replacement: {}", payload.replacement);
+    let mut stdout = io::stdout().lock();
+    write_usage_signals_command_output(&mut stdout, payload)
+        .expect("failed to write usage-signals command output");
+}
+
+fn write_usage_signals_command_output(
+    writer: &mut impl Write,
+    payload: &UsageSignalsCommandOutput,
+) -> io::Result<()> {
+    writeln!(writer, "Deprecated command: --usage-signals")?;
+    writeln!(writer, "Replacement: {}", payload.replacement)
 }
 
 pub(in crate::cli) fn print_site_list_command_output(payload: &SiteListCommandOutput) {
@@ -246,4 +257,27 @@ pub(in crate::cli) fn print_site_delete_command_output(payload: &SiteDeleteComma
         "Effective blocked sites: {}",
         payload.effective_blocked_sites_count
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli::{USAGE_SIGNALS_REPLACEMENT, UsageSignalsCommandOutput};
+
+    use super::write_usage_signals_command_output;
+
+    #[test]
+    fn usage_signals_text_output_includes_deprecation_replacement_lines() {
+        let payload = UsageSignalsCommandOutput {
+            action: "usage-signals",
+            deprecated: true,
+            replacement: USAGE_SIGNALS_REPLACEMENT,
+        };
+        let mut output = Vec::new();
+
+        write_usage_signals_command_output(&mut output, &payload).unwrap();
+
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("Deprecated command: --usage-signals\n"));
+        assert!(text.contains(&format!("Replacement: {}\n", USAGE_SIGNALS_REPLACEMENT)));
+    }
 }

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -125,6 +125,26 @@ fn parse_usage_signals_supports_json_mode() {
 }
 
 #[test]
+fn usage_signals_json_emits_deprecated_replacement_payload() {
+    let payload = UsageSignalsCommandOutput {
+        action: "usage-signals",
+        deprecated: true,
+        replacement: USAGE_SIGNALS_REPLACEMENT,
+    };
+
+    assert_eq!(payload.action, "usage-signals");
+    assert!(payload.deprecated);
+    assert_eq!(
+        payload.replacement,
+        "Use `focustime --feature-inventory` for cleanup reporting; raw usage-signal inspection is no longer a standalone workflow."
+    );
+    let json = serde_json::to_value(&payload).unwrap();
+    assert_eq!(json["deprecated"], true);
+    assert_eq!(json["replacement"], payload.replacement);
+    assert!(json.get("summary").is_none());
+}
+
+#[test]
 fn parse_status_watch_without_interval_uses_default_cadence() {
     let parsed = parse(&["--status", "--watch"]).unwrap();
     assert_eq!(

--- a/src/feature_inventory.rs
+++ b/src/feature_inventory.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 pub(crate) const FEATURE_INVENTORY_JSON_FILE_NAME: &str = "FEATURE_INVENTORY.json";
 pub(crate) const FEATURE_INVENTORY_MARKDOWN_FILE_NAME: &str = "FEATURE_INVENTORY.md";
 
-const SCHEMA_VERSION: u8 = 4;
+const SCHEMA_VERSION: u8 = 5;
 const COMPLEXITY_WEIGHT: f64 = 0.40;
 const SUPPORT_BURDEN_WEIGHT: f64 = 0.35;
 const FAILURE_IMPACT_WEIGHT: f64 = 0.25;
@@ -77,6 +77,7 @@ pub(crate) struct FeatureInventoryReport {
     pub(crate) schema_version: u8,
     pub(crate) scoring_model: FeatureScoringModel,
     pub(crate) summary: FeatureInventorySummary,
+    pub(crate) cleanup_signal_support: UsageSignalCleanupSupport,
     pub(crate) features: Vec<FeatureInventoryEntry>,
 }
 
@@ -122,6 +123,14 @@ pub(crate) struct FeatureInventorySummary {
 pub(crate) struct SurfaceSummary {
     pub(crate) surface: FeatureSurface,
     pub(crate) feature_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct UsageSignalCleanupSupport {
+    pub(crate) retained_dimensions: Vec<&'static str>,
+    pub(crate) retained_summary_fields: Vec<&'static str>,
+    pub(crate) deprecated_cli_flag: &'static str,
+    pub(crate) replacement_cli_flag: &'static str,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -420,15 +429,15 @@ const FEATURE_SEEDS: &[FeatureSeed] = &[
         failure_impact: 2,
     },
     FeatureSeed {
-        feature_id: "usage-signal-inspection",
-        name: "Usage signal inspection",
+        feature_id: "usage-signal-cleanup-support",
+        name: "Usage signal cleanup support",
         surface: FeatureSurface::Stats,
-        description: "Review command and screen frequency summaries to guide feature cleanup decisions.",
+        description: "Keep command and screen frequency summaries available as internal inputs for feature cleanup and inventory decisions.",
         cli_flags: &["--usage-signals"],
         value: 3,
         complexity: 2,
-        support_burden: 2,
-        failure_impact: 2,
+        support_burden: 1,
+        failure_impact: 1,
     },
     FeatureSeed {
         feature_id: "stats-export-artifacts",
@@ -574,7 +583,17 @@ pub(crate) fn build_feature_inventory_report_for_version(
             release_phase_mapping: build_release_phase_mapping(),
         },
         summary,
+        cleanup_signal_support: build_usage_signal_cleanup_support(),
         features,
+    }
+}
+
+fn build_usage_signal_cleanup_support() -> UsageSignalCleanupSupport {
+    UsageSignalCleanupSupport {
+        retained_dimensions: vec!["commands", "screens"],
+        retained_summary_fields: vec!["total_events", "unique_surfaces", "top", "rare"],
+        deprecated_cli_flag: "--usage-signals",
+        replacement_cli_flag: "--feature-inventory",
     }
 }
 
@@ -653,6 +672,25 @@ pub(crate) fn render_markdown_report(report: &FeatureInventoryReport) -> String 
         ));
     }
     markdown.push('\n');
+
+    let cleanup = &report.cleanup_signal_support;
+    markdown.push_str("## Cleanup signal support\n\n");
+    markdown.push_str(&format!(
+        "- Usage-signal dimensions retained: {}\n",
+        cleanup.retained_dimensions.join(", ")
+    ));
+    markdown.push_str(&format!(
+        "- Usage-signal summary fields retained: {}\n",
+        cleanup.retained_summary_fields.join(", ")
+    ));
+    markdown.push_str(&format!(
+        "- Deprecated standalone access: `{}`\n",
+        cleanup.deprecated_cli_flag
+    ));
+    markdown.push_str(&format!(
+        "- Supported reporting workflow: `{}`\n\n",
+        cleanup.replacement_cli_flag
+    ));
 
     markdown.push_str("## Release phase mapping (v0.14.x)\n\n");
     for mapping in &report.scoring_model.release_phase_mapping {
@@ -846,7 +884,7 @@ mod tests {
 
     #[test]
     fn schema_version_tracks_rubric_contract() {
-        assert_eq!(SCHEMA_VERSION, 4);
+        assert_eq!(SCHEMA_VERSION, 5);
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -437,6 +437,7 @@ impl StatsRetentionPruneResult {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct UsageSignalEntry {
     pub(crate) surface: String,
@@ -444,6 +445,7 @@ pub(crate) struct UsageSignalEntry {
     pub(crate) share_pct: u8,
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct UsageSignalSummary {
     pub(crate) total_events: u64,
@@ -452,6 +454,7 @@ pub(crate) struct UsageSignalSummary {
     pub(crate) rare: Vec<UsageSignalEntry>,
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct UsageSignalsSummary {
     pub(crate) commands: UsageSignalSummary,

--- a/src/stats/analytics.rs
+++ b/src/stats/analytics.rs
@@ -795,6 +795,7 @@ impl FocusStats {
         cloned.apply_retention_policy(retention, reference_day)
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn usage_signal_summary(&self, limit: usize) -> UsageSignalsSummary {
         let limit = limit.max(1);
         UsageSignalsSummary {

--- a/src/stats/analytics/support.rs
+++ b/src/stats/analytics/support.rs
@@ -3,6 +3,7 @@ use crate::stats::{
     parse_week_label, percentage_round_nearest,
 };
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn usage_signal_summary_for_counts(
     counts: &BTreeMap<String, u64>,
     limit: usize,
@@ -29,6 +30,7 @@ pub(super) fn usage_signal_summary_for_counts(
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 fn usage_signal_rows(entries: Vec<(String, u64)>, total_events: u64) -> Vec<UsageSignalEntry> {
     entries
         .into_iter()

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -655,7 +655,20 @@ fn feature_inventory_json_exports_scored_report_artifacts() {
             .expect("failed to read exported feature inventory JSON"),
     )
     .expect("feature inventory export JSON should parse");
-    assert_eq!(inventory_payload["schema_version"], 4);
+    assert_eq!(inventory_payload["schema_version"], 5);
+    assert_eq!(
+        inventory_payload["cleanup_signal_support"]["deprecated_cli_flag"],
+        "--usage-signals"
+    );
+    assert_eq!(
+        inventory_payload["cleanup_signal_support"]["replacement_cli_flag"],
+        "--feature-inventory"
+    );
+    assert!(
+        inventory_payload["cleanup_signal_support"]["retained_dimensions"]
+            .as_array()
+            .is_some_and(|dimensions| dimensions.iter().any(|dimension| dimension == "commands"))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Deprecates the standalone `--usage-signals` command output, keeps usage-signal summaries as internal cleanup inputs, and routes cleanup/reporting guidance through `--feature-inventory`.

Closes #441.

## Why

The usage-signal surface should support cleanup and feature-inventory decisions without remaining a broad user-facing inspection command.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and README to deprecate the standalone --usage-signals path and map it to --feature-inventory for cleanup reporting.

* **New Features**
  * Feature inventory now declares "cleanup signal support" and lists retained usage-signal dimensions/summary fields.

* **Changed**
  * The --usage-signals command now emits a deprecation/replacement notice (text and JSON) directing users to --feature-inventory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->