### PR TITLE
Prepare v0.16.4 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.16.3 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.16.4 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -117,7 +117,7 @@ When preparing a release update, keep these files aligned:
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
 - `REGRESSION_MATRIX.md` merged/deprecated/removed feature-path coverage and supported replacement behavior
-- Release tag examples in docs use the current target release version (for example, `v0.16.3`)
+- Release tag examples in docs use the current target release version (for example, `v0.16.4`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,5 +138,5 @@ sequenceDiagram
   owns it.
 - For release docs updates, keep architecture-facing terminology aligned with the
   module names and responsibility language used in `README.md`, `CHANGELOG.md`,
-  and release tag examples in contributor-facing docs (for example, `v0.16.3`
+  and release tag examples in contributor-facing docs (for example, `v0.16.4`
   for this release cycle).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.4] - 2026-06-28
+
 ### Changed
 
 - **Breaking - Allowlist CLI surface cleanup (#563):** retired `--allowlist-sites`, `--allowlist-site-add`, `--allowlist-site-edit`, and `--allowlist-site-delete`, keeping allowlist exceptions as config/internal rules while CLI site management focuses on canonical blocklist commands.
@@ -542,7 +544,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.16.3...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.16.4...HEAD
+[0.16.4]: https://github.com/utilForever/focustime/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/utilForever/focustime/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/utilForever/focustime/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/utilForever/focustime/compare/v0.16.0...v0.16.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Also keep the README roadmap, changelog entry, and deprecation notices aligned
 so every deprecated or retired path names supported replacement behavior before
 the tag is created.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.16.3`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.16.4`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and WakaTime tracking"

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Milestone policy:
 - **v0.16.1:** focused config diagnostics commands are retired in favor of `--diagnostics`; feature inventory CLI export and committed generated inventory snapshots are retired; legacy cleanup-specific regression gates are archived, and current cleanup contracts live in normal CI/module/integration tests.
 - **v0.16.2:** schedule exception dates, calendar annotation cache handling, and retired calendar timezone parsing stay removed; recurring schedule windows remain the supported schedule model, and `chrono-tz` stays out of the manifest and lockfile.
 - **v0.16.3:** task note metadata, focus intention metadata, task-specific goals, session-template command/config surfaces, and per-task WakaTime mappings are retired; task labels are the supported session context in status, recovery, history, and exports, while WakaTime uses one global metadata configuration.
+- **v0.16.4:** allowlist site-management commands, blocklist profile CRUD/selection, custom blocking backend/fallback policy, break-glass workflow, and temporary override runtime state are retired; canonical blocklist commands, config/internal allowlist rules, hosts-file diagnostics, and normal timer controls are the supported replacements.
 - **Future cleanup:** continue retiring overlapping paths only after release notes and docs name supported replacement behavior.
 - **v0.12.0:** remove legacy field/path compatibility after the warning window
 
@@ -275,6 +276,9 @@ Early deprecation notices:
 | Legacy timer duration fields (`focus_secs`, `short_break_secs`, `long_break_secs`, `long_break_interval`) | Use `[custom_profile]`, profile presets, and `--profile`; run `--diagnostics` when stale keys are reported. |
 | Legacy automation and blocklist top-level fields | Use per-profile automation tables and the canonical `Default` blocklist profile; inspect with `--diagnostics`. |
 | Retired blocklist category config is migration-only | `--diagnostics` reports migration guidance to flatten category `sites` and `allowlist_sites` into profile-level lists; manage blocked hostnames directly with `--blocklist-sites`, `--blocklist-site-add`, `--blocklist-site-edit`, and `--blocklist-site-delete`. |
+| Allowlist site-management commands (`--allowlist-sites`, `--allowlist-site-add`, `--allowlist-site-edit`, `--allowlist-site-delete`) | Removed; keep persistent exceptions in `allowlist_sites` config/internal rules and manage canonical blocked hostnames with blocklist site commands. |
+| Blocklist profile CRUD and selection (`--blocklist-profile*`) | Removed; existing profile rules are collapsed into the canonical `Default` blocklist/allowlist, and new site changes use direct blocklist site commands. |
+| Custom command blocking backend and backend fallback policy | Removed; hosts-file blocking is the supported backend, and `--diagnostics` reports hosts-file readiness and preview details. |
 | Temporary allowlist CLI/runtime workflow | Removed; manage blocked hostnames with blocklist commands and keep persistent exceptions in `allowlist_sites` config when needed. |
 | Break-glass temporary override workflow | Removed; use normal timer controls (`--pause`, `--resume`, `--stop`) for session flow changes or blocklist commands for site-rule changes. |
 | Split temporary override runtime fields | Removed; runtime persistence and `--status --json` no longer emit temporary override entries or legacy `break_glass_*` / `temporary_allowlist_*` fields. |
@@ -836,12 +840,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.16.3`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.16.4`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.16.3](https://github.com/utilForever/focustime/releases/tag/v0.16.3).
+The latest stable release is [v0.16.4](https://github.com/utilForever/focustime/releases/tag/v0.16.4).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the v0.16.4 release documentation and version metadata.

Closes #600.

## Why

Align release-facing files for the v0.16.4 release checklist.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] WakaTime integration behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release and contributor docs for the new **v0.16.4** release.
  * Refreshed changelog, release examples, and version references throughout the docs.
  * Expanded cleanup guidance to reflect recently retired command and configuration paths, along with their supported replacements.

* **Chores**
  * Bumped the package version to **0.16.4**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->