### PR TITLE
Audit runtime dependencies for cleanup removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Runtime dependency cleanup audit (#452):** documented runtime dependency removal candidates with owning daemon, calendar, and WakaTime/integration feature paths, and added release-readiness guidance before cleanup removals change `Cargo.toml`.
 - **Daemon API retirement preparation (#451):** marked daemon lifecycle JSON/text output with local API deprecation guidance, documented CLI/TUI replacement workflows, and added focused regression coverage for the retirement notice.
 
 ## [0.15.5] - 2026-06-14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,24 @@ Key dependencies are defined in `Cargo.toml`:
 
 - `ratatui`: terminal UI rendering.
 - `crossterm`: terminal input/output and screen control.
-- `ureq` + `serde`: HTTP and JSON support for WakaTime heartbeats.
-- `base64`: API authorization header encoding.
+- `ureq` + `serde`: HTTP and JSON support for WakaTime heartbeats, optional
+  calendar annotation refreshes, and deprecated daemon client calls.
+- `serde_json`: CLI/status/export JSON, daemon API payloads, and calendar cache
+  persistence.
+- `toml`: config, stats, WakaTime queue, recovery, and daemon metadata
+  persistence.
+- `csv`: stats export artifacts.
+- `chrono` + `chrono-tz`: timer/stat dates, schedule windows, calendar
+  recurrence, and optional calendar `TZID` handling.
+- `base64`: WakaTime Basic auth and deprecated daemon bearer-token encoding.
+- `tiny_http`: deprecated daemon local API server.
+- `getrandom`: deprecated daemon bearer-token generation.
 
 Dependency guidelines:
 
 - Prefer minimal, well-maintained crates.
 - Keep `Cargo.lock` committed.
 - Run `cargo audit` when updating dependencies.
+- When cleanup work removes daemon, calendar, or integration paths, update the
+  README runtime dependency cleanup table with the owning path and run the
+  release readiness checks in `REGRESSION_MATRIX.md`.

--- a/README.md
+++ b/README.md
@@ -363,6 +363,16 @@ Early deprecation notices:
 | Retired encrypted sync flags (`--sync-backup`, `--sync-restore`, `--sync-passphrase`) | Use `--backup` and `--restore` for local portable recovery; there is no direct passphrase replacement because encrypted sync is retired. |
 | Duplicate schedule/session start entry points | Select the task/profile/blocklist/schedule or apply a session template, then start focus through the unified timer flow with `--start` or the TUI. |
 
+Runtime dependency cleanup candidates:
+
+| Dependency | Owning feature paths | Cleanup trigger |
+| --- | --- | --- |
+| `tiny_http` | Deprecated daemon local API server in `src/daemon.rs` and daemon lifecycle CLI paths. | Remove when `--daemon-start`, `--daemon-status`, `--daemon-stop`, `--daemon-port`, and `/v1/*` are retired. |
+| `getrandom` | Deprecated daemon local API bearer-token generation in `src/daemon.rs`. | Remove the direct dependency with the daemon local API removal; transitive RNG crates may remain through TLS dependencies. |
+| `ureq` JSON feature | WakaTime heartbeat transport, deprecated daemon lifecycle client calls, and optional calendar ICS fetches. | Keep while WakaTime or calendar annotations need HTTP; after daemon removal, re-audit whether calendar-only or WakaTime-only usage can narrow enabled features. |
+| `chrono-tz` | Calendar `TZID` parsing in optional schedule annotation cache. | Remove only if calendar annotations stop supporting named time zones or the calendar cache is retired. |
+| `base64` daemon usage | Deprecated daemon token encoding plus WakaTime Basic auth. | Do not remove outright while WakaTime uses Basic auth; after daemon removal, confirm WakaTime still owns the remaining dependency. |
+
 ### Low-value feature retirements
 
 Retired low-value command surfaces and replacements:

--- a/REGRESSION_MATRIX.md
+++ b/REGRESSION_MATRIX.md
@@ -40,6 +40,7 @@ in the normal release readiness command set.
 | v0.15.5 | Status comparison CLI flags stay retired from `--status` and point users to export artifacts or Focus History reports. | Stats cleanup | `parse_rejects_status_comparison_options_with_export_replacement` plus `parse_rejects_equals_status_comparison_options_with_export_replacement` |
 | v0.15.5 | Backup, stats export, and feature-inventory artifact workflows share target-directory creation and JSON path contract behavior. | Artifact cleanup | `artifact_workflows_json_create_target_dirs_and_preserve_path_fields` plus `artifact_workflows_json_report_consistent_target_directory_errors` |
 | v0.15.x | Daemon local API lifecycle commands report retirement guidance while CLI timer/session/workflow commands and the TUI remain supported replacement workflows. | Integration cleanup | `daemon_lifecycle_json_emits_deprecated_replacement_payload` plus `daemon_lifecycle_json_contract_round_trip` |
+| v0.15.x | Runtime dependency removal candidates stay documented with owning daemon, calendar, and integration/WakaTime feature paths before cleanup removals change `Cargo.toml`. | Dependency cleanup | `v015_cleanup_docs_keep_matrix_and_release_guidance_aligned` |
 
 ## Release Readiness
 
@@ -65,3 +66,6 @@ here and add or update the matching focused test before preparing the release
 commit. Documentation-only roadmap updates should still keep README,
 CHANGELOG.md, CONTRIBUTING.md, and this matrix aligned with supported
 replacement behavior.
+When cleanup work changes runtime dependencies, also run `cargo check --all`,
+`cargo clippy --all-targets -- -D warnings`, `cargo test --all`, and
+`cargo audit` before release tagging.

--- a/tests/v015_cleanup_regression.rs
+++ b/tests/v015_cleanup_regression.rs
@@ -112,6 +112,12 @@ fn v015_cleanup_docs_keep_matrix_and_release_guidance_aligned() {
         "Retired encrypted sync flags (`--sync-backup`, `--sync-restore`, `--sync-passphrase`)",
         "Duplicate schedule/session start entry points",
         "Daemon local API lifecycle (`--daemon-start`, `--daemon-status`, `--daemon-stop`, `--daemon-port`, `/v1/*`)",
+        "Runtime dependency cleanup candidates",
+        "`tiny_http`",
+        "`getrandom`",
+        "`ureq` JSON feature",
+        "`chrono-tz`",
+        "`base64` daemon usage",
     ] {
         assert!(
             readme.contains(required),
@@ -122,6 +128,8 @@ fn v015_cleanup_docs_keep_matrix_and_release_guidance_aligned() {
     assert!(changelog.contains("v0.15.x cleanup roadmap and deprecation notices"));
     assert!(contributing.contains("cargo test --test v015_cleanup_regression"));
     assert!(contributing.contains("v0.15.x cleanup releases"));
+    assert!(contributing.contains("deprecated daemon bearer-token generation"));
+    assert!(matrix.contains("Runtime dependency removal candidates stay documented"));
 }
 
 #[test]


### PR DESCRIPTION
## What

Documented runtime dependency cleanup candidates with owning daemon, calendar, and WakaTime/integration feature paths, then guarded that documentation in the v0.15 cleanup regression test.

Closes #452.

## Why

Cleanup removals around daemon, calendar, and integration paths need an explicit dependency audit trail before `Cargo.toml` changes, so future releases can remove or narrow dependencies without dropping still-owned runtime behavior.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with runtime dependency audit entry.
  * Expanded contributing guidelines with enhanced dependency documentation.
  * Added runtime dependency cleanup candidates reference to README.
  * Updated regression matrix with v0.15.x coverage and release readiness checks.

* **Tests**
  * Extended regression test to verify documentation consistency across guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->