### PR TITLE
Narrow calendar annotations to deterministic schedule context

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -266,6 +266,10 @@ fn blocking_backend_config_for_persistence(
 fn load_calendar_busy_windows(
     calendar_sync: &CalendarSyncConfig,
 ) -> (Vec<CalendarBusyWindow>, Option<String>) {
+    if !calendar_sync.enabled {
+        return (Vec::new(), None);
+    }
+
     let _ = crate::calendar::load_cached_windows(Local::now(), calendar_sync.lookahead_days);
     (Vec::new(), None)
 }
@@ -876,7 +880,15 @@ impl App {
             .runtime_options_for_tests()
     }
 
+    fn calendar_annotations_enabled(&self) -> bool {
+        self.calendar_sync.enabled
+    }
+
     fn active_calendar_busy_window(&self, now: DateTime<Local>) -> Option<&CalendarBusyWindow> {
+        if !self.calendar_annotations_enabled() {
+            return None;
+        }
+
         active_calendar_window_at(&self.calendar_busy_windows, now)
     }
 
@@ -884,6 +896,10 @@ impl App {
         &self,
         occurrence: &WindowOccurrence,
     ) -> Option<&CalendarBusyWindow> {
+        if !self.calendar_annotations_enabled() {
+            return None;
+        }
+
         crate::calendar::first_overlap(
             &self.calendar_busy_windows,
             occurrence.start,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3204,6 +3204,46 @@ fn recurring_schedule_auto_starts_focus_when_window_begins_and_task_is_selected(
 }
 
 #[test]
+fn recurring_schedule_auto_start_ignores_cached_calendar_overlap() {
+    let now = local_datetime_today(10, 15);
+    let config = AppConfig {
+        recurring_schedule: RecurringScheduleConfig {
+            windows: vec![crate::config::RecurringFocusWindowConfig {
+                days: vec![weekday_token(now.weekday()).to_string()],
+                start: "10:00".to_string(),
+                end: "11:00".to_string(),
+            }],
+            ..RecurringScheduleConfig::default()
+        },
+        calendar_sync: crate::config::CalendarSyncConfig {
+            enabled: true,
+            ..crate::config::CalendarSyncConfig::default()
+        },
+        ..AppConfig::default()
+    };
+    let mut app = App::from_config(config);
+    app.task_labels = vec!["Coding".to_string()];
+    app.selected_task_label = Some("Coding".to_string());
+    app.set_calendar_busy_windows_for_tests(vec![CalendarBusyWindow {
+        source_name: "work".to_string(),
+        provider: CalendarProviderConfig::Google,
+        summary: "Team meeting".to_string(),
+        start_epoch_secs: local_datetime_today(10, 0).timestamp(),
+        end_epoch_secs: local_datetime_today(10, 30).timestamp(),
+    }]);
+
+    app.sync_recurring_schedule(now);
+
+    assert_eq!(app.timer.phase, TimerPhase::Focus);
+    assert_eq!(app.timer.status, TimerStatus::Running);
+    assert_eq!(
+        app.phase_notification.as_deref(),
+        Some("Scheduled window started. Focus auto-started.")
+    );
+    assert!(app.schedule_armed_occurrence_key.is_none());
+}
+
+#[test]
 fn recurring_schedule_arms_when_window_begins_without_task_label() {
     let now = local_datetime_today(10, 15);
     let config = AppConfig {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2887,6 +2887,10 @@ fn recurring_schedule_next_window_text_flags_calendar_overlap() {
             }],
             ..RecurringScheduleConfig::default()
         },
+        calendar_sync: crate::config::CalendarSyncConfig {
+            enabled: true,
+            ..crate::config::CalendarSyncConfig::default()
+        },
         ..AppConfig::default()
     };
     let mut app = App::from_config(config);
@@ -2917,7 +2921,19 @@ fn recurring_schedule_text_omits_calendar_annotations_when_disabled_or_absent() 
         },
         ..AppConfig::default()
     };
-    let app = App::from_config(config);
+    let absent_app = App::from_config(config.clone());
+    let (absent_next_text, absent_status_text) = absent_app.recurring_schedule_texts_at(now);
+    assert!(!absent_next_text.contains("calendar"));
+    assert!(!absent_status_text.contains("calendar"));
+
+    let mut app = App::from_config(config);
+    app.set_calendar_busy_windows_for_tests(vec![CalendarBusyWindow {
+        source_name: "work".to_string(),
+        provider: CalendarProviderConfig::Google,
+        summary: "Disabled calendar cache".to_string(),
+        start_epoch_secs: local_datetime_today(11, 15).timestamp(),
+        end_epoch_secs: local_datetime_today(11, 45).timestamp(),
+    }]);
 
     let (next_text, status_text) = app.recurring_schedule_texts_at(now);
 
@@ -2936,6 +2952,10 @@ fn recurring_schedule_status_text_mentions_active_calendar_busy_window() {
                 end: "11:00".to_string(),
             }],
             ..RecurringScheduleConfig::default()
+        },
+        calendar_sync: crate::config::CalendarSyncConfig {
+            enabled: true,
+            ..crate::config::CalendarSyncConfig::default()
         },
         ..AppConfig::default()
     };


### PR DESCRIPTION
## What

Narrow calendar busy-window handling so cached calendar data is used only as opt-in schedule annotation context.

Closes #502.

## Why

Calendar cache state should not change schedule compilation, rendering, or focus behavior when calendar sync is disabled or absent. This keeps schedules deterministic after standalone calendar sync removal while preserving helpful text annotations when an enabled cache is present.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Calendar busy windows and overlap annotations now properly respect the calendar sync configuration; when disabled, calendar-related annotations are not displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->