### PR TITLE
Restore SonarCloud coverage reporting

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,6 +30,26 @@ jobs:
         if: ${{ env.SONAR_TOKEN == '' }}
         run: echo "SONAR_TOKEN is not configured. Skipping SonarCloud scan."
 
+      - name: Install stable toolchain
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-llvm-cov
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate Rust coverage report
+        if: ${{ env.SONAR_TOKEN != '' }}
+        run: |
+          mkdir -p target/llvm-cov
+          cargo llvm-cov --workspace --lcov --output-path target/llvm-cov/lcov.info
+
+      - name: Verify coverage report
+        if: ${{ env.SONAR_TOKEN != '' }}
+        run: |
+          test -s target/llvm-cov/lcov.info
+          wc -l target/llvm-cov/lcov.info
+
       - name: Run SonarCloud scan
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@v8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,4 @@ sonar.host.url=https://sonarcloud.io
 
 sonar.sources=src
 sonar.exclusions=target/**
+sonar.rust.lcov.reportPaths=target/llvm-cov/lcov.info


### PR DESCRIPTION
## What

Restore SonarCloud Rust coverage reporting by generating an LCOV report in the SonarCloud workflow and wiring SonarCloud to read it.

Closes #474.

## Why

The SonarCloud workflow was running analysis without producing or referencing a Rust coverage report, so coverage could appear missing, unmeasured, or 0%.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated code coverage analysis in the continuous integration pipeline, with coverage reports now integrated into SonarCloud scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->