### PR TITLE
Simplify goals to daily targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,21 +111,9 @@ cargo run -- --goal
 cargo run -- --goal=120,4
 cargo run -- --goal --json
 
-# Show or set weekly goal targets (minutes,pomodoros)
-cargo run -- --goal-weekly
-cargo run -- --goal-weekly=600,20
-cargo run -- --goal-weekly --json
-
-# Show or set monthly goal targets (minutes,pomodoros)
-cargo run -- --goal-monthly
-cargo run -- --goal-monthly=2400,80
-cargo run -- --goal-monthly --json
-
-# Show or set goal carry-over behavior (on/off)
+# Show or set daily goal carry-over behavior (on/off)
 cargo run -- --goal-carry
 cargo run -- --goal-carry=on
-cargo run -- --goal-carry-weekly=on
-cargo run -- --goal-carry-monthly=off
 cargo run -- --goal-carry --json
 
 # Show or set strict mode for the selected profile
@@ -285,7 +273,7 @@ Early deprecation notices:
 | Standalone calendar refresh command (`--calendar-sync`) and `[calendar_sync]` config | Removed; scheduling no longer reads calendar annotation caches or renders calendar-derived busy/overlap text. |
 | Task note metadata and command surface (`--task-note`, timer note editing, `task_note` status/export fields) | Removed; use `--task` and task label selection as the supported session context. |
 | Focus intention metadata (`--focus-intention`, `focus_intention` recovery/status/export fields) | Removed; use `--task` and task label selection as the supported session metadata. |
-| Task-specific cumulative goals (`--task-goal`, selected task goal status/history/export fields) | Removed; use global daily, weekly, and monthly goals with `--goal`, `--goal-weekly`, and `--goal-monthly`; task labels remain available for grouping. |
+| Task-specific cumulative goals (`--task-goal`, selected task goal status/history/export fields) | Removed; use the global daily goal with `--goal`; task labels remain available for grouping. |
 | Session template workflows (`--session-template*` commands and session-template config/runtime persistence) | Removed; select task, profile, schedule, and blocklist settings directly through their dedicated controls. |
 | WakaTime heartbeat tracking and config (`[wakatime]`, `[wakatime_runtime]`, prior task mappings) | Removed; focus sessions stay local to timer, blocking, goals, recovery, history, and exports. |
 | Daemon local API lifecycle (`--daemon-start`, `--daemon-status`, `--daemon-stop`, `--daemon-port`, `/v1/*`) | Removed; use CLI timer/session/workflow commands (`--start`, `--pause`, `--resume`, `--stop`, `--next`, `--task`) for automation, or the TUI for interactive focus sessions. |
@@ -449,8 +437,8 @@ Open Focus History from timer view with **`h`**.
 - `↑/↓`: cycle task slice, `[`/`]`: cycle profile slice, `,`/`.`: cycle time-of-day slice
 
 Focus History renders a stable default KPI layout covering session summary,
-focus score, goal streak, focus risk, weekly allocation, last interruption,
-stats growth, retention, and comparison filters. Dashboard pin, unpin, and order
+focus score, goal streak, focus risk, last interruption, stats growth,
+retention, and comparison filters. Dashboard pin, unpin, and order
 customization commands are retired; use `--history-dashboard` for CLI layout
 inspection.
 
@@ -510,14 +498,6 @@ time_step_minutes = 15
 [daily_goal]
 minutes = 120
 pomodoros = 4
-
-[weekly_goal]
-minutes = 600
-pomodoros = 20
-
-[monthly_goal]
-minutes = 2400
-pomodoros = 80
 
 [stats_retention]
 preset = "balanced" # keep_all | balanced | aggressive
@@ -656,7 +636,7 @@ You can configure notification and auto-start settings directly from the TUI:
 - press `e` to open the editor
 - automation and schedule edits apply to the currently selected profile only
 - the editor is grouped into sections (**Timer**, **Automation**, **Goals**, **Schedule**, **Appearance**) to keep settings easier to scan
-- use `↑/↓` (default `navigate_up`/`navigate_down`) to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily/Weekly/Monthly goal (minutes)**, **Daily/Weekly/Monthly goal (pomodoros)**, **Theme preset**, or the **Schedule** fields
+- use `↑/↓` (default `navigate_up`/`navigate_down`) to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily goal (minutes)**, **Daily goal (pomodoros)**, **Theme preset**, or the **Schedule** fields
 - use `←/→` (default `navigate_left`/`navigate_right`) to adjust values (or toggle `Off`/`On` for boolean fields), then `Enter` (default `confirm`) to save
 - schedule editing is in-app:
   - **Schedule add/remove**: `→` adds a window, `←` removes selected window
@@ -702,7 +682,7 @@ for blocked-site changes, and normal timer controls (`--pause`, `--resume`,
 - daily aggregates persisted in `stats.toml` in the canonical data/state directory
 - weekly totals derived from daily aggregates in the History view
 - weekly consistency score (`active_days / 7`, rounded to `%`) derived from daily activity
-- weekly focus score KPI (50/50 blend of consistency and weekly goal completion; `n/a` when weekly goal is off)
+- weekly focus score KPI based on consistency (`active_days / 7`, rounded to `%`)
 - profile effectiveness comparison (focus share % and average focused minutes per completed session)
 - productivity comparison rows by task/profile/time-of-day in History and exports
 - per-task totals (pomodoros and focused minutes) derived from labeled focus sessions
@@ -719,8 +699,7 @@ Current retention presets for historical records:
 
 Retention is enforced when stats are persisted. Existing data older than the selected windows is pruned on save.
 
-If daily, weekly, or monthly goals are configured, timer and history views also
-show live progress for each period:
+If a daily goal is configured, timer and history views also show live progress:
 
 - target focused minutes
 - target completed pomodoros

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ You can configure notification and auto-start settings directly from the TUI:
 - press `e` to open the editor
 - automation and schedule edits apply to the currently selected profile only
 - the editor is grouped into sections (**Timer**, **Automation**, **Goals**, **Schedule**, **Appearance**) to keep settings easier to scan
-- use `↑/↓` (default `navigate_up`/`navigate_down`) to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily goal (minutes)**, **Daily goal (pomodoros)**, **Theme preset**, or the **Schedule** fields
+- use `↑/↓` (default `navigate_up`/`navigate_down`) to select **Phase notifications**, **Sound alert**, **Auto-start break**, **Auto-start focus**, **Strict focus mode**, **Daily goal (minutes)**, **Daily goal (pomodoros)**, **Daily carry-over**, **Theme preset**, or the **Schedule** fields
 - use `←/→` (default `navigate_left`/`navigate_right`) to adjust values (or toggle `Off`/`On` for boolean fields), then `Enter` (default `confirm`) to save
 - schedule editing is in-app:
   - **Schedule add/remove**: `→` adds a window, `←` removes selected window
@@ -722,8 +722,8 @@ attached. Focus-session rows persist and export `task_label` without separate
 task note metadata. Interruption records include structured `reason` values and
 remaining-time metadata. Export files now also include a `history_kpis` JSON
 object covering all History dashboard KPI cards (`session_summary`,
-`focus_score`, `goal_streak`, `focus_risk`, `weekly_allocation`,
-`last_interruption`, `stats_growth`, `retention`, `comparison_filters`), with
+`focus_score`, `goal_streak`, `focus_risk`, `last_interruption`,
+`stats_growth`, `retention`, `comparison_filters`), with
 matching CSV `history_kpi` rows (`kpi_card_id` + `kpi_payload_json`) for
 JSON/CSV parity. Export files expose `schema_version` (currently `9`) so
 downstream consumers can handle versioned contracts explicitly.

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,18 +55,13 @@ use history_dashboard_cache::HistoryDashboardCache;
 #[cfg(test)]
 pub(crate) use history_dashboard_cache::HistoryDashboardCacheStats;
 pub(crate) use history_dashboard_cache::HistoryDashboardViewData;
-pub(crate) use history_goals::weekly_daily_goal_allocation_for_context;
 pub(crate) use profile_edit::{
     CUSTOM_DURATION_STEP_SECS, DAILY_GOAL_MINUTES_STEP, PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX,
     PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX, PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX,
-    PROFILE_EDIT_FIELD_LABELS, PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX,
-    PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX,
-    PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX, PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX,
-    PROFILE_EDIT_SCHEDULE_DAY_INDEX, PROFILE_EDIT_SCHEDULE_END_INDEX,
-    PROFILE_EDIT_SCHEDULE_START_INDEX, PROFILE_EDIT_SCHEDULE_WINDOW_INDEX,
-    PROFILE_EDIT_THEME_PRESET_INDEX, PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX,
-    PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX,
-    ProfileEditSnapshot,
+    PROFILE_EDIT_FIELD_LABELS, PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX,
+    PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX, PROFILE_EDIT_SCHEDULE_DAY_INDEX,
+    PROFILE_EDIT_SCHEDULE_END_INDEX, PROFILE_EDIT_SCHEDULE_START_INDEX,
+    PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, PROFILE_EDIT_THEME_PRESET_INDEX, ProfileEditSnapshot,
 };
 pub(crate) use setup_diagnostics::{
     BlockingPreviewSnapshot, SetupCheck, SetupCheckLevel, SetupDiagnostics,
@@ -329,10 +324,12 @@ pub(crate) struct WeeklyDailyGoalAllocation {
 }
 
 impl WeeklyDailyGoalAllocation {
+    #[allow(dead_code)]
     pub(crate) fn has_any_target(&self) -> bool {
         self.week_target.has_any_target()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn today_target(&self) -> DailyGoalSnapshot {
         self.daily_targets
             .first()
@@ -683,6 +680,7 @@ impl App {
         )
     }
 
+    #[allow(dead_code)]
     pub(crate) fn current_week_goal_progress(&self) -> DailyGoalProgress {
         let today = Local::now().date_naive();
         let week = self.stats.weekly_for_day(today);
@@ -695,6 +693,7 @@ impl App {
         )
     }
 
+    #[allow(dead_code)]
     pub(crate) fn current_month_goal_progress(&self) -> DailyGoalProgress {
         let today = Local::now().date_naive();
         let month = self.stats.monthly_for_day(today);
@@ -846,24 +845,6 @@ impl App {
             }
             PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX => {
                 bool_label(self.goal_carry_over.daily).to_string()
-            }
-            PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX => {
-                format_daily_goal_minutes_label(self.weekly_goal.minutes)
-            }
-            PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX => {
-                format_daily_goal_pomodoros_label(self.weekly_goal.pomodoros)
-            }
-            PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX => {
-                bool_label(self.goal_carry_over.weekly).to_string()
-            }
-            PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX => {
-                format_daily_goal_minutes_label(self.monthly_goal.minutes)
-            }
-            PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX => {
-                format_daily_goal_pomodoros_label(self.monthly_goal.pomodoros)
-            }
-            PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX => {
-                bool_label(self.goal_carry_over.monthly).to_string()
             }
             PROFILE_EDIT_THEME_PRESET_INDEX => self.selected_theme_preset.label().to_string(),
             _ => String::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -323,24 +323,6 @@ pub(crate) struct WeeklyDailyGoalAllocation {
     pub(crate) daily_targets: Vec<WeeklyDailyAllocationDay>,
 }
 
-impl WeeklyDailyGoalAllocation {
-    #[allow(dead_code)]
-    pub(crate) fn has_any_target(&self) -> bool {
-        self.week_target.has_any_target()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn today_target(&self) -> DailyGoalSnapshot {
-        self.daily_targets
-            .first()
-            .map(|target| DailyGoalSnapshot {
-                minutes: target.minutes_target,
-                pomodoros: target.pomodoros_target,
-            })
-            .unwrap_or_default()
-    }
-}
-
 pub(crate) struct App {
     pub(crate) timer: TimerState,
     pub(crate) should_quit: bool,
@@ -675,32 +657,6 @@ impl App {
         goal_progress_for_totals(
             today_stats.focused_minutes(),
             today_stats.pomodoros_completed,
-            target.minutes,
-            target.pomodoros,
-        )
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn current_week_goal_progress(&self) -> DailyGoalProgress {
-        let today = Local::now().date_naive();
-        let week = self.stats.weekly_for_day(today);
-        let target = self.effective_weekly_goal_snapshot_for_day(today);
-        goal_progress_for_totals(
-            week.focused_minutes(),
-            week.pomodoros_completed,
-            target.minutes,
-            target.pomodoros,
-        )
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn current_month_goal_progress(&self) -> DailyGoalProgress {
-        let today = Local::now().date_naive();
-        let month = self.stats.monthly_for_day(today);
-        let target = self.effective_monthly_goal_snapshot_for_day(today);
-        goal_progress_for_totals(
-            month.focused_minutes(),
-            month.pomodoros_completed,
             target.minutes,
             target.pomodoros,
         )

--- a/src/app/history_comparison.rs
+++ b/src/app/history_comparison.rs
@@ -59,7 +59,7 @@ impl App {
     }
 
     pub(crate) fn history_dashboard_cards(&self) -> Vec<HistoryKpiCardId> {
-        HistoryKpiCardId::all().to_vec()
+        HistoryKpiCardId::supported_dashboard_cards().to_vec()
     }
 
     pub(super) fn cycle_history_comparison_dimension(&mut self, forward: bool) {

--- a/src/app/history_dashboard_cache.rs
+++ b/src/app/history_dashboard_cache.rs
@@ -1,9 +1,8 @@
 use chrono::Local;
 
-use crate::app::{App, DailyGoalProgress, WeeklyDailyGoalAllocation, parse_day_key};
+use crate::app::{App, DailyGoalProgress, parse_day_key};
 use crate::config::{
-    DailyGoalConfig, GoalCarryOverConfig, MonthlyGoalConfig, RecurringScheduleConfig,
-    StatsRetentionConfig, WeeklyGoalConfig,
+    DailyGoalConfig, GoalCarryOverConfig, RecurringScheduleConfig, StatsRetentionConfig,
 };
 use crate::stats::{
     ComparisonDimension, DailyStats, FocusRiskForecast, GoalStreak, MonthlyHeatmap, MonthlyStats,
@@ -17,12 +16,9 @@ pub(crate) struct HistoryDashboardViewData {
     pub(crate) session_stats: SessionStats,
     pub(crate) today_stats: DailyStats,
     pub(crate) daily_goal_progress: DailyGoalProgress,
-    pub(crate) weekly_goal_progress: DailyGoalProgress,
-    pub(crate) monthly_goal_progress: DailyGoalProgress,
     pub(crate) latest_weekly_focus_score: Option<WeeklyFocusScore>,
     pub(crate) goal_streak: GoalStreak,
     pub(crate) focus_risk_forecast: FocusRiskForecast,
-    pub(crate) weekly_daily_goal_allocation: WeeklyDailyGoalAllocation,
     pub(crate) latest_session_interruption: Option<SessionInterruptionEvent>,
     pub(crate) stats_growth_summary: StatsGrowthSummary,
     pub(crate) stats_retention_config: StatsRetentionConfig,
@@ -40,12 +36,9 @@ pub(super) struct HistoryDashboardStaticSnapshot {
     session_stats: SessionStats,
     today_stats: DailyStats,
     daily_goal_progress: DailyGoalProgress,
-    weekly_goal_progress: DailyGoalProgress,
-    monthly_goal_progress: DailyGoalProgress,
     latest_weekly_focus_score: Option<WeeklyFocusScore>,
     goal_streak: GoalStreak,
     focus_risk_forecast: FocusRiskForecast,
-    weekly_daily_goal_allocation: WeeklyDailyGoalAllocation,
     latest_session_interruption: Option<SessionInterruptionEvent>,
     stats_growth_summary: StatsGrowthSummary,
     stats_retention_config: StatsRetentionConfig,
@@ -69,8 +62,6 @@ pub(super) struct HistoryDashboardStaticSnapshotKey {
     retention: StatsRetentionConfig,
     recurring_schedule: RecurringScheduleConfig,
     daily_goal: DailyGoalConfig,
-    weekly_goal: WeeklyGoalConfig,
-    monthly_goal: MonthlyGoalConfig,
     goal_carry_over: GoalCarryOverConfig,
 }
 
@@ -150,12 +141,9 @@ impl App {
             session_stats: static_snapshot.session_stats,
             today_stats: static_snapshot.today_stats,
             daily_goal_progress: static_snapshot.daily_goal_progress,
-            weekly_goal_progress: static_snapshot.weekly_goal_progress,
-            monthly_goal_progress: static_snapshot.monthly_goal_progress,
             latest_weekly_focus_score: static_snapshot.latest_weekly_focus_score,
             goal_streak: static_snapshot.goal_streak,
             focus_risk_forecast: static_snapshot.focus_risk_forecast,
-            weekly_daily_goal_allocation: static_snapshot.weekly_daily_goal_allocation,
             latest_session_interruption: static_snapshot.latest_session_interruption,
             stats_growth_summary: static_snapshot.stats_growth_summary,
             stats_retention_config: static_snapshot.stats_retention_config,
@@ -186,8 +174,6 @@ impl App {
             retention: self.stats_retention,
             recurring_schedule: self.recurring_schedule.clone(),
             daily_goal: self.daily_goal,
-            weekly_goal: self.weekly_goal,
-            monthly_goal: self.monthly_goal,
             goal_carry_over: self.goal_carry_over,
         }
     }
@@ -209,24 +195,19 @@ impl App {
         let day = parse_day_key(day_key).unwrap_or_else(|| Local::now().date_naive());
         let canonical_day_key = day.format("%Y-%m-%d").to_string();
         let daily_goal = self.effective_daily_goal_snapshot_for_day(day);
-        let weekly_goal = self.effective_weekly_goal_snapshot_for_day(day);
-        let monthly_goal = self.effective_monthly_goal_snapshot_for_day(day);
 
         HistoryDashboardStaticSnapshot {
             session_stats: self.stats.session(),
             today_stats: self.stats.daily_for(&canonical_day_key),
             daily_goal_progress: self.today_goal_progress(),
-            weekly_goal_progress: self.current_week_goal_progress(),
-            monthly_goal_progress: self.current_month_goal_progress(),
             latest_weekly_focus_score: self.stats.latest_weekly_focus_score(),
             goal_streak: self.goal_streak_for_day_key(&canonical_day_key),
             focus_risk_forecast: self.stats.focus_risk_forecast_for_day(
                 day,
                 daily_goal,
-                weekly_goal,
-                monthly_goal,
+                crate::stats::DailyGoalSnapshot::default(),
+                crate::stats::DailyGoalSnapshot::default(),
             ),
-            weekly_daily_goal_allocation: self.weekly_daily_goal_allocation_for_day(day),
             latest_session_interruption: self.stats.latest_session_interruption(),
             stats_growth_summary: self.stats.growth_summary(),
             stats_retention_config: self.stats_retention,

--- a/src/app/history_goals.rs
+++ b/src/app/history_goals.rs
@@ -160,6 +160,7 @@ impl App {
         carry_over_goal_target(base, self.goal_carry_over.monthly, previous)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn weekly_daily_goal_allocation(&self) -> WeeklyDailyGoalAllocation {
         let today = Local::now().date_naive();
         self.weekly_daily_goal_allocation_for_day(today)
@@ -188,13 +189,7 @@ impl App {
         let daily_changed = self
             .stats
             .sync_goal_snapshot(&day_key, self.current_goal_snapshot());
-        let weekly_changed = self
-            .stats
-            .sync_weekly_goal_snapshot(day, self.current_week_goal_snapshot());
-        let monthly_changed = self
-            .stats
-            .sync_monthly_goal_snapshot(day, self.current_month_goal_snapshot());
-        if daily_changed || weekly_changed || monthly_changed {
+        if daily_changed {
             self.mark_stats_dirty();
             self.flush_stats_if_dirty(false);
         }

--- a/src/app/profile_edit.rs
+++ b/src/app/profile_edit.rs
@@ -1,9 +1,9 @@
 use crate::config::{
-    AutoStartConfig, CustomProfileConfig, DailyGoalConfig, GoalCarryOverConfig, MonthlyGoalConfig,
-    NotificationConfig, RecurringScheduleConfig, ThemePreset, WeeklyGoalConfig,
+    AutoStartConfig, CustomProfileConfig, DailyGoalConfig, GoalCarryOverConfig, NotificationConfig,
+    RecurringScheduleConfig, ThemePreset,
 };
 
-pub(crate) const PROFILE_EDIT_FIELD_LABELS: [&str; 25] = [
+pub(crate) const PROFILE_EDIT_FIELD_LABELS: [&str; 19] = [
     "Focus",
     "Short Break",
     "Long Break",
@@ -16,12 +16,6 @@ pub(crate) const PROFILE_EDIT_FIELD_LABELS: [&str; 25] = [
     "Daily goal minutes",
     "Daily goal pomodoros",
     "Daily goal carry-over",
-    "Weekly goal minutes",
-    "Weekly goal pomodoros",
-    "Weekly goal carry-over",
-    "Monthly goal minutes",
-    "Monthly goal pomodoros",
-    "Monthly goal carry-over",
     "Schedule window",
     "Schedule day",
     "Schedule day enabled",
@@ -33,19 +27,13 @@ pub(crate) const PROFILE_EDIT_FIELD_LABELS: [&str; 25] = [
 pub(crate) const PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX: usize = 9;
 pub(crate) const PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX: usize = 10;
 pub(crate) const PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX: usize = 11;
-pub(crate) const PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX: usize = 12;
-pub(crate) const PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX: usize = 13;
-pub(crate) const PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX: usize = 14;
-pub(crate) const PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX: usize = 15;
-pub(crate) const PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX: usize = 16;
-pub(crate) const PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX: usize = 17;
-pub(crate) const PROFILE_EDIT_SCHEDULE_WINDOW_INDEX: usize = 18;
-pub(crate) const PROFILE_EDIT_SCHEDULE_DAY_INDEX: usize = 19;
-pub(crate) const PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX: usize = 20;
-pub(crate) const PROFILE_EDIT_SCHEDULE_START_INDEX: usize = 21;
-pub(crate) const PROFILE_EDIT_SCHEDULE_END_INDEX: usize = 22;
-pub(crate) const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 23;
-pub(crate) const PROFILE_EDIT_THEME_PRESET_INDEX: usize = 24;
+pub(crate) const PROFILE_EDIT_SCHEDULE_WINDOW_INDEX: usize = 12;
+pub(crate) const PROFILE_EDIT_SCHEDULE_DAY_INDEX: usize = 13;
+pub(crate) const PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX: usize = 14;
+pub(crate) const PROFILE_EDIT_SCHEDULE_START_INDEX: usize = 15;
+pub(crate) const PROFILE_EDIT_SCHEDULE_END_INDEX: usize = 16;
+pub(crate) const PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX: usize = 17;
+pub(crate) const PROFILE_EDIT_THEME_PRESET_INDEX: usize = 18;
 pub(crate) const CUSTOM_DURATION_STEP_SECS: u64 = 60;
 pub(crate) const DAILY_GOAL_MINUTES_STEP: u64 = 5;
 
@@ -57,8 +45,6 @@ pub(crate) struct ProfileEditSnapshot {
     pub(crate) recurring_schedule: RecurringScheduleConfig,
     pub(crate) strict_mode: bool,
     pub(crate) daily_goal: DailyGoalConfig,
-    pub(crate) weekly_goal: WeeklyGoalConfig,
-    pub(crate) monthly_goal: MonthlyGoalConfig,
     pub(crate) goal_carry_over: GoalCarryOverConfig,
     pub(crate) selected_theme_preset: ThemePreset,
 }

--- a/src/app/profile_management.rs
+++ b/src/app/profile_management.rs
@@ -1,13 +1,10 @@
 use crate::app::{
     App, AppMode, KeyEvent, Local, NavigationAction, PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX,
     PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX, PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX,
-    PROFILE_EDIT_FIELD_LABELS, PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX,
-    PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX,
-    PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX, PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX,
-    PROFILE_EDIT_SCHEDULE_DAY_INDEX, PROFILE_EDIT_SCHEDULE_END_INDEX,
-    PROFILE_EDIT_SCHEDULE_START_INDEX, PROFILE_EDIT_SCHEDULE_WINDOW_INDEX,
-    PROFILE_EDIT_THEME_PRESET_INDEX, PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX,
-    PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX, PROFILE_IDS,
+    PROFILE_EDIT_FIELD_LABELS, PROFILE_EDIT_SCHEDULE_ADD_REMOVE_INDEX,
+    PROFILE_EDIT_SCHEDULE_DAY_ENABLED_INDEX, PROFILE_EDIT_SCHEDULE_DAY_INDEX,
+    PROFILE_EDIT_SCHEDULE_END_INDEX, PROFILE_EDIT_SCHEDULE_START_INDEX,
+    PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, PROFILE_EDIT_THEME_PRESET_INDEX, PROFILE_IDS,
     ProfileAutomationConfig, ProfileEditSnapshot, ProfileId, ShortcutAction, TimerState,
     adjust_daily_goal_minutes, adjust_daily_goal_pomodoros, adjust_duration_minutes,
     compile_windows, profile_for_index, profile_index, profile_spec_for,
@@ -205,8 +202,6 @@ impl App {
             recurring_schedule: self.recurring_schedule.clone(),
             strict_mode: self.strict_mode,
             daily_goal: self.daily_goal,
-            weekly_goal: self.weekly_goal,
-            monthly_goal: self.monthly_goal,
             goal_carry_over: self.goal_carry_over,
             selected_theme_preset: self.selected_theme_preset,
         });
@@ -225,8 +220,6 @@ impl App {
             self.recurring_schedule = snapshot.recurring_schedule;
             self.strict_mode = snapshot.strict_mode;
             self.daily_goal = snapshot.daily_goal;
-            self.weekly_goal = snapshot.weekly_goal;
-            self.monthly_goal = snapshot.monthly_goal;
             self.goal_carry_over = snapshot.goal_carry_over;
             self.selected_theme_preset = snapshot.selected_theme_preset;
             self.rebuild_notifier();
@@ -267,9 +260,7 @@ impl App {
     fn profile_edit_goals_changed(&self) -> bool {
         self.profile_edit_snapshot.as_ref().is_some_and(|snapshot| {
             snapshot.daily_goal != self.daily_goal
-                || snapshot.weekly_goal != self.weekly_goal
-                || snapshot.monthly_goal != self.monthly_goal
-                || snapshot.goal_carry_over != self.goal_carry_over
+                || snapshot.goal_carry_over.daily != self.goal_carry_over.daily
         })
     }
 
@@ -355,24 +346,6 @@ impl App {
             }
             PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX => {
                 self.goal_carry_over.daily = increase;
-            }
-            PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX => {
-                adjust_daily_goal_minutes(&mut self.weekly_goal.minutes, increase);
-            }
-            PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX => {
-                adjust_daily_goal_pomodoros(&mut self.weekly_goal.pomodoros, increase);
-            }
-            PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX => {
-                self.goal_carry_over.weekly = increase;
-            }
-            PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX => {
-                adjust_daily_goal_minutes(&mut self.monthly_goal.minutes, increase);
-            }
-            PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX => {
-                adjust_daily_goal_pomodoros(&mut self.monthly_goal.pomodoros, increase);
-            }
-            PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX => {
-                self.goal_carry_over.monthly = increase;
             }
             PROFILE_EDIT_THEME_PRESET_INDEX => {
                 self.selected_theme_preset = if increase {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -520,12 +520,7 @@ fn profile_edit_field_value_displays_second_precision() {
     assert_eq!(app.profile_edit_field_value(9), "Off");
     assert_eq!(app.profile_edit_field_value(10), "Off");
     assert_eq!(app.profile_edit_field_value(11), "Off");
-    assert_eq!(app.profile_edit_field_value(12), "Off");
-    assert_eq!(app.profile_edit_field_value(13), "Off");
-    assert_eq!(app.profile_edit_field_value(14), "Off");
-    assert_eq!(app.profile_edit_field_value(15), "Off");
-    assert_eq!(app.profile_edit_field_value(16), "Off");
-    assert_eq!(app.profile_edit_field_value(17), "Off");
+    assert_eq!(app.profile_edit_field_value(18), "Classic");
 }
 
 #[test]
@@ -668,6 +663,7 @@ fn editing_daily_goal_fields_updates_and_persists_settings() {
     assert_eq!(persisted.daily_goal.pomodoros, 1);
 }
 
+#[cfg(any())]
 #[test]
 fn editing_weekly_and_monthly_goal_fields_updates_and_persists_settings() {
     let mut app = App::default();
@@ -708,20 +704,16 @@ fn editing_goal_carry_over_fields_updates_and_persists_settings() {
     app.handle_key(key(KeyCode::Char('e')));
     app.profile_edit_field = PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX;
     app.handle_key(key(KeyCode::Right));
-    app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX;
-    app.handle_key(key(KeyCode::Right));
-    app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX;
-    app.handle_key(key(KeyCode::Right));
     app.handle_key(key(KeyCode::Enter));
 
     assert!(app.goal_carry_over.daily);
-    assert!(app.goal_carry_over.weekly);
-    assert!(app.goal_carry_over.monthly);
+    assert!(!app.goal_carry_over.weekly);
+    assert!(!app.goal_carry_over.monthly);
 
     let persisted = app.persisted_config();
     assert!(persisted.goal_carry_over.daily);
-    assert!(persisted.goal_carry_over.weekly);
-    assert!(persisted.goal_carry_over.monthly);
+    assert!(!persisted.goal_carry_over.weekly);
+    assert!(!persisted.goal_carry_over.monthly);
 }
 
 #[test]
@@ -776,6 +768,7 @@ fn cancelling_profile_edit_restores_daily_goal_settings() {
     assert_eq!(app.daily_goal.pomodoros, 3);
 }
 
+#[cfg(any())]
 #[test]
 fn cancelling_profile_edit_restores_weekly_and_monthly_goal_settings() {
     let config = AppConfig {
@@ -825,15 +818,11 @@ fn cancelling_profile_edit_restores_goal_carry_over_settings() {
     app.handle_key(key(KeyCode::Char('e')));
     app.profile_edit_field = PROFILE_EDIT_DAILY_GOAL_CARRY_OVER_INDEX;
     app.handle_key(key(KeyCode::Left));
-    app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_CARRY_OVER_INDEX;
-    app.handle_key(key(KeyCode::Right));
-    app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_CARRY_OVER_INDEX;
-    app.handle_key(key(KeyCode::Left));
     app.handle_key(key(KeyCode::Esc));
 
     assert!(app.goal_carry_over.daily);
     assert!(!app.goal_carry_over.weekly);
-    assert!(app.goal_carry_over.monthly);
+    assert!(!app.goal_carry_over.monthly);
 }
 
 #[test]
@@ -887,6 +876,7 @@ fn today_goal_progress_reports_ratios_for_minutes_and_pomodoros() {
     assert!((progress.pomodoros.ratio - 0.25).abs() < f64::EPSILON);
 }
 
+#[cfg(any())]
 #[test]
 fn weekly_and_monthly_goal_progress_use_current_period_totals() {
     let config = AppConfig {
@@ -965,6 +955,7 @@ fn daily_goal_progress_applies_previous_day_deficit_when_carry_over_is_enabled()
     assert_eq!(progress.pomodoros.target, 4);
 }
 
+#[cfg(any())]
 #[test]
 fn weekly_goal_progress_applies_previous_week_deficit_when_enabled() {
     let config = AppConfig {
@@ -1007,6 +998,7 @@ fn weekly_goal_progress_applies_previous_week_deficit_when_enabled() {
     assert_eq!(weekly.pomodoros.completed, 1);
 }
 
+#[cfg(any())]
 #[test]
 fn monthly_goal_progress_applies_previous_month_deficit_when_enabled() {
     let config = AppConfig {
@@ -1055,6 +1047,7 @@ fn monthly_goal_progress_applies_previous_month_deficit_when_enabled() {
     assert_eq!(monthly.pomodoros.completed, 1);
 }
 
+#[cfg(any())]
 #[test]
 fn weekly_goal_progress_carries_full_previous_week_when_snapshot_exists_without_activity() {
     let config = AppConfig {
@@ -1091,6 +1084,7 @@ fn weekly_goal_progress_carries_full_previous_week_when_snapshot_exists_without_
     assert_eq!(weekly.pomodoros.completed, 1);
 }
 
+#[cfg(any())]
 #[test]
 fn weekly_daily_goal_allocation_uses_schedule_weights_for_remaining_days() {
     let config = AppConfig {
@@ -1141,6 +1135,7 @@ fn weekly_daily_goal_allocation_uses_schedule_weights_for_remaining_days() {
     assert_eq!(allocation.daily_targets[4].pomodoros_target, 0);
 }
 
+#[cfg(any())]
 #[test]
 fn weekly_daily_goal_allocation_falls_back_to_equal_split_without_schedule_windows() {
     let config = AppConfig {
@@ -1179,6 +1174,7 @@ fn weekly_daily_goal_allocation_falls_back_to_equal_split_without_schedule_windo
     }
 }
 
+#[cfg(any())]
 #[test]
 fn sync_goal_snapshot_for_day_keeps_weekly_and_monthly_carry_across_idle_boundaries() {
     let config = AppConfig {
@@ -1218,6 +1214,7 @@ fn sync_goal_snapshot_for_day_keeps_weekly_and_monthly_carry_across_idle_boundar
     assert_eq!(monthly_target.pomodoros, 0);
 }
 
+#[cfg(any())]
 #[test]
 fn sync_goal_snapshot_for_day_uses_persisted_weekly_and_monthly_base_for_historical_days() {
     let config = AppConfig {
@@ -2950,8 +2947,6 @@ fn strict_mode_blocks_custom_profile_commit_during_active_focus() {
         recurring_schedule: app.recurring_schedule.clone(),
         strict_mode: app.strict_mode,
         daily_goal: app.daily_goal,
-        weekly_goal: app.weekly_goal,
-        monthly_goal: app.monthly_goal,
         goal_carry_over: app.goal_carry_over,
         selected_theme_preset: app.selected_theme_preset,
     });
@@ -3004,8 +2999,6 @@ fn enabling_strict_mode_saves_during_active_focus_for_custom_profile_without_res
         recurring_schedule: app.recurring_schedule.clone(),
         strict_mode: app.strict_mode,
         daily_goal: app.daily_goal,
-        weekly_goal: app.weekly_goal,
-        monthly_goal: app.monthly_goal,
         goal_carry_over: app.goal_carry_over,
         selected_theme_preset: app.selected_theme_preset,
     });
@@ -3362,7 +3355,7 @@ fn history_dashboard_goal_config_change_rebuilds_static_snapshot() {
     let _ = app.history_dashboard_view_data();
     let before = app.history_dashboard_cache_stats();
 
-    app.weekly_goal.minutes = app.weekly_goal.minutes.saturating_add(30);
+    app.daily_goal.minutes = app.daily_goal.minutes.saturating_add(30);
 
     let _ = app.history_dashboard_view_data();
     let after = app.history_dashboard_cache_stats();
@@ -3398,7 +3391,6 @@ fn history_dashboard_uses_stable_default_layout_despite_legacy_customization() {
             HistoryKpiCardId::FocusScore,
             HistoryKpiCardId::GoalStreak,
             HistoryKpiCardId::FocusRisk,
-            HistoryKpiCardId::WeeklyAllocation,
             HistoryKpiCardId::LastInterruption,
             HistoryKpiCardId::StatsGrowth,
             HistoryKpiCardId::Retention,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3435,7 +3435,7 @@ fn history_dashboard_deprecated_shortcuts_do_not_change_feedback() {
 
     assert_eq!(
         app.history_dashboard_cards(),
-        HistoryKpiCardId::all().to_vec()
+        HistoryKpiCardId::supported_dashboard_cards().to_vec()
     );
     assert!(app.history_feedback.is_none());
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
 };
 
-use chrono::{Datelike, NaiveDate};
+use chrono::NaiveDate;
 use serde::Serialize;
 
 #[cfg(test)]
@@ -15,8 +15,8 @@ use crate::blocker::{BlockingPreviewAction, EditSiteResult, InvalidSiteInput, Si
 use crate::config::HistoryKpiCardId;
 use crate::config::{
     AppConfig, BlocklistProfileConfig, ConfigDoctorReport, ConfigMigrationReport,
-    CustomProfileConfig, DailyGoalConfig, MonthlyGoalConfig, ProfileId, RecurringFocusWindowConfig,
-    RecurringScheduleConfig, ThemePreset, WeeklyGoalConfig,
+    CustomProfileConfig, DailyGoalConfig, ProfileId, RecurringFocusWindowConfig,
+    RecurringScheduleConfig, ThemePreset,
 };
 use crate::error::UserMessage;
 use crate::schedule::{format_schedule_conflict, inspect_schedule_conflicts_from_config};
@@ -57,10 +57,9 @@ use output::{
 };
 use parsing::{
     finalize_cli_action, first_removed_option_guidance, invalid_usage, parse_global_tokens,
-    parse_goal_carry_value, parse_goal_value, parse_monthly_goal_value, parse_primary_command,
-    parse_profile_id, parse_schedule_value, parse_site_edit_value, parse_strict_value,
-    parse_theme_preset, parse_watch_interval_option, parse_watch_interval_secs,
-    parse_weekly_goal_value, require_nonempty_key_value,
+    parse_goal_carry_value, parse_goal_value, parse_primary_command, parse_profile_id,
+    parse_schedule_value, parse_site_edit_value, parse_strict_value, parse_theme_preset,
+    parse_watch_interval_option, parse_watch_interval_secs, require_nonempty_key_value,
 };
 use status::{
     available_theme_preset_views, build_status_output, profile_id, profile_view, theme_preset_view,
@@ -79,16 +78,8 @@ const USAGE_TEXT: &str = r#"Usage:
   focustime --theme [classic|high-contrast|deuteranopia-friendly] [--json]
   focustime --goal [--json]
   focustime --goal=MINUTES,POMODOROS [--json]
-  focustime --goal-weekly [--json]
-  focustime --goal-weekly=MINUTES,POMODOROS [--json]
-  focustime --goal-monthly [--json]
-  focustime --goal-monthly=MINUTES,POMODOROS [--json]
   focustime --goal-carry [--json]
   focustime --goal-carry=on|off [--json]
-  focustime --goal-carry-weekly [--json]
-  focustime --goal-carry-weekly=on|off [--json]
-  focustime --goal-carry-monthly [--json]
-  focustime --goal-carry-monthly=on|off [--json]
   focustime --strict [--json]
   focustime --strict=on|off [--json]
   focustime --schedule [--json]
@@ -114,11 +105,7 @@ Options:
   --profile       Show current profile, or set it when value is provided
   --theme         Show current theme preset, or set it when value is provided
   --goal          Show current daily goal, or set minutes/pomodoros targets
-  --goal-weekly   Show current weekly goal, or set minutes/pomodoros targets
-  --goal-monthly  Show current monthly goal, or set minutes/pomodoros targets
-  --goal-carry          Show daily goal carry-over, or set on/off
-  --goal-carry-weekly   Show weekly goal carry-over, or set on/off
-  --goal-carry-monthly  Show monthly goal carry-over, or set on/off
+  --goal-carry    Show daily goal carry-over, or set on/off
   --strict        Show strict mode for selected profile, or set on/off
   --schedule      Show selected profile schedule with overlap/conflict inspection
   --schedule-set  Replace selected profile schedule from JSON payload
@@ -207,19 +194,7 @@ pub(crate) enum CommandKind {
     Goal {
         goal: Option<DailyGoalConfig>,
     },
-    GoalWeekly {
-        goal: Option<WeeklyGoalConfig>,
-    },
-    GoalMonthly {
-        goal: Option<MonthlyGoalConfig>,
-    },
     GoalCarry {
-        enabled: Option<bool>,
-    },
-    GoalCarryWeekly {
-        enabled: Option<bool>,
-    },
-    GoalCarryMonthly {
         enabled: Option<bool>,
     },
     Strict {
@@ -274,11 +249,7 @@ enum PrimaryCommand {
     Profile(Option<ProfileId>),
     Theme(Option<ThemePreset>),
     Goal(Option<DailyGoalConfig>),
-    GoalWeekly(Option<WeeklyGoalConfig>),
-    GoalMonthly(Option<MonthlyGoalConfig>),
     GoalCarry(Option<bool>),
-    GoalCarryWeekly(Option<bool>),
-    GoalCarryMonthly(Option<bool>),
     Strict(Option<bool>),
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
@@ -309,11 +280,7 @@ enum ParsedToken {
     Profile(Option<ProfileId>),
     Theme(Option<ThemePreset>),
     Goal(Option<DailyGoalConfig>),
-    GoalWeekly(Option<WeeklyGoalConfig>),
-    GoalMonthly(Option<MonthlyGoalConfig>),
     GoalCarry(Option<bool>),
-    GoalCarryWeekly(Option<bool>),
-    GoalCarryMonthly(Option<bool>),
     Strict(Option<bool>),
     Schedule,
     ScheduleSet(RecurringScheduleConfig),
@@ -443,29 +410,6 @@ struct LiveStatusOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct WeeklyAllocationDayOutput {
-    date: String,
-    minutes_target: u64,
-    pomodoros_target: u32,
-    allocatable: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct WeeklyAllocationOutput {
-    available: bool,
-    uses_schedule_weights: bool,
-    remaining_days_in_week: usize,
-    allocatable_days: usize,
-    completed_minutes: u64,
-    completed_pomodoros: u32,
-    remaining_minutes: u64,
-    remaining_pomodoros: u32,
-    today_minutes_target: u64,
-    today_pomodoros_target: u32,
-    days: Vec<WeeklyAllocationDayOutput>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct StatusOutput {
     day: String,
     selected_profile: ProfileView,
@@ -475,9 +419,6 @@ struct StatusOutput {
     blocked_sites_count: usize,
     strict_mode: bool,
     goal: GoalOutput,
-    weekly_goal: GoalOutput,
-    weekly_allocation: WeeklyAllocationOutput,
-    monthly_goal: GoalOutput,
     session: SessionOutput,
     today: TodayOutput,
     latest_interruption: Option<SessionInterruptionEvent>,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -4,9 +4,9 @@ pub(super) use key_value::classify_key_value_arg;
 
 use crate::cli::{
     OsString, OutputMode, ParsedToken, PathBuf, ValueArgParser, invalid_usage,
-    parse_goal_carry_value, parse_goal_value, parse_monthly_goal_value, parse_profile_id,
-    parse_schedule_value, parse_site_edit_value, parse_strict_value, parse_theme_preset,
-    parse_watch_interval_secs, parse_weekly_goal_value, require_nonempty_key_value,
+    parse_goal_carry_value, parse_goal_value, parse_profile_id, parse_schedule_value,
+    parse_site_edit_value, parse_strict_value, parse_theme_preset, parse_watch_interval_secs,
+    require_nonempty_key_value,
 };
 
 pub(super) fn infer_output_mode_from_os_args(args: &[OsString]) -> OutputMode {
@@ -59,16 +59,12 @@ fn classify_value_arg(
     index: usize,
     arg: &str,
 ) -> Result<Option<(ParsedToken, usize)>, String> {
-    let parsers: [(&str, ValueArgParser); 18] = [
+    let parsers: [(&str, ValueArgParser); 14] = [
         ("--task", classify_task_arg),
         ("--profile", classify_profile_arg),
         ("--theme", classify_theme_arg),
         ("--goal", classify_goal_arg),
-        ("--goal-weekly", classify_goal_weekly_arg),
-        ("--goal-monthly", classify_goal_monthly_arg),
         ("--goal-carry", classify_goal_carry_arg),
-        ("--goal-carry-weekly", classify_goal_carry_weekly_arg),
-        ("--goal-carry-monthly", classify_goal_carry_monthly_arg),
         ("--strict", classify_strict_arg),
         ("--schedule-set", classify_schedule_set_arg),
         ("--watch", classify_watch_arg),
@@ -259,33 +255,6 @@ fn classify_goal_arg(args: &[String], index: usize) -> Result<(ParsedToken, usiz
     Ok((ParsedToken::Goal(None), 1))
 }
 
-fn classify_goal_weekly_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
-    if let Some(next) = args.get(index + 1)
-        && !next.starts_with('-')
-    {
-        return Ok((
-            ParsedToken::GoalWeekly(Some(parse_weekly_goal_value(next)?)),
-            2,
-        ));
-    }
-    Ok((ParsedToken::GoalWeekly(None), 1))
-}
-
-fn classify_goal_monthly_arg(
-    args: &[String],
-    index: usize,
-) -> Result<(ParsedToken, usize), String> {
-    if let Some(next) = args.get(index + 1)
-        && !next.starts_with('-')
-    {
-        return Ok((
-            ParsedToken::GoalMonthly(Some(parse_monthly_goal_value(next)?)),
-            2,
-        ));
-    }
-    Ok((ParsedToken::GoalMonthly(None), 1))
-}
-
 fn classify_strict_arg(args: &[String], index: usize) -> Result<(ParsedToken, usize), String> {
     if let Some(next) = args.get(index + 1)
         && !next.starts_with('-')
@@ -305,36 +274,6 @@ fn classify_goal_carry_arg(args: &[String], index: usize) -> Result<(ParsedToken
         ));
     }
     Ok((ParsedToken::GoalCarry(None), 1))
-}
-
-fn classify_goal_carry_weekly_arg(
-    args: &[String],
-    index: usize,
-) -> Result<(ParsedToken, usize), String> {
-    if let Some(next) = args.get(index + 1)
-        && !next.starts_with('-')
-    {
-        return Ok((
-            ParsedToken::GoalCarryWeekly(Some(parse_goal_carry_value(next)?)),
-            2,
-        ));
-    }
-    Ok((ParsedToken::GoalCarryWeekly(None), 1))
-}
-
-fn classify_goal_carry_monthly_arg(
-    args: &[String],
-    index: usize,
-) -> Result<(ParsedToken, usize), String> {
-    if let Some(next) = args.get(index + 1)
-        && !next.starts_with('-')
-    {
-        return Ok((
-            ParsedToken::GoalCarryMonthly(Some(parse_goal_carry_value(next)?)),
-            2,
-        ));
-    }
-    Ok((ParsedToken::GoalCarryMonthly(None), 1))
 }
 
 fn classify_schedule_set_arg(

--- a/src/cli/args/key_value.rs
+++ b/src/cli/args/key_value.rs
@@ -1,21 +1,16 @@
 use crate::cli::{
     KeyValueParser, ParsedToken, PathBuf, parse_goal_carry_value, parse_goal_value,
-    parse_monthly_goal_value, parse_profile_id, parse_schedule_value, parse_site_edit_value,
-    parse_strict_value, parse_theme_preset, parse_watch_interval_secs, parse_weekly_goal_value,
-    require_nonempty_key_value,
+    parse_profile_id, parse_schedule_value, parse_site_edit_value, parse_strict_value,
+    parse_theme_preset, parse_watch_interval_secs, require_nonempty_key_value,
 };
 
 pub(in crate::cli) fn classify_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    let parsers: [KeyValueParser; 18] = [
+    let parsers: [KeyValueParser; 14] = [
         parse_task_key_value_arg,
         parse_profile_key_value_arg,
         parse_theme_key_value_arg,
         parse_goal_key_value_arg,
-        parse_goal_weekly_key_value_arg,
-        parse_goal_monthly_key_value_arg,
         parse_goal_carry_key_value_arg,
-        parse_goal_carry_weekly_key_value_arg,
-        parse_goal_carry_monthly_key_value_arg,
         parse_strict_key_value_arg,
         parse_schedule_set_key_value_arg,
         parse_watch_key_value_arg,
@@ -71,32 +66,6 @@ fn parse_goal_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
     Ok(None)
 }
 
-fn parse_goal_weekly_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    if let Some(value) = arg.strip_prefix("--goal-weekly=") {
-        let value = require_nonempty_key_value(
-            value,
-            "`--goal-weekly=` requires values in `MINUTES,POMODOROS` format.",
-        )?;
-        return Ok(Some(ParsedToken::GoalWeekly(Some(
-            parse_weekly_goal_value(value)?,
-        ))));
-    }
-    Ok(None)
-}
-
-fn parse_goal_monthly_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    if let Some(value) = arg.strip_prefix("--goal-monthly=") {
-        let value = require_nonempty_key_value(
-            value,
-            "`--goal-monthly=` requires values in `MINUTES,POMODOROS` format.",
-        )?;
-        return Ok(Some(ParsedToken::GoalMonthly(Some(
-            parse_monthly_goal_value(value)?,
-        ))));
-    }
-    Ok(None)
-}
-
 fn parse_strict_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
     if let Some(value) = arg.strip_prefix("--strict=") {
         let value = require_nonempty_key_value(value, "`--strict=` requires `on` or `off`.")?;
@@ -111,28 +80,6 @@ fn parse_goal_carry_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, Stri
         return Ok(Some(ParsedToken::GoalCarry(Some(parse_goal_carry_value(
             value,
         )?))));
-    }
-    Ok(None)
-}
-
-fn parse_goal_carry_weekly_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    if let Some(value) = arg.strip_prefix("--goal-carry-weekly=") {
-        let value =
-            require_nonempty_key_value(value, "`--goal-carry-weekly=` requires `on` or `off`.")?;
-        return Ok(Some(ParsedToken::GoalCarryWeekly(Some(
-            parse_goal_carry_value(value)?,
-        ))));
-    }
-    Ok(None)
-}
-
-fn parse_goal_carry_monthly_key_value_arg(arg: &str) -> Result<Option<ParsedToken>, String> {
-    if let Some(value) = arg.strip_prefix("--goal-carry-monthly=") {
-        let value =
-            require_nonempty_key_value(value, "`--goal-carry-monthly=` requires `on` or `off`.")?;
-        return Ok(Some(ParsedToken::GoalCarryMonthly(Some(
-            parse_goal_carry_value(value)?,
-        ))));
     }
     Ok(None)
 }

--- a/src/cli/execute.rs
+++ b/src/cli/execute.rs
@@ -9,14 +9,13 @@ use crate::error::UserMessage;
 
 use crate::cli::{
     AppConfig, CliCommand, CommandKind, DailyGoalConfig, FocusStats, GoalCarryCommandOutput,
-    GoalCommandOutput, MonthlyGoalConfig, OutputMode, ProfileId, ProfileOutput, ProfileView,
-    RecurringScheduleConfig, ScheduleCommandOutput, StrictCommandOutput, TaskCommandOutput,
-    ThemeCommandOutput, ThemePreset, TimerCommandOutput, TimerStateOutput, WeeklyGoalConfig,
-    available_theme_preset_views, build_schedule_inspection_output,
-    print_goal_carry_command_output, print_goal_command_output, print_json, print_profile_output,
-    print_schedule_command_output, print_strict_command_output, print_theme_command_output,
-    print_timer_state_output, profile_id, profile_view, theme_preset_view, timer_phase_id,
-    timer_status_id,
+    GoalCommandOutput, OutputMode, ProfileId, ProfileOutput, ProfileView, RecurringScheduleConfig,
+    ScheduleCommandOutput, StrictCommandOutput, TaskCommandOutput, ThemeCommandOutput, ThemePreset,
+    TimerCommandOutput, TimerStateOutput, available_theme_preset_views,
+    build_schedule_inspection_output, print_goal_carry_command_output, print_goal_command_output,
+    print_json, print_profile_output, print_schedule_command_output, print_strict_command_output,
+    print_theme_command_output, print_timer_state_output, profile_id, profile_view,
+    theme_preset_view, timer_phase_id, timer_status_id,
 };
 
 mod blocklists;
@@ -62,16 +61,8 @@ pub(super) fn execute_cli_command(cli_command: CliCommand) -> CliExecuteResult<(
         CommandKind::Profile { profile } => execute_profile_command(profile, cli_command.output),
         CommandKind::Theme { preset } => execute_theme_command(preset, cli_command.output),
         CommandKind::Goal { goal } => execute_goal_command(goal, cli_command.output),
-        CommandKind::GoalWeekly { goal } => execute_weekly_goal_command(goal, cli_command.output),
-        CommandKind::GoalMonthly { goal } => execute_monthly_goal_command(goal, cli_command.output),
         CommandKind::GoalCarry { enabled } => {
             execute_goal_carry_command(enabled, cli_command.output)
-        }
-        CommandKind::GoalCarryWeekly { enabled } => {
-            execute_weekly_goal_carry_command(enabled, cli_command.output)
-        }
-        CommandKind::GoalCarryMonthly { enabled } => {
-            execute_monthly_goal_carry_command(enabled, cli_command.output)
         }
         CommandKind::Strict { enabled } => execute_strict_command(enabled, cli_command.output),
         CommandKind::Schedule { schedule } => {
@@ -115,11 +106,7 @@ fn command_usage_surface_id(command: &CommandKind) -> Option<&'static str> {
         CommandKind::Profile { .. } => Some("profile"),
         CommandKind::Theme { .. } => Some("theme"),
         CommandKind::Goal { .. } => Some("goal"),
-        CommandKind::GoalWeekly { .. } => Some("goal-weekly"),
-        CommandKind::GoalMonthly { .. } => Some("goal-monthly"),
         CommandKind::GoalCarry { .. } => Some("goal-carry"),
-        CommandKind::GoalCarryWeekly { .. } => Some("goal-carry-weekly"),
-        CommandKind::GoalCarryMonthly { .. } => Some("goal-carry-monthly"),
         CommandKind::Strict { .. } => Some("strict"),
         CommandKind::Schedule { .. } => Some("schedule"),
         CommandKind::Diagnostics => Some("diagnostics"),
@@ -311,62 +298,6 @@ fn execute_goal_command(goal: Option<DailyGoalConfig>, output: OutputMode) -> Cl
     Ok(())
 }
 
-fn execute_weekly_goal_command(
-    goal: Option<WeeklyGoalConfig>,
-    output: OutputMode,
-) -> CliExecuteResult<()> {
-    let mut config = AppConfig::load().normalized();
-    let mut updated = false;
-    if let Some(goal) = goal {
-        config.weekly_goal = goal;
-        config
-            .save()
-            .map_err(|error| format!("Failed to save weekly goal: {error}"))?;
-        updated = true;
-    }
-
-    let payload = GoalCommandOutput {
-        updated,
-        configured: config.weekly_goal.minutes > 0 || config.weekly_goal.pomodoros > 0,
-        minutes_target: config.weekly_goal.minutes,
-        pomodoros_target: config.weekly_goal.pomodoros,
-    };
-
-    match output {
-        OutputMode::Text => print_goal_command_output("Weekly", &payload),
-        OutputMode::Json => print_json(&payload)?,
-    }
-    Ok(())
-}
-
-fn execute_monthly_goal_command(
-    goal: Option<MonthlyGoalConfig>,
-    output: OutputMode,
-) -> CliExecuteResult<()> {
-    let mut config = AppConfig::load().normalized();
-    let mut updated = false;
-    if let Some(goal) = goal {
-        config.monthly_goal = goal;
-        config
-            .save()
-            .map_err(|error| format!("Failed to save monthly goal: {error}"))?;
-        updated = true;
-    }
-
-    let payload = GoalCommandOutput {
-        updated,
-        configured: config.monthly_goal.minutes > 0 || config.monthly_goal.pomodoros > 0,
-        minutes_target: config.monthly_goal.minutes,
-        pomodoros_target: config.monthly_goal.pomodoros,
-    };
-
-    match output {
-        OutputMode::Text => print_goal_command_output("Monthly", &payload),
-        OutputMode::Json => print_json(&payload)?,
-    }
-    Ok(())
-}
-
 fn execute_goal_carry_command(enabled: Option<bool>, output: OutputMode) -> CliExecuteResult<()> {
     let mut config = AppConfig::load().normalized();
     let mut updated = false;
@@ -384,56 +315,6 @@ fn execute_goal_carry_command(enabled: Option<bool>, output: OutputMode) -> CliE
     };
     match output {
         OutputMode::Text => print_goal_carry_command_output("Daily", &payload),
-        OutputMode::Json => print_json(&payload)?,
-    }
-    Ok(())
-}
-
-fn execute_weekly_goal_carry_command(
-    enabled: Option<bool>,
-    output: OutputMode,
-) -> CliExecuteResult<()> {
-    let mut config = AppConfig::load().normalized();
-    let mut updated = false;
-    if let Some(enabled) = enabled {
-        config.goal_carry_over.weekly = enabled;
-        config
-            .save()
-            .map_err(|error| format!("Failed to save weekly goal carry-over: {error}"))?;
-        updated = true;
-    }
-
-    let payload = GoalCarryCommandOutput {
-        updated,
-        carry_over: config.goal_carry_over.weekly,
-    };
-    match output {
-        OutputMode::Text => print_goal_carry_command_output("Weekly", &payload),
-        OutputMode::Json => print_json(&payload)?,
-    }
-    Ok(())
-}
-
-fn execute_monthly_goal_carry_command(
-    enabled: Option<bool>,
-    output: OutputMode,
-) -> CliExecuteResult<()> {
-    let mut config = AppConfig::load().normalized();
-    let mut updated = false;
-    if let Some(enabled) = enabled {
-        config.goal_carry_over.monthly = enabled;
-        config
-            .save()
-            .map_err(|error| format!("Failed to save monthly goal carry-over: {error}"))?;
-        updated = true;
-    }
-
-    let payload = GoalCarryCommandOutput {
-        updated,
-        carry_over: config.goal_carry_over.monthly,
-    };
-    match output {
-        OutputMode::Text => print_goal_carry_command_output("Monthly", &payload),
         OutputMode::Json => print_json(&payload)?,
     }
     Ok(())

--- a/src/cli/output/status.rs
+++ b/src/cli/output/status.rs
@@ -32,9 +32,6 @@ pub(in crate::cli) fn print_status_output(payload: &StatusOutput) {
         payload.today.focused_minutes, payload.today.pomodoros_completed
     );
     print_status_goal_line("Daily goal", &payload.goal);
-    print_status_goal_line("Weekly goal", &payload.weekly_goal);
-    print_status_weekly_allocation_line(&payload.weekly_allocation);
-    print_status_goal_line("Monthly goal", &payload.monthly_goal);
     println!(
         "Session: {} focused minutes, {} pomodoros",
         payload.session.focused_minutes, payload.session.pomodoros_completed
@@ -66,42 +63,6 @@ pub(in crate::cli) fn print_status_output(payload: &StatusOutput) {
     }
 }
 
-fn print_status_weekly_allocation_line(allocation: &crate::cli::WeeklyAllocationOutput) {
-    if !allocation.available {
-        println!("Weekly allocation: off (weekly goal off)");
-        return;
-    }
-
-    let strategy = if allocation.uses_schedule_weights {
-        "schedule-weighted"
-    } else {
-        "equal-split fallback"
-    };
-    println!(
-        "Weekly allocation: today {} min, {} pomodoros | remaining {} min, {} pomodoros across {}/{} days ({strategy})",
-        allocation.today_minutes_target,
-        allocation.today_pomodoros_target,
-        allocation.remaining_minutes,
-        allocation.remaining_pomodoros,
-        allocation.allocatable_days,
-        allocation.remaining_days_in_week,
-    );
-
-    let day_breakdown = allocation
-        .days
-        .iter()
-        .map(|day| {
-            let marker = if day.allocatable { "" } else { "*" };
-            format!(
-                "{}={}m/{}p{}",
-                day.date, day.minutes_target, day.pomodoros_target, marker
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
-    println!("Weekly allocation days: {day_breakdown}");
-}
-
 fn print_status_goal_line(label: &str, goal: &GoalOutput) {
     if goal.configured {
         println!(
@@ -122,54 +83,31 @@ fn print_status_goal_line(label: &str, goal: &GoalOutput) {
 fn print_status_focus_score_line(focus_score: &FocusScoreOutput) {
     if focus_score.available {
         println!(
-            "Focus score: {}% (consistency {}%, completion {}%)",
+            "Focus score: {}% (consistency)",
             focus_score.focus_score_pct.unwrap_or(0),
-            focus_score.consistency_score_pct,
-            focus_score.completion_score_pct.unwrap_or(0)
         );
     } else {
-        println!(
-            "Focus score: n/a (weekly goal off; consistency {}%)",
-            focus_score.consistency_score_pct
-        );
+        println!("Focus score: n/a");
     }
 }
 
 fn print_status_focus_risk_line(forecast: &crate::stats::FocusRiskForecast) {
     let alert_active = forecast.alert_active();
     let daily_label = forecast.daily_goal.period.short_label();
-    let weekly_label = forecast.weekly_goal.period.short_label();
-    let monthly_label = forecast.monthly_goal.period.short_label();
     let alert_suffix = if alert_active { " (alert)" } else { "" };
     println!(
-        "Focus risk: {} {} {}% | {} {} {}% | {} {} {}% | Streak {} {}%{}",
+        "Focus risk: {} {} {}% | Streak {} {}%{}",
         daily_label,
         forecast.daily_goal.risk_level.label(),
         forecast.daily_goal.risk_score_pct,
-        weekly_label,
-        forecast.weekly_goal.risk_level.label(),
-        forecast.weekly_goal.risk_score_pct,
-        monthly_label,
-        forecast.monthly_goal.risk_level.label(),
-        forecast.monthly_goal.risk_score_pct,
         forecast.streak.risk_level.label(),
         forecast.streak.risk_score_pct,
         alert_suffix
     );
 
     let mut highest_label = daily_label;
-    let mut highest_score = forecast.daily_goal.risk_score_pct;
+    let highest_score = forecast.daily_goal.risk_score_pct;
     let mut highest_signal = forecast.daily_goal.signals.first();
-    if forecast.weekly_goal.risk_score_pct > highest_score {
-        highest_label = weekly_label;
-        highest_score = forecast.weekly_goal.risk_score_pct;
-        highest_signal = forecast.weekly_goal.signals.first();
-    }
-    if forecast.monthly_goal.risk_score_pct > highest_score {
-        highest_label = monthly_label;
-        highest_score = forecast.monthly_goal.risk_score_pct;
-        highest_signal = forecast.monthly_goal.signals.first();
-    }
     if forecast.streak.risk_score_pct > highest_score {
         highest_label = "Streak";
         highest_signal = forecast.streak.signals.first();

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -5,9 +5,8 @@ pub(super) use options::{
     parse_watch_interval_option, parse_watch_interval_secs, require_nonempty_key_value,
 };
 pub(super) use value::{
-    parse_goal_carry_value, parse_goal_value, parse_monthly_goal_value, parse_profile_id,
-    parse_schedule_value, parse_site_edit_value, parse_strict_value, parse_theme_preset,
-    parse_weekly_goal_value,
+    parse_goal_carry_value, parse_goal_value, parse_profile_id, parse_schedule_value,
+    parse_site_edit_value, parse_strict_value, parse_theme_preset,
 };
 
 use crate::cli::{
@@ -47,11 +46,7 @@ pub(super) fn parse_global_tokens(tokens: &[ParsedToken]) -> Result<(bool, Outpu
             | ParsedToken::Profile(_)
             | ParsedToken::Theme(_)
             | ParsedToken::Goal(_)
-            | ParsedToken::GoalWeekly(_)
-            | ParsedToken::GoalMonthly(_)
             | ParsedToken::GoalCarry(_)
-            | ParsedToken::GoalCarryWeekly(_)
-            | ParsedToken::GoalCarryMonthly(_)
             | ParsedToken::Strict(_)
             | ParsedToken::Schedule
             | ParsedToken::ScheduleSet(_)
@@ -139,7 +134,15 @@ fn removed_option_replacement_guidance(option: &str) -> Option<RemovedOptionGuid
         }),
         "--task-goal" => Some(RemovedOptionGuidance {
             summary: "Task goal commands were removed.",
-            replacement: "Use `--goal`, `--goal-weekly`, or `--goal-monthly` for global goals; task labels remain available through `--task`.",
+            replacement: "Use `--goal` for the daily goal; task labels remain available through `--task`.",
+        }),
+        "--goal-weekly" | "--goal-monthly" => Some(RemovedOptionGuidance {
+            summary: "Weekly and monthly goal commands were removed.",
+            replacement: "Use `--goal` for the supported daily goal target.",
+        }),
+        "--goal-carry-weekly" | "--goal-carry-monthly" => Some(RemovedOptionGuidance {
+            summary: "Weekly and monthly goal carry-over commands were removed.",
+            replacement: "Use `--goal-carry` for daily goal carry-over.",
         }),
         "--allowlist-site-add-temporary" => Some(RemovedOptionGuidance {
             summary: "Temporary allowlist commands were removed.",
@@ -178,20 +181,8 @@ pub(super) fn parse_primary_command(
             ParsedToken::Goal(goal) => {
                 set_primary_command(&mut primary, PrimaryCommand::Goal(*goal))?
             }
-            ParsedToken::GoalWeekly(goal) => {
-                set_primary_command(&mut primary, PrimaryCommand::GoalWeekly(*goal))?
-            }
-            ParsedToken::GoalMonthly(goal) => {
-                set_primary_command(&mut primary, PrimaryCommand::GoalMonthly(*goal))?
-            }
             ParsedToken::GoalCarry(enabled) => {
                 set_primary_command(&mut primary, PrimaryCommand::GoalCarry(*enabled))?
-            }
-            ParsedToken::GoalCarryWeekly(enabled) => {
-                set_primary_command(&mut primary, PrimaryCommand::GoalCarryWeekly(*enabled))?
-            }
-            ParsedToken::GoalCarryMonthly(enabled) => {
-                set_primary_command(&mut primary, PrimaryCommand::GoalCarryMonthly(*enabled))?
             }
             ParsedToken::Strict(enabled) => {
                 set_primary_command(&mut primary, PrimaryCommand::Strict(*enabled))?
@@ -278,24 +269,8 @@ pub(super) fn finalize_cli_action(
             kind: CommandKind::Goal { goal },
             output,
         })),
-        Some(PrimaryCommand::GoalWeekly(goal)) => Ok(CliAction::RunCommand(CliCommand {
-            kind: CommandKind::GoalWeekly { goal },
-            output,
-        })),
-        Some(PrimaryCommand::GoalMonthly(goal)) => Ok(CliAction::RunCommand(CliCommand {
-            kind: CommandKind::GoalMonthly { goal },
-            output,
-        })),
         Some(PrimaryCommand::GoalCarry(enabled)) => Ok(CliAction::RunCommand(CliCommand {
             kind: CommandKind::GoalCarry { enabled },
-            output,
-        })),
-        Some(PrimaryCommand::GoalCarryWeekly(enabled)) => Ok(CliAction::RunCommand(CliCommand {
-            kind: CommandKind::GoalCarryWeekly { enabled },
-            output,
-        })),
-        Some(PrimaryCommand::GoalCarryMonthly(enabled)) => Ok(CliAction::RunCommand(CliCommand {
-            kind: CommandKind::GoalCarryMonthly { enabled },
             output,
         })),
         Some(PrimaryCommand::Strict(enabled)) => Ok(CliAction::RunCommand(CliCommand {
@@ -418,11 +393,7 @@ fn primary_name(command: &PrimaryCommand) -> &'static str {
         PrimaryCommand::Profile(_) => "--profile",
         PrimaryCommand::Theme(_) => "--theme",
         PrimaryCommand::Goal(_) => "--goal",
-        PrimaryCommand::GoalWeekly(_) => "--goal-weekly",
-        PrimaryCommand::GoalMonthly(_) => "--goal-monthly",
         PrimaryCommand::GoalCarry(_) => "--goal-carry",
-        PrimaryCommand::GoalCarryWeekly(_) => "--goal-carry-weekly",
-        PrimaryCommand::GoalCarryMonthly(_) => "--goal-carry-monthly",
         PrimaryCommand::Strict(_) => "--strict",
         PrimaryCommand::Schedule => "--schedule",
         PrimaryCommand::ScheduleSet(_) => "--schedule-set",

--- a/src/cli/parsing/value.rs
+++ b/src/cli/parsing/value.rs
@@ -1,6 +1,6 @@
 use crate::cli::{
-    DailyGoalConfig, MonthlyGoalConfig, ProfileId, RecurringFocusWindowConfig,
-    RecurringScheduleConfig, SiteEditValue, ThemePreset, WeeklyGoalConfig,
+    DailyGoalConfig, ProfileId, RecurringFocusWindowConfig, RecurringScheduleConfig, SiteEditValue,
+    ThemePreset,
 };
 
 use super::invalid_usage;
@@ -35,16 +35,6 @@ pub(in crate::cli) fn parse_theme_preset(value: &str) -> Result<ThemePreset, Str
 pub(in crate::cli) fn parse_goal_value(value: &str) -> Result<DailyGoalConfig, String> {
     let (minutes, pomodoros) = parse_goal_components(value, "--goal")?;
     Ok(DailyGoalConfig { minutes, pomodoros })
-}
-
-pub(in crate::cli) fn parse_weekly_goal_value(value: &str) -> Result<WeeklyGoalConfig, String> {
-    let (minutes, pomodoros) = parse_goal_components(value, "--goal-weekly")?;
-    Ok(WeeklyGoalConfig { minutes, pomodoros })
-}
-
-pub(in crate::cli) fn parse_monthly_goal_value(value: &str) -> Result<MonthlyGoalConfig, String> {
-    let (minutes, pomodoros) = parse_goal_components(value, "--goal-monthly")?;
-    Ok(MonthlyGoalConfig { minutes, pomodoros })
 }
 
 fn parse_goal_components(value: &str, flag: &str) -> Result<(u64, u32), String> {

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,11 +1,9 @@
-use crate::app::weekly_daily_goal_allocation_for_context;
 use crate::cli::{
     AppConfig, CustomProfileConfig, DEFAULT_FOCUS_SECS, DEFAULT_LONG_BREAK_INTERVAL,
-    DEFAULT_LONG_BREAK_SECS, DEFAULT_SHORT_BREAK_SECS, DailyGoalSnapshot, Datelike,
-    FocusScoreOutput, FocusStats, GoalOutput, LiveStatusOutput, NaiveDate, ProfileId, ProfileSpec,
-    ProfileView, SessionOutput, StatsRetentionStatusOutput, StatusOutput, ThemePreset,
-    ThemePresetView, TimerPhase, TimerStatus, TodayOutput, WeeklyAllocationDayOutput,
-    WeeklyAllocationOutput, carry_over_goal_target, current_day_key,
+    DEFAULT_LONG_BREAK_SECS, DEFAULT_SHORT_BREAK_SECS, DailyGoalSnapshot, FocusScoreOutput,
+    FocusStats, GoalOutput, LiveStatusOutput, NaiveDate, ProfileId, ProfileSpec, ProfileView,
+    SessionOutput, StatsRetentionStatusOutput, StatusOutput, ThemePreset, ThemePresetView,
+    TimerPhase, TimerStatus, TodayOutput, carry_over_goal_target, current_day_key,
     effective_blocked_sites_for_profile, session_recovery,
 };
 use crate::timer::TimerState;
@@ -16,13 +14,9 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
     let day_date = NaiveDate::parse_from_str(&day, "%Y-%m-%d")
         .expect("current_day_key should always be a valid ISO date");
     let today = stats.daily_for(&day);
-    let week = stats.weekly_for_day(day_date);
-    let month = stats.monthly_for_day(day_date);
     let (_, selected_task_label) = stats.task_planner_state();
     let selected_task_label = normalize_optional_task_label(selected_task_label);
     let goal_snapshot = effective_daily_goal_snapshot_for_day(config, stats, day_date);
-    let weekly_goal_snapshot = effective_weekly_goal_snapshot(config, stats, day_date);
-    let monthly_goal_snapshot = effective_monthly_goal_snapshot(config, stats, day_date);
     let active_sites_count = config
         .blocklist_profiles
         .first()
@@ -35,29 +29,13 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
     let consistency_score_pct = stats
         .weekly_focus_score_for_day(day_date)
         .consistency_score_pct;
-    let completion_score_pct = if weekly_goal_snapshot.has_any_target() {
-        weekly_goal_completion_score_pct(
-            weekly_goal_snapshot,
-            week.focused_minutes(),
-            week.pomodoros_completed,
-        )
-    } else {
-        None
-    };
-    let focus_score_pct = completion_score_pct.map(|completion| {
-        (u16::from(consistency_score_pct) + u16::from(completion)).div_ceil(2) as u8
-    });
+    let completion_score_pct = None;
+    let focus_score_pct = Some(consistency_score_pct);
     let focus_risk = stats.focus_risk_forecast_for_day(
         day_date,
         goal_snapshot,
-        weekly_goal_snapshot,
-        monthly_goal_snapshot,
-    );
-    let weekly_allocation = build_weekly_allocation_output(
-        day_date,
-        weekly_goal_snapshot,
-        week,
-        &selected_automation.recurring_schedule,
+        DailyGoalSnapshot::default(),
+        DailyGoalSnapshot::default(),
     );
     let stats_growth = stats.growth_summary();
     let retention_windows = config.stats_retention.windows();
@@ -77,23 +55,6 @@ pub(super) fn build_status_output(config: &AppConfig, stats: &FocusStats) -> Sta
             pomodoros_target: goal_snapshot.pomodoros,
             met: goal_snapshot.is_met_by(today),
             carry_over: config.goal_carry_over.daily,
-        },
-        weekly_goal: GoalOutput {
-            configured: weekly_goal_snapshot.has_any_target(),
-            minutes_target: weekly_goal_snapshot.minutes,
-            pomodoros_target: weekly_goal_snapshot.pomodoros,
-            met: weekly_goal_snapshot
-                .is_met_by_totals(week.focused_minutes(), week.pomodoros_completed),
-            carry_over: config.goal_carry_over.weekly,
-        },
-        weekly_allocation,
-        monthly_goal: GoalOutput {
-            configured: monthly_goal_snapshot.has_any_target(),
-            minutes_target: monthly_goal_snapshot.minutes,
-            pomodoros_target: monthly_goal_snapshot.pomodoros,
-            met: monthly_goal_snapshot
-                .is_met_by_totals(month.focused_minutes(), month.pomodoros_completed),
-            carry_over: config.goal_carry_over.monthly,
         },
         session: SessionOutput {
             focused_minutes: session.focused_minutes,
@@ -147,75 +108,6 @@ fn build_session_output(live: &LiveStatusOutput) -> SessionOutput {
     }
 }
 
-fn weekly_goal_completion_score_pct(
-    goal: DailyGoalSnapshot,
-    focused_minutes: u64,
-    pomodoros_completed: u32,
-) -> Option<u8> {
-    let minute_score = if goal.minutes > 0 {
-        Some(percentage_round_nearest(
-            focused_minutes.min(goal.minutes),
-            goal.minutes,
-        ))
-    } else {
-        None
-    };
-    let pomodoro_score = if goal.pomodoros > 0 {
-        Some(percentage_round_nearest(
-            u64::from(pomodoros_completed.min(goal.pomodoros)),
-            u64::from(goal.pomodoros),
-        ))
-    } else {
-        None
-    };
-    match (minute_score, pomodoro_score) {
-        (None, None) => None,
-        (Some(score), None) | (None, Some(score)) => Some(score),
-        (Some(left), Some(right)) => Some((u16::from(left) + u16::from(right)).div_ceil(2) as u8),
-    }
-}
-
-fn build_weekly_allocation_output(
-    day: NaiveDate,
-    weekly_goal_snapshot: DailyGoalSnapshot,
-    week: crate::stats::WeeklyStats,
-    schedule: &crate::config::RecurringScheduleConfig,
-) -> WeeklyAllocationOutput {
-    let allocation =
-        weekly_daily_goal_allocation_for_context(day, weekly_goal_snapshot, week, schedule);
-    let today_target = allocation.today_target();
-    WeeklyAllocationOutput {
-        available: allocation.has_any_target(),
-        uses_schedule_weights: allocation.uses_schedule_weights,
-        remaining_days_in_week: allocation.remaining_days_in_week,
-        allocatable_days: allocation.allocatable_days,
-        completed_minutes: allocation.completed_minutes,
-        completed_pomodoros: allocation.completed_pomodoros,
-        remaining_minutes: allocation.remaining_minutes,
-        remaining_pomodoros: allocation.remaining_pomodoros,
-        today_minutes_target: today_target.minutes,
-        today_pomodoros_target: today_target.pomodoros,
-        days: allocation
-            .daily_targets
-            .into_iter()
-            .map(|target| WeeklyAllocationDayOutput {
-                date: target.day.format("%Y-%m-%d").to_string(),
-                minutes_target: target.minutes_target,
-                pomodoros_target: target.pomodoros_target,
-                allocatable: target.allocatable,
-            })
-            .collect(),
-    }
-}
-
-fn percentage_round_nearest(part: u64, total: u64) -> u8 {
-    if total == 0 {
-        return 0;
-    }
-    let rounded = (u128::from(part) * 100 + (u128::from(total) / 2)) / u128::from(total);
-    rounded.min(u128::from(u8::MAX)) as u8
-}
-
 fn effective_daily_goal_snapshot_for_day(
     config: &AppConfig,
     stats: &FocusStats,
@@ -238,61 +130,6 @@ fn effective_daily_goal_snapshot_for_day(
         })
     });
     carry_over_goal_target(base, config.goal_carry_over.daily, previous)
-}
-
-fn effective_weekly_goal_snapshot(
-    config: &AppConfig,
-    stats: &FocusStats,
-    day: NaiveDate,
-) -> DailyGoalSnapshot {
-    let base = DailyGoalSnapshot {
-        minutes: config.weekly_goal.minutes,
-        pomodoros: config.weekly_goal.pomodoros,
-    };
-    let previous =
-        day.checked_sub_signed(chrono::Duration::weeks(1))
-            .and_then(|previous_week_day| {
-                stats
-                    .weekly_goal_snapshot_for_day(previous_week_day)
-                    .map(|previous_target| {
-                        let week = stats.weekly_for_day(previous_week_day);
-                        (
-                            previous_target,
-                            week.focused_minutes(),
-                            week.pomodoros_completed,
-                        )
-                    })
-            });
-    carry_over_goal_target(base, config.goal_carry_over.weekly, previous)
-}
-
-fn effective_monthly_goal_snapshot(
-    config: &AppConfig,
-    stats: &FocusStats,
-    day: NaiveDate,
-) -> DailyGoalSnapshot {
-    let base = DailyGoalSnapshot {
-        minutes: config.monthly_goal.minutes,
-        pomodoros: config.monthly_goal.pomodoros,
-    };
-    let previous = previous_month_reference_day(day).and_then(|previous_month_day| {
-        stats
-            .monthly_goal_snapshot_for_day(previous_month_day)
-            .map(|previous_target| {
-                let month = stats.monthly_for_day(previous_month_day);
-                (
-                    previous_target,
-                    month.focused_minutes(),
-                    month.pomodoros_completed,
-                )
-            })
-    });
-    carry_over_goal_target(base, config.goal_carry_over.monthly, previous)
-}
-
-fn previous_month_reference_day(day: NaiveDate) -> Option<NaiveDate> {
-    let month_start = NaiveDate::from_ymd_opt(day.year(), day.month(), 1)?;
-    month_start.pred_opt()
 }
 
 fn build_live_status_output(

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -3,7 +3,7 @@ use crate::config::{ConfigDoctorReport, ConfigHealthStatus, ConfigMigrationRepor
 use crate::session_recovery::{
     self, InProgressSessionSnapshot, RecoveryTimerPhase, RecoveryTimerStatus,
 };
-use chrono::{Datelike, Duration};
+use chrono::Duration;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStringExt;
 
@@ -296,9 +296,7 @@ fn parse_task_goal_without_value_is_removed() {
     assert!(error.message.contains("Unknown option `--task-goal`."));
     assert_eq!(
         error.hint.as_deref(),
-        Some(
-            "Use `--goal`, `--goal-weekly`, or `--goal-monthly` for global goals; task labels remain available through `--task`."
-        )
+        Some("Use `--goal` for the daily goal; task labels remain available through `--task`.")
     );
 }
 
@@ -314,9 +312,7 @@ fn parse_task_goal_with_equals_value_is_removed() {
     );
     assert_eq!(
         error.hint.as_deref(),
-        Some(
-            "Use `--goal`, `--goal-weekly`, or `--goal-monthly` for global goals; task labels remain available through `--task`."
-        )
+        Some("Use `--goal` for the daily goal; task labels remain available through `--task`.")
     );
 }
 
@@ -466,6 +462,7 @@ fn parse_goal_with_value_sets_goal() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn parse_weekly_goal_without_value_reads_current_goal() {
     let parsed = parse(&["--goal-weekly"]).unwrap();
@@ -478,6 +475,7 @@ fn parse_weekly_goal_without_value_reads_current_goal() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn parse_weekly_goal_with_equals_sets_goal() {
     let parsed = parse(&["--goal-weekly=420,14"]).unwrap();
@@ -495,6 +493,7 @@ fn parse_weekly_goal_with_equals_sets_goal() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn parse_monthly_goal_with_value_sets_goal() {
     let parsed = parse(&["--goal-monthly", "1800,60"]).unwrap();
@@ -550,6 +549,7 @@ fn parse_goal_carry_without_value_reads_current_state() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn parse_goal_carry_weekly_with_equals_sets_state() {
     let parsed = parse(&["--goal-carry-weekly=on"]).unwrap();
@@ -564,6 +564,7 @@ fn parse_goal_carry_weekly_with_equals_sets_state() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn parse_goal_carry_monthly_with_value_sets_state() {
     let parsed = parse(&["--goal-carry-monthly", "off"]).unwrap();
@@ -1143,6 +1144,7 @@ fn classify_key_value_arg_accepts_goal_equals_value() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn classify_key_value_arg_accepts_weekly_goal_equals_value() {
     let parsed = classify_key_value_arg("--goal-weekly=420,14").unwrap();
@@ -1155,6 +1157,7 @@ fn classify_key_value_arg_accepts_weekly_goal_equals_value() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn classify_key_value_arg_accepts_monthly_goal_equals_value() {
     let parsed = classify_key_value_arg("--goal-monthly=1800,60").unwrap();
@@ -1179,12 +1182,14 @@ fn classify_key_value_arg_accepts_goal_carry_equals_value() {
     assert_eq!(parsed, Some(ParsedToken::GoalCarry(Some(true))));
 }
 
+#[cfg(any())]
 #[test]
 fn classify_key_value_arg_accepts_goal_carry_weekly_equals_value() {
     let parsed = classify_key_value_arg("--goal-carry-weekly=off").unwrap();
     assert_eq!(parsed, Some(ParsedToken::GoalCarryWeekly(Some(false))));
 }
 
+#[cfg(any())]
 #[test]
 fn classify_key_value_arg_accepts_goal_carry_monthly_equals_value() {
     let parsed = classify_key_value_arg("--goal-carry-monthly=on").unwrap();
@@ -1251,12 +1256,14 @@ fn classify_key_value_arg_rejects_empty_goal_equals_value() {
     assert!(error.contains("`--goal=` requires values"));
 }
 
+#[cfg(any())]
 #[test]
 fn classify_key_value_arg_rejects_empty_weekly_goal_equals_value() {
     let error = classify_key_value_arg("--goal-weekly=").unwrap_err();
     assert!(error.contains("`--goal-weekly=` requires values"));
 }
 
+#[cfg(any())]
 #[test]
 fn classify_key_value_arg_rejects_empty_monthly_goal_equals_value() {
     let error = classify_key_value_arg("--goal-monthly=").unwrap_err();
@@ -1275,12 +1282,14 @@ fn classify_key_value_arg_rejects_empty_goal_carry_equals_value() {
     assert!(error.contains("`--goal-carry=` requires `on` or `off`"));
 }
 
+#[cfg(any())]
 #[test]
 fn classify_key_value_arg_rejects_empty_goal_carry_weekly_equals_value() {
     let error = classify_key_value_arg("--goal-carry-weekly=").unwrap_err();
     assert!(error.contains("`--goal-carry-weekly=` requires `on` or `off`"));
 }
 
+#[cfg(any())]
 #[test]
 fn classify_key_value_arg_rejects_empty_goal_carry_monthly_equals_value() {
     let error = classify_key_value_arg("--goal-carry-monthly=").unwrap_err();
@@ -1366,12 +1375,14 @@ fn parse_rejects_goal_without_two_numbers() {
     assert!(error.contains("Invalid goal"));
 }
 
+#[cfg(any())]
 #[test]
 fn parse_rejects_weekly_goal_without_two_numbers() {
     let error = parse(&["--goal-weekly=120"]).unwrap_err();
     assert!(error.contains("Invalid goal"));
 }
 
+#[cfg(any())]
 #[test]
 fn parse_rejects_monthly_goal_without_two_numbers() {
     let error = parse(&["--goal-monthly=120"]).unwrap_err();
@@ -2023,6 +2034,7 @@ fn build_status_output_includes_growth_and_retention_signals() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn build_status_output_reports_daily_weekly_monthly_goal_state() {
     let mut stats = FocusStats::default();
@@ -2153,8 +2165,8 @@ fn build_status_output_keeps_selected_task_label_without_task_goal() {
     let output = build_status_output(&config, &stats);
 
     assert_eq!(output.selected_task_label.as_deref(), Some("Docs"));
-    assert!(!output.focus_score.available);
-    assert!(output.focus_score.focus_score_pct.is_none());
+    assert!(output.focus_score.available);
+    assert!(output.focus_score.focus_score_pct.is_some());
     assert!(!output.focus_risk.daily_goal.configured);
     assert!(!output.focus_risk.streak.configured);
 }
@@ -2181,12 +2193,6 @@ fn build_status_output_applies_carry_over_to_goal_targets_when_enabled() {
         .expect("current day key should parse as a date");
     let yesterday = today_date.pred_opt().expect("yesterday should exist");
     let yesterday_key = yesterday.format("%Y-%m-%d").to_string();
-    let month_start = NaiveDate::from_ymd_opt(today_date.year(), today_date.month(), 1)
-        .expect("month start should be representable");
-    let previous_month_day = month_start
-        .pred_opt()
-        .expect("previous month day should be representable");
-    let previous_month_key = previous_month_day.format("%Y-%m-%d").to_string();
     let previous_daily_goal = DailyGoalSnapshot {
         minutes: 50,
         pomodoros: 3,
@@ -2207,18 +2213,10 @@ fn build_status_output_applies_carry_over_to_goal_targets_when_enabled() {
             minutes: 60,
             pomodoros: 2,
         },
-        weekly_goal: WeeklyGoalConfig {
-            minutes: 100,
-            pomodoros: 3,
-        },
-        monthly_goal: MonthlyGoalConfig {
-            minutes: 300,
-            pomodoros: 10,
-        },
         goal_carry_over: crate::config::GoalCarryOverConfig {
             daily: true,
-            weekly: true,
-            monthly: true,
+            weekly: false,
+            monthly: false,
         },
         ..AppConfig::default()
     };
@@ -2227,23 +2225,6 @@ fn build_status_output_applies_carry_over_to_goal_targets_when_enabled() {
     assert_eq!(output.goal.minutes_target, 80);
     assert_eq!(output.goal.pomodoros_target, 4);
     assert!(output.goal.carry_over);
-
-    let mut monthly_stats = FocusStats::default();
-    monthly_stats.sync_monthly_goal_snapshot(
-        previous_month_day,
-        DailyGoalSnapshot {
-            minutes: 200,
-            pomodoros: 6,
-        },
-    );
-    monthly_stats.record_focus_elapsed(&previous_month_key, 120 * 60, base_daily_goal);
-    for _ in 0..4 {
-        monthly_stats.record_completed_pomodoro(&previous_month_key, base_daily_goal);
-    }
-    let output = build_status_output(&config, &monthly_stats);
-    assert_eq!(output.monthly_goal.minutes_target, 380);
-    assert_eq!(output.monthly_goal.pomodoros_target, 12);
-    assert!(output.monthly_goal.carry_over);
 }
 
 #[test]
@@ -2335,6 +2316,7 @@ fn build_status_output_daily_carry_over_skips_when_previous_day_goal_is_absent()
     assert_eq!(output.goal.pomodoros_target, 2);
 }
 
+#[cfg(any())]
 #[test]
 fn build_status_output_applies_weekly_carry_over_to_goal_targets_when_enabled() {
     let mut stats = FocusStats::default();
@@ -2377,6 +2359,7 @@ fn build_status_output_applies_weekly_carry_over_to_goal_targets_when_enabled() 
     assert!(output.weekly_goal.carry_over);
 }
 
+#[cfg(any())]
 #[test]
 fn build_status_output_weekly_carry_over_skips_when_previous_period_has_no_snapshot() {
     let mut stats = FocusStats::default();
@@ -2409,6 +2392,7 @@ fn build_status_output_weekly_carry_over_skips_when_previous_period_has_no_snaps
     assert_eq!(output.weekly_goal.pomodoros_target, 3);
 }
 
+#[cfg(any())]
 #[test]
 fn build_status_output_includes_weekly_allocation_breakdown() {
     let mut stats = FocusStats::default();
@@ -2475,6 +2459,7 @@ fn build_status_output_includes_weekly_allocation_breakdown() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn build_status_output_weekly_allocation_uses_equal_split_fallback_without_schedule() {
     let config = AppConfig {
@@ -2494,6 +2479,7 @@ fn build_status_output_weekly_allocation_uses_equal_split_fallback_without_sched
     );
 }
 
+#[cfg(any())]
 #[test]
 fn build_status_output_monthly_carry_over_uses_previous_snapshot_after_goal_change() {
     let mut stats = FocusStats::default();

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -462,53 +462,25 @@ fn parse_goal_with_value_sets_goal() {
     );
 }
 
-#[cfg(any())]
 #[test]
-fn parse_weekly_goal_without_value_reads_current_goal() {
-    let parsed = parse(&["--goal-weekly"]).unwrap();
-    assert_eq!(
-        parsed,
-        CliAction::RunCommand(CliCommand {
-            kind: CommandKind::GoalWeekly { goal: None },
-            output: OutputMode::Text
-        })
-    );
+fn parse_rejects_weekly_goal_without_value() {
+    let error = parse(&["--goal-weekly"]).unwrap_err();
+    assert!(error.contains("Unknown option `--goal-weekly`"));
+    assert!(error.contains("Weekly and monthly goal commands were removed."));
 }
 
-#[cfg(any())]
 #[test]
-fn parse_weekly_goal_with_equals_sets_goal() {
-    let parsed = parse(&["--goal-weekly=420,14"]).unwrap();
-    assert_eq!(
-        parsed,
-        CliAction::RunCommand(CliCommand {
-            kind: CommandKind::GoalWeekly {
-                goal: Some(WeeklyGoalConfig {
-                    minutes: 420,
-                    pomodoros: 14
-                })
-            },
-            output: OutputMode::Text
-        })
-    );
+fn parse_rejects_weekly_goal_with_equals_value() {
+    let error = parse(&["--goal-weekly=420,14"]).unwrap_err();
+    assert!(error.contains("Unknown option `--goal-weekly=420,14`"));
+    assert!(error.contains("Weekly and monthly goal commands were removed."));
 }
 
-#[cfg(any())]
 #[test]
-fn parse_monthly_goal_with_value_sets_goal() {
-    let parsed = parse(&["--goal-monthly", "1800,60"]).unwrap();
-    assert_eq!(
-        parsed,
-        CliAction::RunCommand(CliCommand {
-            kind: CommandKind::GoalMonthly {
-                goal: Some(MonthlyGoalConfig {
-                    minutes: 1800,
-                    pomodoros: 60
-                })
-            },
-            output: OutputMode::Text
-        })
-    );
+fn parse_rejects_monthly_goal_with_value() {
+    let error = parse(&["--goal-monthly", "1800,60"]).unwrap_err();
+    assert!(error.contains("Unknown option `--goal-monthly`"));
+    assert!(error.contains("Weekly and monthly goal commands were removed."));
 }
 
 #[test]
@@ -549,34 +521,18 @@ fn parse_goal_carry_without_value_reads_current_state() {
     );
 }
 
-#[cfg(any())]
 #[test]
-fn parse_goal_carry_weekly_with_equals_sets_state() {
-    let parsed = parse(&["--goal-carry-weekly=on"]).unwrap();
-    assert_eq!(
-        parsed,
-        CliAction::RunCommand(CliCommand {
-            kind: CommandKind::GoalCarryWeekly {
-                enabled: Some(true)
-            },
-            output: OutputMode::Text
-        })
-    );
+fn parse_rejects_goal_carry_weekly_with_equals_value() {
+    let error = parse(&["--goal-carry-weekly=on"]).unwrap_err();
+    assert!(error.contains("Unknown option `--goal-carry-weekly=on`"));
+    assert!(error.contains("Weekly and monthly goal carry-over commands were removed."));
 }
 
-#[cfg(any())]
 #[test]
-fn parse_goal_carry_monthly_with_value_sets_state() {
-    let parsed = parse(&["--goal-carry-monthly", "off"]).unwrap();
-    assert_eq!(
-        parsed,
-        CliAction::RunCommand(CliCommand {
-            kind: CommandKind::GoalCarryMonthly {
-                enabled: Some(false)
-            },
-            output: OutputMode::Text
-        })
-    );
+fn parse_rejects_goal_carry_monthly_with_value() {
+    let error = parse(&["--goal-carry-monthly", "off"]).unwrap_err();
+    assert!(error.contains("Unknown option `--goal-carry-monthly`"));
+    assert!(error.contains("Weekly and monthly goal carry-over commands were removed."));
 }
 
 #[test]
@@ -1144,29 +1100,19 @@ fn classify_key_value_arg_accepts_goal_equals_value() {
     );
 }
 
-#[cfg(any())]
 #[test]
-fn classify_key_value_arg_accepts_weekly_goal_equals_value() {
-    let parsed = classify_key_value_arg("--goal-weekly=420,14").unwrap();
+fn classify_key_value_arg_ignores_weekly_goal_equals_value() {
     assert_eq!(
-        parsed,
-        Some(ParsedToken::GoalWeekly(Some(WeeklyGoalConfig {
-            minutes: 420,
-            pomodoros: 14
-        })))
+        classify_key_value_arg("--goal-weekly=420,14").unwrap(),
+        None
     );
 }
 
-#[cfg(any())]
 #[test]
-fn classify_key_value_arg_accepts_monthly_goal_equals_value() {
-    let parsed = classify_key_value_arg("--goal-monthly=1800,60").unwrap();
+fn classify_key_value_arg_ignores_monthly_goal_equals_value() {
     assert_eq!(
-        parsed,
-        Some(ParsedToken::GoalMonthly(Some(MonthlyGoalConfig {
-            minutes: 1800,
-            pomodoros: 60
-        })))
+        classify_key_value_arg("--goal-monthly=1800,60").unwrap(),
+        None
     );
 }
 
@@ -1182,18 +1128,20 @@ fn classify_key_value_arg_accepts_goal_carry_equals_value() {
     assert_eq!(parsed, Some(ParsedToken::GoalCarry(Some(true))));
 }
 
-#[cfg(any())]
 #[test]
-fn classify_key_value_arg_accepts_goal_carry_weekly_equals_value() {
-    let parsed = classify_key_value_arg("--goal-carry-weekly=off").unwrap();
-    assert_eq!(parsed, Some(ParsedToken::GoalCarryWeekly(Some(false))));
+fn classify_key_value_arg_ignores_goal_carry_weekly_equals_value() {
+    assert_eq!(
+        classify_key_value_arg("--goal-carry-weekly=off").unwrap(),
+        None
+    );
 }
 
-#[cfg(any())]
 #[test]
-fn classify_key_value_arg_accepts_goal_carry_monthly_equals_value() {
-    let parsed = classify_key_value_arg("--goal-carry-monthly=on").unwrap();
-    assert_eq!(parsed, Some(ParsedToken::GoalCarryMonthly(Some(true))));
+fn classify_key_value_arg_ignores_goal_carry_monthly_equals_value() {
+    assert_eq!(
+        classify_key_value_arg("--goal-carry-monthly=on").unwrap(),
+        None
+    );
 }
 
 /// Verifies key-value parsing accepts inline schedule JSON payloads.
@@ -1256,18 +1204,14 @@ fn classify_key_value_arg_rejects_empty_goal_equals_value() {
     assert!(error.contains("`--goal=` requires values"));
 }
 
-#[cfg(any())]
 #[test]
-fn classify_key_value_arg_rejects_empty_weekly_goal_equals_value() {
-    let error = classify_key_value_arg("--goal-weekly=").unwrap_err();
-    assert!(error.contains("`--goal-weekly=` requires values"));
+fn classify_key_value_arg_ignores_empty_weekly_goal_equals_value() {
+    assert_eq!(classify_key_value_arg("--goal-weekly=").unwrap(), None);
 }
 
-#[cfg(any())]
 #[test]
-fn classify_key_value_arg_rejects_empty_monthly_goal_equals_value() {
-    let error = classify_key_value_arg("--goal-monthly=").unwrap_err();
-    assert!(error.contains("`--goal-monthly=` requires values"));
+fn classify_key_value_arg_ignores_empty_monthly_goal_equals_value() {
+    assert_eq!(classify_key_value_arg("--goal-monthly=").unwrap(), None);
 }
 
 #[test]
@@ -1282,18 +1226,20 @@ fn classify_key_value_arg_rejects_empty_goal_carry_equals_value() {
     assert!(error.contains("`--goal-carry=` requires `on` or `off`"));
 }
 
-#[cfg(any())]
 #[test]
-fn classify_key_value_arg_rejects_empty_goal_carry_weekly_equals_value() {
-    let error = classify_key_value_arg("--goal-carry-weekly=").unwrap_err();
-    assert!(error.contains("`--goal-carry-weekly=` requires `on` or `off`"));
+fn classify_key_value_arg_ignores_empty_goal_carry_weekly_equals_value() {
+    assert_eq!(
+        classify_key_value_arg("--goal-carry-weekly=").unwrap(),
+        None
+    );
 }
 
-#[cfg(any())]
 #[test]
-fn classify_key_value_arg_rejects_empty_goal_carry_monthly_equals_value() {
-    let error = classify_key_value_arg("--goal-carry-monthly=").unwrap_err();
-    assert!(error.contains("`--goal-carry-monthly=` requires `on` or `off`"));
+fn classify_key_value_arg_ignores_empty_goal_carry_monthly_equals_value() {
+    assert_eq!(
+        classify_key_value_arg("--goal-carry-monthly=").unwrap(),
+        None
+    );
 }
 
 #[test]
@@ -1375,18 +1321,16 @@ fn parse_rejects_goal_without_two_numbers() {
     assert!(error.contains("Invalid goal"));
 }
 
-#[cfg(any())]
 #[test]
-fn parse_rejects_weekly_goal_without_two_numbers() {
+fn parse_rejects_weekly_goal_as_removed_even_with_invalid_shape() {
     let error = parse(&["--goal-weekly=120"]).unwrap_err();
-    assert!(error.contains("Invalid goal"));
+    assert!(error.contains("Unknown option `--goal-weekly=120`"));
 }
 
-#[cfg(any())]
 #[test]
-fn parse_rejects_monthly_goal_without_two_numbers() {
+fn parse_rejects_monthly_goal_as_removed_even_with_invalid_shape() {
     let error = parse(&["--goal-monthly=120"]).unwrap_err();
-    assert!(error.contains("Invalid goal"));
+    assert!(error.contains("Unknown option `--goal-monthly=120`"));
 }
 
 #[test]
@@ -1766,7 +1710,7 @@ fn apply_history_dashboard_show_uses_stable_default_layout() {
     );
     assert_eq!(
         payload.cards.iter().map(|card| card.id).collect::<Vec<_>>(),
-        HistoryKpiCardId::all()
+        HistoryKpiCardId::supported_dashboard_cards()
             .iter()
             .map(|card| card.id())
             .collect::<Vec<_>>()

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,14 +112,14 @@ pub(crate) struct AppConfig {
     /// Weekly goal settings for focus minutes and completed pomodoros.
     ///
     /// A value of `0` disables the corresponding goal.
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     pub(crate) weekly_goal: WeeklyGoalConfig,
     /// Monthly goal settings for focus minutes and completed pomodoros.
     ///
     /// A value of `0` disables the corresponding goal.
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     pub(crate) monthly_goal: MonthlyGoalConfig,
-    /// Carry-over behavior for unmet daily/weekly/monthly targets.
+    /// Carry-over behavior for unmet daily targets.
     #[serde(default)]
     pub(crate) goal_carry_over: GoalCarryOverConfig,
     /// Retention policy for persisted stats history.
@@ -480,11 +480,11 @@ pub(crate) struct GoalCarryOverConfig {
     /// When enabled, unmet daily targets are added to the next day's target.
     #[serde(default)]
     pub(crate) daily: bool,
-    /// When enabled, unmet weekly targets are added to the next week's target.
-    #[serde(default)]
+    /// Deprecated weekly target carry-over, retained only for legacy config reads.
+    #[serde(default, skip_serializing)]
     pub(crate) weekly: bool,
-    /// When enabled, unmet monthly targets are added to the next month's target.
-    #[serde(default)]
+    /// Deprecated monthly target carry-over, retained only for legacy config reads.
+    #[serde(default, skip_serializing)]
     pub(crate) monthly: bool,
 }
 
@@ -596,13 +596,12 @@ impl HistoryKpiCardId {
         }
     }
 
-    pub(crate) const fn all() -> [Self; 9] {
+    pub(crate) const fn all() -> [Self; 8] {
         [
             Self::SessionSummary,
             Self::FocusScore,
             Self::GoalStreak,
             Self::FocusRisk,
-            Self::WeeklyAllocation,
             Self::LastInterruption,
             Self::StatsGrowth,
             Self::Retention,
@@ -1095,6 +1094,10 @@ impl AppConfig {
         self.schedule_runtime = self.schedule_runtime.normalized();
         self.history_dashboard = self.history_dashboard.normalized();
         self.shortcuts = self.shortcuts.normalized();
+        self.weekly_goal = WeeklyGoalConfig::default();
+        self.monthly_goal = MonthlyGoalConfig::default();
+        self.goal_carry_over.weekly = false;
+        self.goal_carry_over.monthly = false;
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -596,7 +596,7 @@ impl HistoryKpiCardId {
         }
     }
 
-    pub(crate) const fn all() -> [Self; 8] {
+    pub(crate) const fn supported_dashboard_cards() -> [Self; 8] {
         [
             Self::SessionSummary,
             Self::FocusScore,
@@ -701,11 +701,11 @@ fn default_schedule_window_end() -> String {
 }
 
 fn default_history_dashboard_pinned_cards() -> Vec<HistoryKpiCardId> {
-    HistoryKpiCardId::all().to_vec()
+    HistoryKpiCardId::supported_dashboard_cards().to_vec()
 }
 
 fn default_history_dashboard_card_order() -> Vec<HistoryKpiCardId> {
-    HistoryKpiCardId::all().to_vec()
+    HistoryKpiCardId::supported_dashboard_cards().to_vec()
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -259,9 +259,11 @@ fn round_trip_full_config() {
     assert_eq!(parsed.profile_automation, original.profile_automation);
     assert!(!parsed.strict_mode);
     assert_eq!(parsed.daily_goal, original.daily_goal);
-    assert_eq!(parsed.weekly_goal, original.weekly_goal);
-    assert_eq!(parsed.monthly_goal, original.monthly_goal);
-    assert_eq!(parsed.goal_carry_over, original.goal_carry_over);
+    assert_eq!(parsed.weekly_goal, WeeklyGoalConfig::default());
+    assert_eq!(parsed.monthly_goal, MonthlyGoalConfig::default());
+    assert_eq!(parsed.goal_carry_over.daily, original.goal_carry_over.daily);
+    assert!(!parsed.goal_carry_over.weekly);
+    assert!(!parsed.goal_carry_over.monthly);
     assert_eq!(parsed.stats_retention, original.stats_retention);
     assert_eq!(parsed.history_dashboard, HistoryDashboardConfig::default());
     assert_eq!(parsed.feature_flags, original.feature_flags);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -190,16 +190,12 @@ impl FocusRiskLevel {
 #[serde(rename_all = "snake_case")]
 pub(crate) enum GoalPeriod {
     Daily,
-    Weekly,
-    Monthly,
 }
 
 impl GoalPeriod {
     pub(crate) fn short_label(self) -> &'static str {
         match self {
             Self::Daily => "D",
-            Self::Weekly => "W",
-            Self::Monthly => "M",
         }
     }
 }
@@ -236,19 +232,13 @@ pub(crate) struct StreakRiskForecast {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct FocusRiskForecast {
     pub(crate) daily_goal: GoalRiskForecast,
-    pub(crate) weekly_goal: GoalRiskForecast,
-    pub(crate) monthly_goal: GoalRiskForecast,
     pub(crate) streak: StreakRiskForecast,
 }
 
 impl FocusRiskForecast {
     pub(crate) fn highest_risk_level(&self) -> FocusRiskLevel {
         let mut level = self.daily_goal.risk_level;
-        for candidate in [
-            self.weekly_goal.risk_level,
-            self.monthly_goal.risk_level,
-            self.streak.risk_level,
-        ] {
+        for candidate in [self.streak.risk_level] {
             if candidate.rank() > level.rank() {
                 level = candidate;
             }
@@ -262,26 +252,16 @@ impl FocusRiskForecast {
             return true;
         }
 
-        let medium_count = [
-            self.daily_goal.risk_level,
-            self.weekly_goal.risk_level,
-            self.monthly_goal.risk_level,
-            self.streak.risk_level,
-        ]
-        .into_iter()
-        .filter(|level| matches!(level, FocusRiskLevel::Medium))
-        .count();
+        let medium_count = [self.daily_goal.risk_level, self.streak.risk_level]
+            .into_iter()
+            .filter(|level| matches!(level, FocusRiskLevel::Medium))
+            .count();
         if medium_count >= 2 {
             return true;
         }
 
         [
             (self.daily_goal.risk_level, self.daily_goal.risk_score_pct),
-            (self.weekly_goal.risk_level, self.weekly_goal.risk_score_pct),
-            (
-                self.monthly_goal.risk_level,
-                self.monthly_goal.risk_score_pct,
-            ),
             (self.streak.risk_level, self.streak.risk_score_pct),
         ]
         .into_iter()
@@ -289,6 +269,7 @@ impl FocusRiskForecast {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct FocusRiskCalibrationMetrics {
     pub(crate) sample_count: u32,
@@ -875,7 +856,6 @@ struct HistoryKpiExport {
     focus_score: HistoryKpiFocusScore,
     goal_streak: HistoryKpiGoalStreak,
     focus_risk: HistoryKpiFocusRisk,
-    weekly_allocation: HistoryKpiWeeklyAllocation,
     last_interruption: HistoryKpiLastInterruption,
     stats_growth: HistoryKpiStatsGrowth,
     retention: HistoryKpiRetention,
@@ -912,8 +892,6 @@ struct HistoryKpiGoalPeriodProgress {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 struct HistoryKpiGoalStreak {
     daily: HistoryKpiGoalPeriodProgress,
-    weekly: HistoryKpiGoalPeriodProgress,
-    monthly: HistoryKpiGoalPeriodProgress,
     current_days: u32,
     best_days: u32,
 }
@@ -927,37 +905,8 @@ struct HistoryKpiFocusRisk {
     highest_signal_value: Option<String>,
     daily_risk_level: FocusRiskLevel,
     daily_risk_score_pct: u8,
-    weekly_risk_level: FocusRiskLevel,
-    weekly_risk_score_pct: u8,
-    monthly_risk_level: FocusRiskLevel,
-    monthly_risk_score_pct: u8,
     streak_risk_level: FocusRiskLevel,
     streak_risk_score_pct: u8,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-struct HistoryKpiWeeklyAllocation {
-    week_target_minutes: u64,
-    week_target_pomodoros: u32,
-    completed_minutes: u64,
-    completed_pomodoros: u32,
-    remaining_minutes: u64,
-    remaining_pomodoros: u32,
-    remaining_days_in_week: usize,
-    allocatable_days: usize,
-    uses_schedule_weights: bool,
-    today_target_minutes: u64,
-    today_target_pomodoros: u32,
-    daily_targets: Vec<HistoryKpiWeeklyAllocationDay>,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-struct HistoryKpiWeeklyAllocationDay {
-    day: String,
-    minutes_target: u64,
-    pomodoros_target: u32,
-    allocatable: bool,
-    weight_minutes: u64,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -1039,9 +988,9 @@ struct CsvExportRow {
 struct PersistedStats {
     #[serde(default)]
     daily: BTreeMap<String, DailyStats>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     weekly_goal_snapshots: BTreeMap<String, DailyGoalSnapshot>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     monthly_goal_snapshots: BTreeMap<String, DailyGoalSnapshot>,
     #[serde(default)]
     task_labels: Vec<String>,

--- a/src/stats/analytics.rs
+++ b/src/stats/analytics.rs
@@ -16,7 +16,7 @@ use crate::stats::{
 };
 use forecast::{
     classify_calibration_signal, goal_risk_forecast, observed_goal_miss_for_candidate,
-    remaining_days_in_month, remaining_days_in_week, rolling_cadence_window, streak_risk_forecast,
+    rolling_cadence_window, streak_risk_forecast,
 };
 use support::{
     estimated_serialized_bytes, is_day_key_on_or_after, is_month_key_on_or_after,
@@ -144,13 +144,11 @@ impl FocusStats {
         &self,
         day: chrono::NaiveDate,
         daily_goal: DailyGoalSnapshot,
-        weekly_goal: DailyGoalSnapshot,
-        monthly_goal: DailyGoalSnapshot,
+        _weekly_goal: DailyGoalSnapshot,
+        _monthly_goal: DailyGoalSnapshot,
     ) -> FocusRiskForecast {
         let day_key = day.format("%Y-%m-%d").to_string();
         let daily_stats = self.daily_for(&day_key);
-        let weekly_stats = self.weekly_for_day(day);
-        let monthly_stats = self.monthly_for_day(day);
         let cadence = rolling_cadence_window(self, day, 7);
         let daily_goal_forecast = goal_risk_forecast(
             GoalPeriod::Daily,
@@ -160,22 +158,6 @@ impl FocusStats {
             1,
             cadence,
         );
-        let weekly_goal_forecast = goal_risk_forecast(
-            GoalPeriod::Weekly,
-            weekly_goal,
-            weekly_stats.focused_minutes(),
-            weekly_stats.pomodoros_completed,
-            remaining_days_in_week(day),
-            cadence,
-        );
-        let monthly_goal_forecast = goal_risk_forecast(
-            GoalPeriod::Monthly,
-            monthly_goal,
-            monthly_stats.focused_minutes(),
-            monthly_stats.pomodoros_completed,
-            remaining_days_in_month(day),
-            cadence,
-        );
 
         let streak = self.goal_streak_with_day_goal(day, daily_goal, daily_stats, |_| daily_goal);
         let streak_forecast =
@@ -183,13 +165,11 @@ impl FocusStats {
 
         FocusRiskForecast {
             daily_goal: daily_goal_forecast,
-            weekly_goal: weekly_goal_forecast,
-            monthly_goal: monthly_goal_forecast,
             streak: streak_forecast,
         }
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[allow(dead_code)]
     pub(crate) fn focus_risk_calibration_metrics_for_day(
         &self,
         day: chrono::NaiveDate,

--- a/src/stats/analytics/forecast.rs
+++ b/src/stats/analytics/forecast.rs
@@ -7,13 +7,14 @@ use crate::stats::{
     percentage_round_nearest, weekly_completion_score_pct,
 };
 
+#[allow(dead_code)]
 pub(super) fn observed_goal_miss_for_candidate(
-    stats: &FocusStats,
-    candidate: chrono::NaiveDate,
+    _stats: &FocusStats,
+    _candidate: chrono::NaiveDate,
     day_stats: DailyStats,
     daily_goal: DailyGoalSnapshot,
-    weekly_goal: DailyGoalSnapshot,
-    monthly_goal: DailyGoalSnapshot,
+    _weekly_goal: DailyGoalSnapshot,
+    _monthly_goal: DailyGoalSnapshot,
 ) -> Option<bool> {
     let mut observed_outcome = false;
     let mut observed_miss = false;
@@ -23,29 +24,10 @@ pub(super) fn observed_goal_miss_for_candidate(
         observed_miss |= !daily_goal.is_met_by(day_stats);
     }
 
-    if candidate.weekday().num_days_from_monday() == 6 && weekly_goal.has_any_target() {
-        observed_outcome = true;
-        let weekly_stats = stats.weekly_for_day(candidate);
-        observed_miss |= !weekly_goal.is_met_by_totals(
-            weekly_stats.focused_minutes(),
-            weekly_stats.pomodoros_completed,
-        );
-    }
-
-    if candidate.day() == days_in_month(candidate.year(), candidate.month())
-        && monthly_goal.has_any_target()
-    {
-        observed_outcome = true;
-        let monthly_stats = stats.monthly_for_day(candidate);
-        observed_miss |= !monthly_goal.is_met_by_totals(
-            monthly_stats.focused_minutes(),
-            monthly_stats.pomodoros_completed,
-        );
-    }
-
     observed_outcome.then_some(observed_miss)
 }
 
+#[allow(dead_code)]
 pub(super) fn classify_calibration_signal(
     alert_active: bool,
     observed_miss: bool,
@@ -405,10 +387,12 @@ pub(super) fn risk_signal(label: &str, value: &str) -> FocusRiskSignal {
     }
 }
 
+#[allow(dead_code)]
 pub(super) fn remaining_days_in_week(day: chrono::NaiveDate) -> u32 {
     7_u32.saturating_sub(day.weekday().num_days_from_monday())
 }
 
+#[allow(dead_code)]
 pub(super) fn remaining_days_in_month(day: chrono::NaiveDate) -> u32 {
     let total_days = days_in_month(day.year(), day.month());
     total_days.saturating_sub(day.day()).saturating_add(1)

--- a/src/stats/export.rs
+++ b/src/stats/export.rs
@@ -1,6 +1,5 @@
 use chrono::{Datelike, Duration, NaiveDate};
 
-use crate::app::weekly_daily_goal_allocation_for_context;
 use crate::config::HistoryKpiCardId;
 use crate::stats::{
     CSV_EXPORT_FILE_NAME, ComparisonDimension, CsvExportRow, DailyExportRow, DailyGoalSnapshot,
@@ -8,12 +7,12 @@ use crate::stats::{
     HistoryKpiComparisonFilters, HistoryKpiExport, HistoryKpiExportContext, HistoryKpiFocusRisk,
     HistoryKpiFocusScore, HistoryKpiGoalPeriodProgress, HistoryKpiGoalStreak,
     HistoryKpiLastInterruption, HistoryKpiRetention, HistoryKpiSessionSummary,
-    HistoryKpiStatsGrowth, HistoryKpiWeeklyAllocation, HistoryKpiWeeklyAllocationDay,
-    JSON_EXPORT_FILE_NAME, Path, ProductivityComparisonExportRow, ProductivityComparisonFilter,
-    ProfileEffectivenessExportRow, SessionExportRow, SessionInterruptionExportRow, StatsExport,
-    TaskTotalsExportRow, TaskTrendExportRow, WeeklyConsistencyExportRow, WeeklyExportRow,
-    WeeklyFocusScore, average_two_percentages, consistency_score_from_active_days,
-    format_week_label, fs, io, weekly_completion_score_pct, write_atomic_bytes,
+    HistoryKpiStatsGrowth, JSON_EXPORT_FILE_NAME, Path, ProductivityComparisonExportRow,
+    ProductivityComparisonFilter, ProfileEffectivenessExportRow, SessionExportRow,
+    SessionInterruptionExportRow, StatsExport, TaskTotalsExportRow, TaskTrendExportRow,
+    WeeklyConsistencyExportRow, WeeklyExportRow, WeeklyFocusScore, average_two_percentages,
+    consistency_score_from_active_days, format_week_label, fs, io, weekly_completion_score_pct,
+    write_atomic_bytes,
 };
 
 impl FocusStats {
@@ -75,27 +74,13 @@ impl FocusStats {
         let day_key = day.format("%Y-%m-%d").to_string();
         let today_stats = self.daily_for(&day_key);
         let session_stats = self.session();
-        let weekly_stats = self.weekly_for_day(day);
-        let monthly_stats = self.monthly_for_day(day);
 
         let daily_goal = self.effective_daily_goal_snapshot_for_day(day, context);
-        let weekly_goal = self.effective_weekly_goal_snapshot_for_day(day, context);
-        let monthly_goal = self.effective_monthly_goal_snapshot_for_day(day, context);
 
         let daily_progress = goal_period_progress(
             today_stats.focused_minutes(),
             today_stats.pomodoros_completed,
             daily_goal,
-        );
-        let weekly_progress = goal_period_progress(
-            weekly_stats.focused_minutes(),
-            weekly_stats.pomodoros_completed,
-            weekly_goal,
-        );
-        let monthly_progress = goal_period_progress(
-            monthly_stats.focused_minutes(),
-            monthly_stats.pomodoros_completed,
-            monthly_goal,
         );
 
         let goal_streak =
@@ -103,18 +88,15 @@ impl FocusStats {
                 self.effective_daily_goal_snapshot_for_day(target_day, context)
             });
         let focus_score = self.focus_score_for_day(day, context);
-        let focus_risk =
-            self.focus_risk_forecast_for_day(day, daily_goal, weekly_goal, monthly_goal);
+        let focus_risk = self.focus_risk_forecast_for_day(
+            day,
+            daily_goal,
+            DailyGoalSnapshot::default(),
+            DailyGoalSnapshot::default(),
+        );
         let (highest_signal_scope, highest_signal_label, highest_signal_value) =
             focus_risk_highest_signal(&focus_risk);
 
-        let weekly_allocation = weekly_daily_goal_allocation_for_context(
-            day,
-            weekly_goal,
-            weekly_stats,
-            &context.recurring_schedule,
-        );
-        let today_target = weekly_allocation.today_target();
         let latest_interruption = self.latest_session_interruption();
         let growth_summary = self.growth_summary();
         let retention_preview = self.retention_preview(context.stats_retention, day);
@@ -139,8 +121,6 @@ impl FocusStats {
             },
             goal_streak: HistoryKpiGoalStreak {
                 daily: daily_progress,
-                weekly: weekly_progress,
-                monthly: monthly_progress,
                 current_days: goal_streak.current,
                 best_days: goal_streak.best,
             },
@@ -152,36 +132,8 @@ impl FocusStats {
                 highest_signal_value,
                 daily_risk_level: focus_risk.daily_goal.risk_level,
                 daily_risk_score_pct: focus_risk.daily_goal.risk_score_pct,
-                weekly_risk_level: focus_risk.weekly_goal.risk_level,
-                weekly_risk_score_pct: focus_risk.weekly_goal.risk_score_pct,
-                monthly_risk_level: focus_risk.monthly_goal.risk_level,
-                monthly_risk_score_pct: focus_risk.monthly_goal.risk_score_pct,
                 streak_risk_level: focus_risk.streak.risk_level,
                 streak_risk_score_pct: focus_risk.streak.risk_score_pct,
-            },
-            weekly_allocation: HistoryKpiWeeklyAllocation {
-                week_target_minutes: weekly_allocation.week_target.minutes,
-                week_target_pomodoros: weekly_allocation.week_target.pomodoros,
-                completed_minutes: weekly_allocation.completed_minutes,
-                completed_pomodoros: weekly_allocation.completed_pomodoros,
-                remaining_minutes: weekly_allocation.remaining_minutes,
-                remaining_pomodoros: weekly_allocation.remaining_pomodoros,
-                remaining_days_in_week: weekly_allocation.remaining_days_in_week,
-                allocatable_days: weekly_allocation.allocatable_days,
-                uses_schedule_weights: weekly_allocation.uses_schedule_weights,
-                today_target_minutes: today_target.minutes,
-                today_target_pomodoros: today_target.pomodoros,
-                daily_targets: weekly_allocation
-                    .daily_targets
-                    .into_iter()
-                    .map(|entry| HistoryKpiWeeklyAllocationDay {
-                        day: entry.day.format("%Y-%m-%d").to_string(),
-                        minutes_target: entry.minutes_target,
-                        pomodoros_target: entry.pomodoros_target,
-                        allocatable: entry.allocatable,
-                        weight_minutes: entry.weight_minutes,
-                    })
-                    .collect(),
             },
             last_interruption: HistoryKpiLastInterruption {
                 timestamp_epoch_secs: latest_interruption
@@ -446,28 +398,6 @@ impl FocusStats {
                     })
             });
         crate::stats::carry_over_goal_target(base, context.carry_over_weekly, previous)
-    }
-
-    fn effective_monthly_goal_snapshot_for_day(
-        &self,
-        day: NaiveDate,
-        context: &HistoryKpiExportContext,
-    ) -> DailyGoalSnapshot {
-        let base = self
-            .monthly_goal_snapshot_for_day(day)
-            .unwrap_or(context.monthly_goal);
-        let previous = previous_month_reference_day(day).and_then(|previous_month_day| {
-            self.monthly_goal_snapshot_for_day(previous_month_day)
-                .map(|previous_target| {
-                    let month = self.monthly_for_day(previous_month_day);
-                    (
-                        previous_target,
-                        month.focused_minutes(),
-                        month.pomodoros_completed,
-                    )
-                })
-        });
-        crate::stats::carry_over_goal_target(base, context.carry_over_monthly, previous)
     }
 
     fn focus_score_for_day(
@@ -760,11 +690,6 @@ impl StatsExport {
                 ..Self::csv_row_defaults("history_kpi")
             },
             CsvExportRow {
-                kpi_card_id: Some(HistoryKpiCardId::WeeklyAllocation.id().to_string()),
-                kpi_payload_json: Some(payload_json(&self.history_kpis.weekly_allocation)?),
-                ..Self::csv_row_defaults("history_kpi")
-            },
-            CsvExportRow {
                 kpi_card_id: Some(HistoryKpiCardId::LastInterruption.id().to_string()),
                 kpi_payload_json: Some(payload_json(&self.history_kpis.last_interruption)?),
                 ..Self::csv_row_defaults("history_kpi")
@@ -805,13 +730,6 @@ fn goal_period_progress(
     }
 }
 
-fn previous_month_reference_day(day: NaiveDate) -> Option<NaiveDate> {
-    let first_of_month = day.with_day(1)?;
-    let previous_month_last_day = first_of_month.checked_sub_signed(Duration::days(1))?;
-    let reference_day = day.day().min(previous_month_last_day.day());
-    previous_month_last_day.with_day(reference_day)
-}
-
 fn comparison_filter_summary(context: &HistoryKpiExportContext) -> String {
     let task = context
         .comparison_task_filter
@@ -833,18 +751,8 @@ fn focus_risk_highest_signal(
     forecast: &FocusRiskForecast,
 ) -> (Option<String>, Option<String>, Option<String>) {
     let mut highest_scope = "daily";
-    let mut highest_score = forecast.daily_goal.risk_score_pct;
+    let highest_score = forecast.daily_goal.risk_score_pct;
     let mut highest_signal = forecast.daily_goal.signals.first();
-    if forecast.weekly_goal.risk_score_pct > highest_score {
-        highest_scope = "weekly";
-        highest_score = forecast.weekly_goal.risk_score_pct;
-        highest_signal = forecast.weekly_goal.signals.first();
-    }
-    if forecast.monthly_goal.risk_score_pct > highest_score {
-        highest_scope = "monthly";
-        highest_score = forecast.monthly_goal.risk_score_pct;
-        highest_signal = forecast.monthly_goal.signals.first();
-    }
     if forecast.streak.risk_score_pct > highest_score {
         highest_scope = "streak";
         highest_signal = forecast.streak.signals.first();

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -102,8 +102,8 @@ impl FocusStats {
         Self {
             session: SessionStats::default(),
             daily: persisted.daily,
-            weekly_goal_snapshots: persisted.weekly_goal_snapshots,
-            monthly_goal_snapshots: persisted.monthly_goal_snapshots,
+            weekly_goal_snapshots: Default::default(),
+            monthly_goal_snapshots: Default::default(),
             task_labels,
             selected_task_label,
             task_label_favorites,
@@ -118,8 +118,8 @@ impl FocusStats {
     pub(super) fn to_persisted(&self) -> PersistedStats {
         PersistedStats {
             daily: self.daily.clone(),
-            weekly_goal_snapshots: self.weekly_goal_snapshots.clone(),
-            monthly_goal_snapshots: self.monthly_goal_snapshots.clone(),
+            weekly_goal_snapshots: Default::default(),
+            monthly_goal_snapshots: Default::default(),
             task_labels: self.task_labels.clone(),
             selected_task_label: self.selected_task_label.clone(),
             task_label_favorites: planner_state_labels_for_keys(

--- a/src/stats/recording.rs
+++ b/src/stats/recording.rs
@@ -130,6 +130,7 @@ impl FocusStats {
         true
     }
 
+    #[allow(dead_code)]
     pub(crate) fn sync_weekly_goal_snapshot(
         &mut self,
         day: chrono::NaiveDate,
@@ -143,6 +144,7 @@ impl FocusStats {
         true
     }
 
+    #[allow(dead_code)]
     pub(crate) fn sync_monthly_goal_snapshot(
         &mut self,
         day: chrono::NaiveDate,

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -722,12 +722,11 @@ fn focus_risk_forecast_stays_low_when_goals_are_met() {
     );
 
     assert_eq!(forecast.daily_goal.risk_score_pct, 0);
-    assert_eq!(forecast.weekly_goal.risk_score_pct, 0);
-    assert_eq!(forecast.monthly_goal.risk_score_pct, 0);
     assert_eq!(forecast.daily_goal.risk_level, FocusRiskLevel::Low);
     assert!(!forecast.alert_active());
 }
 
+#[cfg(any())]
 #[test]
 fn focus_risk_calibration_metrics_track_false_positives_without_end_period_outcomes() {
     let mut stats = FocusStats::default();
@@ -774,6 +773,7 @@ fn focus_risk_calibration_metrics_track_false_positives_without_end_period_outco
     assert_eq!(metrics.missed_warning_rate_pct, 0);
 }
 
+#[cfg(any())]
 #[test]
 fn focus_risk_calibration_metrics_count_missing_daily_row_weekly_outcomes() {
     let stats = FocusStats::default();
@@ -811,8 +811,6 @@ fn focus_risk_forecast_marks_goals_off_when_targets_are_disabled() {
     );
 
     assert!(!forecast.daily_goal.configured);
-    assert!(!forecast.weekly_goal.configured);
-    assert!(!forecast.monthly_goal.configured);
     assert!(!forecast.streak.configured);
     assert_eq!(forecast.daily_goal.signals[0].value, "goal off",);
     assert!(!forecast.alert_active());
@@ -928,7 +926,7 @@ fn persisted_stats_round_trip_preserves_focus_session_profile() {
 }
 
 #[test]
-fn persisted_stats_round_trip_preserves_weekly_and_monthly_goal_snapshots() {
+fn persisted_stats_round_trip_drops_weekly_and_monthly_goal_snapshots() {
     let mut original = FocusStats::default();
     let day = chrono::NaiveDate::from_ymd_opt(2026, 4, 9).expect("day should be valid");
     let weekly_goal = DailyGoalSnapshot {
@@ -945,14 +943,8 @@ fn persisted_stats_round_trip_preserves_weekly_and_monthly_goal_snapshots() {
     let toml_str = toml::to_string_pretty(&original.to_persisted()).unwrap();
     let restored = FocusStats::try_from_toml(&toml_str).unwrap();
 
-    assert_eq!(
-        restored.weekly_goal_snapshot_for_day(day),
-        Some(weekly_goal)
-    );
-    assert_eq!(
-        restored.monthly_goal_snapshot_for_day(day),
-        Some(monthly_goal)
-    );
+    assert_eq!(restored.weekly_goal_snapshot_for_day(day), None);
+    assert_eq!(restored.monthly_goal_snapshot_for_day(day), None);
 }
 
 #[test]
@@ -1632,7 +1624,6 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
         "focus_score",
         "goal_streak",
         "focus_risk",
-        "weekly_allocation",
         "last_interruption",
         "stats_growth",
         "retention",
@@ -1770,13 +1761,12 @@ fn export_to_dir_writes_daily_and_weekly_json_and_csv() {
         csv_kpi_payloads.insert(card_id, parsed_payload);
     }
 
-    assert_eq!(csv_kpi_payloads.len(), 9);
+    assert_eq!(csv_kpi_payloads.len(), 8);
     for card_id in [
         "session_summary",
         "focus_score",
         "goal_streak",
         "focus_risk",
-        "weekly_allocation",
         "last_interruption",
         "stats_growth",
         "retention",

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -941,6 +941,10 @@ fn persisted_stats_round_trip_drops_weekly_and_monthly_goal_snapshots() {
     original.sync_monthly_goal_snapshot(day, monthly_goal);
 
     let toml_str = toml::to_string_pretty(&original.to_persisted()).unwrap();
+    assert!(!toml_str.contains("weekly_goal_snapshots"));
+    assert!(!toml_str.contains("monthly_goal_snapshots"));
+    assert!(!toml_str.contains(&day.format("%Y-%m-%d").to_string()));
+
     let restored = FocusStats::try_from_toml(&toml_str).unwrap();
 
     assert_eq!(restored.weekly_goal_snapshot_for_day(day), None);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -19,14 +19,12 @@ mod history;
 #[cfg(test)]
 use history::{
     format_history_focus_risk_line, format_history_goal_streak_line,
-    format_history_interruption_line, format_history_weekly_allocation_line, format_month_label,
+    format_history_interruption_line, format_month_label,
 };
 use history::{readable_goal_streak_text, render_stats_history};
 mod profile_manager;
 use profile_manager::render_profile_manager;
 mod session_planner;
-#[cfg(test)]
-use session_planner::planner_weekly_allocation_summary;
 use session_planner::render_session_planner;
 mod site_manager;
 use site_manager::render_site_manager;
@@ -95,18 +93,11 @@ fn format_goal_metric_progress(
 
 fn format_timer_goal_streak_line(app: &App) -> String {
     let daily_goal_progress = app.today_goal_progress();
-    let weekly_goal_progress = app.current_week_goal_progress();
-    let monthly_goal_progress = app.current_month_goal_progress();
     let streak = app.goal_streak();
-    if daily_goal_progress.has_any_target()
-        || weekly_goal_progress.has_any_target()
-        || monthly_goal_progress.has_any_target()
-    {
+    if daily_goal_progress.has_any_target() {
         format!(
-            "Goals: {} · {} · {}   Streaks: {}d current · {}d best",
+            "Goal: {}   Streaks: {}d current · {}d best",
             format_goal_period_progress("D", daily_goal_progress),
-            format_goal_period_progress("W", weekly_goal_progress),
-            format_goal_period_progress("M", monthly_goal_progress),
             streak.current,
             streak.best
         )

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -19,7 +19,7 @@ mod history;
 #[cfg(test)]
 use history::{
     format_history_focus_risk_line, format_history_goal_streak_line,
-    format_history_interruption_line, format_month_label,
+    format_history_interruption_line, format_history_weekly_allocation_line, format_month_label,
 };
 use history::{readable_goal_streak_text, render_stats_history};
 mod profile_manager;

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -227,9 +227,7 @@ fn history_kpi_card_text(
             readable_goal_streak_text(&format_history_goal_streak_line_from_data(history_data))
         }
         HistoryKpiCardId::FocusRisk => format_history_focus_risk_line_from_data(history_data),
-        HistoryKpiCardId::WeeklyAllocation => {
-            format_history_weekly_allocation_line_from_data(history_data)
-        }
+        HistoryKpiCardId::WeeklyAllocation => "Weekly allocation: retired".to_string(),
         HistoryKpiCardId::LastInterruption => {
             format_history_interruption_line_from_data(history_data)
         }
@@ -366,18 +364,11 @@ pub(super) fn format_history_goal_streak_line(app: &App) -> String {
 
 fn format_history_goal_streak_line_from_data(history_data: &HistoryDashboardViewData) -> String {
     let daily_goal_progress = history_data.daily_goal_progress;
-    let weekly_goal_progress = history_data.weekly_goal_progress;
-    let monthly_goal_progress = history_data.monthly_goal_progress;
     let streak = history_data.goal_streak;
-    if daily_goal_progress.has_any_target()
-        || weekly_goal_progress.has_any_target()
-        || monthly_goal_progress.has_any_target()
-    {
+    if daily_goal_progress.has_any_target() {
         format!(
-            "Goals: {} · {} · {}   Streaks: {}d current · {}d best",
+            "Goal: {}   Streaks: {}d current · {}d best",
             format_goal_period_progress("D", daily_goal_progress),
-            format_goal_period_progress("W", weekly_goal_progress),
-            format_goal_period_progress("M", monthly_goal_progress),
             streak.current,
             streak.best
         )
@@ -394,16 +385,10 @@ pub(super) fn format_history_focus_score_line(app: &App) -> String {
 
 fn format_history_focus_score_line_from_data(history_data: &HistoryDashboardViewData) -> String {
     match history_data.latest_weekly_focus_score.as_ref() {
-        Some(score) => match (score.focus_score_pct, score.completion_score_pct) {
-            (Some(focus_score), Some(completion_score)) => format!(
-                "Focus score: {focus_score}% (consistency {}% · completion {completion_score}%)",
-                score.consistency_score_pct
-            ),
-            _ => format!(
-                "Focus score: n/a (weekly goal off; consistency {}% ({}/7 days))",
-                score.consistency_score_pct, score.active_days
-            ),
-        },
+        Some(score) => format!(
+            "Focus score: {}% (consistency, {}/7 active days)",
+            score.consistency_score_pct, score.active_days
+        ),
         None => "Focus score: n/a".to_string(),
     }
 }
@@ -418,21 +403,9 @@ fn format_history_focus_risk_line_from_data(history_data: &HistoryDashboardViewD
     let forecast = &history_data.focus_risk_forecast;
     let alert_active = forecast.alert_active();
     let daily_label = forecast.daily_goal.period.short_label();
-    let weekly_label = forecast.weekly_goal.period.short_label();
-    let monthly_label = forecast.monthly_goal.period.short_label();
     let mut highest_label = daily_label;
-    let mut highest_score = forecast.daily_goal.risk_score_pct;
+    let highest_score = forecast.daily_goal.risk_score_pct;
     let mut highest_signal = forecast.daily_goal.signals.first();
-    if forecast.weekly_goal.risk_score_pct > highest_score {
-        highest_label = weekly_label;
-        highest_score = forecast.weekly_goal.risk_score_pct;
-        highest_signal = forecast.weekly_goal.signals.first();
-    }
-    if forecast.monthly_goal.risk_score_pct > highest_score {
-        highest_label = monthly_label;
-        highest_score = forecast.monthly_goal.risk_score_pct;
-        highest_signal = forecast.monthly_goal.signals.first();
-    }
     if forecast.streak.risk_score_pct > highest_score {
         highest_label = "S";
         highest_signal = forecast.streak.signals.first();
@@ -446,16 +419,10 @@ fn format_history_focus_risk_line_from_data(history_data: &HistoryDashboardViewD
     };
     let alert_suffix = if alert_active { " · ALERT" } else { "" };
     format!(
-        "Risk: {} {} {}% · {} {} {}% · {} {} {}% · S {} {}%{}{}",
+        "Risk: {} {} {}% · S {} {}%{}{}",
         daily_label,
         forecast.daily_goal.risk_level.label(),
         forecast.daily_goal.risk_score_pct,
-        weekly_label,
-        forecast.weekly_goal.risk_level.label(),
-        forecast.weekly_goal.risk_score_pct,
-        monthly_label,
-        forecast.monthly_goal.risk_level.label(),
-        forecast.monthly_goal.risk_score_pct,
         forecast.streak.risk_level.label(),
         forecast.streak.risk_score_pct,
         alert_suffix,
@@ -470,29 +437,9 @@ pub(super) fn format_history_weekly_allocation_line(app: &App) -> String {
 }
 
 fn format_history_weekly_allocation_line_from_data(
-    history_data: &HistoryDashboardViewData,
+    _history_data: &HistoryDashboardViewData,
 ) -> String {
-    let allocation = &history_data.weekly_daily_goal_allocation;
-    if !allocation.has_any_target() {
-        return "Weekly allocation: off".to_string();
-    }
-    if allocation.remaining_minutes == 0 && allocation.remaining_pomodoros == 0 {
-        return format!(
-            "Weekly allocation: met · 0m/0p remaining · {} day(s) left",
-            allocation.remaining_days_in_week
-        );
-    }
-
-    let today_target = allocation.today_target();
-    format!(
-        "Weekly allocation: today {}m/{}p · remaining {}m/{}p across {}/{} days",
-        today_target.minutes,
-        today_target.pomodoros,
-        allocation.remaining_minutes,
-        allocation.remaining_pomodoros,
-        allocation.allocatable_days,
-        allocation.remaining_days_in_week
-    )
+    "Weekly allocation: retired".to_string()
 }
 
 #[allow(dead_code)]

--- a/src/ui/profile_manager.rs
+++ b/src/ui/profile_manager.rs
@@ -6,9 +6,9 @@ use crate::ui::{
 
 const PROFILE_EDIT_GROUP_TIMER: [usize; 4] = [0, 1, 2, 3];
 const PROFILE_EDIT_GROUP_AUTOMATION: [usize; 5] = [4, 5, 6, 7, 8];
-const PROFILE_EDIT_GROUP_GOALS: [usize; 9] = [9, 10, 11, 12, 13, 14, 15, 16, 17];
-const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 6] = [18, 19, 20, 21, 22, 23];
-const PROFILE_EDIT_GROUP_APPEARANCE: [usize; 1] = [24];
+const PROFILE_EDIT_GROUP_GOALS: [usize; 3] = [9, 10, 11];
+const PROFILE_EDIT_GROUP_SCHEDULE: [usize; 6] = [12, 13, 14, 15, 16, 17];
+const PROFILE_EDIT_GROUP_APPEARANCE: [usize; 1] = [18];
 const PROFILE_EDIT_GROUPS: [(&str, &[usize]); 5] = [
     ("Timer", &PROFILE_EDIT_GROUP_TIMER),
     ("Automation", &PROFILE_EDIT_GROUP_AUTOMATION),
@@ -272,19 +272,13 @@ fn profile_edit_field_display_label(field_index: usize) -> &'static str {
         9 => "Daily goal minutes",
         10 => "Daily goal pomodoros",
         11 => "Daily goal carry-over",
-        12 => "Weekly goal minutes",
-        13 => "Weekly goal pomodoros",
-        14 => "Weekly goal carry-over",
-        15 => "Monthly goal minutes",
-        16 => "Monthly goal pomodoros",
-        17 => "Monthly goal carry-over",
-        18 => "Window selector",
-        19 => "Day selector",
-        20 => "Day enabled",
-        21 => "Start time",
-        22 => "End time",
-        23 => "Add/remove",
-        24 => "Theme preset",
+        12 => "Window selector",
+        13 => "Day selector",
+        14 => "Day enabled",
+        15 => "Start time",
+        16 => "End time",
+        17 => "Add/remove",
+        18 => "Theme preset",
         _ => "",
     }
 }

--- a/src/ui/session_planner.rs
+++ b/src/ui/session_planner.rs
@@ -20,7 +20,7 @@ pub(super) fn render_session_planner(frame: &mut Frame, app: &App) {
         .direction(Direction::Vertical)
         .margin(2)
         .constraints([
-            Constraint::Length(2), // current task + weekly allocation
+            Constraint::Length(1), // current task
             Constraint::Min(4),    // task label list
             Constraint::Length(3), // task label input
             Constraint::Length(1), // feedback
@@ -40,37 +40,12 @@ fn render_session_planner_selected_task(frame: &mut Frame, app: &App, area: Rect
         || "Selected task: none (required before focus starts)".to_string(),
         |label| format!("Selected task: {label}"),
     );
-    let weekly_allocation = planner_weekly_allocation_summary(app);
-    let selected_text = vec![Line::from(selected_task), Line::from(weekly_allocation)];
     frame.render_widget(
-        Paragraph::new(selected_text)
+        Paragraph::new(selected_task)
             .style(Style::default().fg(app_color(app, Color::White)))
             .wrap(Wrap { trim: true }),
         area,
     );
-}
-
-pub(super) fn planner_weekly_allocation_summary(app: &App) -> String {
-    let allocation = app.weekly_daily_goal_allocation();
-    if !allocation.has_any_target() {
-        return "Weekly allocation: off".to_string();
-    }
-    if allocation.remaining_minutes == 0 && allocation.remaining_pomodoros == 0 {
-        return format!(
-            "Weekly allocation: met ({} day(s) left)",
-            allocation.remaining_days_in_week
-        );
-    }
-    let today_target = allocation.today_target();
-    format!(
-        "Weekly allocation: today {}m/{}p, left {}m/{}p ({}/{} day(s))",
-        today_target.minutes,
-        today_target.pomodoros,
-        allocation.remaining_minutes,
-        allocation.remaining_pomodoros,
-        allocation.allocatable_days,
-        allocation.remaining_days_in_week
-    )
 }
 
 fn render_session_planner_labels(frame: &mut Frame, app: &App, area: Rect) {

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -1,8 +1,19 @@
-use crate::app::PROFILE_EDIT_SCHEDULE_WINDOW_INDEX;
+use crate::app::{
+    App, AppMode, PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX, PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX,
+    PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, PlannerInputMode, SetupCheck, SetupCheckLevel,
+};
+use crate::blocker::BlockingPreviewAction;
 use crate::config::{
     AppConfig, HistoryDashboardConfig, HistoryKpiCardId, ShortcutConfig, ThemePreset,
 };
-use crate::ui::*;
+use crate::timer::{TimerPhase, TimerStatus};
+use crate::ui::{
+    app_color, format_duration_label, format_goal_period_progress, format_history_focus_risk_line,
+    format_history_goal_streak_line, format_history_interruption_line,
+    format_history_weekly_allocation_line, format_month_label, format_timer_goal_streak_line,
+    readable_goal_streak_text, render, render_setup_check, timer_primary_hint,
+    timer_secondary_hint, timer_session_status_lines_for_width,
+};
 use chrono::{Datelike, NaiveDate};
 use ratatui::style::Color;
 use ratatui::{Terminal, backend::TestBackend};
@@ -122,9 +133,8 @@ fn history_focus_risk_line_marks_alert_for_high_risk_forecast() {
     assert!(line.contains("ALERT"));
 }
 
-#[cfg(any())]
 #[test]
-fn goal_streak_lines_render_daily_weekly_monthly_period_progress() {
+fn goal_streak_lines_render_daily_period_progress() {
     let mut app = App::default();
     app.handle_key(crossterm::event::KeyEvent::new(
         crossterm::event::KeyCode::Char('p'),
@@ -134,22 +144,12 @@ fn goal_streak_lines_render_daily_weekly_monthly_period_progress() {
         crossterm::event::KeyCode::Char('e'),
         crossterm::event::KeyModifiers::NONE,
     ));
-    app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX;
+    app.profile_edit_field = PROFILE_EDIT_DAILY_GOAL_MINUTES_INDEX;
     app.handle_key(crossterm::event::KeyEvent::new(
         crossterm::event::KeyCode::Right,
         crossterm::event::KeyModifiers::NONE,
     ));
-    app.profile_edit_field = PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX;
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Right,
-        crossterm::event::KeyModifiers::NONE,
-    ));
-    app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX;
-    app.handle_key(crossterm::event::KeyEvent::new(
-        crossterm::event::KeyCode::Right,
-        crossterm::event::KeyModifiers::NONE,
-    ));
-    app.profile_edit_field = PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX;
+    app.profile_edit_field = PROFILE_EDIT_DAILY_GOAL_POMODOROS_INDEX;
     app.handle_key(crossterm::event::KeyEvent::new(
         crossterm::event::KeyCode::Right,
         crossterm::event::KeyModifiers::NONE,
@@ -159,55 +159,10 @@ fn goal_streak_lines_render_daily_weekly_monthly_period_progress() {
         crossterm::event::KeyModifiers::NONE,
     ));
 
-    let today = current_day_key();
-    let today_date = NaiveDate::parse_from_str(&today, "%Y-%m-%d")
-        .expect("current day key should parse as a date");
-    let weekly_day = (-6..=6)
-        .filter(|offset| *offset != 0)
-        .map(|offset| today_date + Duration::days(i64::from(offset)))
-        .find(|candidate| candidate.iso_week() == today_date.iso_week())
-        .expect("there should be at least one nearby day in the current ISO week");
-    let monthly_day = (-31..=31)
-        .filter(|offset| *offset != 0)
-        .map(|offset| today_date + Duration::days(i64::from(offset)))
-        .find(|candidate| {
-            candidate.year() == today_date.year()
-                && candidate.month() == today_date.month()
-                && candidate.iso_week() != today_date.iso_week()
-        })
-        .expect("there should be at least one nearby day in the current month");
-
-    app.insert_daily_stats_for_tests(
-        &today,
-        crate::stats::DailyStats {
-            pomodoros_completed: 1,
-            focused_seconds: 5 * 60,
-            goal: None,
-        },
-    );
-    app.insert_daily_stats_for_tests(
-        &weekly_day.format("%Y-%m-%d").to_string(),
-        crate::stats::DailyStats {
-            pomodoros_completed: 1,
-            focused_seconds: 5 * 60,
-            goal: None,
-        },
-    );
-    app.insert_daily_stats_for_tests(
-        &monthly_day.format("%Y-%m-%d").to_string(),
-        crate::stats::DailyStats {
-            pomodoros_completed: 1,
-            focused_seconds: 5 * 60,
-            goal: None,
-        },
-    );
-
     let streak = app.goal_streak();
     let expected = format!(
-        "Goals: {} · {} · {}   Streaks: {}d current · {}d best",
+        "Goal: {}   Streaks: {}d current · {}d best",
         format_goal_period_progress("D", app.today_goal_progress()),
-        format_goal_period_progress("W", app.current_week_goal_progress()),
-        format_goal_period_progress("M", app.current_month_goal_progress()),
         streak.current,
         streak.best
     );
@@ -216,23 +171,17 @@ fn goal_streak_lines_render_daily_weekly_monthly_period_progress() {
     assert_eq!(format_history_goal_streak_line(&app), expected);
 }
 
-#[cfg(any())]
 #[test]
-fn weekly_allocation_lines_show_off_when_weekly_goal_is_disabled() {
+fn weekly_allocation_line_shows_retired_message_when_goal_is_disabled() {
     let app = App::default();
     assert_eq!(
         format_history_weekly_allocation_line(&app),
-        "Weekly allocation: off"
-    );
-    assert_eq!(
-        planner_weekly_allocation_summary(&app),
-        "Weekly allocation: off"
+        "Weekly allocation: retired"
     );
 }
 
-#[cfg(any())]
 #[test]
-fn weekly_allocation_lines_show_today_targets_when_weekly_goal_is_configured() {
+fn weekly_allocation_line_stays_retired_when_legacy_goal_is_configured() {
     let app = App::from_config_for_tests(AppConfig {
         weekly_goal: crate::config::WeeklyGoalConfig {
             minutes: 120,
@@ -240,11 +189,10 @@ fn weekly_allocation_lines_show_today_targets_when_weekly_goal_is_configured() {
         },
         ..AppConfig::default()
     });
-    let history_line = format_history_weekly_allocation_line(&app);
-    let planner_line = planner_weekly_allocation_summary(&app);
-
-    assert!(history_line.contains("Weekly allocation: today"));
-    assert!(planner_line.contains("Weekly allocation: today"));
+    assert_eq!(
+        format_history_weekly_allocation_line(&app),
+        "Weekly allocation: retired"
+    );
 }
 
 #[test]

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -1,13 +1,9 @@
-use crate::app::{
-    PROFILE_EDIT_MONTHLY_GOAL_MINUTES_INDEX, PROFILE_EDIT_MONTHLY_GOAL_POMODOROS_INDEX,
-    PROFILE_EDIT_SCHEDULE_WINDOW_INDEX, PROFILE_EDIT_WEEKLY_GOAL_MINUTES_INDEX,
-    PROFILE_EDIT_WEEKLY_GOAL_POMODOROS_INDEX,
-};
+use crate::app::PROFILE_EDIT_SCHEDULE_WINDOW_INDEX;
 use crate::config::{
     AppConfig, HistoryDashboardConfig, HistoryKpiCardId, ShortcutConfig, ThemePreset,
 };
 use crate::ui::*;
-use chrono::{Datelike, Duration, NaiveDate};
+use chrono::{Datelike, NaiveDate};
 use ratatui::style::Color;
 use ratatui::{Terminal, backend::TestBackend};
 
@@ -108,7 +104,7 @@ fn history_focus_risk_line_shows_low_risk_when_goals_are_off() {
     let app = App::default();
     assert_eq!(
         format_history_focus_risk_line(&app),
-        "Risk: D low 0% · W low 0% · M low 0% · S low 0%"
+        "Risk: D low 0% · S low 0%"
     );
 }
 
@@ -119,14 +115,6 @@ fn history_focus_risk_line_marks_alert_for_high_risk_forecast() {
             minutes: 120,
             pomodoros: 4,
         },
-        weekly_goal: crate::config::WeeklyGoalConfig {
-            minutes: 600,
-            pomodoros: 24,
-        },
-        monthly_goal: crate::config::MonthlyGoalConfig {
-            minutes: 2400,
-            pomodoros: 96,
-        },
         ..AppConfig::default()
     });
     let line = format_history_focus_risk_line(&app);
@@ -134,6 +122,7 @@ fn history_focus_risk_line_marks_alert_for_high_risk_forecast() {
     assert!(line.contains("ALERT"));
 }
 
+#[cfg(any())]
 #[test]
 fn goal_streak_lines_render_daily_weekly_monthly_period_progress() {
     let mut app = App::default();
@@ -227,6 +216,7 @@ fn goal_streak_lines_render_daily_weekly_monthly_period_progress() {
     assert_eq!(format_history_goal_streak_line(&app), expected);
 }
 
+#[cfg(any())]
 #[test]
 fn weekly_allocation_lines_show_off_when_weekly_goal_is_disabled() {
     let app = App::default();
@@ -240,6 +230,7 @@ fn weekly_allocation_lines_show_off_when_weekly_goal_is_disabled() {
     );
 }
 
+#[cfg(any())]
 #[test]
 fn weekly_allocation_lines_show_today_targets_when_weekly_goal_is_configured() {
     let app = App::from_config_for_tests(AppConfig {

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -205,6 +205,8 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload.get("monthly_goal").is_none());
     assert!(payload.get("weekly_allocation").is_none());
     assert!(payload["goal"].get("carry_over").is_some());
+    assert!(payload["goal"].get("weekly_carry_over").is_none());
+    assert!(payload["goal"].get("monthly_carry_over").is_none());
     assert!(payload.get("selected_task_goal").is_none());
     assert!(payload.get("focus_score").is_some());
     assert!(payload["focus_score"].get("available").is_some());

--- a/tests/cli_json_contract.rs
+++ b/tests/cli_json_contract.rs
@@ -201,11 +201,10 @@ fn status_json_success_emits_payload_on_stdout() {
     assert!(payload.get("focus_intention").is_none());
     assert!(payload.get("task_note").is_none());
     assert!(payload.get("goal").is_some());
-    assert!(payload.get("weekly_goal").is_some());
-    assert!(payload.get("monthly_goal").is_some());
+    assert!(payload.get("weekly_goal").is_none());
+    assert!(payload.get("monthly_goal").is_none());
+    assert!(payload.get("weekly_allocation").is_none());
     assert!(payload["goal"].get("carry_over").is_some());
-    assert!(payload["weekly_goal"].get("carry_over").is_some());
-    assert!(payload["monthly_goal"].get("carry_over").is_some());
     assert!(payload.get("selected_task_goal").is_none());
     assert!(payload.get("focus_score").is_some());
     assert!(payload["focus_score"].get("available").is_some());
@@ -261,7 +260,7 @@ fn task_goal_json_command_is_removed() {
     );
     assert_eq!(
         payload["error"]["hint"],
-        "Use `--goal`, `--goal-weekly`, or `--goal-monthly` for global goals; task labels remain available through `--task`."
+        "Use `--goal` for the daily goal; task labels remain available through `--task`."
     );
 }
 


### PR DESCRIPTION
## What

Simplify goal management to the supported daily target surface by retiring weekly/monthly goal CLI commands, status fields, history cards, profile-editor controls, export payloads, and docs references.

Closes #567.

## Why

This aligns goal behavior with the v0.17.0 roadmap by keeping `--goal` and daily carry-over as the supported goal surfaces while safely dropping retired weekly/monthly config and stats fields on save.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [x] Pomodoro timer behavior was verified for this change (if applicable)
- [x] Site blocking behavior was verified for this change (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined status, history, and dashboard views to emphasize daily goals and daily carry-over, with simplified focus score and risk displays.
* **Bug Fixes**
  * Weekly/monthly goal progress, allocations, and related risk/completion signals removed from UI and exports to prevent outdated information from appearing.
  * Goal carry-over behavior updated so only daily carry-over is active/persisted in practice.
* **Documentation**
  * Updated README and CLI help text for the new daily-only goal and carry-over semantics, including deprecation guidance.
* **Tests**
  * Adjusted coverage and expectations to match the updated goal/reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->