### PR TITLE
Remove schedule exception dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Schedule exception date cleanup (#549):** removed schedule exception-date config, runtime skipping, CLI text output, and profile editor controls so recurring schedules are represented only as recurring windows.
 - **Calendar timezone dependency cleanup (#547):** confirmed retired calendar timezone parsing no longer owns a runtime or test dependency, kept `chrono-tz` out of the manifest/lockfile, and updated dependency cleanup guidance before the v0.16.2 release.
 - **Calendar annotation cache cleanup (#546):** removed calendar annotation cache runtime handling, dropped `[calendar_sync]` from normalized config persistence/examples, and kept schedule output deterministic without calendar-derived busy/overlap text.
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cargo run -- --allowlist-site-delete reddit.com
 
 # Show/set schedule for the selected profile (including overlap/conflict inspection)
 cargo run -- --schedule
-cargo run -- --schedule-set='{"windows":[{"days":["mon","tue"],"start":"09:00","end":"11:00"}],"exception_dates":["2026-12-25"]}'
+cargo run -- --schedule-set='{"windows":[{"days":["mon","tue"],"start":"09:00","end":"11:00"}]}'
 cargo run -- --schedule-delay
 cargo run -- --schedule --json
 
@@ -574,8 +574,6 @@ sound = false
 focus_to_break = false
 break_to_focus = false
 
-[profile_automation.advanced.recurring_schedule]
-exception_dates = ["2026-12-25", "2027-01-01"]
 [[profile_automation.advanced.recurring_schedule.windows]]
 days = ["mon", "tue", "wed", "thu", "fri"]
 start = "09:00"
@@ -772,7 +770,6 @@ Recurring schedule windows can also trigger focus behavior at wall-clock times:
 
 - `profile_automation.<preset>.recurring_schedule.windows[].days` accepts day tokens (`mon`..`sun`, case-insensitive)
 - `profile_automation.<preset>.recurring_schedule.windows[].start` / `end` use 24-hour `HH:MM` local time (`start < end`)
-- `profile_automation.<preset>.recurring_schedule.exception_dates` accepts `YYYY-MM-DD` local dates and skips automatic schedule triggering on those days
 - when a window begins, focus auto-starts if possible; otherwise schedule mode arms and shows a reminder until you manually start focus
 - while a schedule window is active and focus is not already running, press `z` to delay the scheduled start (configurable via `[schedule_runtime].delay_secs`, default `10m`, clamped `60..43200` seconds)
 - if multiple windows overlap, the most recently started active window takes precedence; windows with the same start time are resolved deterministically
@@ -795,9 +792,6 @@ You can configure notification and auto-start settings directly from the TUI:
   - **Schedule window**: `←/→` changes which window is selected
   - **Schedule day** + **Schedule day enabled**: choose day cursor and toggle it `Off/On`
   - **Schedule start/end**: adjust times in `[schedule_runtime].time_step_minutes` steps (default `15`, clamped `1..60`)
-  - **Schedule exception**: `←/→` changes which exception date is selected
-  - **Exception date**: `←/→` moves selected exception date backward/forward by 1 day
-  - **Exception add/remove**: `→` adds a date (starting from today), `←` removes selected date
   - **Automation trigger**: deprecated compatibility fields for older trigger rules
   - **Automation condition/time/action**: deprecated compatibility fields for older event/time rules
   - **Automation add/remove**: deprecated compatibility controls for older trigger rules

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{BTreeSet, HashSet},
+    collections::BTreeSet,
     time::{Duration, Instant},
 };
 
@@ -23,7 +23,7 @@ use crate::config::{
 use crate::integration::IntegrationRuntime;
 use crate::notifications::PhaseNotifier;
 use crate::schedule::{
-    RecurringWindow, WindowOccurrence, active_occurrence, compile_exception_dates, compile_windows,
+    RecurringWindow, WindowOccurrence, active_occurrence, compile_windows,
     format_schedule_conflict, inspect_schedule_conflicts_from_config, next_occurrence_after,
     occurrence_key,
 };
@@ -83,13 +83,11 @@ pub(crate) use profile_edit::{
     PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX,
     PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX, PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX,
     PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX, PROFILE_EDIT_SCHEDULE_DAY_INDEX,
-    PROFILE_EDIT_SCHEDULE_END_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX,
-    PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX,
-    PROFILE_EDIT_SCHEDULE_START_INDEX, PROFILE_EDIT_SCHEDULE_WINDOW_INDEX,
-    PROFILE_EDIT_THEME_PRESET_INDEX, PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX,
-    PROFILE_EDIT_WAKATIME_PROJECT_INDEX, PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX,
-    PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX,
-    ProfileEditSnapshot,
+    PROFILE_EDIT_SCHEDULE_END_INDEX, PROFILE_EDIT_SCHEDULE_START_INDEX,
+    PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, PROFILE_EDIT_THEME_PRESET_INDEX,
+    PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX, PROFILE_EDIT_WAKATIME_PROJECT_INDEX,
+    PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX, PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX,
+    PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX, ProfileEditSnapshot,
 };
 pub(crate) use setup_diagnostics::{
     BlockingPreviewSnapshot, SetupCheck, SetupCheckLevel, SetupDiagnostics,
@@ -276,7 +274,6 @@ struct ScheduleDisplayState {
     has_schedule_windows: bool,
     active_window: Option<WindowOccurrence>,
     next_window: Option<WindowOccurrence>,
-    is_exception_today: bool,
     is_armed: bool,
     delayed_until: Option<DateTime<Local>>,
     has_selected_task: bool,
@@ -508,14 +505,12 @@ pub(crate) struct App {
     pub(crate) profile_edit_field: usize,
     profile_edit_schedule_window: usize,
     profile_edit_schedule_day: usize,
-    profile_edit_schedule_exception: usize,
     profile_edit_snapshot: Option<ProfileEditSnapshot>,
     notification_settings: NotificationConfig,
     auto_start: AutoStartConfig,
     recurring_schedule: RecurringScheduleConfig,
     schedule_runtime: ScheduleRuntimeConfig,
     recurring_windows: Vec<RecurringWindow>,
-    recurring_exception_dates: HashSet<NaiveDate>,
     schedule_armed_occurrence_key: Option<String>,
     schedule_delayed_occurrence_key: Option<String>,
     schedule_delay_until: Option<DateTime<Local>>,
@@ -575,8 +570,6 @@ impl App {
         let auto_start = selected_automation.auto_start;
         let recurring_schedule = selected_automation.recurring_schedule.clone();
         let recurring_windows = compile_windows(&recurring_schedule.windows);
-        let recurring_exception_dates =
-            compile_exception_dates(&recurring_schedule.exception_dates);
         let strict_mode = selected_automation.strict_mode;
         let schedule_runtime = config.schedule_runtime;
         let break_glass_duration_secs = config.break_glass_duration_secs;
@@ -715,14 +708,12 @@ impl App {
             profile_edit_field: 0,
             profile_edit_schedule_window: 0,
             profile_edit_schedule_day: 0,
-            profile_edit_schedule_exception: 0,
             profile_edit_snapshot: None,
             notification_settings,
             auto_start,
             recurring_schedule,
             schedule_runtime,
             recurring_windows,
-            recurring_exception_dates,
             schedule_armed_occurrence_key: None,
             schedule_delayed_occurrence_key: None,
             schedule_delay_until: None,
@@ -1483,10 +1474,6 @@ fn parse_hhmm_minutes(value: &str) -> Option<u16> {
     Some(hour * 60 + minute)
 }
 
-fn parse_schedule_exception_date(value: &str) -> Option<NaiveDate> {
-    NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").ok()
-}
-
 fn format_hhmm(total_minutes: u16) -> String {
     let hours = total_minutes / 60;
     let minutes = total_minutes % 60;
@@ -1504,17 +1491,6 @@ fn sort_schedule_days(days: &mut Vec<String>) {
         sorted.push(SCHEDULE_DAY_TOKENS[0].to_string());
     }
     *days = sorted;
-}
-
-fn sort_schedule_exception_dates(dates: &mut Vec<String>) {
-    let mut sorted = BTreeSet::new();
-    for value in dates.iter() {
-        let Some(date) = parse_schedule_exception_date(value) else {
-            continue;
-        };
-        sorted.insert(date.format("%Y-%m-%d").to_string());
-    }
-    *dates = sorted.into_iter().collect();
 }
 
 fn format_schedule_days_for_display(days: &[String]) -> String {

--- a/src/app/history_goals.rs
+++ b/src/app/history_goals.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use chrono::{Datelike, Duration, NaiveDate, Weekday};
 
 use crate::app::{
@@ -304,37 +302,23 @@ fn remaining_days_in_current_iso_week(day: NaiveDate) -> Vec<NaiveDate> {
 }
 
 fn schedule_weights_for_days(days: &[NaiveDate], schedule: &RecurringScheduleConfig) -> Vec<u64> {
-    let exception_dates: HashSet<NaiveDate> = schedule
-        .exception_dates
-        .iter()
-        .filter_map(|value| parse_schedule_date(value))
-        .collect();
     days.iter()
-        .map(|day| scheduled_weight_minutes_for_day(*day, schedule, &exception_dates))
+        .map(|day| scheduled_weight_minutes_for_day(*day, schedule))
         .collect()
 }
 
-fn scheduled_weight_minutes_for_day(
-    day: NaiveDate,
-    schedule: &RecurringScheduleConfig,
-    exception_dates: &HashSet<NaiveDate>,
-) -> u64 {
-    let exception_applies = exception_dates.contains(&day);
-    if exception_applies {
-        0
-    } else {
-        schedule
-            .windows
-            .iter()
-            .filter(|window| {
-                window
-                    .days
-                    .iter()
-                    .any(|token| weekday_token_matches(token, day.weekday()))
-            })
-            .map(|window| window_duration_minutes(&window.start, &window.end))
-            .sum()
-    }
+fn scheduled_weight_minutes_for_day(day: NaiveDate, schedule: &RecurringScheduleConfig) -> u64 {
+    schedule
+        .windows
+        .iter()
+        .filter(|window| {
+            window
+                .days
+                .iter()
+                .any(|token| weekday_token_matches(token, day.weekday()))
+        })
+        .map(|window| window_duration_minutes(&window.start, &window.end))
+        .sum()
 }
 
 fn weekday_token_matches(token: &str, weekday: Weekday) -> bool {
@@ -348,10 +332,6 @@ fn weekday_token_matches(token: &str, weekday: Weekday) -> bool {
         Weekday::Sun => "sun",
     };
     token.eq_ignore_ascii_case(expected)
-}
-
-fn parse_schedule_date(value: &str) -> Option<NaiveDate> {
-    NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").ok()
 }
 
 fn parse_schedule_time_minutes(value: &str) -> Option<u16> {

--- a/src/app/profile_edit.rs
+++ b/src/app/profile_edit.rs
@@ -4,7 +4,7 @@ use crate::config::{
     WeeklyGoalConfig,
 };
 
-pub(crate) const PROFILE_EDIT_FIELD_LABELS: [&str; 31] = [
+pub(crate) const PROFILE_EDIT_FIELD_LABELS: [&str; 28] = [
     "Focus",
     "Short Break",
     "Long Break",
@@ -31,9 +31,6 @@ pub(crate) const PROFILE_EDIT_FIELD_LABELS: [&str; 31] = [
     "Schedule start",
     "Schedule end",
     "Schedule add/remove",
-    "Schedule exception",
-    "Exception date",
-    "Exception add/remove",
     "Schedule conflicts",
     "Theme preset",
 ];
@@ -54,11 +51,8 @@ pub(crate) const PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX: usize = 22;
 pub(crate) const PROFILE_EDIT_SCHEDULE_START_INDEX: usize = 23;
 pub(crate) const PROFILE_EDIT_SCHEDULE_END_INDEX: usize = 24;
 pub(crate) const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 25;
-pub(crate) const PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX: usize = 26;
-pub(crate) const PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX: usize = 27;
-pub(crate) const PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX: usize = 28;
-pub(crate) const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 29;
-pub(crate) const PROFILE_EDIT_THEME_PRESET_INDEX: usize = 30;
+pub(crate) const PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX: usize = 26;
+pub(crate) const PROFILE_EDIT_THEME_PRESET_INDEX: usize = 27;
 pub(crate) const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 pub(crate) const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 

--- a/src/app/profile_management.rs
+++ b/src/app/profile_management.rs
@@ -5,15 +5,13 @@ use crate::app::{
     PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX,
     PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX, PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX,
     PROFILE_EDIT_SCHEDULE_DAY_INDEX, PROFILE_EDIT_SCHEDULE_END_INDEX,
-    PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX,
-    PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX, PROFILE_EDIT_SCHEDULE_START_INDEX,
-    PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, PROFILE_EDIT_THEME_PRESET_INDEX,
-    PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX, PROFILE_EDIT_WAKATIME_PROJECT_INDEX,
-    PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX, PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX,
-    PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX, PROFILE_IDS, ProfileAutomationConfig,
-    ProfileEditSnapshot, ProfileId, ShortcutAction, TimerState, WakatimeHeartbeatMetadata,
-    adjust_daily_goal_minutes, adjust_daily_goal_pomodoros, adjust_duration_minutes,
-    compile_exception_dates, compile_windows, profile_for_index, profile_index, profile_spec_for,
+    PROFILE_EDIT_SCHEDULE_START_INDEX, PROFILE_EDIT_SCHEDULE_WINDOW_INDEX,
+    PROFILE_EDIT_THEME_PRESET_INDEX, PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX,
+    PROFILE_EDIT_WAKATIME_PROJECT_INDEX, PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX,
+    PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX, PROFILE_IDS,
+    ProfileAutomationConfig, ProfileEditSnapshot, ProfileId, ShortcutAction, TimerState,
+    WakatimeHeartbeatMetadata, adjust_daily_goal_minutes, adjust_daily_goal_pomodoros,
+    adjust_duration_minutes, compile_windows, profile_for_index, profile_index, profile_spec_for,
 };
 
 const PROFILE_MANAGER_SHORTCUT_ACTIONS: [ShortcutAction; 2] = [
@@ -24,8 +22,6 @@ const PROFILE_MANAGER_SHORTCUT_ACTIONS: [ShortcutAction; 2] = [
 impl App {
     pub(super) fn rebuild_recurring_schedule_runtime(&mut self) {
         self.recurring_windows = compile_windows(&self.recurring_schedule.windows);
-        self.recurring_exception_dates =
-            compile_exception_dates(&self.recurring_schedule.exception_dates);
     }
 
     pub(super) fn selected_profile_automation(&self) -> ProfileAutomationConfig {
@@ -106,7 +102,6 @@ impl App {
         self.profile_edit_field = 0;
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
-        self.profile_edit_schedule_exception = 0;
         self.profile_edit_snapshot = None;
         self.profile_selection_index = profile_index(self.selected_profile);
         self.clamp_profile_selection();
@@ -222,7 +217,6 @@ impl App {
         self.profile_edit_field = 0;
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
-        self.profile_edit_schedule_exception = 0;
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -247,7 +241,6 @@ impl App {
         self.profile_edit_field = 0;
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
-        self.profile_edit_schedule_exception = 0;
         self.clamp_profile_edit_schedule_selection();
     }
 
@@ -274,7 +267,6 @@ impl App {
         self.profile_edit_field = 0;
         self.profile_edit_schedule_window = 0;
         self.profile_edit_schedule_day = 0;
-        self.profile_edit_schedule_exception = 0;
         self.clamp_profile_edit_schedule_selection();
         self.profile_edit_snapshot = None;
     }
@@ -414,15 +406,6 @@ impl App {
             }
             PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX => {
                 self.adjust_schedule_windows_collection(increase);
-            }
-            PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX => {
-                self.cycle_schedule_exception(increase);
-            }
-            PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX => {
-                self.adjust_selected_schedule_exception_date(increase);
-            }
-            PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX => {
-                self.adjust_schedule_exceptions_collection(increase);
             }
             PROFILE_EDIT_WAKATIME_PROJECT_INDEX | PROFILE_EDIT_WAKATIME_LANGUAGE_INDEX => {}
             _ => {}

--- a/src/app/schedule_editor.rs
+++ b/src/app/schedule_editor.rs
@@ -1,13 +1,11 @@
 use crate::app::{
     App, PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX, PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX,
     PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX, PROFILE_EDIT_SCHEDULE_DAY_INDEX,
-    PROFILE_EDIT_SCHEDULE_END_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX,
-    PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX, PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX,
-    PROFILE_EDIT_SCHEDULE_START_INDEX, PROFILE_EDIT_SCHEDULE_WINDOW_INDEX,
-    RecurringFocusWindowConfig, SCHEDULE_DAY_LABELS, SCHEDULE_DAY_TOKENS, bool_label, format_hhmm,
-    format_schedule_conflict, format_schedule_days_for_display,
-    inspect_schedule_conflicts_from_config, parse_hhmm_minutes, parse_schedule_exception_date,
-    sort_schedule_days, sort_schedule_exception_dates,
+    PROFILE_EDIT_SCHEDULE_END_INDEX, PROFILE_EDIT_SCHEDULE_START_INDEX,
+    PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, RecurringFocusWindowConfig, SCHEDULE_DAY_LABELS,
+    SCHEDULE_DAY_TOKENS, bool_label, format_hhmm, format_schedule_conflict,
+    format_schedule_days_for_display, inspect_schedule_conflicts_from_config, parse_hhmm_minutes,
+    sort_schedule_days,
 };
 
 impl App {
@@ -28,14 +26,6 @@ impl App {
                 .map(|window| window.end.clone())
                 .unwrap_or_else(|| "n/a".to_string()),
             PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX => self.schedule_window_collection_value(),
-            PROFILE_EDIT_SCHEDULE_EXCEPTION_INDEX => self.schedule_exception_selector_value(),
-            PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX => self
-                .selected_schedule_exception_date()
-                .cloned()
-                .unwrap_or_else(|| "n/a".to_string()),
-            PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX => {
-                self.schedule_exception_collection_value()
-            }
             PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX => self.schedule_conflict_summary_value(),
             _ => String::new(),
         }
@@ -87,26 +77,6 @@ impl App {
         }
     }
 
-    fn schedule_exception_selector_value(&self) -> String {
-        if self.recurring_schedule.exception_dates.is_empty() {
-            "none".to_string()
-        } else {
-            format!(
-                "{}/{}",
-                self.profile_edit_schedule_exception.saturating_add(1),
-                self.recurring_schedule.exception_dates.len()
-            )
-        }
-    }
-
-    fn schedule_exception_collection_value(&self) -> String {
-        if self.recurring_schedule.exception_dates.is_empty() {
-            "→ Add date".to_string()
-        } else {
-            "← Remove · → Add".to_string()
-        }
-    }
-
     fn selected_schedule_window(&self) -> Option<&RecurringFocusWindowConfig> {
         self.recurring_schedule
             .windows
@@ -117,12 +87,6 @@ impl App {
         self.recurring_schedule
             .windows
             .get_mut(self.profile_edit_schedule_window)
-    }
-
-    fn selected_schedule_exception_date(&self) -> Option<&String> {
-        self.recurring_schedule
-            .exception_dates
-            .get(self.profile_edit_schedule_exception)
     }
 
     fn selected_schedule_day_token(&self) -> &'static str {
@@ -158,16 +122,6 @@ impl App {
         self.profile_edit_schedule_day = self
             .profile_edit_schedule_day
             .min(SCHEDULE_DAY_TOKENS.len().saturating_sub(1));
-        if self.recurring_schedule.exception_dates.is_empty() {
-            self.profile_edit_schedule_exception = 0;
-        } else {
-            self.profile_edit_schedule_exception = self.profile_edit_schedule_exception.min(
-                self.recurring_schedule
-                    .exception_dates
-                    .len()
-                    .saturating_sub(1),
-            );
-        }
     }
 
     pub(super) fn cycle_schedule_window(&mut self, increase: bool) {
@@ -192,22 +146,6 @@ impl App {
             self.profile_edit_schedule_day = total - 1;
         } else {
             self.profile_edit_schedule_day = self.profile_edit_schedule_day.saturating_sub(1);
-        }
-    }
-
-    pub(super) fn cycle_schedule_exception(&mut self, increase: bool) {
-        if self.recurring_schedule.exception_dates.is_empty() {
-            return;
-        }
-        let total = self.recurring_schedule.exception_dates.len();
-        if increase {
-            self.profile_edit_schedule_exception =
-                (self.profile_edit_schedule_exception + 1) % total;
-        } else if self.profile_edit_schedule_exception == 0 {
-            self.profile_edit_schedule_exception = total - 1;
-        } else {
-            self.profile_edit_schedule_exception =
-                self.profile_edit_schedule_exception.saturating_sub(1);
         }
     }
 
@@ -275,53 +213,6 @@ impl App {
         window.end = format_hhmm(end);
     }
 
-    pub(super) fn adjust_selected_schedule_exception_date(&mut self, increase: bool) {
-        let selected_index = self.profile_edit_schedule_exception;
-        let Some(current_value) = self.selected_schedule_exception_date().cloned() else {
-            return;
-        };
-        let Some(current_date) = parse_schedule_exception_date(&current_value) else {
-            return;
-        };
-        let next_date = if increase {
-            current_date.succ_opt().unwrap_or(current_date)
-        } else {
-            current_date.pred_opt().unwrap_or(current_date)
-        };
-        let next_value = next_date.format("%Y-%m-%d").to_string();
-        if let Some(existing_position) = self
-            .recurring_schedule
-            .exception_dates
-            .iter()
-            .position(|value| value == &next_value)
-        {
-            if existing_position != selected_index {
-                self.recurring_schedule
-                    .exception_dates
-                    .remove(selected_index);
-                self.profile_edit_schedule_exception =
-                    adjusted_index_after_removal(selected_index, existing_position);
-            }
-            return;
-        }
-        if let Some(target) = self
-            .recurring_schedule
-            .exception_dates
-            .get_mut(selected_index)
-        {
-            *target = next_value.clone();
-        }
-        sort_schedule_exception_dates(&mut self.recurring_schedule.exception_dates);
-        if let Some(position) = self
-            .recurring_schedule
-            .exception_dates
-            .iter()
-            .position(|value| value == &next_value)
-        {
-            self.profile_edit_schedule_exception = position;
-        }
-    }
-
     pub(super) fn adjust_schedule_windows_collection(&mut self, increase: bool) {
         if increase {
             self.recurring_schedule
@@ -338,51 +229,5 @@ impl App {
             .windows
             .remove(self.profile_edit_schedule_window);
         self.clamp_profile_edit_schedule_selection();
-    }
-
-    pub(super) fn adjust_schedule_exceptions_collection(&mut self, increase: bool) {
-        if increase {
-            let mut candidate = self.current_frame_now.date_naive();
-            let mut candidate_value = candidate.format("%Y-%m-%d").to_string();
-            while self
-                .recurring_schedule
-                .exception_dates
-                .iter()
-                .any(|value| value == &candidate_value)
-            {
-                let Some(next_candidate) = candidate.succ_opt() else {
-                    return;
-                };
-                candidate = next_candidate;
-                candidate_value = candidate.format("%Y-%m-%d").to_string();
-            }
-            self.recurring_schedule
-                .exception_dates
-                .push(candidate_value.clone());
-            sort_schedule_exception_dates(&mut self.recurring_schedule.exception_dates);
-            self.profile_edit_schedule_exception = self
-                .recurring_schedule
-                .exception_dates
-                .iter()
-                .position(|value| value == &candidate_value)
-                .unwrap_or(0);
-            return;
-        }
-
-        if self.recurring_schedule.exception_dates.is_empty() {
-            return;
-        }
-        self.recurring_schedule
-            .exception_dates
-            .remove(self.profile_edit_schedule_exception);
-        self.clamp_profile_edit_schedule_selection();
-    }
-}
-
-fn adjusted_index_after_removal(removed_index: usize, target_index: usize) -> usize {
-    if removed_index < target_index {
-        target_index.saturating_sub(1)
-    } else {
-        target_index
     }
 }

--- a/src/app/schedule_runtime.rs
+++ b/src/app/schedule_runtime.rs
@@ -32,13 +32,8 @@ impl App {
     }
 
     fn schedule_display_state_at(&self, now: DateTime<Local>) -> ScheduleDisplayState {
-        let today = now.date_naive();
         let active_window = self.active_schedule_occurrence_at(now);
-        let next_window = next_occurrence_after(
-            now,
-            &self.recurring_windows,
-            &self.recurring_exception_dates,
-        );
+        let next_window = next_occurrence_after(now, &self.recurring_windows);
         let delayed_until = active_window.as_ref().and_then(|occurrence| {
             self.schedule_delay_until_for_occurrence_key(&occurrence_key(occurrence), now)
         });
@@ -46,7 +41,6 @@ impl App {
             has_schedule_windows: !self.recurring_windows.is_empty(),
             active_window,
             next_window,
-            is_exception_today: self.recurring_exception_dates.contains(&today),
             is_armed: self.schedule_armed_occurrence_key.is_some(),
             delayed_until,
             has_selected_task: self.has_selectable_task_label_for_focus(),
@@ -59,11 +53,7 @@ impl App {
         &self,
         now: DateTime<Local>,
     ) -> Option<WindowOccurrence> {
-        active_occurrence(
-            now,
-            &self.recurring_windows,
-            &self.recurring_exception_dates,
-        )
+        active_occurrence(now, &self.recurring_windows)
     }
 
     pub(super) fn sync_recurring_schedule(&mut self, now: DateTime<Local>) {
@@ -295,10 +285,6 @@ fn schedule_status_text_from_state(
 
     if state.is_armed {
         return schedule_armed_status_text(state.has_selected_task, labels);
-    }
-
-    if state.is_exception_today {
-        return "⚙  Schedule status: skipped today (exception date)".to_string();
     }
 
     "⚙  Schedule status: ready for next window".to_string()

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -213,7 +213,6 @@ fn applying_profile_loads_profile_scoped_automation_rules() {
             start: "09:00".to_string(),
             end: "11:00".to_string(),
         }],
-        exception_dates: Vec::new(),
     };
     let config = AppConfig {
         selected_profile: ProfileId::Classic,
@@ -278,7 +277,6 @@ fn applying_profile_with_missing_automation_uses_neutral_defaults() {
             start: "09:00".to_string(),
             end: "10:00".to_string(),
         }],
-        exception_dates: vec!["2026-12-25".to_string()],
     };
     app.profile_automation.standard = None;
 
@@ -703,37 +701,6 @@ fn editing_recurring_schedule_fields_updates_and_persists_settings() {
     assert_eq!(persisted.recurring_schedule, app.recurring_schedule);
 }
 
-#[test]
-fn editing_schedule_exception_fields_updates_and_persists_settings() {
-    let mut app = App::default();
-    let base_date = local_datetime_today(10, 15).date_naive();
-    app.current_frame_now = local_datetime_today(10, 15);
-
-    app.handle_key(key(KeyCode::Char('p')));
-    app.handle_key(key(KeyCode::Char('e')));
-    app.profile_edit_field = PROFILE_EDIT_SCHEDULE_EXCEPTION_ADD_REMOVE_INDEX;
-    app.handle_key(key(KeyCode::Right)); // add exception on base date
-    app.profile_edit_field = PROFILE_EDIT_SCHEDULE_EXCEPTION_DATE_INDEX;
-    app.handle_key(key(KeyCode::Right)); // shift to next day
-    app.handle_key(key(KeyCode::Enter));
-
-    let expected_date = base_date
-        .succ_opt()
-        .expect("next day should be representable")
-        .format("%Y-%m-%d")
-        .to_string();
-    assert_eq!(
-        app.recurring_schedule.exception_dates,
-        vec![expected_date.clone()]
-    );
-
-    let persisted = app.persisted_config();
-    assert_eq!(
-        persisted.recurring_schedule.exception_dates,
-        vec![expected_date]
-    );
-}
-
 /// Verifies daily goal editor changes are persisted.
 #[test]
 fn editing_daily_goal_fields_updates_and_persists_settings() {
@@ -822,7 +789,6 @@ fn cancelling_profile_edit_restores_recurring_schedule_settings() {
             start: "13:00".to_string(),
             end: "14:30".to_string(),
         }],
-        ..RecurringScheduleConfig::default()
     };
     let config = AppConfig {
         recurring_schedule: original_schedule.clone(),
@@ -1380,7 +1346,6 @@ fn weekly_daily_goal_allocation_uses_schedule_weights_for_remaining_days() {
                 start: "09:00".to_string(),
                 end: "12:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2627,7 +2592,6 @@ fn recurring_schedule_next_window_text_shows_upcoming_window_for_today() {
                 start: "11:00".to_string(),
                 end: "12:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2656,7 +2620,6 @@ fn recurring_schedule_next_window_text_shows_active_window_then_next_window() {
                     end: "15:00".to_string(),
                 },
             ],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2678,7 +2641,6 @@ fn recurring_schedule_display_texts_use_current_frame_timestamp() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2706,7 +2668,6 @@ fn recurring_schedule_status_text_guides_task_selection_when_active_and_armed() 
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2729,7 +2690,6 @@ fn recurring_schedule_status_text_guides_start_when_active_and_idle() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2753,7 +2713,6 @@ fn recurring_schedule_status_text_guides_resume_when_active_and_paused() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2779,7 +2738,6 @@ fn recurring_schedule_status_text_guides_switch_to_focus_when_active_in_break() 
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2803,7 +2761,6 @@ fn recurring_schedule_status_text_shows_ready_for_upcoming_window() {
                 start: "11:00".to_string(),
                 end: "12:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2825,7 +2782,6 @@ fn recurring_schedule_text_has_no_calendar_annotations() {
                 start: "11:00".to_string(),
                 end: "12:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2835,19 +2791,6 @@ fn recurring_schedule_text_has_no_calendar_annotations() {
 
     assert!(!next_text.contains("calendar"));
     assert!(!status_text.contains("calendar"));
-}
-
-#[test]
-fn adjusting_schedule_exception_date_to_existing_entry_deduplicates_and_selects_existing() {
-    let mut app = App::default();
-    app.recurring_schedule.exception_dates =
-        vec!["2026-05-10".to_string(), "2026-05-11".to_string()];
-    app.profile_edit_schedule_exception = 0;
-
-    app.adjust_selected_schedule_exception_date(true);
-
-    assert_eq!(app.recurring_schedule.exception_dates, vec!["2026-05-11"]);
-    assert_eq!(app.profile_edit_schedule_exception, 0);
 }
 
 #[test]
@@ -2867,7 +2810,6 @@ fn profile_edit_schedule_conflict_summary_reports_overlap() {
                     end: "12:00".to_string(),
                 },
             ],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2876,68 +2818,6 @@ fn profile_edit_schedule_conflict_summary_reports_overlap() {
     let summary = app.profile_edit_field_value(PROFILE_EDIT_SCHEDULE_CONFLICTS_INDEX);
     assert!(summary.contains("1 detected"));
     assert!(summary.contains("recurring #1 overlaps recurring #2"));
-}
-
-#[test]
-fn recurring_schedule_status_text_shows_exception_skip_for_today() {
-    let now = local_datetime_today(10, 15);
-    let today = now.date_naive();
-    let tomorrow = today.succ_opt().expect("tomorrow should be representable");
-    let config = AppConfig {
-        recurring_schedule: RecurringScheduleConfig {
-            windows: vec![
-                crate::config::RecurringFocusWindowConfig {
-                    days: vec![weekday_token(today.weekday()).to_string()],
-                    start: "10:00".to_string(),
-                    end: "11:00".to_string(),
-                },
-                crate::config::RecurringFocusWindowConfig {
-                    days: vec![weekday_token(tomorrow.weekday()).to_string()],
-                    start: "09:00".to_string(),
-                    end: "10:00".to_string(),
-                },
-            ],
-            exception_dates: vec![today.format("%Y-%m-%d").to_string()],
-        },
-        ..AppConfig::default()
-    };
-    let app = App::from_config(config);
-
-    assert_eq!(
-        app.recurring_schedule_texts_at(now).0,
-        "🗓  Next schedule: tomorrow 09:00-10:00"
-    );
-    assert_eq!(
-        app.recurring_schedule_texts_at(now).1,
-        "⚙  Schedule status: skipped today (exception date)"
-    );
-}
-
-#[test]
-fn recurring_schedule_does_not_trigger_on_exception_date() {
-    let now = local_datetime_today(10, 15);
-    let today = now.date_naive();
-    let config = AppConfig {
-        recurring_schedule: RecurringScheduleConfig {
-            windows: vec![crate::config::RecurringFocusWindowConfig {
-                days: vec![weekday_token(today.weekday()).to_string()],
-                start: "10:00".to_string(),
-                end: "11:00".to_string(),
-            }],
-            exception_dates: vec![today.format("%Y-%m-%d").to_string()],
-        },
-        ..AppConfig::default()
-    };
-    let mut app = App::from_config(config);
-    app.task_labels = vec!["Coding".to_string()];
-    app.selected_task_label = Some("Coding".to_string());
-
-    app.sync_recurring_schedule(now);
-
-    assert_eq!(app.timer.phase, TimerPhase::Focus);
-    assert_eq!(app.timer.status, TimerStatus::Idle);
-    assert!(app.schedule_armed_occurrence_key.is_none());
-    assert!(app.phase_notification.is_none());
 }
 
 #[test]
@@ -2950,7 +2830,6 @@ fn recurring_schedule_auto_starts_focus_when_window_begins_and_task_is_selected(
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2979,7 +2858,6 @@ fn recurring_schedule_arms_when_window_begins_without_task_label() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3008,7 +2886,6 @@ fn recurring_schedule_arms_when_selected_task_label_is_archived() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3040,7 +2917,6 @@ fn schedule_delay_key_sets_delay_for_active_window() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3073,7 +2949,6 @@ fn schedule_delay_key_uses_configured_runtime_delay_duration() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         schedule_runtime: ScheduleRuntimeConfig {
             time_step_minutes: 15,
@@ -3113,7 +2988,6 @@ fn schedule_delay_clamps_until_active_window_end() {
                 start: "10:00".to_string(),
                 end: "10:20".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3140,7 +3014,6 @@ fn schedule_delay_suppresses_trigger_until_delay_expires() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3192,7 +3065,6 @@ fn recurring_schedule_status_text_shows_delayed_state() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3217,7 +3089,6 @@ fn schedule_editor_uses_configured_runtime_step_minutes() {
                 start: "09:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         schedule_runtime: ScheduleRuntimeConfig {
             time_step_minutes: 30,
@@ -3242,7 +3113,6 @@ fn recurring_schedule_auto_start_switches_idle_break_to_focus() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3274,7 +3144,6 @@ fn recurring_schedule_does_not_retrigger_within_same_window_occurrence() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3309,7 +3178,6 @@ fn recurring_schedule_triggers_overlapping_window_when_new_window_starts() {
                     end: "11:30".to_string(),
                 },
             ],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3350,7 +3218,6 @@ fn recurring_schedule_does_not_retrigger_within_same_overlapping_occurrence() {
                     end: "11:30".to_string(),
                 },
             ],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -3388,7 +3255,6 @@ fn schedule_window_transition_does_not_delay_schedule_runtime_without_delay_requ
                     end: "10:40".to_string(),
                 },
             ],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -4852,7 +4718,6 @@ fn cli_schedule_delay_sets_delay_for_active_window() {
                 start: "00:00".to_string(),
                 end: "23:59".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -4878,7 +4743,6 @@ fn cli_schedule_delay_persists_workflow_state() {
                 start: "00:00".to_string(),
                 end: "23:59".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -4907,7 +4771,6 @@ fn cli_workflow_snapshot_skips_last_occurrence_for_active_delayed_window() {
                 start: "00:00".to_string(),
                 end: "23:59".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -5097,7 +4960,6 @@ fn app_restores_schedule_arming_continuity_from_workflow_snapshot() {
                 start: "00:00".to_string(),
                 end: "23:59".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };
@@ -5879,7 +5741,6 @@ fn startup_recovery_rehydrates_profile_automation_runtime_for_snapshot_profile()
             start: "09:00".to_string(),
             end: "11:00".to_string(),
         }],
-        exception_dates: vec!["2026-12-25".to_string()],
     };
     let config = AppConfig {
         selected_profile: ProfileId::Custom,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -625,6 +625,6 @@ fn classify_schedule_set_arg(
         return Ok((ParsedToken::ScheduleSet(parse_schedule_value(next)?), 2));
     }
     Err(invalid_usage(
-        "`--schedule-set` requires a JSON payload. Use `--schedule-set='{\"windows\":[...],\"exception_dates\":[...]}'`.",
+        "`--schedule-set` requires a JSON payload. Use `--schedule-set='{\"windows\":[...]}'`.",
     ))
 }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -177,14 +177,6 @@ pub(super) fn print_schedule_command_output(payload: &ScheduleCommandOutput) {
             );
         }
     }
-    if payload.schedule.exception_dates.is_empty() {
-        println!("Exception dates: none");
-    } else {
-        println!(
-            "Exception dates: {}",
-            payload.schedule.exception_dates.join(", ")
-        );
-    }
     if payload.inspection.conflicts.is_empty() {
         println!("Schedule conflicts: none");
     } else {

--- a/src/cli/parsing/value.rs
+++ b/src/cli/parsing/value.rs
@@ -1,5 +1,5 @@
 use crate::cli::{
-    DailyGoalConfig, MonthlyGoalConfig, NaiveDate, ProfileId, RecurringFocusWindowConfig,
+    DailyGoalConfig, MonthlyGoalConfig, ProfileId, RecurringFocusWindowConfig,
     RecurringScheduleConfig, SiteEditValue, ThemePreset, WeeklyGoalConfig,
 };
 
@@ -132,7 +132,7 @@ pub(in crate::cli) fn parse_site_edit_value(value: &str) -> Result<SiteEditValue
 pub(in crate::cli) fn parse_schedule_value(value: &str) -> Result<RecurringScheduleConfig, String> {
     let schedule = serde_json::from_str::<RecurringScheduleConfig>(value).map_err(|error| {
         invalid_usage(&format!(
-            "Invalid schedule JSON payload: {error}. Use `--schedule-set='{{\"windows\":[...],\"exception_dates\":[...]}}'`."
+            "Invalid schedule JSON payload: {error}. Use `--schedule-set='{{\"windows\":[...]}}'`."
         ))
     })?;
     validate_schedule_value(&schedule)?;
@@ -142,9 +142,6 @@ pub(in crate::cli) fn parse_schedule_value(value: &str) -> Result<RecurringSched
 fn validate_schedule_value(schedule: &RecurringScheduleConfig) -> Result<(), String> {
     for (index, window) in schedule.windows.iter().enumerate() {
         validate_schedule_window(window, index)?;
-    }
-    for (index, date) in schedule.exception_dates.iter().enumerate() {
-        validate_schedule_exception_date(date, index)?;
     }
     Ok(())
 }
@@ -184,15 +181,6 @@ fn validate_schedule_window(
             "Invalid schedule window at index {index}: start must be earlier than end."
         )));
     }
-    Ok(())
-}
-
-fn validate_schedule_exception_date(value: &str, index: usize) -> Result<(), String> {
-    NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").map_err(|_| {
-        invalid_usage(&format!(
-            "Invalid exception date at index {index}: `{value}` must be YYYY-MM-DD."
-        ))
-    })?;
     Ok(())
 }
 

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -708,7 +708,7 @@ fn parse_break_glass_cancel_defaults_to_text_mode() {
 
 #[test]
 fn parse_schedule_set_accepts_json_payload() {
-    let payload = r#"{"windows":[{"days":["mon","wed"],"start":"09:00","end":"11:00"}],"exception_dates":["2026-12-25"]}"#;
+    let payload = r#"{"windows":[{"days":["mon","wed"],"start":"09:00","end":"11:00"}]}"#;
     let parsed = parse_args([OsString::from("--schedule-set"), OsString::from(payload)]).unwrap();
     assert_eq!(
         parsed,
@@ -720,7 +720,6 @@ fn parse_schedule_set_accepts_json_payload() {
                         start: "09:00".to_string(),
                         end: "11:00".to_string(),
                     }],
-                    exception_dates: vec!["2026-12-25".to_string()],
                 }),
             },
             output: OutputMode::Text
@@ -730,7 +729,7 @@ fn parse_schedule_set_accepts_json_payload() {
 
 #[test]
 fn parse_schedule_set_rejects_one_time_windows_payload() {
-    let payload = r#"{"windows":[],"exception_dates":[],"one_time_windows":[{"date":"2026-05-02","start":"14:00","end":"15:30"}]}"#;
+    let payload = r#"{"windows":[],"one_time_windows":[{"date":"2026-05-02","start":"14:00","end":"15:30"}]}"#;
     let error = parse_args([OsString::from("--schedule-set"), OsString::from(payload)])
         .expect_err("one-time schedule windows should be rejected");
 
@@ -763,7 +762,6 @@ fn schedule_inspection_output_reports_detected_conflicts() {
                 end: "12:00".to_string(),
             },
         ],
-        ..RecurringScheduleConfig::default()
     };
 
     let output = build_schedule_inspection_output(&schedule);
@@ -781,7 +779,6 @@ fn schedule_inspection_output_reports_no_conflicts() {
             start: "09:00".to_string(),
             end: "10:00".to_string(),
         }],
-        ..RecurringScheduleConfig::default()
     };
 
     let output = build_schedule_inspection_output(&schedule);
@@ -1472,7 +1469,8 @@ fn classify_key_value_arg_accepts_goal_carry_monthly_equals_value() {
 /// Verifies key-value parsing accepts inline schedule JSON payloads.
 #[test]
 fn classify_key_value_arg_accepts_schedule_set_equals_value() {
-    let payload = "--schedule-set={\"windows\":[{\"days\":[\"fri\"],\"start\":\"10:00\",\"end\":\"11:00\"}],\"exception_dates\":[]}";
+    let payload =
+        "--schedule-set={\"windows\":[{\"days\":[\"fri\"],\"start\":\"10:00\",\"end\":\"11:00\"}]}";
     let parsed = classify_key_value_arg(payload).unwrap();
     assert_eq!(
         parsed,
@@ -1482,7 +1480,6 @@ fn classify_key_value_arg_accepts_schedule_set_equals_value() {
                 start: "10:00".to_string(),
                 end: "11:00".to_string(),
             }],
-            exception_dates: Vec::new(),
         }))
     );
 }
@@ -1780,24 +1777,23 @@ fn parse_rejects_blocklist_site_edit_without_old_new_separator() {
 /// Verifies invalid schedule weekday tokens are rejected.
 #[test]
 fn parse_rejects_schedule_set_with_invalid_weekday() {
-    let payload =
-        r#"{"windows":[{"days":["nonday"],"start":"09:00","end":"10:00"}],"exception_dates":[]}"#;
+    let payload = r#"{"windows":[{"days":["nonday"],"start":"09:00","end":"10:00"}]}"#;
     let error =
         parse_args([OsString::from("--schedule-set"), OsString::from(payload)]).unwrap_err();
     assert!(error.contains("unknown weekday"));
 }
 
 #[test]
-fn parse_rejects_schedule_set_with_invalid_exception_date() {
+fn parse_rejects_schedule_set_with_deprecated_exception_dates() {
     let payload = r#"{"windows":[{"days":["mon"],"start":"09:00","end":"10:00"}],"exception_dates":["2026-99-99"]}"#;
     let error =
         parse_args([OsString::from("--schedule-set"), OsString::from(payload)]).unwrap_err();
-    assert!(error.contains("must be YYYY-MM-DD"));
+    assert!(error.contains("exception_dates"));
 }
 
 #[test]
 fn parse_rejects_schedule_set_with_deprecated_one_time_windows() {
-    let payload = r#"{"windows":[],"exception_dates":[],"one_time_windows":[]}"#;
+    let payload = r#"{"windows":[],"one_time_windows":[]}"#;
     let error =
         parse_args([OsString::from("--schedule-set"), OsString::from(payload)]).unwrap_err();
     assert!(error.contains("one_time_windows"));
@@ -2961,7 +2957,6 @@ fn build_status_output_includes_weekly_allocation_breakdown() {
                 start: "09:00".to_string(),
                 end: "10:00".to_string(),
             }],
-            ..RecurringScheduleConfig::default()
         },
         ..AppConfig::default()
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
-use chrono::NaiveDate;
 use serde::{Deserialize, Deserializer, Serialize};
 
 mod blocklists;
@@ -355,8 +354,6 @@ pub(crate) struct AutoStartConfig {
 pub(crate) struct RecurringScheduleConfig {
     #[serde(default)]
     pub(crate) windows: Vec<RecurringFocusWindowConfig>,
-    #[serde(default)]
-    pub(crate) exception_dates: Vec<String>,
 }
 
 impl RecurringScheduleConfig {
@@ -375,11 +372,7 @@ impl RecurringScheduleConfig {
                 start_minutes < end_minutes
             })
             .collect();
-        let exception_dates = normalize_schedule_exception_dates(&self.exception_dates);
-        Self {
-            windows,
-            exception_dates,
-        }
+        Self { windows }
     }
 }
 
@@ -1355,26 +1348,6 @@ fn parse_schedule_time_minutes(value: &str) -> Option<u16> {
         return None;
     }
     Some(hour * 60 + minute)
-}
-
-fn normalize_schedule_exception_dates(dates: &[String]) -> Vec<String> {
-    let mut normalized = Vec::new();
-    let mut seen = HashSet::new();
-    for date in dates {
-        let Some(parsed) = parse_schedule_exception_date(date) else {
-            continue;
-        };
-        let canonical = parsed.format("%Y-%m-%d").to_string();
-        if seen.insert(canonical.clone()) {
-            normalized.push(canonical);
-        }
-    }
-    normalized.sort();
-    normalized
-}
-
-fn parse_schedule_exception_date(value: &str) -> Option<NaiveDate> {
-    NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").ok()
 }
 
 fn normalize_session_templates(

--- a/src/config/migration.rs
+++ b/src/config/migration.rs
@@ -70,6 +70,16 @@ pub(super) fn migrate_config_toml_to_current_detailed(
                 .to_string(),
         });
     }
+    let schedule_exception_dates_input = config_toml.clone();
+    remove_schedule_exception_dates(&mut config_toml);
+    if schedule_exception_dates_input != config_toml {
+        steps.push(ConfigMigrationStepReport {
+            from_schema_version,
+            to_schema_version: from_schema_version,
+            summary: "Remove deprecated schedule exception dates; schedules now use recurring windows only."
+                .to_string(),
+        });
+    }
     let blocklist_category_input = config_toml.clone();
     migrate_blocklist_categories_to_profile_rules(&mut config_toml);
     if blocklist_category_input != config_toml {
@@ -125,6 +135,63 @@ pub(super) fn remove_automation_triggers(config_toml: &mut toml::Value) {
         return;
     }
     table.remove("automation_triggers");
+}
+
+/// Removes retired schedule exception dates from all persisted schedule surfaces.
+pub(super) fn remove_schedule_exception_dates(config_toml: &mut toml::Value) {
+    let Some(table) = config_toml.as_table_mut() else {
+        return;
+    };
+    remove_exception_dates_from_named_schedule(table, "recurring_schedule");
+    remove_profile_automation_schedule_exception_dates(table);
+    remove_session_template_schedule_exception_dates(table);
+}
+
+fn remove_exception_dates_from_named_schedule(
+    table: &mut toml::map::Map<String, toml::Value>,
+    schedule_key: &str,
+) {
+    let Some(schedule) = table
+        .get_mut(schedule_key)
+        .and_then(toml::Value::as_table_mut)
+    else {
+        return;
+    };
+    schedule.remove("exception_dates");
+}
+
+fn remove_profile_automation_schedule_exception_dates(
+    table: &mut toml::map::Map<String, toml::Value>,
+) {
+    let Some(profile_automation) = table
+        .get_mut("profile_automation")
+        .and_then(toml::Value::as_table_mut)
+    else {
+        return;
+    };
+    for (_, preset) in profile_automation.iter_mut() {
+        let Some(preset) = preset.as_table_mut() else {
+            continue;
+        };
+        remove_exception_dates_from_named_schedule(preset, "recurring_schedule");
+    }
+}
+
+fn remove_session_template_schedule_exception_dates(
+    table: &mut toml::map::Map<String, toml::Value>,
+) {
+    let Some(templates) = table
+        .get_mut("session_templates")
+        .and_then(toml::Value::as_array_mut)
+    else {
+        return;
+    };
+    for template in templates {
+        let Some(template) = template.as_table_mut() else {
+            continue;
+        };
+        remove_exception_dates_from_named_schedule(template, "schedule");
+    }
 }
 
 /// Moves deprecated blocklist category rules into profile-level blocked-site entries.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -135,7 +135,6 @@ fn round_trip_full_config() {
                     start: "09:15".to_string(),
                     end: "11:00".to_string(),
                 }],
-                exception_dates: vec!["2026-04-27".to_string()],
             },
         }],
         selected_session_template: "Morning deep work".to_string(),
@@ -154,7 +153,6 @@ fn round_trip_full_config() {
                 start: "09:15".to_string(),
                 end: "11:00".to_string(),
             }],
-            exception_dates: vec!["2026-04-27".to_string(), "2026-05-05".to_string()],
         },
         schedule_runtime: ScheduleRuntimeConfig {
             time_step_minutes: 20,
@@ -189,7 +187,6 @@ fn round_trip_full_config() {
                         start: "09:15".to_string(),
                         end: "11:00".to_string(),
                     }],
-                    exception_dates: vec!["2026-04-27".to_string(), "2026-05-05".to_string()],
                 },
             }),
             advanced: Some(ProfileAutomationConfig {
@@ -615,7 +612,6 @@ start = "08:30"
     assert_eq!(window.start, "08:30");
     assert_eq!(window.end, default_schedule_window_end());
     assert_eq!(window.days, default_schedule_window_days());
-    assert!(cfg.recurring_schedule.exception_dates.is_empty());
 }
 
 #[test]
@@ -649,7 +645,6 @@ fn normalize_drops_recurring_windows_with_invalid_time_ranges() {
                     end: "09:00".to_string(),
                 },
             ],
-            exception_dates: Vec::new(),
         },
         ..AppConfig::default()
     }
@@ -658,29 +653,6 @@ fn normalize_drops_recurring_windows_with_invalid_time_ranges() {
     assert_eq!(cfg.recurring_schedule.windows.len(), 1);
     assert_eq!(cfg.recurring_schedule.windows[0].start, "09:00");
     assert_eq!(cfg.recurring_schedule.windows[0].end, "11:00");
-}
-
-#[test]
-fn normalize_recurring_schedule_exception_dates_dedupes_and_drops_invalid_entries() {
-    let cfg = AppConfig {
-        recurring_schedule: RecurringScheduleConfig {
-            windows: Vec::new(),
-            exception_dates: vec![
-                " 2026-12-25 ".to_string(),
-                "2026-02-30".to_string(),
-                "2026-01-01".to_string(),
-                "2026-12-25".to_string(),
-                "not-a-date".to_string(),
-            ],
-        },
-        ..AppConfig::default()
-    }
-    .normalize();
-
-    assert_eq!(
-        cfg.recurring_schedule.exception_dates,
-        vec!["2026-01-01".to_string(), "2026-12-25".to_string()]
-    );
 }
 
 #[test]
@@ -2018,7 +1990,6 @@ fn normalize_migrates_legacy_automation_into_per_profile_settings() {
             start: "09:00".to_string(),
             end: "10:30".to_string(),
         }],
-        exception_dates: vec!["2026-12-25".to_string()],
     };
     let cfg = AppConfig {
         selected_profile: ProfileId::DeepWork,
@@ -2088,7 +2059,6 @@ fn normalize_selected_profile_automation_keeps_top_level_legacy_fields() {
                 start: "13:00".to_string(),
                 end: "15:00".to_string(),
             }],
-            exception_dates: Vec::new(),
         },
     };
 
@@ -2131,7 +2101,6 @@ fn normalize_legacy_automation_fields_do_not_override_profile_automation() {
                 start: "13:00".to_string(),
                 end: "15:00".to_string(),
             }],
-            exception_dates: Vec::new(),
         },
     };
     let cfg = AppConfig {
@@ -2275,6 +2244,41 @@ allowlist_sites = []
     );
     assert!(steps.iter().any(|step| {
         step.summary == "Flatten deprecated blocklist category rules into profile-level site lists."
+    }));
+}
+
+#[test]
+fn config_migration_removes_schedule_exception_dates() {
+    let original: toml::Value = toml::from_str(
+        r#"
+schema_version = 2
+
+[recurring_schedule]
+exception_dates = ["2026-12-25"]
+
+[profile_automation.basic.recurring_schedule]
+exception_dates = ["2026-12-25"]
+
+[[session_templates]]
+name = "Morning"
+task_label = "Docs"
+profile = "basic"
+blocklist_profile = "Default"
+
+[session_templates.schedule]
+exception_dates = ["2026-12-25"]
+"#,
+    )
+    .unwrap();
+
+    let (migrated, _, steps) = migrate_config_toml_to_current_detailed(original).unwrap();
+    assert!(
+        !migrated.to_string().contains("exception_dates"),
+        "migrated config should not retain schedule exception date keys"
+    );
+    assert!(steps.iter().any(|step| {
+        step.summary
+            == "Remove deprecated schedule exception dates; schedules now use recurring windows only."
     }));
 }
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,6 +1,4 @@
-use std::collections::HashSet;
-
-use chrono::{DateTime, Local, NaiveDate, Weekday};
+use chrono::{DateTime, Local, Weekday};
 
 use crate::config::RecurringFocusWindowConfig;
 
@@ -13,7 +11,7 @@ pub(crate) use conflicts::inspect_schedule_conflicts;
 pub(crate) use conflicts::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
 pub(crate) use occurrence::{active_occurrence, next_occurrence_after, occurrence_key};
 
-use parsing::{parse_exception_date, parse_time_minutes, parse_weekdays};
+use parsing::{parse_time_minutes, parse_weekdays};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RecurringWindow {
@@ -44,13 +42,6 @@ pub(crate) fn compile_windows(
     config_windows
         .iter()
         .filter_map(RecurringWindow::from_config)
-        .collect()
-}
-
-pub(crate) fn compile_exception_dates(config_dates: &[String]) -> HashSet<NaiveDate> {
-    config_dates
-        .iter()
-        .filter_map(|value| parse_exception_date(value))
         .collect()
 }
 

--- a/src/schedule/occurrence.rs
+++ b/src/schedule/occurrence.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use chrono::{DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, TimeZone, Timelike};
 
 use super::{RecurringWindow, WindowOccurrence};
@@ -15,13 +13,9 @@ pub(crate) fn occurrence_key(occurrence: &WindowOccurrence) -> String {
 pub(crate) fn active_occurrence(
     now: DateTime<Local>,
     windows: &[RecurringWindow],
-    exception_dates: &HashSet<NaiveDate>,
 ) -> Option<WindowOccurrence> {
     let now_minutes = now.hour() as u16 * 60 + now.minute() as u16;
     let today = now.date_naive();
-    if exception_dates.contains(&today) {
-        return None;
-    }
     let mut selected: Option<WindowOccurrence> = None;
 
     for (window_index, window) in windows.iter().enumerate() {
@@ -60,21 +54,12 @@ pub(crate) fn active_occurrence(
 pub(crate) fn next_occurrence_after(
     now: DateTime<Local>,
     windows: &[RecurringWindow],
-    exception_dates: &HashSet<NaiveDate>,
 ) -> Option<WindowOccurrence> {
     let mut selected: Option<WindowOccurrence> = None;
     let today = now.date_naive();
-    let future_exception_count = exception_dates
-        .iter()
-        .filter(|date| **date >= today)
-        .count();
-    let search_days = 7_i64.saturating_mul((future_exception_count as i64).saturating_add(1));
 
-    for day_offset in 0..=search_days {
+    for day_offset in 0..=7 {
         let date = today + Duration::days(day_offset);
-        if exception_dates.contains(&date) {
-            continue;
-        }
         for (window_index, window) in windows.iter().enumerate() {
             if !window.days.contains(&date.weekday()) {
                 continue;

--- a/src/schedule/parsing.rs
+++ b/src/schedule/parsing.rs
@@ -1,4 +1,4 @@
-use chrono::{NaiveDate, Weekday};
+use chrono::Weekday;
 
 pub(super) fn parse_weekdays(raw_days: &[String]) -> Vec<Weekday> {
     let mut weekdays = Vec::new();
@@ -38,8 +38,4 @@ pub(super) fn parse_time_minutes(raw: &str) -> Option<u16> {
         return None;
     }
     Some(hour * 60 + minute)
-}
-
-pub(super) fn parse_exception_date(raw: &str) -> Option<NaiveDate> {
-    NaiveDate::parse_from_str(raw.trim(), "%Y-%m-%d").ok()
 }

--- a/src/schedule/tests.rs
+++ b/src/schedule/tests.rs
@@ -1,9 +1,7 @@
 use super::{
-    ScheduleConflict, active_occurrence, compile_exception_dates, compile_windows,
-    format_schedule_conflict, inspect_schedule_conflicts_from_config, next_occurrence_after,
+    ScheduleConflict, active_occurrence, compile_windows, format_schedule_conflict,
+    inspect_schedule_conflicts_from_config, next_occurrence_after,
 };
-
-use std::collections::HashSet;
 
 use chrono::{DateTime, Datelike, Duration, Local, LocalResult, NaiveDate, TimeZone, Weekday};
 
@@ -43,19 +41,6 @@ fn compile_windows_ignores_invalid_entries() {
 }
 
 #[test]
-fn compile_exception_dates_ignores_invalid_and_deduplicates() {
-    let dates = compile_exception_dates(&[
-        " 2026-12-25 ".to_string(),
-        "2026-12-25".to_string(),
-        "not-a-date".to_string(),
-        "".to_string(),
-    ]);
-
-    assert_eq!(dates.len(), 1);
-    assert!(dates.contains(&NaiveDate::from_ymd_opt(2026, 12, 25).expect("valid date literal")));
-}
-
-#[test]
 fn active_occurrence_returns_window_when_inside_range() {
     let date = Local::now().date_naive();
     let now = local_datetime(date, 10, 15);
@@ -65,8 +50,7 @@ fn active_occurrence_returns_window_when_inside_range() {
         end: "11:00".to_string(),
     }]);
 
-    let active =
-        active_occurrence(now, &windows, &HashSet::new()).expect("window should be active");
+    let active = active_occurrence(now, &windows).expect("window should be active");
 
     assert_eq!(active.start, local_datetime(date, 10, 0));
     assert_eq!(active.end, local_datetime(date, 11, 0));
@@ -89,38 +73,10 @@ fn next_occurrence_after_skips_current_or_past_start_times() {
         },
     ]);
 
-    let next =
-        next_occurrence_after(now, &windows, &HashSet::new()).expect("next window should exist");
+    let next = next_occurrence_after(now, &windows).expect("next window should exist");
 
     assert_eq!(next.start, local_datetime(date, 11, 0));
     assert_eq!(next.end, local_datetime(date, 12, 0));
-}
-
-#[test]
-fn active_and_next_occurrences_skip_exception_dates() {
-    let date = Local::now().date_naive();
-    let now = local_datetime(date, 10, 15);
-    let tomorrow = date.succ_opt().expect("tomorrow should be representable");
-    let windows = compile_windows(&[
-        RecurringFocusWindowConfig {
-            days: vec![date.weekday().to_string()],
-            start: "10:00".to_string(),
-            end: "11:00".to_string(),
-        },
-        RecurringFocusWindowConfig {
-            days: vec![tomorrow.weekday().to_string()],
-            start: "09:00".to_string(),
-            end: "10:00".to_string(),
-        },
-    ]);
-    let exception_dates = compile_exception_dates(&[date.format("%Y-%m-%d").to_string()]);
-
-    assert!(active_occurrence(now, &windows, &exception_dates).is_none());
-
-    let next = next_occurrence_after(now, &windows, &exception_dates)
-        .expect("next window should skip exception date");
-    assert_eq!(next.start, local_datetime(tomorrow, 9, 0));
-    assert_eq!(next.end, local_datetime(tomorrow, 10, 0));
 }
 
 #[test]
@@ -140,8 +96,7 @@ fn active_occurrence_prefers_most_recent_overlap_start() {
         },
     ]);
 
-    let active =
-        active_occurrence(now, &windows, &HashSet::new()).expect("window should be active");
+    let active = active_occurrence(now, &windows).expect("window should be active");
 
     assert_eq!(active.window_index, 1);
     assert_eq!(active.start, local_datetime(date, 10, 30));
@@ -165,8 +120,7 @@ fn active_occurrence_tie_on_start_prefers_first_window_index() {
         },
     ]);
 
-    let active =
-        active_occurrence(now, &windows, &HashSet::new()).expect("window should be active");
+    let active = active_occurrence(now, &windows).expect("window should be active");
 
     assert_eq!(active.window_index, 0);
     assert_eq!(active.start, local_datetime(date, 10, 0));
@@ -190,8 +144,8 @@ fn next_occurrence_after_tie_on_start_prefers_first_window_index() {
         },
     ]);
 
-    let next = next_occurrence_after(now, &windows, &HashSet::new())
-        .expect("next window should exist for tied start");
+    let next =
+        next_occurrence_after(now, &windows).expect("next window should exist for tied start");
 
     assert_eq!(next.window_index, 0);
     assert_eq!(next.start, local_datetime(date, 10, 0));
@@ -199,23 +153,20 @@ fn next_occurrence_after_tie_on_start_prefers_first_window_index() {
 }
 
 #[test]
-fn next_occurrence_after_skips_weekly_exception_and_returns_following_week() {
+fn next_occurrence_after_returns_next_weekly_window() {
     let date = Local::now().date_naive();
     let now = local_datetime(date, 12, 15);
     let next_week = date + Duration::days(7);
-    let following_week = date + Duration::days(14);
     let windows = compile_windows(&[RecurringFocusWindowConfig {
         days: vec![date.weekday().to_string()],
         start: "11:00".to_string(),
         end: "12:00".to_string(),
     }]);
-    let exception_dates = compile_exception_dates(&[next_week.format("%Y-%m-%d").to_string()]);
 
-    let next = next_occurrence_after(now, &windows, &exception_dates)
-        .expect("next window should skip the excepted weekly occurrence");
+    let next = next_occurrence_after(now, &windows).expect("next weekly window should be selected");
 
-    assert_eq!(next.start, local_datetime(following_week, 11, 0));
-    assert_eq!(next.end, local_datetime(following_week, 12, 0));
+    assert_eq!(next.start, local_datetime(next_week, 11, 0));
+    assert_eq!(next.end, local_datetime(next_week, 12, 0));
 }
 
 #[test]
@@ -234,7 +185,6 @@ fn inspect_schedule_conflicts_detects_recurring_overlap_on_shared_weekday() {
                 end: "12:00".to_string(),
             },
         ],
-        ..RecurringScheduleConfig::default()
     };
 
     let conflicts = inspect_schedule_conflicts_from_config(&schedule);

--- a/src/ui/profile_manager.rs
+++ b/src/ui/profile_manager.rs
@@ -275,11 +275,8 @@ fn profile_edit_field_display_label(field_index: usize) -> &'static str {
         23 => "Start time",
         24 => "End time",
         25 => "Add/remove",
-        26 => "Exception selector",
-        27 => "Exception date",
-        28 => "Exception add/remove",
-        29 => "Conflict inspector",
-        30 => "Theme preset",
+        26 => "Conflict inspector",
+        27 => "Theme preset",
         _ => "",
     }
 }

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -918,8 +918,7 @@ fn profile_editor_renders_schedule_fields() {
     assert!(text.contains("Window selector"));
     assert!(text.contains("Day selector"));
     assert!(text.contains("Start time"));
-    assert!(text.contains("Exception selector"));
-    assert!(text.contains("more fields"));
+    assert!(text.contains("Conflict inspector"));
 }
 
 #[test]

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -1102,7 +1102,7 @@ fn recurring_schedule_is_profile_scoped_via_cli_commands() {
     assert!(stderr_text(&select_deep_work).trim().is_empty());
 
     let set_schedule = env.run(&[
-        "--schedule-set={\"windows\":[{\"days\":[\"mon\"],\"start\":\"09:00\",\"end\":\"11:00\"}],\"exception_dates\":[]}",
+        "--schedule-set={\"windows\":[{\"days\":[\"mon\"],\"start\":\"09:00\",\"end\":\"11:00\"}]}",
         "--json",
     ]);
     assert_eq!(set_schedule.status.code(), Some(0));


### PR DESCRIPTION
## What

Remove schedule exception-date support so recurring schedules are represented only as recurring windows.

Closes #549.

## Why

This is part of the v0.16.2 cleanup roadmap to remove skipped-date schedule behavior and simplify schedule runtime, config, CLI output, and editor state.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recurring schedules now use recurring windows only, with schedule configuration, editing, and runtime behavior simplified accordingly.
* **Bug Fixes**
  * Removed “exception date” handling from scheduling, status text, and conflict calculations for more consistent behavior.
* **Documentation**
  * Updated changelog, README examples, and CLI help text to reflect the new schedule format.
* **Tests**
  * Aligned automated tests and JSON contract checks with the updated recurring schedule structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->