### PR TITLE
Consolidate artifact workflow handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Artifact workflow handling (#450):** consolidated backup, stats export, and feature-inventory target-directory handling while preserving existing JSON path fields and text output labels.
 - **Focus History dashboard simplification (#448):** replaced customizable KPI card pin/order state with the stable default dashboard layout, kept deprecated dashboard customization CLI commands as guidance-only compatibility paths, and stopped persisting `[history_dashboard]` config.
 - **Core site rule cleanup (#447):** simplified blocklist/allowlist site CRUD to operate directly on profile-level site rules, removed category controls from the TUI site manager, and kept deprecated category workflows isolated to CLI/config compatibility paths.
 - **Temporary override consolidation (#446):** mapped temporary allowlist exceptions and break-glass controls into one runtime recovery/status model while keeping existing command paths and legacy status fields compatible.

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ cargo run -- --feature-inventory=./reports --json
 
 Backup/restore behavior:
 
+- `--backup`, `--export`, and `--feature-inventory` share the same target-directory handling: omitted directories use the current working directory and explicit targets are created before artifact files are written.
 - `--backup` creates the target directory if needed, then copies `config.toml` and `stats.toml` into it.
 - `--restore` requires both files in the source directory and uses staged replacement so failed restores roll back to the original files.
 - Runtime persistence is canonical-path only; if only legacy `stats.toml` exists, copy it to the canonical stats path (the backup/restore commands can help).

--- a/REGRESSION_MATRIX.md
+++ b/REGRESSION_MATRIX.md
@@ -38,6 +38,7 @@ in the normal release readiness command set.
 | v0.15.4 | Temporary allowlist and break-glass workflows share one temporary override runtime model while legacy fields remain readable for compatibility. | Blocking/runtime cleanup | `app_restores_temporary_overrides_from_canonical_snapshot` plus `build_status_output_includes_break_glass_temporary_override` |
 | v0.15.4 | Focus History uses a stable default KPI layout while deprecated dashboard pin, unpin, and order commands report guidance without persisting customization state. | Stats cleanup | `history_dashboard_uses_stable_default_layout_despite_legacy_customization` plus `apply_history_dashboard_pin_is_deprecated_and_keeps_default_layout` |
 | v0.15.4 | Status comparison CLI flags stay retired from `--status` and point users to export artifacts or Focus History reports. | Stats cleanup | `parse_rejects_status_comparison_options_with_export_replacement` plus `parse_rejects_equals_status_comparison_options_with_export_replacement` |
+| v0.15.4 | Backup, stats export, and feature-inventory artifact workflows share target-directory creation and JSON path contract behavior. | Artifact cleanup | `artifact_workflows_json_create_target_dirs_and_preserve_path_fields` plus `artifact_workflows_json_report_consistent_target_directory_errors` |
 
 ## Release Readiness
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -285,46 +285,57 @@ fn classify_task_note_arg(args: &[String], index: usize) -> Result<(ParsedToken,
 }
 
 fn classify_export_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
-    if let Some(next) = args.get(index + 1)
-        && !next.starts_with('-')
-    {
-        return Ok((ParsedToken::Export(Some(PathBuf::from(next))), 2));
-    }
-    Ok((ParsedToken::Export(None), 1))
+    classify_optional_artifact_path_arg(
+        args,
+        index,
+        ParsedToken::Export,
+        "`--export` requires a target directory.",
+    )
 }
 
 fn classify_feature_inventory_arg(
     args: &[String],
     index: usize,
 ) -> Result<(ParsedToken, usize), String> {
-    if let Some(next) = args.get(index + 1)
-        && !next.starts_with('-')
-    {
-        let value =
-            require_nonempty_key_value(next, "`--feature-inventory` requires a target directory.")?;
-        return Ok((ParsedToken::FeatureInventory(Some(PathBuf::from(value))), 2));
-    }
-    Ok((ParsedToken::FeatureInventory(None), 1))
+    classify_optional_artifact_path_arg(
+        args,
+        index,
+        ParsedToken::FeatureInventory,
+        "`--feature-inventory` requires a target directory.",
+    )
 }
 
 fn classify_backup_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
-    if let Some(next) = args.get(index + 1)
-        && !next.starts_with('-')
-    {
-        let value = require_nonempty_key_value(next, "`--backup` requires a target directory.")?;
-        return Ok((ParsedToken::Backup(Some(PathBuf::from(value))), 2));
-    }
-    Ok((ParsedToken::Backup(None), 1))
+    classify_optional_artifact_path_arg(
+        args,
+        index,
+        ParsedToken::Backup,
+        "`--backup` requires a target directory.",
+    )
 }
 
 fn classify_restore_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
+    classify_optional_artifact_path_arg(
+        args,
+        index,
+        ParsedToken::Restore,
+        "`--restore` requires a source directory.",
+    )
+}
+
+fn classify_optional_artifact_path_arg(
+    args: &[String],
+    index: usize,
+    token: fn(Option<PathBuf>) -> ParsedToken,
+    empty_value_message: &'static str,
+) -> Result<(ParsedToken, usize), String> {
     if let Some(next) = args.get(index + 1)
         && !next.starts_with('-')
     {
-        let value = require_nonempty_key_value(next, "`--restore` requires a source directory.")?;
-        return Ok((ParsedToken::Restore(Some(PathBuf::from(value))), 2));
+        let value = require_nonempty_key_value(next, empty_value_message)?;
+        return Ok((token(Some(PathBuf::from(value))), 2));
     }
-    Ok((ParsedToken::Restore(None), 1))
+    Ok((token(None), 1))
 }
 
 fn classify_watch_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {

--- a/src/cli/args/key_value.rs
+++ b/src/cli/args/key_value.rs
@@ -235,38 +235,50 @@ fn parse_automation_triggers_set_key_value_arg(arg: &str) -> Result<Option<Parse
 }
 
 fn parse_export_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    if let Some(value) = arg.strip_prefix("--export=") {
-        let value = require_nonempty_key_value(value, "`--export=` requires a target directory.")?;
-        return Ok(Some(ParsedToken::Export(Some(PathBuf::from(value)))));
-    }
-    Ok(None)
+    parse_artifact_key_value_arg(
+        arg,
+        "--export=",
+        ParsedToken::Export,
+        "`--export=` requires a target directory.",
+    )
 }
 
 fn parse_feature_inventory_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    if let Some(value) = arg.strip_prefix("--feature-inventory=") {
-        let value = require_nonempty_key_value(
-            value,
-            "`--feature-inventory=` requires a target directory.",
-        )?;
-        return Ok(Some(ParsedToken::FeatureInventory(Some(PathBuf::from(
-            value,
-        )))));
-    }
-    Ok(None)
+    parse_artifact_key_value_arg(
+        arg,
+        "--feature-inventory=",
+        ParsedToken::FeatureInventory,
+        "`--feature-inventory=` requires a target directory.",
+    )
 }
 
 fn parse_backup_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    if let Some(value) = arg.strip_prefix("--backup=") {
-        let value = require_nonempty_key_value(value, "`--backup=` requires a target directory.")?;
-        return Ok(Some(ParsedToken::Backup(Some(PathBuf::from(value)))));
-    }
-    Ok(None)
+    parse_artifact_key_value_arg(
+        arg,
+        "--backup=",
+        ParsedToken::Backup,
+        "`--backup=` requires a target directory.",
+    )
 }
 
 fn parse_restore_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    if let Some(value) = arg.strip_prefix("--restore=") {
-        let value = require_nonempty_key_value(value, "`--restore=` requires a source directory.")?;
-        return Ok(Some(ParsedToken::Restore(Some(PathBuf::from(value)))));
+    parse_artifact_key_value_arg(
+        arg,
+        "--restore=",
+        ParsedToken::Restore,
+        "`--restore=` requires a source directory.",
+    )
+}
+
+fn parse_artifact_key_value_arg(
+    arg: &str,
+    prefix: &'static str,
+    token: fn(Option<PathBuf>) -> ParsedToken,
+    empty_value_message: &'static str,
+) -> Result<Option<ParsedToken>, String> {
+    if let Some(value) = arg.strip_prefix(prefix) {
+        let value = require_nonempty_key_value(value, empty_value_message)?;
+        return Ok(Some(token(Some(PathBuf::from(value)))));
     }
     Ok(None)
 }

--- a/src/cli/execute/data.rs
+++ b/src/cli/execute/data.rs
@@ -10,6 +10,35 @@ use crate::feature_inventory::{build_feature_inventory_report, export_feature_in
 
 const CONFIG_FILE_NAME: &str = "config.toml";
 const STATS_FILE_NAME: &str = "stats.toml";
+
+#[derive(Clone, Copy)]
+struct ArtifactDirectoryWorkflow {
+    name: &'static str,
+    role: &'static str,
+    create: bool,
+}
+
+const EXPORT_ARTIFACTS: ArtifactDirectoryWorkflow = ArtifactDirectoryWorkflow {
+    name: "Export",
+    role: "target",
+    create: true,
+};
+const FEATURE_INVENTORY_ARTIFACTS: ArtifactDirectoryWorkflow = ArtifactDirectoryWorkflow {
+    name: "Feature inventory export",
+    role: "target",
+    create: true,
+};
+const BACKUP_ARTIFACTS: ArtifactDirectoryWorkflow = ArtifactDirectoryWorkflow {
+    name: "Backup",
+    role: "target",
+    create: true,
+};
+const RESTORE_ARTIFACTS: ArtifactDirectoryWorkflow = ArtifactDirectoryWorkflow {
+    name: "Restore",
+    role: "source",
+    create: false,
+};
+
 pub(super) fn execute_export_command(
     dir: Option<PathBuf>,
     output: OutputMode,
@@ -18,11 +47,7 @@ pub(super) fn execute_export_command(
     let stats = FocusStats::load_with_options(stats_load_options(&config))
         .map_err(|error| format!("Failed to load stats: {error}"))?;
     let history_kpi_context = build_history_kpi_export_context(&config);
-    let target_dir = match dir {
-        Some(path) => path,
-        None => env::current_dir()
-            .map_err(|error| format!("Failed to determine current directory: {error}"))?,
-    };
+    let target_dir = resolve_artifact_directory(dir, EXPORT_ARTIFACTS)?;
     let exported = stats
         .export_to_dir_with_context(&target_dir, &history_kpi_context)
         .map_err(|error| format!("Export failed: {error}"))?;
@@ -43,11 +68,7 @@ pub(super) fn execute_feature_inventory_command(
     dir: Option<PathBuf>,
     output: OutputMode,
 ) -> Result<(), String> {
-    let target_dir = match dir {
-        Some(path) => path,
-        None => env::current_dir()
-            .map_err(|error| format!("Failed to determine current directory: {error}"))?,
-    };
+    let target_dir = resolve_artifact_directory(dir, FEATURE_INVENTORY_ARTIFACTS)?;
 
     let report = build_feature_inventory_report();
     let exported = export_feature_inventory_report(&target_dir, &report)
@@ -102,14 +123,7 @@ pub(super) fn execute_backup_command(
     output: OutputMode,
 ) -> Result<(), String> {
     let _config = AppConfig::load().normalized();
-    let backup_dir = match dir {
-        Some(path) => path,
-        None => env::current_dir().map_err(|error| {
-            format!("Backup failed: could not determine current directory: {error}")
-        })?,
-    };
-    fs::create_dir_all(&backup_dir)
-        .map_err(|error| format!("Backup failed: could not create backup directory: {error}"))?;
+    let backup_dir = resolve_artifact_directory(dir, BACKUP_ARTIFACTS)?;
 
     let source_config = config_file_path()?;
     let source_stats = stats_persistence_path()?;
@@ -138,12 +152,7 @@ pub(super) fn execute_restore_command(
     output: OutputMode,
 ) -> Result<(), String> {
     let _config = AppConfig::load().normalized();
-    let restore_dir = match dir {
-        Some(path) => path,
-        None => env::current_dir().map_err(|error| {
-            format!("Restore failed: could not determine current directory: {error}")
-        })?,
-    };
+    let restore_dir = resolve_artifact_directory(dir, RESTORE_ARTIFACTS)?;
     let source_config = restore_dir.join(CONFIG_FILE_NAME);
     let source_stats = restore_dir.join(STATS_FILE_NAME);
     ensure_restore_source_file(&source_config, CONFIG_FILE_NAME)?;
@@ -305,6 +314,34 @@ fn is_wrapper_punctuation(ch: char) -> bool {
         ch,
         '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | '"' | '\'' | ',' | ';'
     )
+}
+
+fn resolve_artifact_directory(
+    dir: Option<PathBuf>,
+    workflow: ArtifactDirectoryWorkflow,
+) -> Result<PathBuf, String> {
+    let directory = match dir {
+        Some(path) => path,
+        None => env::current_dir().map_err(|error| {
+            format!(
+                "{} failed: could not determine current directory: {error}",
+                workflow.name
+            )
+        })?,
+    };
+
+    if workflow.create {
+        fs::create_dir_all(&directory).map_err(|error| {
+            format!(
+                "{} failed: could not create {} directory `{}`: {error}",
+                workflow.name,
+                workflow.role,
+                directory.display()
+            )
+        })?;
+    }
+
+    Ok(directory)
 }
 
 fn ensure_restore_source_file(path: &Path, file_name: &str) -> Result<(), String> {
@@ -478,4 +515,68 @@ fn copy_file_with_context(source: &Path, destination: &Path, context: &str) -> R
         )
     })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BACKUP_ARTIFACTS, RESTORE_ARTIFACTS, resolve_artifact_directory};
+    use crate::cli::PathBuf;
+    use std::{
+        fs,
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn artifact_producer_creates_target_directory() {
+        let root = unique_temp_dir("artifact-create");
+        let target = root.join("nested").join("reports");
+
+        let resolved = resolve_artifact_directory(Some(target.clone()), BACKUP_ARTIFACTS)
+            .expect("target artifact directory should be created");
+
+        assert_eq!(resolved, target);
+        assert!(resolved.is_dir());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn artifact_consumer_does_not_create_source_directory() {
+        let root = unique_temp_dir("artifact-source");
+        let source = root.join("missing-backup");
+
+        let resolved = resolve_artifact_directory(Some(source.clone()), RESTORE_ARTIFACTS)
+            .expect("source artifact directory should be passed through");
+
+        assert_eq!(resolved, source);
+        assert!(!resolved.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn artifact_producer_reports_consistent_directory_creation_error() {
+        let root = unique_temp_dir("artifact-file-target");
+        let target = root.join("occupied");
+        fs::create_dir_all(&root).expect("failed to create temp root");
+        fs::write(&target, "not a directory").expect("failed to write occupied file");
+
+        let error = resolve_artifact_directory(Some(target), BACKUP_ARTIFACTS).unwrap_err();
+
+        assert!(error.contains("Backup failed: could not create target directory"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let unique = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "focustime-{label}-{}-{now}-{unique}",
+            std::process::id()
+        ))
+    }
 }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -2,6 +2,8 @@ mod diagnostics;
 mod sites;
 mod status;
 
+use std::path::Path;
+
 pub(super) use diagnostics::{
     build_blocking_preview_command_output, build_diagnostics_blocking_preview_error,
     build_diagnostics_blocking_preview_output, build_diagnostics_command_output,
@@ -84,8 +86,7 @@ pub(super) fn print_theme_command_output(payload: &ThemeCommandOutput) {
 
 pub(super) fn print_export_output(payload: &ExportOutput) {
     println!("Exported stats to {}", payload.export_dir.display());
-    println!("JSON: {}", payload.json_path.display());
-    println!("CSV: {}", payload.csv_path.display());
+    print_artifact_paths(&[("JSON", &payload.json_path), ("CSV", &payload.csv_path)]);
 }
 
 pub(super) fn print_feature_inventory_output(payload: &FeatureInventoryOutput) {
@@ -93,8 +94,10 @@ pub(super) fn print_feature_inventory_output(payload: &FeatureInventoryOutput) {
         "Exported feature inventory report to {}",
         payload.export_dir.display()
     );
-    println!("JSON: {}", payload.json_path.display());
-    println!("Markdown: {}", payload.markdown_path.display());
+    print_artifact_paths(&[
+        ("JSON", &payload.json_path),
+        ("Markdown", &payload.markdown_path),
+    ]);
     println!(
         "Features: {} (keep {}, merge {}, remove {})",
         payload.total_features, payload.keep_count, payload.merge_count, payload.remove_count
@@ -103,14 +106,24 @@ pub(super) fn print_feature_inventory_output(payload: &FeatureInventoryOutput) {
 
 pub(super) fn print_backup_output(payload: &BackupOutput) {
     println!("Backed up app data to {}", payload.backup_dir.display());
-    println!("Config: {}", payload.config_backup_path.display());
-    println!("Stats: {}", payload.stats_backup_path.display());
+    print_artifact_paths(&[
+        ("Config", &payload.config_backup_path),
+        ("Stats", &payload.stats_backup_path),
+    ]);
 }
 
 pub(super) fn print_restore_output(payload: &RestoreOutput) {
     println!("Restored app data from {}", payload.restore_dir.display());
-    println!("Config: {}", payload.config_restored_path.display());
-    println!("Stats: {}", payload.stats_restored_path.display());
+    print_artifact_paths(&[
+        ("Config", &payload.config_restored_path),
+        ("Stats", &payload.stats_restored_path),
+    ]);
+}
+
+fn print_artifact_paths(paths: &[(&str, &Path)]) {
+    for (label, path) in paths {
+        println!("{label}: {}", path.display());
+    }
 }
 
 pub(super) fn print_calendar_sync_command_output(payload: &CalendarSyncCommandOutput) {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -2306,6 +2306,12 @@ fn parse_rejects_restore_with_blank_positional_value() {
 }
 
 #[test]
+fn parse_rejects_export_with_blank_positional_value() {
+    let error = parse(&["--export", "   "]).unwrap_err();
+    assert!(error.contains("`--export` requires a target directory."));
+}
+
+#[test]
 fn parse_rejects_watch_with_zero_seconds() {
     let error = parse(&["--status", "--watch=0"]).unwrap_err();
     assert!(error.contains("positive whole number of seconds"));

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -619,6 +619,106 @@ fn backup_and_restore_json_round_trip_config_and_stats_files() {
 }
 
 #[test]
+fn artifact_workflows_json_create_target_dirs_and_preserve_path_fields() {
+    let env = TestEnv::new("artifact-workflows-json");
+
+    let set_goal_output = env.run(&["--goal=120,4", "--json"]);
+    assert_eq!(set_goal_output.status.code(), Some(0));
+    assert!(stderr_text(&set_goal_output).trim().is_empty());
+
+    let set_task_goal_output = env.run(&["--task-goal=Docs:90,3", "--json"]);
+    assert_eq!(set_task_goal_output.status.code(), Some(0));
+    assert!(stderr_text(&set_task_goal_output).trim().is_empty());
+
+    let backup_dir = env.root.join("artifacts").join("backup").join("nested");
+    let export_dir = env.root.join("artifacts").join("export").join("nested");
+    let inventory_dir = env.root.join("artifacts").join("inventory").join("nested");
+    let backup_arg = format!("--backup={}", backup_dir.display());
+    let export_arg = format!("--export={}", export_dir.display());
+    let inventory_arg = format!("--feature-inventory={}", inventory_dir.display());
+
+    let backup_output = env.run(&[backup_arg.as_str(), "--json"]);
+    assert_eq!(backup_output.status.code(), Some(0));
+    assert!(stderr_text(&backup_output).trim().is_empty());
+    let backup_payload: Value =
+        serde_json::from_slice(&backup_output.stdout).expect("stdout should be JSON");
+    assert_eq!(path_value(&backup_payload, "backup_dir"), backup_dir);
+    assert_eq!(
+        path_value(&backup_payload, "config_backup_path"),
+        backup_dir.join("config.toml")
+    );
+    assert_eq!(
+        path_value(&backup_payload, "stats_backup_path"),
+        backup_dir.join("stats.toml")
+    );
+
+    let export_output = env.run(&[export_arg.as_str(), "--json"]);
+    assert_eq!(export_output.status.code(), Some(0));
+    assert!(stderr_text(&export_output).trim().is_empty());
+    let export_payload: Value =
+        serde_json::from_slice(&export_output.stdout).expect("stdout should be JSON");
+    assert_eq!(path_value(&export_payload, "export_dir"), export_dir);
+    assert_eq!(
+        path_value(&export_payload, "json_path"),
+        export_dir.join("focustime-stats.json")
+    );
+    assert_eq!(
+        path_value(&export_payload, "csv_path"),
+        export_dir.join("focustime-stats.csv")
+    );
+
+    let inventory_output = env.run(&[inventory_arg.as_str(), "--json"]);
+    assert_eq!(inventory_output.status.code(), Some(0));
+    assert!(stderr_text(&inventory_output).trim().is_empty());
+    let inventory_payload: Value =
+        serde_json::from_slice(&inventory_output.stdout).expect("stdout should be JSON");
+    assert_eq!(path_value(&inventory_payload, "export_dir"), inventory_dir);
+    assert_eq!(
+        path_value(&inventory_payload, "json_path"),
+        inventory_dir.join("FEATURE_INVENTORY.json")
+    );
+    assert_eq!(
+        path_value(&inventory_payload, "markdown_path"),
+        inventory_dir.join("FEATURE_INVENTORY.md")
+    );
+}
+
+#[test]
+fn artifact_workflows_json_report_consistent_target_directory_errors() {
+    let env = TestEnv::new("artifact-target-errors");
+    let occupied_path = env.root.join("occupied");
+    fs::write(&occupied_path, "not a directory").expect("failed to write occupied target");
+    let backup_arg = format!("--backup={}", occupied_path.display());
+    let export_arg = format!("--export={}", occupied_path.display());
+    let inventory_arg = format!("--feature-inventory={}", occupied_path.display());
+
+    for (args, command_name) in [
+        ([backup_arg.as_str(), "--json"], "Backup"),
+        ([export_arg.as_str(), "--json"], "Export"),
+        (
+            [inventory_arg.as_str(), "--json"],
+            "Feature inventory export",
+        ),
+    ] {
+        let output = env.run(&args);
+        assert_eq!(output.status.code(), Some(1));
+        assert!(stderr_text(&output).trim().is_empty());
+        let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+        assert_eq!(payload["ok"], false);
+        assert_eq!(payload["error"]["kind"], "runtime");
+        let message = payload["error"]["message"]
+            .as_str()
+            .expect("runtime error message should be a string");
+        assert!(
+            message.contains(&format!(
+                "{command_name} failed: could not create target directory"
+            )),
+            "runtime error should use shared artifact target wording: {message}"
+        );
+    }
+}
+
+#[test]
 fn feature_inventory_json_exports_scored_report_artifacts() {
     let env = TestEnv::new("feature-inventory-json");
     let report_dir = env.root.join("reports");
@@ -663,6 +763,13 @@ fn feature_inventory_json_exports_scored_report_artifacts() {
             .as_array()
             .is_some_and(|dimensions| dimensions.iter().any(|dimension| dimension == "commands"))
     );
+}
+
+fn path_value(payload: &Value, key: &str) -> PathBuf {
+    payload[key]
+        .as_str()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| panic!("payload field `{key}` should be a path string: {payload:#?}"))
 }
 
 #[test]


### PR DESCRIPTION
## What

Consolidate artifact workflow handling for backup, stats export, restore source resolution, and feature-inventory export paths.

Closes #450.

## Why

Backup, export, and feature-inventory commands each had their own destination parsing and output-path handling, which made behavior drift easier as artifact workflows evolved.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation describing consistent target-directory handling for backup, export, and feature-inventory commands.

* **Bug Fixes**
  * Improved validation for empty values in artifact-related commands with clearer error messages.
  * Ensured backup and export commands create target directories when needed.

* **Tests**
  * Added tests verifying artifact commands create nested directories correctly and preserve expected output fields.
  * Added tests validating consistent error reporting when target paths cannot be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->