### PR TITLE
Prepare v0.17.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ cargo audit
 
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `perf:`, `test:`, `docs:`, `chore:`
 - Split commits by behavior or another meaningful unit of change.
-- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.16.4 — short summary`)
+- Release commits: `feat: vX.Y.Z — short summary` (for example, `feat: v0.17.0 — short summary`)
 - Hotfix: `fix: description` (no version in message)
 
 ## Release Documentation Checklist
@@ -116,7 +116,7 @@ When preparing a release update, keep these files aligned:
 - `CHANGELOG.md` release section and compare links
 - `CONTRIBUTING.md` release workflow/tag examples
 - `REGRESSION_MATRIX.md` merged/deprecated/removed feature-path coverage and supported replacement behavior
-- Release tag examples in docs use the current target release version (for example, `v0.16.4`)
+- Release tag examples in docs use the current target release version (for example, `v0.17.0`)
 - `AGENTS.md` release checklist and process guidance
 - `ARCHITECTURE.md` when release-facing guidance changes
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,5 +127,5 @@ sequenceDiagram
   owns it.
 - For release docs updates, keep architecture-facing terminology aligned with the
   module names and responsibility language used in `README.md`, `CHANGELOG.md`,
-  and release tag examples in contributor-facing docs (for example, `v0.16.4`
+  and release tag examples in contributor-facing docs (for example, `v0.17.0`
   for this release cycle).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-30
+
 ### Changed
 
 - **Breaking - Stats export format reduction (#570):** kept JSON as the canonical `--export` artifact, removed CSV writer/output contracts, and simplified export docs/tests around `focustime-stats.json`.
@@ -552,7 +554,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional WakaTime heartbeat integration for focus activity tracking.
 - Release automation for tagged builds across Linux, macOS, and Windows.
 
-[Unreleased]: https://github.com/utilForever/focustime/compare/v0.16.4...HEAD
+[Unreleased]: https://github.com/utilForever/focustime/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/utilForever/focustime/compare/v0.16.4...v0.17.0
 [0.16.4]: https://github.com/utilForever/focustime/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/utilForever/focustime/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/utilForever/focustime/compare/v0.16.1...v0.16.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Also keep the README roadmap, changelog entry, and deprecation notices aligned
 so every deprecated or retired path names supported replacement behavior before
 the tag is created.
 
-To publish a release artifact set, create and push a `v*` tag (for example, `v0.16.4`).
+To publish a release artifact set, create and push a `v*` tag (for example, `v0.17.0`).
 The release workflow will:
 
 - run `cargo check --all --locked`, `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --all --locked`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focustime"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "focustime"
-version = "0.16.4"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.85"
 description = "TUI Pomodoro timer with site blocking and focus history"

--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ Milestone policy:
 - **Future cleanup:** continue retiring overlapping paths only after release notes and docs name supported replacement behavior.
 - **v0.12.0:** remove legacy field/path compatibility after the warning window
 
-### v0.16.x cleanup roadmap
+### v0.17.x cleanup roadmap
 
-The v0.16.x line continues the cleanup work started in v0.14.x by reducing
+The v0.17.x line continues the cleanup work started in v0.14.x by reducing
 overlapping command and config paths while keeping supported behavior available
 through canonical surfaces. The guiding rule is that a path is only retired when
 release notes and diagnostics name the replacement behavior.
@@ -748,12 +748,12 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## Release automation
 
-Pushing a tag that matches `v*` (for example, `v0.16.4`) triggers the release
+Pushing a tag that matches `v*` (for example, `v0.17.0`) triggers the release
 workflow. It runs CI quality gates (`check`, `fmt`, `clippy`, `test`, dependency
 `audit`, and `typos`), builds binaries for Linux/macOS/Windows, and publishes
 them to the GitHub Release attached to that tag.
 
-The latest stable release is [v0.16.4](https://github.com/utilForever/focustime/releases/tag/v0.16.4).
+The latest stable release is [v0.17.0](https://github.com/utilForever/focustime/releases/tag/v0.17.0).
 
 For a human-readable summary of notable changes in this release, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## What

Prepare the v0.17.0 release documentation and package metadata for issue #602.

Closes #602.

## Why

The release issue asks to align Cargo metadata and release-facing documentation for v0.17.0 before tagging.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #25`)

### Functional Validation

- [ ] Pomodoro timer behavior was verified for this change (if applicable)
- [ ] Site blocking behavior was verified for this change (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md` or relevant docs, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version references across project documentation to **v0.17.0**.
  * Added a new **v0.17.0** release section and refreshed release comparison links.
  * Brought package metadata in line with the new release version.
  * Adjusted README examples and release guidance to match the latest stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->