### PR TITLE
Simplify single-plugin integration runtime facade

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -4,22 +4,8 @@ use crate::wakatime::{
 
 const WAKATIME_PLUGIN_NAME: &str = "wakatime";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum IntegrationId {
-    Wakatime,
-}
-
-impl IntegrationId {
-    fn from_config_name(value: &str) -> Option<Self> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            WAKATIME_PLUGIN_NAME => Some(Self::Wakatime),
-            _ => None,
-        }
-    }
-}
-
 pub(crate) struct IntegrationRuntime {
-    wakatime: Option<WakatimeIntegration>,
+    wakatime: Option<WakatimeTracker>,
 }
 
 impl IntegrationRuntime {
@@ -31,61 +17,53 @@ impl IntegrationRuntime {
         let mut warnings = Vec::new();
         let mut wakatime = None;
         for plugin_name in normalized_enabled_plugins(enabled_plugins) {
-            let Some(plugin_id) = IntegrationId::from_config_name(&plugin_name) else {
+            if plugin_name == WAKATIME_PLUGIN_NAME {
+                wakatime = Some(WakatimeTracker::new_with_settings(
+                    wakatime_metadata.clone(),
+                    wakatime_runtime.clone(),
+                ));
+            } else {
                 warnings.push(format!("unknown integration `{plugin_name}` ignored"));
-                continue;
-            };
-            match plugin_id {
-                IntegrationId::Wakatime => {
-                    wakatime = Some(WakatimeIntegration::new(
-                        wakatime_metadata.clone(),
-                        wakatime_runtime.clone(),
-                    ));
-                }
             }
         }
         (Self { wakatime }, warnings)
     }
 
     pub(crate) fn poll_wakatime_events(&mut self) {
-        let Some(wakatime) = self.wakatime.as_mut() else {
-            return;
-        };
-        wakatime.poll_events();
+        if let Some(wakatime) = self.wakatime.as_mut() {
+            wakatime.poll_events();
+        }
     }
 
     pub(crate) fn set_wakatime_tracking(&mut self, focus_running: bool) {
-        let Some(wakatime) = self.wakatime.as_mut() else {
-            return;
-        };
-        wakatime.set_tracking(focus_running);
+        if let Some(wakatime) = self.wakatime.as_mut() {
+            wakatime.set_focus_tracking(focus_running);
+        }
     }
 
     pub(crate) fn advance_wakatime(&mut self, elapsed_secs: u64) {
-        let Some(wakatime) = self.wakatime.as_mut() else {
-            return;
-        };
-        wakatime.advance(elapsed_secs);
+        if let Some(wakatime) = self.wakatime.as_mut() {
+            wakatime.tick_elapsed(elapsed_secs);
+        }
     }
 
     pub(crate) fn set_wakatime_metadata(&mut self, metadata: WakatimeHeartbeatMetadata) {
-        let Some(wakatime) = self.wakatime.as_mut() else {
-            return;
-        };
-        wakatime.set_metadata(metadata);
+        if let Some(wakatime) = self.wakatime.as_mut() {
+            wakatime.set_heartbeat_metadata(metadata);
+        }
     }
 
     pub(crate) fn wakatime_runtime_state(&self) -> WakatimeRuntimeState {
         self.wakatime
             .as_ref()
-            .map(|wakatime| wakatime.tracker().runtime_state())
+            .map(WakatimeTracker::runtime_state)
             .unwrap_or(WakatimeRuntimeState::NotConfigured)
     }
 
     pub(crate) fn wakatime_last_successful_heartbeat_epoch_secs(&self) -> Option<u64> {
         self.wakatime
             .as_ref()
-            .and_then(|wakatime| wakatime.tracker().last_successful_heartbeat_epoch_secs())
+            .and_then(WakatimeTracker::last_successful_heartbeat_epoch_secs)
     }
 
     #[cfg(test)]
@@ -95,56 +73,19 @@ impl IntegrationRuntime {
 
     #[cfg(test)]
     pub(crate) fn replace_wakatime_tracker_for_tests(&mut self, tracker: WakatimeTracker) {
-        let Some(wakatime) = self.wakatime.as_mut() else {
-            return;
-        };
-        wakatime.tracker = tracker;
+        if let Some(wakatime) = self.wakatime.as_mut() {
+            *wakatime = tracker;
+        }
     }
 
     #[cfg(test)]
     pub(crate) fn wakatime_tracker_mut_for_tests(&mut self) -> Option<&mut WakatimeTracker> {
-        self.wakatime.as_mut().map(|wakatime| &mut wakatime.tracker)
+        self.wakatime.as_mut()
     }
 
     #[cfg(test)]
     pub(crate) fn wakatime_tracker_for_tests(&self) -> Option<&WakatimeTracker> {
-        self.wakatime.as_ref().map(WakatimeIntegration::tracker)
-    }
-}
-
-struct WakatimeIntegration {
-    tracker: WakatimeTracker,
-}
-
-impl WakatimeIntegration {
-    fn new(metadata: WakatimeHeartbeatMetadata, runtime: WakatimeRuntimeOptions) -> Self {
-        Self {
-            tracker: WakatimeTracker::new_with_settings(metadata, runtime),
-        }
-    }
-
-    fn tracker(&self) -> &WakatimeTracker {
-        &self.tracker
-    }
-
-    fn poll_events(&mut self) {
-        self.tracker.poll_events();
-    }
-
-    fn set_tracking(&mut self, focus_running: bool) {
-        if focus_running && !self.tracker.is_tracking() {
-            self.tracker.on_focus_start();
-        } else if !focus_running && self.tracker.is_tracking() {
-            self.tracker.on_focus_stop();
-        }
-    }
-
-    fn advance(&mut self, elapsed_secs: u64) {
-        self.tracker.tick_elapsed(elapsed_secs);
-    }
-
-    fn set_metadata(&mut self, metadata: WakatimeHeartbeatMetadata) {
-        self.tracker.set_heartbeat_metadata(metadata);
+        self.wakatime.as_ref()
     }
 }
 

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -507,6 +507,14 @@ impl WakatimeTracker {
         self.set_tracking_state(false);
     }
 
+    pub(crate) fn set_focus_tracking(&mut self, focus_running: bool) {
+        if focus_running && !self.is_tracking() {
+            self.on_focus_start();
+        } else if !focus_running && self.is_tracking() {
+            self.on_focus_stop();
+        }
+    }
+
     pub(crate) fn set_heartbeat_metadata(&mut self, metadata: WakatimeHeartbeatMetadata) {
         self.heartbeat_metadata = metadata.normalized();
     }

--- a/src/wakatime/tests.rs
+++ b/src/wakatime/tests.rs
@@ -185,6 +185,27 @@ fn on_focus_stop_clears_tracking() {
 }
 
 #[test]
+fn set_focus_tracking_syncs_running_state() {
+    let mut tracker = tracker_with(Some("test-key"), false, 50);
+
+    tracker.set_focus_tracking(true);
+
+    assert!(tracker.is_tracking());
+    assert_eq!(tracker.secs_since_last_heartbeat, 0);
+    assert!(tracker.heartbeat_in_flight);
+
+    tracker.set_focus_tracking(true);
+
+    assert!(tracker.is_tracking());
+    assert!(tracker.heartbeat_in_flight);
+
+    tracker.set_focus_tracking(false);
+
+    assert!(!tracker.is_tracking());
+    assert!(!tracker.pending_immediate_heartbeat);
+}
+
+#[test]
 fn set_heartbeat_metadata_normalizes_and_updates_values() {
     let mut tracker = tracker_with(None, false, 0);
     tracker.set_heartbeat_metadata(WakatimeHeartbeatMetadata {


### PR DESCRIPTION
## What

Simplify the single-plugin integration runtime facade so `IntegrationRuntime` stores the WakaTime tracker directly instead of routing through an extra WakaTime-only wrapper.

Closes #507.

## Why

WakaTime is the only remaining integration after the v0.16.0 cleanup path, so the additional `WakatimeIntegration` wrapper and single-plugin enum branch added forwarding without preserving a useful abstraction.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Wakatime integration architecture for improved maintainability.
  * Enhanced focus tracking state management with better internal control flow.

* **Tests**
  * Added test coverage for focus tracking state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->