### PR TITLE
Prepare v0.15.7 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.15.6 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.15.7 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -117,7 +117,7 @@ When preparing a release update, keep these files aligned:
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
 - `REGRESSION_MATRIX.md` merged/deprecated/removed feature-path coverage and supported replacement behavior
-- Release tag examples in docs use the current target release version (for example, `v0.15.6`)
+- Release tag examples in docs use the current target release version (for example, `v0.15.7`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -149,5 +149,5 @@ sequenceDiagram
   owns it.
 - For release docs updates, keep architecture-facing terminology aligned with the
   module names and responsibility language used in `README.md`, `CHANGELOG.md`,
-  and release tag examples in contributor-facing docs (for example, `v0.15.6`
+  and release tag examples in contributor-facing docs (for example, `v0.15.7`
   for this release cycle).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.7] - 2026-06-19
+
 ### Changed
 
 - **Blocking preview command removal (#492):** removed the standalone `--blocking-preview` CLI surface while keeping backend-selected preview details available from `--diagnostics` text and JSON output.
@@ -482,7 +484,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.15.6...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.15.7...HEAD
+[0.15.7]: https://github.com/utilForever/focustime/compare/v0.15.6...v0.15.7
 [0.15.6]: https://github.com/utilForever/focustime/compare/v0.15.5...v0.15.6
 [0.15.5]: https://github.com/utilForever/focustime/compare/v0.15.4...v0.15.5
 [0.15.4]: https://github.com/utilForever/focustime/compare/v0.15.3...v0.15.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ For v0.15.x cleanup releases, also keep the README roadmap, changelog entry, and
 deprecation notices aligned so every deprecated or retired path names supported
 replacement behavior before the tag is created.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.15.6`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.15.7`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.15.6"
+version = "0.15.7"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Milestone policy:
 - **v0.15.4:** blocklist/allowlist site management operates on profile-level rules without selected-category branching, while temporary allowlist and break-glass controls share the canonical temporary override runtime model.
 - **v0.15.5:** Focus History uses a stable default KPI layout, export/history remain the deeper comparison paths, and backup/export/feature-inventory artifact workflows share target-directory handling.
 - **v0.15.6:** daemon local API lifecycle commands report retirement guidance, runtime dependency cleanup candidates stay documented, and WakaTime integration uses explicit supported runtime calls.
+- **v0.15.7:** standalone blocking preview access, Focus History dashboard customization paths, and dedicated status comparison guidance stay removed while diagnostics, the stable KPI dashboard, export artifacts, and Focus History remain the supported replacements.
 - **v0.15.x future cleanup:** continue retiring overlapping paths only after release notes and diagnostics name supported replacement behavior.
 - **v0.12.0:** remove legacy field/path compatibility after the warning window
 
@@ -1044,12 +1045,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.15.6`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.15.7`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.15.6](https://github.com/utilForever/focustime/releases/tag/v0.15.6).
+The latest stable release is [v0.15.7](https://github.com/utilForever/focustime/releases/tag/v0.15.7).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the v0.15.7 release metadata and documentation updates.

- Bump the crate version from `0.15.6` to `0.15.7` in `Cargo.toml` and `Cargo.lock`.
- Promote the existing Unreleased changelog entries into a `0.15.7` release section dated 2026-06-19.
- Align README, architecture, contributor, and agent release guidance around `v0.15.7`.

Closes #514.

## Why

This completes the release documentation checklist for the v0.15.7 release.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation and version references for v0.15.7 release.

* **Documentation**
  * Added deprecation notice for v0.15.7: standalone blocking preview access, Focus History dashboard customization, and dedicated status comparison guidance have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->