### PR TITLE
Remove calendar-owned timezone dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Calendar timezone dependency cleanup (#547):** confirmed retired calendar timezone parsing no longer owns a runtime or test dependency, kept `chrono-tz` out of the manifest/lockfile, and updated dependency cleanup guidance before the v0.16.2 release.
 - **Calendar annotation cache cleanup (#546):** removed calendar annotation cache runtime handling, dropped `[calendar_sync]` from normalized config persistence/examples, and kept schedule output deterministic without calendar-derived busy/overlap text.
 
 ## [0.16.1] - 2026-06-24
@@ -32,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Daemon local API command retirement (#504):** removed `--daemon-start`, `--daemon-status`, `--daemon-stop`, and `--daemon-port` parsing/execution plus the loopback daemon runtime surface; CLI timer/session/workflow commands remain the supported automation path.
 - **Calendar sync command cleanup (#501):** removed standalone `--calendar-sync` parsing/output while keeping calendar data as optional schedule annotation context when a supported cache is present.
-- **Calendar dependency cleanup audit (#503):** re-audited calendar-owned dependency notes after standalone refresh removal, documenting that runtime `ureq` is now owned by WakaTime heartbeats and `chrono-tz` is only test-owned unless calendar cache refresh support is reintroduced.
+- **Calendar dependency cleanup audit (#503):** re-audited calendar-owned dependency notes after standalone refresh removal, documenting that runtime `ureq` is now owned by WakaTime heartbeats while calendar timezone parsing remained a cleanup candidate for the later calendar cache retirement.
 
 ## [0.15.8] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -325,14 +325,14 @@ Early deprecation notices:
 | Daemon local API lifecycle (`--daemon-start`, `--daemon-status`, `--daemon-stop`, `--daemon-port`, `/v1/*`) | Removed; use CLI timer/session/workflow commands (`--start`, `--pause`, `--resume`, `--stop`, `--next`, `--task`, `--focus-intention`, `--task-note`, `--schedule-delay`, `--break-glass-trigger`, `--break-glass-cancel`) for automation, or the TUI for interactive focus sessions. |
 | Duplicate schedule/session start entry points | Select the task/profile/blocklist/schedule or apply a session template, then start focus through the unified timer flow with `--start` or the TUI. |
 
-Runtime dependency ownership after daemon cleanup:
+Runtime dependency ownership after daemon and calendar cleanup:
 
 | Dependency | Owning feature paths | Ownership note |
 | --- | --- | --- |
 | `ureq` JSON feature | WakaTime heartbeat transport. Retired calendar annotation and daemon paths no longer own runtime HTTP. | Keep while WakaTime heartbeat submission uses `send_json`; re-audit if the transport changes. |
 | `base64` | WakaTime Basic auth. | Keep while WakaTime uses Basic auth. |
 
-When changing `Cargo.toml` dependency ownership, run `rg -n "ureq|chrono_tz|chrono-tz" src tests`, `cargo check --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all`, and `cargo audit`.
+When changing `Cargo.toml` dependency ownership, run `rg -n "chrono_tz|chrono-tz" src tests Cargo.toml Cargo.lock` to confirm retired calendar timezone parsing stays removed, then run `rg -n "ureq" src tests`, `cargo check --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all`, and `cargo audit`.
 
 ### CLI JSON/error contract
 

--- a/REGRESSION_MATRIX.md
+++ b/REGRESSION_MATRIX.md
@@ -20,7 +20,7 @@ contracts now live in normal module and integration tests that run with
 | Artifacts | Backup and stats export artifact workflows share target-directory creation and JSON path/error contracts. | `artifact_workflows_json_create_target_dirs_and_preserve_path_fields`, `artifact_workflows_json_report_consistent_target_directory_errors` |
 | Integration runtime | Daemon local API lifecycle paths remain removed; CLI timer/session/workflow commands and the TUI remain the supported automation/runtime surface. | `parse_rejects_retired_daemon_lifecycle_options`, `retired_daemon_lifecycle_commands_emit_json_usage_errors`, `usage_text_keeps_supported_cli_automation_replacements` |
 | WakaTime runtime | WakaTime exposes only supported runtime calls for heartbeat polling, focus-running sync, elapsed focus tracking, and metadata updates. | `poll_wakatime_events_applies_async_updates`, `disabled_wakatime_runtime_ignores_supported_hooks` |
-| Dependency ownership | Runtime HTTP and Basic auth stay owned by WakaTime, while removed daemon and calendar paths do not reintroduce direct runtime ownership. | `Cargo.toml`, `Cargo.lock`, `src/wakatime/transport.rs`, plus `rg -n "ureq\|chrono_tz\|chrono-tz" src tests` during dependency cleanup |
+| Dependency ownership | Runtime HTTP and Basic auth stay owned by WakaTime, while removed daemon paths do not reintroduce direct runtime ownership and retired calendar timezone parsing stays absent. | `Cargo.toml`, `Cargo.lock`, `src/wakatime/transport.rs`, plus `rg -n "chrono_tz\|chrono-tz" src tests Cargo.toml Cargo.lock` and `rg -n "ureq" src tests` during dependency cleanup |
 
 ## Release Readiness
 
@@ -38,7 +38,8 @@ here and add or update the matching normal module or integration test before
 preparing the release commit. Documentation-only roadmap updates should still
 keep README, CHANGELOG.md, CONTRIBUTING.md, and this matrix aligned with
 supported replacement behavior.
-When cleanup work changes runtime dependencies, first confirm ownership with
-`rg -n "ureq|chrono_tz|chrono-tz" src tests`, then run `cargo check --all`,
-`cargo clippy --all-targets -- -D warnings`, `cargo test --all`, and
-`cargo audit` before release tagging.
+When cleanup work changes runtime dependencies, first confirm retired calendar
+timezone parsing stays absent with `rg -n "chrono_tz|chrono-tz" src tests Cargo.toml Cargo.lock`
+and confirm WakaTime HTTP ownership with `rg -n "ureq" src tests`, then run
+`cargo check --all`, `cargo clippy --all-targets -- -D warnings`,
+`cargo test --all`, and `cargo audit` before release tagging.


### PR DESCRIPTION
## What

Clarifies the calendar timezone dependency cleanup after calendar annotation cache retirement.

- Documents that retired calendar timezone parsing must stay absent from source, tests, `Cargo.toml`, and `Cargo.lock`.
- Splits the dependency cleanup release checks between calendar timezone absence and WakaTime `ureq` ownership.
- Records the #547 cleanup in the unreleased changelog and adjusts the older #503 note so it no longer reads as active `chrono-tz` ownership.

Closes #547.

## Why

The v0.16.2 roadmap removes calendar-owned `chrono-tz` after calendar annotation cache removal. The manifest and lockfile already no longer include `chrono-tz`, so this PR locks that state into the dependency ownership docs and release readiness checks.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release notes and dependency ownership guidance for calendar timezone cleanup.
  * Updated verification steps to separately check that retired calendar timezone parsing is gone and that `ureq` usage remains properly owned.
  * Refined pre-release readiness instructions to include these checks alongside the existing build, lint, test, and audit steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->