### PR TITLE
Remove task note metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Focus intention metadata cleanup (#554):** removed `--focus-intention` CLI parsing/help/output, dropped focus intention recovery and stats/export fields, and kept task labels plus `task_note` as the supported session metadata.
+- **Task note metadata cleanup (#555):** removed `--task-note` CLI parsing/help/output, dropped task note editing, recovery, status, and stats/export fields, and kept task labels as the supported session context.
+- **Focus intention metadata cleanup (#554):** removed `--focus-intention` CLI parsing/help/output, dropped focus intention recovery and stats/export fields, and kept task labels as the supported session metadata.
 - **Session template workflow cleanup (#552):** removed `--session-template*` command parsing/help/output, dropped session template config/runtime persistence, and kept task, profile, schedule, and blocklist workflows available through their direct controls.
 
 ## [0.16.2] - 2026-06-26

--- a/README.md
+++ b/README.md
@@ -101,10 +101,6 @@ cargo run -- --task-goal "Write docs"
 cargo run -- --task-goal "Write docs:120,4"
 cargo run -- --task-goal=Write-docs:120,4 --json
 
-# Show or set session note metadata while focus is running/paused
-cargo run -- --task-note
-cargo run -- --task-note="Capture blockers for retro" --json
-
 # Show or set the active profile
 cargo run -- --profile
 cargo run -- --profile standard
@@ -206,7 +202,7 @@ cargo run -- --export=./reports --json
 ### Retired local daemon API
 
 - The local daemon API lifecycle commands (`--daemon-start`, `--daemon-status`, `--daemon-stop`, and `--daemon-port`) are removed.
-- New automation should use CLI timer/session/workflow commands (`--start`, `--pause`, `--resume`, `--stop`, `--next`, `--task`, `--task-note`, `--break-glass-trigger`, `--break-glass-cancel`) or the TUI for interactive focus sessions.
+- New automation should use CLI timer/session/workflow commands (`--start`, `--pause`, `--resume`, `--stop`, `--next`, `--task`, `--break-glass-trigger`, `--break-glass-cancel`) or the TUI for interactive focus sessions.
 - The loopback `/v1/*` daemon endpoints are no longer a supported runtime surface.
 
 Backup/restore/export behavior:
@@ -267,6 +263,7 @@ Milestone policy:
 - **v0.16.0:** daemon-owned runtime dependency cleanup is locked; WakaTime owns runtime HTTP and Basic auth while daemon-only local API server and direct random-token dependencies stay removed.
 - **v0.16.1:** focused config diagnostics commands are retired in favor of `--diagnostics`; feature inventory CLI export and committed generated inventory snapshots are retired; legacy cleanup-specific regression gates are archived, and current cleanup contracts live in normal CI/module/integration tests.
 - **v0.16.2:** schedule exception dates, calendar annotation cache handling, and retired calendar timezone parsing stay removed; recurring schedule windows remain the supported schedule model, and `chrono-tz` stays out of the manifest and lockfile.
+- **v0.16.3:** task note metadata and `--task-note` command surfaces are retired; task labels are the supported session context in status, recovery, history, and exports.
 - **Future cleanup:** continue retiring overlapping paths only after release notes and docs name supported replacement behavior.
 - **v0.12.0:** remove legacy field/path compatibility after the warning window
 
@@ -312,7 +309,8 @@ Early deprecation notices:
 | Standalone feature inventory export (`--feature-inventory`) | Removed; generated inventory snapshots are no longer committed or regenerated for releases. Use GitHub roadmap issues, release notes, and static cleanup documentation for planning. |
 | Schedule exception dates | Removed; represent focus availability with recurring schedule windows, inspect overlaps with `--schedule`, and use supported timer controls for one-off workflow adjustments. |
 | Standalone calendar refresh command (`--calendar-sync`) and `[calendar_sync]` config | Removed; scheduling no longer reads calendar annotation caches or renders calendar-derived busy/overlap text. |
-| Daemon local API lifecycle (`--daemon-start`, `--daemon-status`, `--daemon-stop`, `--daemon-port`, `/v1/*`) | Removed; use CLI timer/session/workflow commands (`--start`, `--pause`, `--resume`, `--stop`, `--next`, `--task`, `--task-note`, `--break-glass-trigger`, `--break-glass-cancel`) for automation, or the TUI for interactive focus sessions. |
+| Task note metadata and command surface (`--task-note`, timer note editing, `task_note` status/export fields) | Removed; use `--task` and task label selection as the supported session context. |
+| Daemon local API lifecycle (`--daemon-start`, `--daemon-status`, `--daemon-stop`, `--daemon-port`, `/v1/*`) | Removed; use CLI timer/session/workflow commands (`--start`, `--pause`, `--resume`, `--stop`, `--next`, `--task`, `--break-glass-trigger`, `--break-glass-cancel`) for automation, or the TUI for interactive focus sessions. |
 | Duplicate schedule/session start entry points | Select the task/profile/blocklist/schedule directly, then start focus through the unified timer flow with `--start` or the TUI. |
 
 Runtime dependency ownership after daemon and calendar cleanup:
@@ -478,21 +476,9 @@ stats growth, retention, and comparison filters. Dashboard pin, unpin, and order
 customization commands are retired; use `--history-dashboard` for CLI layout
 inspection.
 
-### Mid-session notes
-
-While a focus session is running or paused, press **`m`** in timer view to edit a
-quick session note.
-
-- type or paste note text
-- `Enter`: save (replaces the previous note); if the draft is blank or only whitespace, the note is not saved and the task label is used instead
-- `Esc`: cancel without changing the current note
-
-Saved notes are reflected in live status metadata (`task_note`), recovery state,
-and interruption/completed-session history export fields.
-
-CLI parity is available via `--task-note`, `--break-glass-trigger`, and `--break-glass-cancel` for
-non-interactive inspection and in-session workflow control. `--history-dashboard`
-remains available for layout inspection.
+CLI parity is available via `--break-glass-trigger` and `--break-glass-cancel`
+for non-interactive in-session workflow control. `--history-dashboard` remains
+available for layout inspection.
 
 Blocklist rules support exact hosts and wildcard subdomain rules. `*.example.com`
 matches `docs.example.com` and `api.example.com`, but does **not** match
@@ -773,9 +759,8 @@ You can configure notification and auto-start settings directly from the TUI:
 
 `focustime` persists in-progress timer sessions so restart/crash recovery can resume where you left off.
 
-- while a focus/break phase is running or paused, the app saves phase, remaining time, task metadata (`task_label`, `task_note`), and active profile
+- while a focus/break phase is running or paused, the app saves phase, remaining time, task label, and active profile
 - startup recovery also reconciles transient workflow runtime artifacts when still valid (schedule arming continuity, break-glass state, and strict-reset confirmation state)
-- while editing with `m`, pressing `Enter` replaces the in-progress session `task_note` and immediately syncs recovery metadata; if the draft is blank or only whitespace, the note is not saved and the task label is used instead
 - on startup, valid in-progress state is restored and shown in the timer notice line
 - on startup, blocking is reconciled with recovered timer state: recovered active focus re-applies blocking, while non-recovered startup attempts to remove stale crash-era block entries
 - stale or invalid saved recovery/runtime artifacts are ignored safely with a startup warning notice
@@ -863,15 +848,14 @@ From timer view:
 Exports include daily/weekly aggregates, weekly consistency, weekly focus score,
 profile effectiveness, productivity comparisons, task summaries/trends,
 interruption records, and labeled focus-session records where task labels were
-attached. Focus-session rows persist and export `task_label` and `task_note`
-fields; when dedicated note input is not provided, `task_note` defaults to the
-selected `task_label`. Interruption records include structured `reason` values
-and remaining-time metadata. Export files now also include a `history_kpis` JSON
+attached. Focus-session rows persist and export `task_label` without separate
+task note metadata. Interruption records include structured `reason` values and
+remaining-time metadata. Export files now also include a `history_kpis` JSON
 object covering all History dashboard KPI cards (`session_summary`,
 `focus_score`, `goal_streak`, `focus_risk`, `weekly_allocation`,
 `last_interruption`, `stats_growth`, `retention`, `comparison_filters`), with
 matching CSV `history_kpi` rows (`kpi_card_id` + `kpi_payload_json`) for
-JSON/CSV parity. Export files expose `schema_version` (currently `8`) so
+JSON/CSV parity. Export files expose `schema_version` (currently `9`) so
 downstream consumers can handle versioned contracts explicitly.
 
 ## The way the system works

--- a/src/app.rs
+++ b/src/app.rs
@@ -275,7 +275,6 @@ struct FocusInterruptionContext {
     timestamp_epoch_secs: u64,
     reason: SessionInterruptionReason,
     task_label: Option<String>,
-    task_note: Option<String>,
     remaining_secs: u64,
     profile: Option<ProfileId>,
 }
@@ -445,9 +444,6 @@ pub(crate) struct App {
     pub(crate) planner_input_mode: Option<PlannerInputMode>,
     pub(crate) planner_feedback: Option<PlannerFeedback>,
     active_focus_task_label: Option<String>,
-    active_focus_task_note: Option<String>,
-    timer_note_input: String,
-    timer_note_input_active: bool,
     active_focus_profile: Option<ProfileId>,
     site_list_mode: SiteListMode,
     /// Index of the highlighted site in the SiteManager list.
@@ -641,9 +637,6 @@ impl App {
             planner_input_mode: None,
             planner_feedback: None,
             active_focus_task_label: None,
-            active_focus_task_note: None,
-            timer_note_input: String::new(),
-            timer_note_input_active: false,
             active_focus_profile: None,
             site_list_mode: SiteListMode::Blocklist,
             selected_site: 0,
@@ -793,24 +786,6 @@ impl App {
         }
     }
 
-    pub(crate) fn current_task_note(&self) -> Option<&str> {
-        if !self.focus_session_active_for_current_state() {
-            return None;
-        }
-        self.active_focus_task_note
-            .as_deref()
-            .or(self.active_focus_task_label.as_deref())
-            .or(self.selected_task_label.as_deref())
-    }
-
-    pub(crate) fn can_edit_session_note(&self) -> bool {
-        self.focus_session_active_for_current_state()
-    }
-
-    pub(crate) fn timer_note_input_active(&self) -> bool {
-        self.timer_note_input_active
-    }
-
     pub(super) fn shortcut_matches(&self, action: ShortcutAction, key: &KeyEvent) -> bool {
         self.shortcuts.matches(action, key)
     }
@@ -833,10 +808,6 @@ impl App {
 
     pub(crate) fn navigation_label(&self, action: NavigationAction) -> String {
         self.shortcuts.navigation_label(action)
-    }
-
-    pub(crate) fn timer_note_input_value(&self) -> &str {
-        &self.timer_note_input
     }
 
     pub(crate) fn profile_values(&self, profile: ProfileId) -> (u64, u64, u64, u32) {
@@ -1190,17 +1161,6 @@ impl App {
     }
 
     pub(crate) fn handle_paste(&mut self, text: String) {
-        if self.mode == AppMode::Timer && self.timer_note_input_active {
-            let sanitized = normalize_timer_note_paste(&text);
-            if !sanitized.is_empty() {
-                if !self.timer_note_input.is_empty() {
-                    self.timer_note_input.push(' ');
-                }
-                self.timer_note_input.push_str(&sanitized);
-            }
-            return;
-        }
-
         if self.mode != AppMode::SiteManager {
             return;
         }
@@ -1335,22 +1295,6 @@ fn adjust_duration_minutes(value: &mut u64, increase: bool) {
             .saturating_sub(CUSTOM_DURATION_STEP_SECS)
             .max(CUSTOM_DURATION_STEP_SECS);
     }
-}
-
-fn normalize_timer_note_paste(input: &str) -> String {
-    input
-        .chars()
-        .map(|c| {
-            if c == '\r' || c == '\n' || c.is_control() {
-                ' '
-            } else {
-                c
-            }
-        })
-        .collect::<String>()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
 }
 
 fn adjust_daily_goal_minutes(value: &mut u64, increase: bool) {

--- a/src/app/cli_api.rs
+++ b/src/app/cli_api.rs
@@ -145,21 +145,6 @@ impl App {
         self.selected_task_label.clone()
     }
 
-    pub(crate) fn task_note_for_cli(&self) -> Option<String> {
-        if self.focus_session_active_for_current_state() {
-            return self.active_focus_task_note.clone();
-        }
-        None
-    }
-
-    pub(crate) fn set_task_note_for_cli(&mut self, value: &str) -> AppResult<()> {
-        self.ensure_focus_active_for_cli_metadata_update("--task-note")?;
-        let value = self.resolve_cli_metadata_value(value)?;
-        self.active_focus_task_note = Some(value);
-        self.sync_recovery_snapshot();
-        Ok(())
-    }
-
     pub(crate) fn timer_state_for_cli(&self) -> (TimerPhase, TimerStatus, u64, u32) {
         (
             self.timer.phase,
@@ -167,20 +152,5 @@ impl App {
             self.timer.remaining_secs,
             self.timer.pomodoros_completed,
         )
-    }
-
-    fn ensure_focus_active_for_cli_metadata_update(&self, command: &'static str) -> AppResult<()> {
-        if self.focus_session_active_for_current_state() {
-            Ok(())
-        } else {
-            Err(AppError::SessionMetadataInactive { command })
-        }
-    }
-
-    fn resolve_cli_metadata_value(&self, value: &str) -> AppResult<String> {
-        normalize_task_label(value)
-            .or_else(|| self.active_focus_task_label.clone())
-            .or_else(|| self.selected_task_label.clone())
-            .ok_or(AppError::SessionMetadataMissingTaskLabel)
     }
 }

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -13,8 +13,6 @@ pub(crate) enum AppError {
     StrictModeActive { action: &'static str },
     TimerAlreadyIdle,
     BreakGlassNoConfirmation,
-    SessionMetadataInactive { command: &'static str },
-    SessionMetadataMissingTaskLabel,
     TaskLabelEmpty,
     TaskLabelLookupFailed,
     ArchivedTaskLabel { label: String },
@@ -74,18 +72,6 @@ impl UserFacingError for AppError {
                 "app.break_glass.no_confirmation",
                 "Cannot cancel break-glass: no confirmation is pending.",
                 "Trigger break-glass first before trying to cancel the pending confirmation.",
-            ),
-            Self::SessionMetadataInactive { command } => UserMessage::with_hint(
-                "app.session_metadata.inactive",
-                format!(
-                    "Cannot set session metadata with `{command}`: focus session is not active or paused."
-                ),
-                "Start or pause a focus session before setting session metadata.",
-            ),
-            Self::SessionMetadataMissingTaskLabel => UserMessage::with_hint(
-                "app.session_metadata.missing_task_label",
-                "Cannot set session metadata: no task label is selected.",
-                "Select a task with `focustime --task LABEL` first.",
             ),
             Self::TaskLabelEmpty => UserMessage::with_hint(
                 "app.task_label.empty",

--- a/src/app/history_goals.rs
+++ b/src/app/history_goals.rs
@@ -26,7 +26,6 @@ impl App {
             timestamp_epoch_secs,
             reason,
             task_label: task_label.clone(),
-            task_note: self.active_focus_task_note.clone().or(task_label),
             remaining_secs: self.timer.remaining_secs,
             profile: self.active_focus_profile.or(Some(self.selected_profile)),
         }
@@ -39,7 +38,6 @@ impl App {
             context.reason,
             FocusSessionMetadata {
                 task_label: context.task_label.as_deref(),
-                task_note: context.task_note.as_deref(),
             },
             context.remaining_secs,
             context.profile,
@@ -57,16 +55,11 @@ impl App {
         let day_key = current_day_key();
         let goal = self.current_goal_snapshot();
         if let Some(active_task_label) = self.active_focus_task_label.clone() {
-            let task_note = self
-                .active_focus_task_note
-                .clone()
-                .unwrap_or_else(|| active_task_label.clone());
             self.stats.record_completed_pomodoro_with_metadata(
                 &day_key,
                 goal,
                 FocusSessionMetadata {
                     task_label: Some(active_task_label.as_str()),
-                    task_note: Some(task_note.as_str()),
                 },
                 focused_seconds,
                 self.active_focus_profile,

--- a/src/app/mode_keys.rs
+++ b/src/app/mode_keys.rs
@@ -1,9 +1,9 @@
 use crate::app::{
-    App, AppMode, FocusStartOutcome, KeyCode, KeyEvent, KeyModifiers, NavigationAction,
-    PendingTimerAction, SessionInterruptionReason, ShortcutAction, TimerState,
+    App, AppMode, FocusStartOutcome, KeyCode, KeyEvent, NavigationAction, PendingTimerAction,
+    SessionInterruptionReason, ShortcutAction, TimerState,
 };
 
-const TIMER_SHORTCUT_ACTIONS: [ShortcutAction; 10] = [
+const TIMER_SHORTCUT_ACTIONS: [ShortcutAction; 9] = [
     ShortcutAction::TimerTogglePause,
     ShortcutAction::TimerStopReset,
     ShortcutAction::TimerNextPhase,
@@ -12,17 +12,11 @@ const TIMER_SHORTCUT_ACTIONS: [ShortcutAction; 10] = [
     ShortcutAction::OpenTaskSetup,
     ShortcutAction::OpenStatsHistory,
     ShortcutAction::OpenSetupDiagnostics,
-    ShortcutAction::TimerEditNote,
     ShortcutAction::BreakGlassOverride,
 ];
 
 impl App {
     pub(super) fn handle_key_timer(&mut self, key: KeyEvent) {
-        if self.timer_note_input_active {
-            self.handle_timer_note_input_key(key);
-            return;
-        }
-
         if self.handle_quit_key(&key, true) {
             return;
         }
@@ -57,7 +51,6 @@ impl App {
             ShortcutAction::OpenTaskSetup => self.open_session_planner(),
             ShortcutAction::OpenStatsHistory => self.open_stats_history(),
             ShortcutAction::OpenSetupDiagnostics => self.open_setup_diagnostics(),
-            ShortcutAction::TimerEditNote => self.start_timer_note_input(),
             ShortcutAction::BreakGlassOverride => self.handle_break_glass_key(),
             _ => {}
         }
@@ -124,80 +117,6 @@ impl App {
             TimerState::next_phase,
             Some(SessionInterruptionReason::ManualSkip),
         );
-    }
-
-    fn start_timer_note_input(&mut self) {
-        if !self.focus_session_active_for_current_state() {
-            self.phase_notification = Some(
-                "Mid-session notes are available only during active or paused focus.".to_string(),
-            );
-            return;
-        }
-
-        self.timer_note_input = self
-            .current_task_note()
-            .map(str::to_string)
-            .unwrap_or_default();
-        self.timer_note_input_active = true;
-        self.phase_notification = Some(format!(
-            "Editing session note: type text, then press {} to save.",
-            self.navigation_hint(NavigationAction::Confirm)
-        ));
-    }
-
-    fn handle_timer_note_input_key(&mut self, key: KeyEvent) {
-        match key.code {
-            _ if self.navigation_matches(NavigationAction::Confirm, &key) => {
-                self.commit_timer_note_input();
-            }
-            _ if self.navigation_matches(NavigationAction::Cancel, &key) => {
-                self.clear_timer_note_input();
-                self.phase_notification = Some("Session note edit canceled.".to_string());
-            }
-            _ if self.navigation_matches(NavigationAction::Backspace, &key) => {
-                self.timer_note_input.pop();
-            }
-            KeyCode::Char(c)
-                if !key
-                    .modifiers
-                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-            {
-                self.timer_note_input.push(c);
-            }
-            _ => {}
-        }
-    }
-
-    fn commit_timer_note_input(&mut self) {
-        if !self.focus_session_active_for_current_state() {
-            self.clear_timer_note_input();
-            self.phase_notification =
-                Some("Session note save failed: focus is no longer active.".to_string());
-            return;
-        }
-
-        let note = if self.timer_note_input.trim().is_empty() {
-            self.active_focus_task_label
-                .clone()
-                .or_else(|| self.selected_task_label.clone())
-        } else {
-            Some(self.timer_note_input.trim().to_string())
-        };
-
-        self.clear_timer_note_input();
-        if let Some(note) = note {
-            self.active_focus_task_note = Some(note);
-            self.sync_recovery_snapshot();
-            self.phase_notification = Some("Session note updated.".to_string());
-        } else {
-            self.phase_notification =
-                Some("Session note save failed: no task selected.".to_string());
-        }
-    }
-
-    pub(super) fn clear_timer_note_input(&mut self) {
-        self.timer_note_input.clear();
-        self.timer_note_input_active = false;
     }
 
     pub(super) fn handle_key_stats_history(&mut self, key: KeyEvent) {

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -323,11 +323,6 @@ impl App {
         } else {
             None
         };
-        self.active_focus_task_note = if focus_active {
-            reconciled_snapshot.normalized_task_note()
-        } else {
-            None
-        };
         self.active_focus_profile = if focus_active {
             Some(self.selected_profile)
         } else {
@@ -346,16 +341,9 @@ impl App {
         } else {
             self.selected_task_label.clone()
         };
-        let recovery_task_note = if focus_active {
-            self.active_focus_task_note.clone()
-        } else {
-            None
-        };
-
         let snapshot = InProgressSessionSnapshot::from_timer_state_with_metadata(
             &self.timer,
             recovery_task_label,
-            recovery_task_note,
             self.selected_profile,
         );
 

--- a/src/app/session_planner.rs
+++ b/src/app/session_planner.rs
@@ -353,13 +353,6 @@ impl App {
             .is_some_and(|active| active.eq_ignore_ascii_case(&current_label))
         {
             self.active_focus_task_label = Some(label.clone());
-            let should_sync_note_to_label = match self.active_focus_task_note.as_deref() {
-                None => true,
-                Some(note) => note.eq_ignore_ascii_case(&current_label),
-            };
-            if should_sync_note_to_label {
-                self.active_focus_task_note = Some(label.clone());
-            }
         }
         self.stats.rename_task_goal_target(&current_label, &label);
         if let Some(index) = self.planner_display_index_for_label(&label) {

--- a/src/app/shortcuts.rs
+++ b/src/app/shortcuts.rs
@@ -15,7 +15,6 @@ pub(crate) enum ShortcutAction {
     OpenTaskSetup,
     OpenStatsHistory,
     OpenSetupDiagnostics,
-    TimerEditNote,
     BreakGlassOverride,
     BackSiteManager,
     ToggleSiteListMode,
@@ -72,7 +71,7 @@ enum ShortcutKey {
     Delete,
 }
 
-const TIMER_SCOPE_ACTIONS: [ShortcutAction; 10] = [
+const TIMER_SCOPE_ACTIONS: [ShortcutAction; 9] = [
     ShortcutAction::TimerTogglePause,
     ShortcutAction::TimerStopReset,
     ShortcutAction::TimerNextPhase,
@@ -81,7 +80,6 @@ const TIMER_SCOPE_ACTIONS: [ShortcutAction; 10] = [
     ShortcutAction::OpenTaskSetup,
     ShortcutAction::OpenStatsHistory,
     ShortcutAction::OpenSetupDiagnostics,
-    ShortcutAction::TimerEditNote,
     ShortcutAction::BreakGlassOverride,
 ];
 
@@ -163,12 +161,6 @@ const PROFILE_EDIT_NAV_ACTIONS: [NavigationAction; 7] = [
     NavigationAction::MoveUp,
     NavigationAction::MoveLeft,
     NavigationAction::MoveRight,
-    NavigationAction::Confirm,
-    NavigationAction::Cancel,
-    NavigationAction::Backspace,
-];
-
-const NOTE_EDIT_NAV_ACTIONS: [NavigationAction; 3] = [
     NavigationAction::Confirm,
     NavigationAction::Cancel,
     NavigationAction::Backspace,
@@ -291,14 +283,6 @@ impl ShortcutBindings {
         resolve_navigation_scope(
             &mut navigation_keys,
             &command_keys,
-            &TIMER_SCOPE_ACTIONS,
-            &NOTE_EDIT_NAV_ACTIONS,
-            "note editor",
-            &mut diagnostics,
-        );
-        resolve_navigation_scope(
-            &mut navigation_keys,
-            &command_keys,
             &STATS_HISTORY_SCOPE_ACTIONS,
             &[NavigationAction::Cancel],
             "history view",
@@ -333,7 +317,6 @@ impl ShortcutBindings {
             open_session_planner: key_token(self.key(ShortcutAction::OpenTaskSetup)),
             open_stats_history: key_token(self.key(ShortcutAction::OpenStatsHistory)),
             open_setup_diagnostics: key_token(self.key(ShortcutAction::OpenSetupDiagnostics)),
-            timer_edit_note: key_token(self.key(ShortcutAction::TimerEditNote)),
             break_glass_override: key_token(self.key(ShortcutAction::BreakGlassOverride)),
             back_site_manager: key_token(self.key(ShortcutAction::BackSiteManager)),
             toggle_site_list_mode: key_token(self.key(ShortcutAction::ToggleSiteListMode)),
@@ -523,7 +506,6 @@ fn requested_shortcut_char(config: &ShortcutConfig, action: ShortcutAction) -> c
         ShortcutAction::OpenTaskSetup => &config.open_session_planner,
         ShortcutAction::OpenStatsHistory => &config.open_stats_history,
         ShortcutAction::OpenSetupDiagnostics => &config.open_setup_diagnostics,
-        ShortcutAction::TimerEditNote => &config.timer_edit_note,
         ShortcutAction::BreakGlassOverride => &config.break_glass_override,
         ShortcutAction::BackSiteManager => &config.back_site_manager,
         ShortcutAction::ToggleSiteListMode => &config.toggle_site_list_mode,
@@ -582,7 +564,6 @@ fn default_shortcut_char(action: ShortcutAction) -> char {
         ShortcutAction::OpenTaskSetup => 't',
         ShortcutAction::OpenStatsHistory => 'h',
         ShortcutAction::OpenSetupDiagnostics => 'd',
-        ShortcutAction::TimerEditNote => 'm',
         ShortcutAction::BreakGlassOverride => 'u',
         ShortcutAction::BackSiteManager => 'b',
         ShortcutAction::ToggleSiteListMode => 'm',

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -89,14 +89,12 @@ fn snapshot_for_tests(
     task_label: Option<&str>,
     selected_profile: ProfileId,
 ) -> InProgressSessionSnapshot {
-    let metadata_value = task_label.map(str::to_string);
     InProgressSessionSnapshot {
         phase: RecoveryTimerPhase::from_timer_phase(phase),
         status: RecoveryTimerStatus::from_timer_status(status),
         remaining_secs,
         pomodoros_completed: 0,
-        selected_task_label: metadata_value.clone(),
-        task_note: metadata_value,
+        selected_task_label: task_label.map(str::to_string),
         selected_profile,
         captured_at_epoch_secs: None,
     }
@@ -2038,20 +2036,6 @@ fn site_manager_ctrl_c_quits_during_text_input_modes() {
     app.handle_key(ctrl_key(KeyCode::Char('c')));
 
     assert!(app.should_quit);
-}
-
-#[test]
-fn timer_note_paste_sanitizes_multiline_and_control_characters() {
-    let mut app = App::default();
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(key(KeyCode::Char(' ')));
-    app.handle_key(key(KeyCode::Char('m')));
-    app.timer_note_input.clear();
-
-    app.handle_paste("  line1\nline2\r\n\tline3\u{0007}  ".to_string());
-
-    assert_eq!(app.timer_note_input, "line1 line2 line3");
 }
 
 #[test]
@@ -4172,135 +4156,19 @@ fn focus_does_not_start_without_selected_task_label() {
 }
 
 #[test]
-fn mid_session_note_input_requires_active_focus() {
-    let mut app = App::default();
-    app.selected_task_label = Some("Docs".to_string());
-
-    app.handle_key(key(KeyCode::Char('m')));
-
-    assert!(!app.timer_note_input_active);
-    assert_eq!(
-        app.phase_notification.as_deref(),
-        Some("Mid-session notes are available only during active or paused focus.")
-    );
-}
-
-#[test]
-fn mid_session_note_input_commits_and_syncs_recovery_snapshot() {
+fn planner_rename_updates_active_focus_task_label() {
     let mut app = App::default();
     app.task_labels = vec!["Docs".to_string()];
     app.selected_task_label = Some("Docs".to_string());
     app.handle_key(key(KeyCode::Char(' ')));
-
-    app.handle_key(key(KeyCode::Char('m')));
-    assert!(app.timer_note_input_active);
-    assert_eq!(app.timer_note_input, "Docs");
-
-    app.timer_note_input = "Capture blockers for retro".to_string();
-    app.handle_key(key(KeyCode::Enter));
-
-    assert!(!app.timer_note_input_active);
-    assert_eq!(
-        app.active_focus_task_note.as_deref(),
-        Some("Capture blockers for retro")
-    );
-    let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
-    assert_eq!(
-        snapshot.task_note.as_deref(),
-        Some("Capture blockers for retro")
-    );
-}
-
-#[test]
-fn mid_session_note_input_uses_custom_confirm_shortcut() {
-    let config = AppConfig {
-        shortcuts: ShortcutConfig {
-            confirm: "v".to_string(),
-            ..ShortcutConfig::default()
-        },
-        ..AppConfig::default()
-    };
-    let mut app = App::from_config(config);
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(key(KeyCode::Char(' ')));
-
-    app.handle_key(key(KeyCode::Char('m')));
-    assert!(app.timer_note_input_active);
-    assert_eq!(
-        app.phase_notification.as_deref(),
-        Some("Editing session note: type text, then press [v] to save.")
-    );
-    app.timer_note_input = "Capture blockers for retro".to_string();
-    app.handle_key(key(KeyCode::Char('v')));
-
-    assert!(!app.timer_note_input_active);
-    assert_eq!(
-        app.active_focus_task_note.as_deref(),
-        Some("Capture blockers for retro")
-    );
-}
-
-#[test]
-fn mid_session_note_input_empty_commit_falls_back_to_task_label() {
-    let mut app = App::default();
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(key(KeyCode::Char(' ')));
-
-    app.handle_key(key(KeyCode::Char('m')));
-    app.timer_note_input = "   ".to_string();
-    app.handle_key(key(KeyCode::Enter));
-
-    assert_eq!(app.active_focus_task_note.as_deref(), Some("Docs"));
-    let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
-    assert_eq!(snapshot.task_note.as_deref(), Some("Docs"));
-}
-
-#[test]
-fn mid_session_note_input_updates_interruption_metadata() {
-    let mut app = App::default();
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(key(KeyCode::Char(' ')));
-
-    app.handle_key(key(KeyCode::Char('m')));
-    app.timer_note_input = "Pulled into production incident".to_string();
-    app.handle_key(key(KeyCode::Enter));
-    app.timer.remaining_secs = 1_000;
-
-    app.handle_key(key(KeyCode::Char('s')));
-
-    let interruptions = app.recent_session_interruptions(1);
-    assert_eq!(interruptions.len(), 1);
-    assert_eq!(
-        interruptions[0].task_note.as_deref(),
-        Some("Pulled into production incident")
-    );
-}
-
-#[test]
-fn planner_rename_preserves_custom_mid_session_note() {
-    let mut app = App::default();
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(key(KeyCode::Char(' ')));
-
-    app.handle_key(key(KeyCode::Char('m')));
-    app.timer_note_input = "Keep this custom note".to_string();
-    app.handle_key(key(KeyCode::Enter));
 
     app.open_session_planner();
     app.planner_selection_index = 0;
     app.commit_planner_rename_input("Writing".to_string());
 
     assert_eq!(app.active_focus_task_label.as_deref(), Some("Writing"));
-    assert_eq!(
-        app.active_focus_task_note.as_deref(),
-        Some("Keep this custom note")
-    );
     let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
-    assert_eq!(snapshot.task_note.as_deref(), Some("Keep this custom note"));
+    assert_eq!(snapshot.selected_task_label.as_deref(), Some("Writing"));
 }
 
 #[test]
@@ -4336,30 +4204,6 @@ fn cli_start_begins_focus_when_task_label_exists() {
     assert!(result.is_ok());
     assert_eq!(app.timer.status, TimerStatus::Running);
     assert_eq!(app.active_focus_task_label, Some("Docs".to_string()));
-}
-
-#[test]
-fn cli_metadata_update_requires_active_or_paused_focus() {
-    let mut app = App::default();
-
-    let note_error = app.set_task_note_for_cli("Capture blockers").unwrap_err();
-    assert_eq!(
-        note_error,
-        "Cannot set session metadata with `--task-note`: focus session is not active or paused."
-    );
-}
-
-#[test]
-fn cli_metadata_update_syncs_active_state_and_recovery_snapshot() {
-    let mut app = App::default();
-    app.selected_task_label = Some("Docs".to_string());
-    app.start_focus_for_cli().unwrap();
-
-    app.set_task_note_for_cli("Capture blockers").unwrap();
-
-    assert_eq!(app.task_note_for_cli().as_deref(), Some("Capture blockers"));
-    let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
-    assert_eq!(snapshot.task_note.as_deref(), Some("Capture blockers"));
 }
 
 #[test]
@@ -5180,7 +5024,6 @@ fn startup_reconciles_elapsed_recovery_time_while_session_is_running() {
         remaining_secs: 120,
         pomodoros_completed: 0,
         selected_task_label: Some("Docs".to_string()),
-        task_note: Some("Docs".to_string()),
         selected_profile: ProfileId::Classic,
         captured_at_epoch_secs: Some(now_epoch_secs - 10),
     }));
@@ -5201,7 +5044,6 @@ fn startup_reconciles_elapsed_recovery_time_when_phase_completed_offline() {
         remaining_secs: 1,
         pomodoros_completed: 0,
         selected_task_label: Some("Docs".to_string()),
-        task_note: Some("Section 1".to_string()),
         selected_profile: ProfileId::Classic,
         captured_at_epoch_secs: Some(0),
     }));
@@ -5213,7 +5055,6 @@ fn startup_reconciles_elapsed_recovery_time_when_phase_completed_offline() {
     assert_eq!(app.timer.remaining_secs, app.timer.short_break_secs);
     assert_eq!(app.timer.pomodoros_completed, 1);
     assert_eq!(app.selected_task_label.as_deref(), Some("Docs"));
-    assert!(app.active_focus_task_note.is_none());
     assert!(app.phase_notification.as_deref().is_some_and(|message| {
         message.contains("Recovered elapsed timer state into Short Break phase")
     }));
@@ -5279,7 +5120,6 @@ fn startup_restores_pomodoro_count_for_phase_cadence() {
         remaining_secs: 1,
         pomodoros_completed: 3,
         selected_task_label: Some("Docs".to_string()),
-        task_note: Some("Docs".to_string()),
         selected_profile: ProfileId::Classic,
         captured_at_epoch_secs: None,
     }));
@@ -5358,7 +5198,6 @@ fn recovery_snapshot_prefers_active_focus_label_over_selected_label() {
 
     let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
     assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task A"));
-    assert_eq!(snapshot.task_note.as_deref(), Some("Task A"));
 }
 
 #[test]
@@ -5380,7 +5219,6 @@ fn planner_label_change_during_running_break_updates_recovery_snapshot() {
 
     let snapshot = session_recovery::test_saved_snapshot().expect("snapshot should be saved");
     assert_eq!(snapshot.selected_task_label.as_deref(), Some("Task B"));
-    assert_eq!(snapshot.task_note, None);
     assert_eq!(snapshot.phase, RecoveryTimerPhase::ShortBreak);
     assert_eq!(snapshot.status, RecoveryTimerStatus::Running);
 }

--- a/src/app/timer_flow.rs
+++ b/src/app/timer_flow.rs
@@ -162,16 +162,12 @@ impl App {
 
     fn start_focus_runtime(&mut self) {
         self.active_focus_task_label = self.selected_task_label.clone();
-        self.active_focus_task_note = self.selected_task_label.clone();
-        self.clear_timer_note_input();
         self.active_focus_profile = Some(self.selected_profile);
         self.schedule_armed_occurrence_key = None;
     }
 
     pub(super) fn clear_focus_runtime(&mut self) {
         self.active_focus_task_label = None;
-        self.active_focus_task_note = None;
-        self.clear_timer_note_input();
         self.active_focus_profile = None;
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,11 +52,10 @@ use output::{
     print_diagnostics_command_output, print_export_output, print_goal_carry_command_output,
     print_goal_command_output, print_history_dashboard_command_output, print_json,
     print_json_compact, print_profile_output, print_restore_output, print_schedule_command_output,
-    print_session_metadata_command_output, print_site_add_command_output,
-    print_site_delete_command_output, print_site_edit_command_output,
-    print_site_list_command_output, print_status_output, print_strict_command_output,
-    print_task_goal_command_output, print_temporary_site_add_command_output,
-    print_theme_command_output, print_timer_state_output,
+    print_site_add_command_output, print_site_delete_command_output,
+    print_site_edit_command_output, print_site_list_command_output, print_status_output,
+    print_strict_command_output, print_task_goal_command_output,
+    print_temporary_site_add_command_output, print_theme_command_output, print_timer_state_output,
 };
 use parsing::{
     finalize_cli_action, first_removed_option_guidance, invalid_usage, parse_global_tokens,
@@ -80,8 +79,6 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --task=LABEL [--json]
   focustime --task-goal [LABEL|LABEL:MINUTES,POMODOROS] [--json]
   focustime --task-goal=LABEL[:MINUTES,POMODOROS] [--json]
-  focustime --task-note [TEXT] [--json]
-  focustime --task-note=TEXT [--json]
   focustime --profile [basic|standard|advanced] [--json]
   focustime --theme [classic|high-contrast|deuteranopia-friendly] [--json]
   focustime --goal [--json]
@@ -130,7 +127,6 @@ Options:
   --next          Skip to the next phase
   --task          Select task label (auto-creates unknown labels)
   --task-goal     Show or set per-task cumulative goal targets
-  --task-note        Show current task note, or set it for the active/paused focus session
   --profile       Show current profile, or set it when value is provided
   --theme         Show current theme preset, or set it when value is provided
   --goal          Show current daily goal, or set minutes/pomodoros targets
@@ -233,9 +229,6 @@ pub(crate) enum CommandKind {
         label: Option<String>,
         goal: Option<DailyGoalConfig>,
     },
-    TaskNote {
-        value: Option<String>,
-    },
     Profile {
         profile: Option<ProfileId>,
     },
@@ -321,7 +314,6 @@ enum PrimaryCommand {
         label: Option<String>,
         goal: Option<DailyGoalConfig>,
     },
-    TaskNote(Option<String>),
     Profile(Option<ProfileId>),
     Theme(Option<ThemePreset>),
     Goal(Option<DailyGoalConfig>),
@@ -370,7 +362,6 @@ enum ParsedToken {
         label: Option<String>,
         goal: Option<DailyGoalConfig>,
     },
-    TaskNote(Option<String>),
     Status,
     Watch(Option<u64>),
     Profile(Option<ProfileId>),
@@ -538,7 +529,6 @@ struct LiveStatusOutput {
     pomodoros_completed: u32,
     selected_profile: ProfileView,
     selected_task_label: Option<String>,
-    task_note: Option<String>,
     strict_mode_enforced: bool,
 }
 
@@ -588,7 +578,6 @@ struct StatusOutput {
     selected_profile: ProfileView,
     selected_theme_preset: ThemePresetView,
     selected_task_label: Option<String>,
-    task_note: Option<String>,
     selected_blocklist_profile: String,
     blocked_sites_count: usize,
     temporary_overrides_active_count: usize,
@@ -648,7 +637,6 @@ struct TimerStateOutput {
     pomodoros_completed: u32,
     selected_profile: ProfileView,
     selected_task_label: Option<String>,
-    task_note: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -684,14 +672,6 @@ struct TaskGoalCommandOutput {
     focused_minutes: u64,
     pomodoros_completed: u32,
     met: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct SessionMetadataCommandOutput {
-    action: &'static str,
-    updated: bool,
-    task_note: Option<String>,
-    timer: TimerStateOutput,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -60,10 +60,9 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 27] = [
+    let parsers: [(&str, ValueArgParser); 26] = [
         ("--task", classify_task_arg),
         ("--task-goal", classify_task_goal_arg),
-        ("--task-note", classify_task_note_arg),
         ("--profile", classify_profile_arg),
         ("--theme", classify_theme_arg),
         ("--goal", classify_goal_arg),
@@ -193,19 +192,6 @@ fn classify_theme_arg(args: &[String], index: usize) -> Result<(ParsedToken, usi
         return Ok((ParsedToken::Theme(Some(selected)), 2));
     }
     Ok((ParsedToken::Theme(None), 1))
-}
-
-fn classify_task_note_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
-    if let Some(next) = args.get(index + 1)
-        && !next.starts_with('-')
-    {
-        let value = require_nonempty_key_value(
-            next,
-            "`--task-note` requires a value when one is provided.",
-        )?;
-        return Ok((ParsedToken::TaskNote(Some(value.to_string())), 2));
-    }
-    Ok((ParsedToken::TaskNote(None), 1))
 }
 
 fn classify_export_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {

--- a/src/cli/args/key_value.rs
+++ b/src/cli/args/key_value.rs
@@ -6,10 +6,9 @@ use crate::cli::{
 };
 
 pub(in crate::cli) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 27] = [
+    let parsers: [KeyValueParser; 26] = [
         parse_task_key_value_arg,
         parse_task_goal_key_value_arg,
-        parse_task_note_key_value_arg,
         parse_profile_key_value_arg,
         parse_theme_key_value_arg,
         parse_goal_key_value_arg,
@@ -64,15 +63,6 @@ fn parse_task_goal_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, Strin
             label: Some(label),
             goal,
         }));
-    }
-    Ok(None)
-}
-
-fn parse_task_note_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    if let Some(value) = arg.strip_prefix("--task-note=") {
-        let value =
-            require_nonempty_key_value(value, "`--task-note=` requires a non-empty value.")?;
-        return Ok(Some(ParsedToken::TaskNote(Some(value.to_string()))));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -11,16 +11,15 @@ use crate::cli::{
     AppConfig, BreakGlassCommandOutput, CliCommand, CommandKind, DailyGoalConfig,
     DailyGoalSnapshot, FocusStats, GoalCarryCommandOutput, GoalCommandOutput, MonthlyGoalConfig,
     OutputMode, ProfileId, ProfileOutput, ProfileView, RecurringScheduleConfig,
-    ScheduleCommandOutput, SessionMetadataCommandOutput, StrictCommandOutput, TaskCommandOutput,
-    TaskGoalCommandOutput, TaskGoalOutput, TemporaryAllowlistStatusOutput,
-    TemporarySiteAddCommandOutput, ThemeCommandOutput, ThemePreset, TimerCommandOutput,
-    TimerStateOutput, WeeklyGoalConfig, available_theme_preset_views,
-    build_schedule_inspection_output, build_task_goal_output, print_break_glass_command_output,
-    print_goal_carry_command_output, print_goal_command_output, print_json, print_profile_output,
-    print_schedule_command_output, print_session_metadata_command_output,
-    print_strict_command_output, print_task_goal_command_output,
-    print_temporary_site_add_command_output, print_theme_command_output, print_timer_state_output,
-    profile_id, profile_view, theme_preset_view, timer_phase_id, timer_status_id,
+    ScheduleCommandOutput, StrictCommandOutput, TaskCommandOutput, TaskGoalCommandOutput,
+    TaskGoalOutput, TemporaryAllowlistStatusOutput, TemporarySiteAddCommandOutput,
+    ThemeCommandOutput, ThemePreset, TimerCommandOutput, TimerStateOutput, WeeklyGoalConfig,
+    available_theme_preset_views, build_schedule_inspection_output, build_task_goal_output,
+    print_break_glass_command_output, print_goal_carry_command_output, print_goal_command_output,
+    print_json, print_profile_output, print_schedule_command_output, print_strict_command_output,
+    print_task_goal_command_output, print_temporary_site_add_command_output,
+    print_theme_command_output, print_timer_state_output, profile_id, profile_view,
+    theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 mod blocklists;
@@ -67,7 +66,6 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> CliExecuteResult<(
         CommandKind::TaskGoal { label, goal } => {
             execute_task_goal_command(label, goal, cli_command.output)
         }
-        CommandKind::TaskNote { value } => execute_task_note_command(value, cli_command.output),
         CommandKind::Profile { profile } => execute_profile_command(profile, cli_command.output),
         CommandKind::Theme { preset } => execute_theme_command(preset, cli_command.output),
         CommandKind::Goal { goal } => execute_goal_command(goal, cli_command.output),
@@ -131,7 +129,6 @@ fn command_usage_surface_id(command: &CommandKind) -> Option<&'static str> {
         CommandKind::Next => Some("next"),
         CommandKind::Task { .. } => Some("task"),
         CommandKind::TaskGoal { .. } => Some("task-goal"),
-        CommandKind::TaskNote { .. } => Some("task-note"),
         CommandKind::Profile { .. } => Some("profile"),
         CommandKind::Theme { .. } => Some("theme"),
         CommandKind::Goal { .. } => Some("goal"),
@@ -165,7 +162,6 @@ fn command_usage_records_via_app(command: &CommandKind) -> bool {
             | CommandKind::Stop
             | CommandKind::Next
             | CommandKind::Task { .. }
-            | CommandKind::TaskNote { .. }
             | CommandKind::AllowlistSiteAddTemporary { .. }
             | CommandKind::BreakGlassTrigger
             | CommandKind::BreakGlassCancel
@@ -308,18 +304,6 @@ fn execute_task_goal_command(
         OutputMode::Text => print_task_goal_command_output(&payload),
         OutputMode::Json => print_json(&payload)?,
     }
-    Ok(())
-}
-
-fn execute_task_note_command(value: Option<String>, output: OutputMode) -> CliExecuteResult<()> {
-    let mut app = App::new();
-    app.record_command_usage_for_cli("task-note");
-    let mut updated = false;
-    if let Some(value) = value {
-        app.set_task_note_for_cli(&value)?;
-        updated = true;
-    }
-    emit_session_metadata_command_output("task-note", updated, &app, output)?;
     Ok(())
 }
 
@@ -657,25 +641,6 @@ fn emit_timer_command_output(
     Ok(())
 }
 
-fn emit_session_metadata_command_output(
-    action: &'static str,
-    updated: bool,
-    app: &App,
-    output: OutputMode,
-) -> Result<(), String> {
-    let payload = SessionMetadataCommandOutput {
-        action,
-        updated,
-        task_note: app.task_note_for_cli(),
-        timer: build_timer_state_output(app),
-    };
-    match output {
-        OutputMode::Text => print_session_metadata_command_output(&payload),
-        OutputMode::Json => print_json(&payload)?,
-    }
-    Ok(())
-}
-
 fn emit_break_glass_command_output(
     action: &'static str,
     app: &App,
@@ -701,7 +666,6 @@ fn build_timer_state_output(app: &App) -> TimerStateOutput {
     let (focus_secs, short_break_secs, long_break_secs, long_break_interval) =
         app.profile_values(profile);
     let selected_task_label = app.selected_task_label_for_cli();
-    let task_note = app.task_note_for_cli();
 
     TimerStateOutput {
         phase: timer_phase_id(phase),
@@ -717,7 +681,6 @@ fn build_timer_state_output(app: &App) -> TimerStateOutput {
             long_break_interval,
         },
         selected_task_label,
-        task_note,
     }
 }
 

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -16,8 +16,7 @@ pub(super) use sites::{
     print_temporary_site_add_command_output,
 };
 pub(super) use status::{
-    print_break_glass_command_output, print_session_metadata_command_output, print_status_output,
-    print_timer_state_output,
+    print_break_glass_command_output, print_status_output, print_timer_state_output,
 };
 
 use crate::cli::{

--- a/src/cli/output/status.rs
+++ b/src/cli/output/status.rs
@@ -1,24 +1,9 @@
 use crate::cli::{
-    BreakGlassCommandOutput, FocusScoreOutput, GoalOutput, SessionMetadataCommandOutput,
-    StatsGrowthSummary, StatsRetentionStatusOutput, StatusOutput, TaskGoalOutput, TimerStateOutput,
+    BreakGlassCommandOutput, FocusScoreOutput, GoalOutput, StatsGrowthSummary,
+    StatsRetentionStatusOutput, StatusOutput, TaskGoalOutput, TimerStateOutput,
 };
 
 use super::{format_duration, format_expiry_clock_suffix};
-
-pub(in crate::cli) fn print_session_metadata_command_output(
-    payload: &SessionMetadataCommandOutput,
-) {
-    if payload.updated {
-        println!("Session metadata updated: {}.", payload.action);
-    } else {
-        println!("Session metadata: {}.", payload.action);
-    }
-    println!(
-        "Task note: {}",
-        payload.task_note.as_deref().unwrap_or("none")
-    );
-    print_timer_state_output(&payload.timer);
-}
 
 pub(in crate::cli) fn print_status_output(payload: &StatusOutput) {
     println!("Date: {}", payload.day);
@@ -33,10 +18,6 @@ pub(in crate::cli) fn print_status_output(payload: &StatusOutput) {
     println!(
         "Task label: {}",
         payload.selected_task_label.as_deref().unwrap_or("none")
-    );
-    println!(
-        "Task note: {}",
-        payload.task_note.as_deref().unwrap_or("none")
     );
     println!(
         "Blocklist profile: {} ({} sites)",
@@ -81,10 +62,6 @@ pub(in crate::cli) fn print_status_output(payload: &StatusOutput) {
         payload.live.status,
         format_duration(payload.live.remaining_secs),
         payload.live.state_source
-    );
-    println!(
-        "Live task note: {}",
-        payload.live.task_note.as_deref().unwrap_or("none")
     );
     if let Some(error) = payload.live.recovery_error.as_deref() {
         println!("Live timer warning: {error}");
@@ -349,10 +326,6 @@ pub(in crate::cli) fn print_timer_state_output(timer: &TimerStateOutput) {
     println!(
         "Task label: {}",
         timer.selected_task_label.as_deref().unwrap_or("none")
-    );
-    println!(
-        "Task note: {}",
-        timer.task_note.as_deref().unwrap_or("none")
     );
     println!(
         "Profile: {} ({})",

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -44,7 +44,6 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::Next
             | ParsedToken::Task(_)
             | ParsedToken::TaskGoal { .. }
-            | ParsedToken::TaskNote(_)
             | ParsedToken::Status
             | ParsedToken::Watch(_)
             | ParsedToken::Profile(_)
@@ -133,6 +132,10 @@ fn removed_option_replacement_guidance(option: &str) -> Option<RemovedOptionGuid
                 replacement: "Use `focustime --diagnostics` for setup checks, config health, and migration guidance.",
             })
         }
+        "--task-note" => Some(RemovedOptionGuidance {
+            summary: "Task note commands were removed.",
+            replacement: "Use `--task` to select the active task label; task labels are the supported session context.",
+        }),
         _ => None,
     }
 }
@@ -158,9 +161,6 @@ pub(super) fn parse_primary_command(
                     goal: *goal,
                 },
             )?,
-            ParsedToken::TaskNote(value) => {
-                set_primary_command(&mut primary, PrimaryCommand::TaskNote(value.clone()))?
-            }
             ParsedToken::Status => set_primary_command(&mut primary, PrimaryCommand::Status)?,
             ParsedToken::Watch(_) => {}
             ParsedToken::Profile(profile) => {
@@ -382,10 +382,6 @@ pub(super) fn finalize_cli_action(
             kind: CommandKind::TaskGoal { label, goal },
             output,
         })),
-        Some(PrimaryCommand::TaskNote(value)) => Ok(CliAction::RunCommand(CliCommand {
-            kind: CommandKind::TaskNote { value },
-            output,
-        })),
         Some(PrimaryCommand::Status) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::Status {
                 watch_interval_secs,
@@ -528,7 +524,6 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Next => "--next",
         PrimaryCommand::Task(_) => "--task",
         PrimaryCommand::TaskGoal { .. } => "--task-goal",
-        PrimaryCommand::TaskNote(_) => "--task-note",
         PrimaryCommand::Profile(_) => "--profile",
         PrimaryCommand::Theme(_) => "--theme",
         PrimaryCommand::Goal(_) => "--goal",

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -22,7 +22,7 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
     let week = stats.weekly_for_day(day_date);
     let month = stats.monthly_for_day(day_date);
     let (_, selected_task_label) = stats.task_planner_state();
-    let (selected_task_label, task_note) = mirror_metadata_from_task_label(selected_task_label);
+    let selected_task_label = normalize_optional_task_label(selected_task_label);
     let goal_snapshot = effective_daily_goal_snapshot_for_day(config, stats, day_date);
     let weekly_goal_snapshot = effective_weekly_goal_snapshot(config, stats, day_date);
     let monthly_goal_snapshot = effective_monthly_goal_snapshot(config, stats, day_date);
@@ -85,7 +85,6 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
         selected_profile: profile_view(config.selected_profile, &config.effective_custom_profile()),
         selected_theme_preset: theme_preset_view(config.selected_theme_preset),
         selected_task_label,
-        task_note,
         selected_blocklist_profile: config.selected_blocklist_profile.clone(),
         blocked_sites_count: active_sites_count,
         temporary_overrides_active_count,
@@ -446,8 +445,7 @@ fn build_live_status_output(
     let strict_mode_enabled = config
         .profile_automation_for(config.selected_profile)
         .strict_mode;
-    let (fallback_task_label, fallback_task_note) =
-        mirror_metadata_from_task_label(fallback_task_label);
+    let fallback_task_label = normalize_optional_task_label(fallback_task_label);
     match session_recovery::load() {
         Ok(Some(snapshot)) => {
             let pre_reconcile_in_progress = snapshot.status() != TimerStatus::Idle;
@@ -472,7 +470,6 @@ fn build_live_status_output(
                 pomodoros_completed: snapshot.pomodoros_completed,
                 selected_profile,
                 selected_task_label: snapshot.normalized_task_label(),
-                task_note: snapshot.normalized_task_note(),
                 strict_mode_enforced: strict_mode_enabled
                     && phase == TimerPhase::Focus
                     && status != TimerStatus::Idle,
@@ -490,7 +487,6 @@ fn build_live_status_output(
                 pomodoros_completed: 0,
                 selected_profile,
                 selected_task_label: fallback_task_label.clone(),
-                task_note: fallback_task_note.clone(),
                 strict_mode_enforced: false,
             }
         }
@@ -506,21 +502,16 @@ fn build_live_status_output(
                 pomodoros_completed: 0,
                 selected_profile,
                 selected_task_label: fallback_task_label,
-                task_note: fallback_task_note,
                 strict_mode_enforced: false,
             }
         }
     }
 }
 
-pub(super) fn mirror_metadata_from_task_label(
-    task_label: Option<String>,
-) -> (Option<String>, Option<String>) {
-    let task_label = task_label
+pub(super) fn normalize_optional_task_label(task_label: Option<String>) -> Option<String> {
+    task_label
         .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
-    let task_note = None;
-    (task_label, task_note)
+        .filter(|value| !value.is_empty())
 }
 
 pub(super) fn profile_view(profile: ProfileId, custom: &CustomProfileConfig) -> ProfileView {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -188,7 +188,6 @@ fn usage_text_keeps_supported_cli_automation_replacements() {
         "--stop",
         "--next",
         "--task",
-        "--task-note",
         "--break-glass-trigger",
         "--break-glass-cancel",
     ] {
@@ -342,29 +341,25 @@ fn parse_task_goal_with_colon_in_label_reads_specific_goal() {
 }
 
 #[test]
-fn parse_task_note_without_value_reads_current_metadata() {
-    let parsed = parse(&["--task-note"]).unwrap();
+fn parse_task_note_without_value_is_removed() {
+    let error = parse_with_contract(&["--task-note"]).unwrap_err();
+
+    assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert!(error.message.contains("Unknown option `--task-note`."));
     assert_eq!(
-        parsed,
-        CliAction::RunCommand(CliCommand {
-            kind: CommandKind::TaskNote { value: None },
-            output: OutputMode::Text
-        })
+        error.hint.as_deref(),
+        Some(
+            "Use `--task` to select the active task label; task labels are the supported session context."
+        )
     );
 }
 
 #[test]
-fn parse_task_note_with_value_sets_metadata() {
-    let parsed = parse(&["--task-note", "Capture blockers"]).unwrap();
-    assert_eq!(
-        parsed,
-        CliAction::RunCommand(CliCommand {
-            kind: CommandKind::TaskNote {
-                value: Some("Capture blockers".to_string())
-            },
-            output: OutputMode::Text
-        })
-    );
+fn parse_task_note_with_value_is_removed() {
+    let error = parse_with_contract(&["--task-note", "Capture blockers"]).unwrap_err();
+
+    assert_eq!(error.exit_code(), EXIT_CODE_USAGE_ERROR);
+    assert!(error.message.contains("Unknown option `--task-note`."));
 }
 
 #[test]
@@ -1494,9 +1489,9 @@ fn parse_rejects_task_with_blank_value() {
 }
 
 #[test]
-fn parse_rejects_task_note_with_blank_equals_value() {
+fn parse_rejects_task_note_with_blank_equals_value_as_removed_option() {
     let error = parse(&["--task-note="]).unwrap_err();
-    assert!(error.contains("`--task-note=` requires a non-empty value."));
+    assert!(error.contains("Unknown option `--task-note=`."));
 }
 
 #[test]
@@ -2497,8 +2492,7 @@ fn build_status_output_does_not_mirror_task_label_metadata() {
     let output = build_status_output(&config, &stats);
 
     assert_eq!(output.selected_task_label.as_deref(), Some("Docs"));
-    assert!(output.task_note.is_none());
-    assert!(output.live.task_note.is_none());
+    assert_eq!(output.live.selected_task_label.as_deref(), Some("Docs"));
 }
 
 #[test]
@@ -2875,7 +2869,6 @@ fn build_status_output_uses_recovery_snapshot_for_live_state() {
         remaining_secs: 42,
         pomodoros_completed: 3,
         selected_task_label: Some("Docs".to_string()),
-        task_note: Some("API section".to_string()),
         selected_profile: ProfileId::DeepWork,
         captured_at_epoch_secs: None,
     }));
@@ -2891,7 +2884,6 @@ fn build_status_output_uses_recovery_snapshot_for_live_state() {
     assert_eq!(output.live.remaining_secs, 42);
     assert_eq!(output.live.pomodoros_completed, 3);
     assert_eq!(output.live.selected_task_label.as_deref(), Some("Docs"));
-    assert_eq!(output.live.task_note.as_deref(), Some("API section"));
     assert_eq!(output.live.selected_profile.id, "standard");
     assert!(output.live.recovery_error.is_none());
     assert_eq!(output.session.pomodoros_completed, 3);
@@ -2906,7 +2898,6 @@ fn build_status_output_reconciles_elapsed_running_recovery_snapshot() {
         remaining_secs: 1,
         pomodoros_completed: 0,
         selected_task_label: Some("Docs".to_string()),
-        task_note: Some("API section".to_string()),
         selected_profile: ProfileId::Classic,
         captured_at_epoch_secs: Some(0),
     }));
@@ -2924,7 +2915,6 @@ fn build_status_output_reconciles_elapsed_running_recovery_snapshot() {
     assert_eq!(output.session.pomodoros_completed, 1);
     assert_eq!(output.session.focused_minutes, DEFAULT_FOCUS_SECS / 60);
     assert_eq!(output.live.selected_task_label.as_deref(), Some("Docs"));
-    assert!(output.live.task_note.is_none());
     assert!(!output.live.strict_mode_enforced);
 }
 
@@ -2937,7 +2927,6 @@ fn build_status_output_includes_latest_session_interruption() {
         crate::stats::SessionInterruptionReason::ManualSkip,
         crate::stats::FocusSessionMetadata {
             task_label: Some("Docs"),
-            task_note: Some("Skipped due urgent review"),
         },
         600,
         Some(ProfileId::Classic),

--- a/src/config/shortcuts.rs
+++ b/src/config/shortcuts.rs
@@ -20,8 +20,6 @@ pub(crate) struct ShortcutConfig {
     pub(crate) open_stats_history: String,
     #[serde(default = "default_shortcut_open_setup_diagnostics")]
     pub(crate) open_setup_diagnostics: String,
-    #[serde(default = "default_shortcut_timer_edit_note")]
-    pub(crate) timer_edit_note: String,
     #[serde(default = "default_shortcut_break_glass_override")]
     pub(crate) break_glass_override: String,
     #[serde(default = "default_shortcut_back_site_manager")]
@@ -148,10 +146,6 @@ impl ShortcutConfig {
             open_setup_diagnostics: normalize_shortcut_token(
                 &self.open_setup_diagnostics,
                 &default_shortcut_open_setup_diagnostics(),
-            ),
-            timer_edit_note: normalize_shortcut_token(
-                &self.timer_edit_note,
-                &default_shortcut_timer_edit_note(),
             ),
             break_glass_override: normalize_shortcut_token(
                 &self.break_glass_override,
@@ -305,7 +299,6 @@ impl Default for ShortcutConfig {
             open_session_planner: default_shortcut_open_session_planner(),
             open_stats_history: default_shortcut_open_stats_history(),
             open_setup_diagnostics: default_shortcut_open_setup_diagnostics(),
-            timer_edit_note: default_shortcut_timer_edit_note(),
             break_glass_override: default_shortcut_break_glass_override(),
             back_site_manager: default_shortcut_back_site_manager(),
             toggle_site_list_mode: default_shortcut_toggle_site_list_mode(),
@@ -381,10 +374,6 @@ fn default_shortcut_open_stats_history() -> String {
 
 fn default_shortcut_open_setup_diagnostics() -> String {
     "d".to_string()
-}
-
-fn default_shortcut_timer_edit_note() -> String {
-    "m".to_string()
 }
 
 fn default_shortcut_break_glass_override() -> String {

--- a/src/session_recovery.rs
+++ b/src/session_recovery.rs
@@ -89,8 +89,6 @@ pub(crate) struct InProgressSessionSnapshot {
     #[serde(default)]
     pub(crate) pomodoros_completed: u32,
     pub(crate) selected_task_label: Option<String>,
-    #[serde(default)]
-    pub(crate) task_note: Option<String>,
     pub(crate) selected_profile: ProfileId,
     #[serde(default)]
     pub(crate) captured_at_epoch_secs: Option<i64>,
@@ -177,7 +175,6 @@ impl InProgressSessionSnapshot {
     pub(crate) fn from_timer_state_with_metadata(
         timer: &TimerState,
         selected_task_label: Option<String>,
-        task_note: Option<String>,
         selected_profile: ProfileId,
     ) -> Option<Self> {
         if timer.status == TimerStatus::Idle {
@@ -187,7 +184,6 @@ impl InProgressSessionSnapshot {
         let selected_task_label = selected_task_label
             .as_deref()
             .and_then(normalize_task_label)?;
-        let task_note = task_note.as_deref().and_then(normalize_metadata_text);
 
         Some(Self {
             phase: RecoveryTimerPhase::from_timer_phase(timer.phase),
@@ -195,7 +191,6 @@ impl InProgressSessionSnapshot {
             remaining_secs: timer.remaining_secs,
             pomodoros_completed: timer.pomodoros_completed,
             selected_task_label: Some(selected_task_label),
-            task_note,
             selected_profile,
             captured_at_epoch_secs: current_epoch_secs(),
         })
@@ -213,11 +208,6 @@ impl InProgressSessionSnapshot {
         self.selected_task_label
             .as_deref()
             .and_then(normalize_task_label)
-    }
-
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn normalized_task_note(&self) -> Option<String> {
-        self.task_note.as_deref().and_then(normalize_metadata_text)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -313,7 +303,6 @@ impl InProgressSessionSnapshot {
         }
 
         reconciled.status = RecoveryTimerStatus::Idle;
-        reconciled.task_note = None;
         reconciled
     }
 }
@@ -589,15 +578,6 @@ fn next_phase_after_focus(timer: &TimerState, completed_focus_count: u32) -> Tim
     }
 }
 
-fn normalize_metadata_text(value: &str) -> Option<String> {
-    let normalized = value.trim();
-    if normalized.is_empty() {
-        None
-    } else {
-        Some(normalized.to_string())
-    }
-}
-
 fn current_epoch_secs() -> Option<i64> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -707,7 +687,6 @@ mod tests {
             remaining_secs: 10,
             pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: None,
         };
@@ -724,7 +703,6 @@ mod tests {
             remaining_secs: 0,
             pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: None,
         };
@@ -741,7 +719,6 @@ mod tests {
             remaining_secs: 31,
             pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: None,
         };
@@ -758,7 +735,6 @@ mod tests {
             remaining_secs: 50,
             pomodoros_completed: 0,
             selected_task_label: None,
-            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: None,
         };
@@ -775,7 +751,6 @@ mod tests {
             remaining_secs: 90,
             pomodoros_completed: 2,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::DeepWork,
             captured_at_epoch_secs: None,
         };
@@ -784,20 +759,21 @@ mod tests {
     }
 
     #[test]
-    fn metadata_remains_empty_for_legacy_snapshots_without_backfill() {
+    fn legacy_task_note_field_is_ignored() {
         let timer = TimerState::with_profile(60, 30, 90, 4);
-        let snapshot = InProgressSessionSnapshot {
-            phase: RecoveryTimerPhase::Focus,
-            status: RecoveryTimerStatus::Running,
-            remaining_secs: 60,
-            pomodoros_completed: 1,
-            selected_task_label: Some("Docs".to_string()),
-            task_note: None,
-            selected_profile: ProfileId::Classic,
-            captured_at_epoch_secs: None,
-        };
+        let snapshot: InProgressSessionSnapshot = toml::from_str(
+            r#"
+phase = "focus"
+status = "running"
+remaining_secs = 60
+pomodoros_completed = 1
+selected_task_label = "Docs"
+task_note = "legacy note"
+selected_profile = "classic"
+"#,
+        )
+        .expect("legacy payload should deserialize");
 
-        assert_eq!(snapshot.normalized_task_note(), None);
         assert!(snapshot.validate_for_timer(&timer).is_ok());
     }
 
@@ -810,7 +786,6 @@ mod tests {
             remaining_secs: 50,
             pomodoros_completed: 1,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("Section 1".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: Some(100),
         };
@@ -821,7 +796,7 @@ mod tests {
         assert_eq!(reconciled.status, RecoveryTimerStatus::Running);
         assert_eq!(reconciled.remaining_secs, 30);
         assert_eq!(reconciled.pomodoros_completed, 1);
-        assert_eq!(reconciled.task_note.as_deref(), Some("Section 1"));
+        assert_eq!(reconciled.selected_task_label.as_deref(), Some("Docs"));
     }
 
     #[test]
@@ -833,7 +808,6 @@ mod tests {
             remaining_secs: 10,
             pomodoros_completed: 1,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("Section 1".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: Some(100),
         };
@@ -844,7 +818,6 @@ mod tests {
         assert_eq!(reconciled.status, RecoveryTimerStatus::Idle);
         assert_eq!(reconciled.remaining_secs, 90);
         assert_eq!(reconciled.pomodoros_completed, 2);
-        assert!(reconciled.task_note.is_none());
         assert_eq!(reconciled.selected_task_label.as_deref(), Some("Docs"));
     }
 
@@ -857,7 +830,6 @@ mod tests {
             remaining_secs: 0,
             pomodoros_completed: 1,
             selected_task_label: Some("Docs".to_string()),
-            task_note: None,
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: Some(100),
         };
@@ -880,7 +852,6 @@ mod tests {
             remaining_secs: 0,
             pomodoros_completed: 0,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("Docs".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: Some(100),
         };
@@ -897,7 +868,6 @@ mod tests {
             remaining_secs: 50,
             pomodoros_completed: 1,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("Section 1".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: Some(100),
         };
@@ -934,7 +904,6 @@ selected_profile = "classic"
             remaining_secs: 120,
             pomodoros_completed: 2,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("API section".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: Some(1_700_000_000),
         };
@@ -957,7 +926,6 @@ selected_profile = "classic"
             remaining_secs: 120,
             pomodoros_completed: 2,
             selected_task_label: Some("Docs".to_string()),
-            task_note: Some("API section".to_string()),
             selected_profile: ProfileId::Classic,
             captured_at_epoch_secs: Some(1_700_000_000),
         };

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -19,10 +19,10 @@ use helpers::create_unique_temp_path;
 use helpers::{
     average_two_percentages, backfilled_time_of_day_bucket, best_goal_streak,
     consistency_score_from_active_days, current_goal_streak, daily_has_activity, days_in_month,
-    format_week_label, month_key_for_day, normalize_session_metadata_text,
-    normalize_task_goal_targets, normalize_task_planner_state, normalize_usage_counts,
-    parse_week_label, percentage_round_nearest, planner_state_labels_for_keys, profile_bucket_for,
-    week_key_for_day, weekly_completion_score_pct, write_atomic_bytes,
+    format_week_label, month_key_for_day, normalize_task_goal_targets,
+    normalize_task_planner_state, normalize_usage_counts, parse_week_label,
+    percentage_round_nearest, planner_state_labels_for_keys, profile_bucket_for, week_key_for_day,
+    weekly_completion_score_pct, write_atomic_bytes,
 };
 mod analytics;
 mod export;
@@ -35,7 +35,7 @@ mod trends;
 const STATS_FILE_NAME: &str = "stats.toml";
 const JSON_EXPORT_FILE_NAME: &str = "focustime-stats.json";
 const CSV_EXPORT_FILE_NAME: &str = "focustime-stats.csv";
-const EXPORT_SCHEMA_VERSION: u32 = 8;
+const EXPORT_SCHEMA_VERSION: u32 = 9;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -465,8 +465,6 @@ pub(crate) struct UsageSignalsSummary {
 pub(crate) struct FocusSessionRecord {
     pub(crate) date: String,
     pub(crate) task_label: String,
-    #[serde(default)]
-    pub(crate) task_note: String,
     pub(crate) focused_seconds: u64,
     #[serde(default)]
     pub(crate) profile: Option<ProfileId>,
@@ -479,7 +477,6 @@ pub(crate) struct FocusSessionRecord {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct FocusSessionMetadata<'a> {
     pub(crate) task_label: Option<&'a str>,
-    pub(crate) task_note: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -505,8 +502,6 @@ pub(crate) struct SessionInterruptionEvent {
     pub(crate) reason: SessionInterruptionReason,
     #[serde(default)]
     pub(crate) task_label: Option<String>,
-    #[serde(default)]
-    pub(crate) task_note: Option<String>,
     #[serde(default)]
     pub(crate) remaining_secs: u64,
     #[serde(default)]
@@ -816,7 +811,6 @@ struct WeeklyExportRow {
 struct SessionExportRow {
     date: String,
     task_label: String,
-    task_note: String,
     focused_seconds: u64,
     focused_minutes: u64,
     profile: Option<ProfileId>,
@@ -837,7 +831,6 @@ struct SessionInterruptionExportRow {
     date: String,
     reason: SessionInterruptionReason,
     task_label: Option<String>,
-    task_note: Option<String>,
     remaining_secs: u64,
     profile: Option<ProfileId>,
 }
@@ -1008,7 +1001,6 @@ struct HistoryKpiLastInterruption {
     timestamp_epoch_secs: Option<u64>,
     reason: Option<SessionInterruptionReason>,
     task_label: Option<String>,
-    task_note: Option<String>,
     remaining_secs: Option<u64>,
     profile_name: Option<String>,
 }
@@ -1057,7 +1049,6 @@ struct CsvExportRow {
     interruption_timestamp_epoch_secs: Option<u64>,
     interruption_reason: Option<SessionInterruptionReason>,
     interruption_remaining_secs: Option<u64>,
-    task_note: Option<String>,
     recent_window_start: Option<String>,
     recent_window_end: Option<String>,
     previous_window_start: Option<String>,

--- a/src/stats/export.rs
+++ b/src/stats/export.rs
@@ -193,9 +193,6 @@ impl FocusStats {
                 task_label: latest_interruption
                     .as_ref()
                     .and_then(|event| event.task_label.clone()),
-                task_note: latest_interruption
-                    .as_ref()
-                    .and_then(|event| event.task_note.clone()),
                 remaining_secs: latest_interruption
                     .as_ref()
                     .map(|event| event.remaining_secs),
@@ -261,7 +258,6 @@ impl FocusStats {
             .map(|session| SessionExportRow {
                 date: session.date.clone(),
                 task_label: session.task_label.clone(),
-                task_note: session.task_note.clone(),
                 focused_seconds: session.focused_seconds,
                 focused_minutes: session.focused_seconds / 60,
                 profile: session.profile,
@@ -277,7 +273,6 @@ impl FocusStats {
                 date: event.date.clone(),
                 reason: event.reason,
                 task_label: event.task_label.clone(),
-                task_note: event.task_note.clone(),
                 remaining_secs: event.remaining_secs,
                 profile: event.profile,
             })
@@ -572,7 +567,6 @@ impl StatsExport {
             interruption_timestamp_epoch_secs: None,
             interruption_reason: None,
             interruption_remaining_secs: None,
-            task_note: None,
             recent_window_start: None,
             recent_window_end: None,
             previous_window_start: None,
@@ -646,7 +640,6 @@ impl StatsExport {
                 focused_seconds: session.focused_seconds,
                 focused_minutes: session.focused_minutes,
                 task_label: Some(session.task_label.clone()),
-                task_note: Some(session.task_note.clone()),
                 profile_name: session.profile.map(|profile| profile.label().to_string()),
                 ..Self::csv_row_defaults("focus_session")
             });
@@ -659,7 +652,6 @@ impl StatsExport {
                 interruption_timestamp_epoch_secs: Some(interruption.timestamp_epoch_secs),
                 interruption_reason: Some(interruption.reason),
                 interruption_remaining_secs: Some(interruption.remaining_secs),
-                task_note: interruption.task_note.clone(),
                 profile_name: interruption
                     .profile
                     .map(|profile| profile.label().to_string()),

--- a/src/stats/helpers.rs
+++ b/src/stats/helpers.rs
@@ -132,11 +132,6 @@ pub(super) fn normalize_usage_counts(input: BTreeMap<String, u64>) -> BTreeMap<S
     normalized
 }
 
-pub(super) fn normalize_session_metadata_text(input: &str) -> Option<String> {
-    let trimmed = input.trim();
-    (!trimmed.is_empty()).then(|| trimmed.to_string())
-}
-
 pub(super) fn current_goal_streak(
     completed_days: &BTreeSet<chrono::NaiveDate>,
     today: chrono::NaiveDate,

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -5,9 +5,9 @@ use crate::stats::fs;
 use crate::stats::{
     BreakGlassOverrideEvent, FocusSessionRecord, FocusStats, PersistedStats, STATS_FILE_NAME,
     SessionInterruptionEvent, SessionStats, StatsLoadOptions, StatsSaveOptions,
-    backfilled_time_of_day_bucket, io, normalize_session_metadata_text,
-    normalize_task_goal_targets, normalize_task_label, normalize_task_planner_state,
-    normalize_usage_counts, planner_state_labels_for_keys, write_atomic_bytes,
+    backfilled_time_of_day_bucket, io, normalize_task_goal_targets, normalize_task_label,
+    normalize_task_planner_state, normalize_usage_counts, planner_state_labels_for_keys,
+    write_atomic_bytes,
 };
 
 impl FocusStats {
@@ -75,12 +75,9 @@ impl FocusStats {
         let mut focus_sessions = Vec::new();
         for session in persisted.focus_sessions {
             if let Some(task_label) = normalize_task_label(&session.task_label) {
-                let task_note = normalize_session_metadata_text(&session.task_note);
-                let task_note = task_note.unwrap_or_default();
                 focus_sessions.push(FocusSessionRecord {
                     date: session.date.trim().to_string(),
                     task_label,
-                    task_note,
                     focused_seconds: session.focused_seconds,
                     profile: session.profile,
                     completion_timestamp_epoch_secs: session.completion_timestamp_epoch_secs,
@@ -100,9 +97,6 @@ impl FocusStats {
                 task_label: event
                     .task_label
                     .and_then(|label| normalize_task_label(&label)),
-                task_note: event
-                    .task_note
-                    .and_then(|value| normalize_session_metadata_text(&value)),
                 remaining_secs: event.remaining_secs,
                 profile: event.profile,
             });

--- a/src/stats/recording.rs
+++ b/src/stats/recording.rs
@@ -1,8 +1,7 @@
 use crate::stats::{
     BTreeMap, BreakGlassOverrideEvent, DailyGoalSnapshot, FocusSessionMetadata, FocusSessionRecord,
     FocusStats, ProfileId, SessionInterruptionEvent, SessionInterruptionReason, TimeOfDayBucket,
-    month_key_for_day, normalize_session_metadata_text, normalize_task_label, task_label_index,
-    week_key_for_day,
+    month_key_for_day, normalize_task_label, task_label_index, week_key_for_day,
 };
 use chrono::Timelike;
 
@@ -38,10 +37,7 @@ impl FocusStats {
         self.record_completed_pomodoro_with_metadata(
             day_key,
             goal,
-            FocusSessionMetadata {
-                task_label,
-                task_note: task_label,
-            },
+            FocusSessionMetadata { task_label },
             focused_seconds,
             profile,
         );
@@ -84,14 +80,9 @@ impl FocusStats {
                 self.task_labels.push(task_label.clone());
             }
             self.selected_task_label = Some(task_label.clone());
-            let task_note = metadata
-                .task_note
-                .and_then(normalize_session_metadata_text)
-                .unwrap_or_else(|| task_label.clone());
             self.focus_sessions.push(FocusSessionRecord {
                 date: day_key.to_string(),
                 task_label,
-                task_note,
                 focused_seconds,
                 profile,
                 completion_timestamp_epoch_secs,
@@ -149,7 +140,6 @@ impl FocusStats {
             date: day_key.to_string(),
             reason,
             task_label: normalized_task_label,
-            task_note: metadata.task_note.and_then(normalize_session_metadata_text),
             remaining_secs,
             profile,
         });

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -972,7 +972,6 @@ fn persisted_stats_round_trip_preserves_session_interruptions() {
         SessionInterruptionReason::ManualStop,
         FocusSessionMetadata {
             task_label: Some("Project A"),
-            task_note: Some("Urgent incident"),
         },
         720,
         Some(ProfileId::DeepWork),
@@ -988,7 +987,6 @@ fn persisted_stats_round_trip_preserves_session_interruptions() {
     assert_eq!(recent[0].timestamp_epoch_secs, 1_711_000_123);
     assert_eq!(recent[0].reason, SessionInterruptionReason::ManualStop);
     assert_eq!(recent[0].task_label.as_deref(), Some("Project A"));
-    assert_eq!(recent[0].task_note.as_deref(), Some("Urgent incident"));
     assert_eq!(recent[0].remaining_secs, 720);
     assert_eq!(recent[0].profile, Some(ProfileId::DeepWork));
 }
@@ -1002,7 +1000,6 @@ fn latest_session_interruption_prefers_greatest_timestamp() {
         SessionInterruptionReason::ManualStop,
         FocusSessionMetadata {
             task_label: Some("Project A"),
-            task_note: Some("Urgent incident"),
         },
         720,
         Some(ProfileId::Classic),
@@ -1013,7 +1010,6 @@ fn latest_session_interruption_prefers_greatest_timestamp() {
         SessionInterruptionReason::ManualSkip,
         FocusSessionMetadata {
             task_label: Some("Project B"),
-            task_note: Some("Interrupt"),
         },
         600,
         Some(ProfileId::DeepWork),
@@ -1135,7 +1131,8 @@ fn legacy_focus_sessions_keep_empty_metadata() {
     let export = restored.export_data();
     assert_eq!(export.sessions.len(), 1);
     assert_eq!(export.sessions[0].task_label, "Project A");
-    assert!(export.sessions[0].task_note.is_empty());
+    let value = serde_json::to_value(&export.sessions[0]).unwrap();
+    assert!(value.get("task_note").is_none());
 }
 
 #[test]
@@ -1213,7 +1210,7 @@ fn persisted_focus_session_uses_stored_time_of_day_bucket() {
 }
 
 #[test]
-fn session_export_preserves_persisted_metadata_fields() {
+fn session_export_omits_task_note_metadata_fields() {
     let mut stats = FocusStats::default();
     let goal = DailyGoalSnapshot {
         minutes: 25,
@@ -1225,7 +1222,6 @@ fn session_export_preserves_persisted_metadata_fields() {
         goal,
         FocusSessionMetadata {
             task_label: Some("Project A"),
-            task_note: Some("Capture blockers for follow-up"),
         },
         30 * 60,
         Some(ProfileId::Classic),
@@ -1234,10 +1230,8 @@ fn session_export_preserves_persisted_metadata_fields() {
     let export = stats.export_data();
     assert_eq!(export.sessions.len(), 1);
     assert_eq!(export.sessions[0].task_label, "Project A");
-    assert_eq!(
-        export.sessions[0].task_note,
-        "Capture blockers for follow-up"
-    );
+    let value = serde_json::to_value(&export.sessions[0]).unwrap();
+    assert!(value.get("task_note").is_none());
 }
 
 #[test]
@@ -1566,7 +1560,6 @@ fn productivity_comparison_groups_time_of_day_buckets_and_unknown() {
         goal,
         FocusSessionMetadata {
             task_label: Some("Docs"),
-            task_note: None,
         },
         30 * 60,
         Some(ProfileId::Classic),
@@ -1577,7 +1570,6 @@ fn productivity_comparison_groups_time_of_day_buckets_and_unknown() {
         goal,
         FocusSessionMetadata {
             task_label: Some("Build"),
-            task_note: None,
         },
         20 * 60,
         Some(ProfileId::DeepWork),
@@ -1588,7 +1580,6 @@ fn productivity_comparison_groups_time_of_day_buckets_and_unknown() {
         goal,
         FocusSessionMetadata {
             task_label: Some("Review"),
-            task_note: None,
         },
         10 * 60,
         Some(ProfileId::Custom),
@@ -1631,7 +1622,6 @@ fn productivity_comparison_applies_task_and_time_filters() {
         goal,
         FocusSessionMetadata {
             task_label: Some("Docs"),
-            task_note: None,
         },
         30 * 60,
         Some(ProfileId::Classic),
@@ -1642,7 +1632,6 @@ fn productivity_comparison_applies_task_and_time_filters() {
         goal,
         FocusSessionMetadata {
             task_label: Some("Docs"),
-            task_note: None,
         },
         20 * 60,
         Some(ProfileId::DeepWork),
@@ -1653,7 +1642,6 @@ fn productivity_comparison_applies_task_and_time_filters() {
         goal,
         FocusSessionMetadata {
             task_label: Some("Docs"),
-            task_note: None,
         },
         15 * 60,
         Some(ProfileId::Classic),
@@ -1664,7 +1652,6 @@ fn productivity_comparison_applies_task_and_time_filters() {
         goal,
         FocusSessionMetadata {
             task_label: Some("Coding"),
-            task_note: None,
         },
         40 * 60,
         Some(ProfileId::Classic),
@@ -1744,7 +1731,6 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
         SessionInterruptionReason::ManualSkip,
         FocusSessionMetadata {
             task_label: Some("Project A"),
-            task_note: Some("Pulled into urgent review"),
         },
         600,
         Some(ProfileId::Classic),
@@ -1812,7 +1798,7 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
     assert!(weekly.iter().any(|entry| entry["focused_minutes"] == 75));
     assert_eq!(sessions[0]["task_label"], "Project A");
     assert!(sessions[0].get("focus_intention").is_none());
-    assert_eq!(sessions[0]["task_note"], "Project A");
+    assert!(sessions[0].get("task_note").is_none());
     assert_eq!(sessions[0]["focused_minutes"], 30);
     assert_eq!(sessions[0]["profile"], "basic");
     assert_eq!(interruptions[0]["reason"], "manual_skip");
@@ -2033,7 +2019,6 @@ fn growth_summary_reports_sections_and_high_volume_groups() {
         SessionInterruptionReason::ManualStop,
         FocusSessionMetadata {
             task_label: Some("Docs"),
-            task_note: Some("API section"),
         },
         300,
         None,
@@ -2105,7 +2090,6 @@ fn apply_retention_policy_prunes_old_high_volume_entries() {
         SessionInterruptionReason::ManualStop,
         FocusSessionMetadata {
             task_label: Some("Docs"),
-            task_note: Some("Old note"),
         },
         600,
         None,
@@ -2116,7 +2100,6 @@ fn apply_retention_policy_prunes_old_high_volume_entries() {
         SessionInterruptionReason::ManualSkip,
         FocusSessionMetadata {
             task_label: Some("Docs"),
-            task_note: Some("Recent note"),
         },
         600,
         None,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -42,9 +42,8 @@ mod timer;
 use timer::{format_duration_label, format_wakatime_heartbeat_timestamp, render_timer};
 #[cfg(test)]
 use timer::{
-    note_phase_notice_text, timer_primary_hint, timer_secondary_hint,
-    timer_session_status_lines_for_width, timer_status_text, timer_tertiary_hint,
-    wakatime_status_line,
+    timer_primary_hint, timer_secondary_hint, timer_session_status_lines_for_width,
+    timer_status_text, wakatime_status_line,
 };
 
 const PROFILE_EDIT_GROUP_TIMER: [usize; 4] = [0, 1, 2, 3];

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -55,9 +55,9 @@ fn timer_primary_hint_includes_break_glass_shortcut() {
 }
 
 #[test]
-fn timer_primary_hint_includes_note_shortcut() {
+fn timer_primary_hint_omits_note_shortcut() {
     let app = App::default();
-    assert!(timer_primary_hint(&app).contains("[m] Note"));
+    assert!(!timer_primary_hint(&app).contains("Note"));
 }
 
 #[test]
@@ -80,101 +80,6 @@ fn app_color_uses_deuteranopia_friendly_mapping() {
 
     assert_eq!(app_color(&app, Color::Red), Color::Blue);
     assert_eq!(app_color(&app, Color::Green), Color::Cyan);
-}
-
-#[test]
-fn timer_primary_hint_marks_note_as_focus_only_when_not_editable() {
-    let app = App::default();
-    assert!(timer_primary_hint(&app).contains("[m] Note (Focus only)"));
-}
-
-#[test]
-fn timer_hints_switch_when_note_edit_is_active() {
-    let mut app = App::default();
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char(' '),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char('m'),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-
-    assert_eq!(
-        timer_primary_hint(&app),
-        "Note: Type text  [Enter] Save  [Esc] Cancel"
-    );
-    assert_eq!(
-        timer_secondary_hint(&app),
-        "Views: shortcuts paused while editing note"
-    );
-    assert_eq!(timer_tertiary_hint(&app), "Note edit: [Esc] Cancel");
-}
-
-#[test]
-fn timer_hints_allow_note_edit_while_focus_is_paused() {
-    let mut app = App::default();
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char(' '),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char(' '),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-    assert_eq!(app.timer.status, TimerStatus::Paused);
-    assert!(timer_primary_hint(&app).contains("[m] Note"));
-    assert!(!timer_primary_hint(&app).contains("Focus only"));
-
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char('m'),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-    assert_eq!(
-        timer_primary_hint(&app),
-        "Note: Type text  [Enter] Save  [Esc] Cancel"
-    );
-    assert_eq!(
-        timer_secondary_hint(&app),
-        "Views: shortcuts paused while editing note"
-    );
-    assert_eq!(timer_tertiary_hint(&app), "Note edit: [Esc] Cancel");
-}
-
-#[test]
-fn timer_note_hints_reflect_custom_confirm_and_cancel_shortcuts() {
-    let mut app = App::from_config_for_tests(AppConfig {
-        shortcuts: ShortcutConfig {
-            confirm: "v".to_string(),
-            cancel: "o".to_string(),
-            ..ShortcutConfig::default()
-        },
-        ..AppConfig::default()
-    });
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char(' '),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char('m'),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-
-    assert_eq!(
-        timer_primary_hint(&app),
-        "Note: Type text  [v] Save  [o] Cancel"
-    );
-    assert_eq!(
-        note_phase_notice_text(&app),
-        "📝 Note: Docs   [v] Save   [o] Cancel"
-    );
-    assert_eq!(timer_tertiary_hint(&app), "Note edit: [o] Cancel");
 }
 
 #[test]
@@ -813,71 +718,6 @@ fn timer_view_renders_selected_task_label() {
 
     let text = terminal_text(&terminal, width, height);
     assert!(text.contains("Task: Docs"));
-}
-
-#[test]
-fn timer_view_shows_note_unavailable_outside_active_focus() {
-    let width = 100;
-    let height = 24;
-    let backend = TestBackend::new(width, height);
-    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
-    let app = App::default();
-
-    terminal
-        .draw(|frame| render(frame, &app))
-        .expect("render should succeed");
-
-    let text = terminal_text(&terminal, width, height);
-    assert!(text.contains("Note: unavailable"));
-}
-
-#[test]
-fn timer_view_renders_active_session_note() {
-    let width = 100;
-    let height = 24;
-    let backend = TestBackend::new(width, height);
-    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
-    let mut app = App::default();
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char(' '),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-
-    terminal
-        .draw(|frame| render(frame, &app))
-        .expect("render should succeed");
-
-    let text = terminal_text(&terminal, width, height);
-    assert!(text.contains("Note: Docs"));
-}
-
-#[test]
-fn timer_view_renders_note_edit_notice() {
-    let width = 100;
-    let height = 24;
-    let backend = TestBackend::new(width, height);
-    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
-    let mut app = App::default();
-    app.task_labels = vec!["Docs".to_string()];
-    app.selected_task_label = Some("Docs".to_string());
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char(' '),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Char('m'),
-        crossterm::event::KeyModifiers::NONE,
-    ));
-
-    terminal
-        .draw(|frame| render(frame, &app))
-        .expect("render should succeed");
-
-    let text = terminal_text(&terminal, width, height);
-    assert!(text.contains("[Enter] Save"));
-    assert!(text.contains("Cancel"));
 }
 
 #[test]

--- a/src/ui/timer.rs
+++ b/src/ui/timer.rs
@@ -1,8 +1,8 @@
 use crate::ui::{
     Alignment, App, Block, Borders, Color, Constraint, Direction, Frame, Gauge, Layout, Line,
-    Local, Modifier, NavigationAction, Paragraph, Rect, ShortcutAction, Style, TimeZone,
-    TimerPhase, TimerStatus, WakatimeRuntimeState, Wrap, app_color, centered_rect,
-    format_timer_goal_streak_line, readable_goal_streak_text, render_hint_lines,
+    Local, Modifier, Paragraph, Rect, ShortcutAction, Style, TimeZone, TimerPhase, TimerStatus,
+    WakatimeRuntimeState, Wrap, app_color, centered_rect, format_timer_goal_streak_line,
+    readable_goal_streak_text, render_hint_lines,
 };
 
 pub(super) fn render_timer(frame: &mut Frame, app: &App) {
@@ -144,26 +144,6 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(app_color(app, Color::Yellow)),
         )
     };
-    let can_edit_session_note = app.can_edit_session_note();
-    let (note_text, note_style) = if let Some(note) = app.current_task_note() {
-        (
-            format!("📝 Note: {note}"),
-            Style::default().fg(app_color(app, Color::Cyan)),
-        )
-    } else if can_edit_session_note {
-        (
-            format!(
-                "📝 Note: none yet ({} Edit note)",
-                app.shortcut_hint(ShortcutAction::TimerEditNote)
-            ),
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        )
-    } else {
-        (
-            "📝 Note: unavailable (start or resume focus to edit)".to_string(),
-            Style::default().fg(app_color(app, Color::DarkGray)),
-        )
-    };
     let (stats_text, stats_style) = timer_stats_line(app);
     let goal_text = readable_goal_streak_text(&format_timer_goal_streak_line(app));
     let (waka_text, waka_color) = wakatime_status_line(app);
@@ -171,7 +151,6 @@ fn render_timer_session_panel(frame: &mut Frame, app: &App, area: Rect) {
 
     let mut lines = vec![
         Line::styled(task_text, task_style),
-        Line::styled(note_text, note_style),
         Line::styled(
             status_text,
             Style::default().fg(app_color(app, Color::Gray)),
@@ -398,19 +377,6 @@ fn render_timer_phase_notice(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn phase_notice_line(app: &App) -> (String, Style) {
-    if app.timer_note_input_active() {
-        let draft = app.timer_note_input_value().trim();
-        let draft = if draft.is_empty() { "<empty>" } else { draft };
-        return (
-            format!(
-                "📝 Note: {draft}   {} Save   {} Cancel",
-                app.navigation_hint(NavigationAction::Confirm),
-                app.navigation_hint(NavigationAction::Cancel)
-            ),
-            Style::default().fg(app_color(app, Color::Cyan)),
-        );
-    }
-
     if let Some(message) = app.phase_notification.as_ref() {
         (
             format!("🔔 {message}"),
@@ -422,11 +388,6 @@ fn phase_notice_line(app: &App) -> (String, Style) {
             Style::default().fg(app_color(app, Color::DarkGray)),
         )
     }
-}
-
-#[cfg(test)]
-pub(super) fn note_phase_notice_text(app: &App) -> String {
-    phase_notice_line(app).0
 }
 
 fn timer_stats_line(app: &App) -> (String, Style) {
@@ -550,34 +511,23 @@ pub(super) fn timer_primary_hint(app: &App) -> String {
     let timer_toggle = app.shortcut_hint(ShortcutAction::TimerTogglePause);
     let timer_stop = app.shortcut_hint(ShortcutAction::TimerStopReset);
     let timer_next = app.shortcut_hint(ShortcutAction::TimerNextPhase);
-    let timer_note = app.shortcut_hint(ShortcutAction::TimerEditNote);
     let timer_unblock = app.shortcut_hint(ShortcutAction::BreakGlassOverride);
 
-    if app.timer_note_input_active() {
+    if app.break_glass_confirmation_pending() {
         format!(
-            "Note: Type text  {} Save  {} Cancel",
-            app.navigation_hint(NavigationAction::Confirm),
-            app.navigation_hint(NavigationAction::Cancel)
-        )
-    } else if app.break_glass_confirmation_pending() {
-        format!(
-            "Timer: {timer_toggle} Run/Pause  {timer_stop} Stop/Reset  {timer_next} Next  {timer_note} Note  {timer_unblock} Confirm unblock"
+            "Timer: {timer_toggle} Run/Pause  {timer_stop} Stop/Reset  {timer_next} Next  {timer_unblock} Confirm unblock"
         )
     } else if app.strict_reset_confirmation_pending() {
         format!(
-            "Timer: {timer_toggle} Run/Pause  {timer_stop} Confirm reset  {timer_next} Next (Locked)  {timer_note} Note  {timer_unblock} Unblock"
+            "Timer: {timer_toggle} Run/Pause  {timer_stop} Confirm reset  {timer_next} Next (Locked)  {timer_unblock} Unblock"
         )
     } else if app.strict_mode_enforced_for_focus() {
         format!(
-            "Timer: {timer_toggle} Run/Pause  {timer_stop} Stop/Reset (Confirm)  {timer_next} Next (Locked)  {timer_note} Note  {timer_unblock} Unblock"
-        )
-    } else if app.can_edit_session_note() {
-        format!(
-            "Timer: {timer_toggle} Run/Pause  {timer_stop} Stop/Reset  {timer_next} Next  {timer_note} Note  {timer_unblock} Unblock"
+            "Timer: {timer_toggle} Run/Pause  {timer_stop} Stop/Reset (Confirm)  {timer_next} Next (Locked)  {timer_unblock} Unblock"
         )
     } else {
         format!(
-            "Timer: {timer_toggle} Run/Pause  {timer_stop} Stop/Reset  {timer_next} Next  {timer_note} Note (Focus only)  {timer_unblock} Unblock"
+            "Timer: {timer_toggle} Run/Pause  {timer_stop} Stop/Reset  {timer_next} Next  {timer_unblock} Unblock"
         )
     }
 }
@@ -589,9 +539,7 @@ pub(super) fn timer_secondary_hint(app: &App) -> String {
     let profiles = app.shortcut_hint(ShortcutAction::OpenProfileManager);
     let setup = app.shortcut_hint(ShortcutAction::OpenSetupDiagnostics);
 
-    if app.timer_note_input_active() {
-        "Views: shortcuts paused while editing note".to_string()
-    } else if app.strict_mode_enforced_for_focus() {
+    if app.strict_mode_enforced_for_focus() {
         format!(
             "Views: {tasks} Tasks  {history} History  {sites} Sites  {profiles} Profiles (Locked)  {setup} Setup"
         )
@@ -604,12 +552,7 @@ pub(super) fn timer_secondary_hint(app: &App) -> String {
 
 pub(super) fn timer_tertiary_hint(app: &App) -> String {
     let quit = app.shortcut_label(ShortcutAction::Quit);
-    if app.timer_note_input_active() {
-        format!(
-            "Note edit: {} Cancel",
-            app.navigation_hint(NavigationAction::Cancel)
-        )
-    } else if app.strict_mode_enforced_for_focus() {
+    if app.strict_mode_enforced_for_focus() {
         format!("Navigate: [{quit}/Esc] Quit (Locked during active focus)")
     } else {
         format!("Navigate: [{quit}/Esc] Quit")

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -199,7 +199,7 @@ fn status_json_success_emits_payload_on_stdout() {
     let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
     assert!(payload.get("day").is_some());
     assert!(payload.get("focus_intention").is_none());
-    assert!(payload.get("task_note").is_some());
+    assert!(payload.get("task_note").is_none());
     assert!(payload.get("goal").is_some());
     assert!(payload.get("weekly_goal").is_some());
     assert!(payload.get("monthly_goal").is_some());
@@ -232,7 +232,7 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload["focus_score"].get("focus_score_pct").is_some());
     assert!(payload.get("live").is_some());
     assert!(payload["live"].get("focus_intention").is_none());
-    assert!(payload["live"].get("task_note").is_some());
+    assert!(payload["live"].get("task_note").is_none());
     assert!(payload.get("comparison").is_none());
 }
 
@@ -330,78 +330,27 @@ fn task_goal_json_reads_unconfigured_selected_task_goal() {
 }
 
 #[test]
-fn session_metadata_json_does_not_fallback_from_selected_task_label() {
-    let env = TestEnv::new("metadata-json-read-no-fallback");
-
-    let select_output = env.run(&["--task", "Docs", "--json"]);
-    assert_eq!(select_output.status.code(), Some(0));
-    assert!(stderr_text(&select_output).trim().is_empty());
-
-    let read_output = env.run(&["--task-note", "--json"]);
-    assert_eq!(read_output.status.code(), Some(0));
-    assert!(stderr_text(&read_output).trim().is_empty());
-
-    let payload: Value =
-        serde_json::from_slice(&read_output.stdout).expect("stdout should be JSON");
-    assert_eq!(payload["action"], "task-note");
-    assert_eq!(payload["updated"], false);
-    assert!(payload.get("focus_intention").is_none());
-    assert!(payload["task_note"].is_null());
-    assert_eq!(payload["timer"]["selected_task_label"], "Docs");
-}
-
-#[test]
-fn session_metadata_json_set_and_read_updates_recovery_backed_state() {
-    let env = TestEnv::new("metadata-json-set-read");
-    write_recovery_snapshot(
-        &env,
-        r#"phase = "focus"
-status = "running"
-remaining_secs = 1200
-pomodoros_completed = 2
-selected_task_label = "Docs"
-focus_intention = "Write docs"
-task_note = "Draft outline"
-selected_profile = "classic"
-"#,
-    );
-
-    let set_note_output = env.run(&["--task-note", "Capture blockers", "--json"]);
-    assert_eq!(set_note_output.status.code(), Some(0));
-    assert!(stderr_text(&set_note_output).trim().is_empty());
-    let set_note_payload: Value =
-        serde_json::from_slice(&set_note_output.stdout).expect("stdout should be JSON");
-    assert_eq!(set_note_payload["action"], "task-note");
-    assert_eq!(set_note_payload["updated"], true);
-    assert!(set_note_payload.get("focus_intention").is_none());
-    assert_eq!(set_note_payload["task_note"], "Capture blockers");
-
-    let read_output = env.run(&["--task-note", "--json"]);
-    assert_eq!(read_output.status.code(), Some(0));
-    assert!(stderr_text(&read_output).trim().is_empty());
-    let read_payload: Value = serde_json::from_slice(&read_output.stdout).expect("stdout JSON");
-    assert_eq!(read_payload["action"], "task-note");
-    assert_eq!(read_payload["updated"], false);
-    assert!(read_payload.get("focus_intention").is_none());
-    assert_eq!(read_payload["task_note"], "Capture blockers");
-}
-
-#[test]
-fn session_metadata_set_json_requires_active_focus_session() {
-    let env = TestEnv::new("metadata-json-set-requires-active-session");
+fn task_note_json_command_is_removed() {
+    let env = TestEnv::new("task-note-json-removed");
     let output = env.run(&["--task-note", "Write docs", "--json"]);
 
-    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output.status.code(), Some(2));
     assert!(stderr_text(&output).trim().is_empty());
     let payload: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
     assert_eq!(payload["ok"], false);
-    assert_eq!(payload["error"]["kind"], "runtime");
-    assert_eq!(payload["error"]["exit_code"], 1);
+    assert_eq!(payload["error"]["kind"], "usage");
+    assert_eq!(payload["error"]["exit_code"], 2);
     assert!(
         payload["error"]["message"]
             .as_str()
             .expect("error message should be a string")
-            .contains("focus session is not active or paused")
+            .contains("Unknown option `--task-note`")
+    );
+    assert!(
+        payload["error"]["hint"]
+            .as_str()
+            .expect("hint should be a string")
+            .contains("Use `--task`")
     );
 }
 
@@ -866,7 +815,7 @@ captured_at_epoch_secs = 0
     assert_eq!(payload["live"]["pomodoros_completed"], 1);
     assert_eq!(payload["live"]["selected_task_label"], "Docs");
     assert!(payload["live"].get("focus_intention").is_none());
-    assert!(payload["live"]["task_note"].is_null());
+    assert!(payload["live"].get("task_note").is_none());
     assert!(
         payload["live"]["remaining_secs"]
             .as_u64()
@@ -961,14 +910,10 @@ fn parse_errors_in_json_mode_preserve_contract_across_parser_stages() {
 #[test]
 fn runtime_errors_in_json_mode_preserve_contract_across_command_families() {
     let env = TestEnv::new("json-runtime-contract-matrix");
-    let cases: [(&[&str], &str); 4] = [
+    let cases: [(&[&str], &str); 3] = [
         (&["--start", "--json"], "select a task label first"),
         (&["--pause", "--json"], "Cannot pause"),
         (&["--resume", "--json"], "Cannot resume"),
-        (
-            &["--task-note", "Write docs", "--json"],
-            "focus session is not active or paused",
-        ),
     ];
 
     for (args, message_fragment) in cases {


### PR DESCRIPTION
## What

Remove task note metadata and command surfaces so task labels are the only supported session context.

Closes #555.

## Why

This follows the v0.16.3 cleanup roadmap by retiring `--task-note`, TUI note editing, recovery/status/export `task_note` fields, and related persistence paths.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI and workflow docs to remove the retired task-note option and point users to task labels instead.
  * Clarified session recovery, status output, and export behavior with the new metadata format.

* **Bug Fixes**
  * Status, history, and export outputs now consistently omit retired task-note data.
  * CLI help and JSON responses now correctly reject the removed option and guide users to the supported replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->