### PR TITLE
Prepare v0.15.2 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.15.1 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.15.2 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -117,7 +117,7 @@ When preparing a release update, keep these files aligned:
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
 - `REGRESSION_MATRIX.md` merged/deprecated/removed feature-path coverage and supported replacement behavior
-- Release tag examples in docs use the current target release version (for example, `v0.15.1`)
+- Release tag examples in docs use the current target release version (for example, `v0.15.2`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,5 +148,5 @@ sequenceDiagram
   owns it.
 - For release docs updates, keep architecture-facing terminology aligned with the
   module names and responsibility language used in `README.md`, `CHANGELOG.md`,
-  and release tag examples in contributor-facing docs (for example, `v0.15.1`
+  and release tag examples in contributor-facing docs (for example, `v0.15.2`
   for this release cycle).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-06-10
+
 ### Changed
 
 - **Blocking preview diagnostics merge (#440):** moved backend-selected blocking preview details into the canonical `--diagnostics` output model and marked the standalone `--blocking-preview` path with replacement guidance.
@@ -442,7 +444,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.15.1...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.15.2...HEAD
+[0.15.2]: https://github.com/utilForever/focustime/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/utilForever/focustime/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/utilForever/focustime/compare/v0.14.4...v0.15.0
 [0.14.4]: https://github.com/utilForever/focustime/compare/v0.14.3...v0.14.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ For v0.15.x cleanup releases, also keep the README roadmap, changelog entry, and
 deprecation notices aligned so every deprecated or retired path names supported
 replacement behavior before the tag is created.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.15.1`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.15.2`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Milestone policy:
 
 - **v0.10.x migration window:** warning-only window with migration tooling (`--migrate`, `--backup`, `--restore`)
 - **v0.11.0+:** retired temporary migration-only CLI compatibility flags (`--migrate`, `--dry-run`); `--backup`/`--restore` remain supported.
-- **Unreleased/main branch:** consolidated diagnostics are available through `--diagnostics`; config migration assistant + doctor commands remain available for focused config checks (`--config-migrate`, `--config-migrate-apply`, `--config-doctor`).
+- **v0.15.2:** consolidated diagnostics are available through `--diagnostics`; config migration assistant + doctor commands remain available for focused config checks (`--config-migrate`, `--config-migrate-apply`, `--config-doctor`).
 - **v0.12.0:** remove legacy field/path compatibility after the warning window
 
 ### v0.15.x cleanup roadmap
@@ -1028,12 +1028,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.15.1`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.15.2`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.15.1](https://github.com/utilForever/focustime/releases/tag/v0.15.1).
+The latest stable release is [v0.15.2](https://github.com/utilForever/focustime/releases/tag/v0.15.2).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/REGRESSION_MATRIX.md
+++ b/REGRESSION_MATRIX.md
@@ -27,9 +27,9 @@ in the normal release readiness command set.
 | v0.15.1 | Deprecated config compatibility fields stay visible in diagnostics with canonical replacement guidance. | Config diagnostics | `v015_deprecated_config_paths_report_supported_replacements` |
 | v0.15.1 | Merged legacy profile names continue to migrate to canonical presets (`basic`, `standard`, `advanced`). | Config migration | `v015_merged_profile_paths_keep_migration_guidance` |
 | v0.15.1 | Removed migration-window and encrypted sync flags stay unavailable and emit targeted JSON `error.hint` replacement guidance. | Removed command | `v015_removed_command_paths_keep_targeted_json_guidance` |
-| Unreleased | Setup diagnostics, config doctor, and migration preview guidance stay available from one canonical CLI diagnostics workflow. | Config diagnostics | `diagnostics_output_includes_config_health_and_migration_guidance` |
-| Unreleased | Backend-selected blocking preview details are available from `--diagnostics`, while standalone preview output points to the canonical replacement. | Blocking diagnostics | `diagnostics_json_includes_blocking_preview_payload` plus `blocking_preview_json_emits_payload_on_stdout` |
-| Unreleased | Raw usage-signal inspection stays deprecated and points cleanup/reporting workflows to feature inventory output. | Usage cleanup | `usage_signals_json_emits_deprecated_replacement_payload` plus committed feature inventory coverage |
+| v0.15.2 | Setup diagnostics, config doctor, and migration preview guidance stay available from one canonical CLI diagnostics workflow. | Config diagnostics | `diagnostics_output_includes_config_health_and_migration_guidance` |
+| v0.15.2 | Backend-selected blocking preview details are available from `--diagnostics`, while standalone preview output points to the canonical replacement. | Blocking diagnostics | `diagnostics_json_includes_blocking_preview_payload` plus `blocking_preview_json_emits_payload_on_stdout` |
+| v0.15.2 | Raw usage-signal inspection stays deprecated and points cleanup/reporting workflows to feature inventory output. | Usage cleanup | `usage_signals_json_emits_deprecated_replacement_payload` plus committed feature inventory coverage |
 
 ## Release Readiness
 


### PR DESCRIPTION
## What

Prepare the v0.15.2 release by bumping the package version, promoting the current changelog entries into a dated release section, and aligning release-facing documentation and regression matrix references.

Closes #462.

## Why

This completes the release documentation checklist for #462 and keeps the package metadata, changelog compare links, latest-release references, and cleanup regression coverage aligned for the v0.15.2 tag.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to v0.15.2.

* **Documentation**
  * Updated release examples and documentation across multiple files to reflect v0.15.2.
  * Updated regression matrix to reflect v0.15.2 diagnostics coverage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->